### PR TITLE
Refactor ThenvoiLink to use async iterator pattern

### DIFF
--- a/src/thenvoi/platform/link.py
+++ b/src/thenvoi/platform/link.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Awaitable, Callable, Set
+from typing import TYPE_CHECKING, Set
 
 from thenvoi.client.rest import AsyncRestClient
 from thenvoi.client.streaming import WebSocketClient
@@ -37,17 +37,14 @@ class ThenvoiLink:
 
     Example:
         link = ThenvoiLink(agent_id="...", api_key="...")
+        await link.connect()
+        await link.subscribe_agent_rooms(agent_id)
 
-        async def handle_event(event: PlatformEvent):
+        async for event in link:
             if event.is_message:
                 print(f"Message: {event.payload['content']}")
             elif event.is_room_added:
                 await link.subscribe_room(event.room_id)
-
-        link.on_event = handle_event
-        await link.connect()
-        await link.subscribe_agent_rooms(agent_id)
-        await link.run_forever()
     """
 
     def __init__(
@@ -72,12 +69,22 @@ class ThenvoiLink:
         # Subscription tracking (from ThenvoiAgent._subscribed_rooms)
         self._subscribed_rooms: Set[str] = set()
 
-        # Single event callback (replaces ThenvoiAgent's multiple handlers)
-        self.on_event: Callable[[PlatformEvent], Awaitable[None]] | None = None
+        # Event queue for async iteration
+        self._event_queue: asyncio.Queue[PlatformEvent] = asyncio.Queue(maxsize=1000)
 
     @property
     def is_connected(self) -> bool:
         return self._is_connected
+
+    # --- Async iterator protocol ---
+
+    def __aiter__(self):
+        """Return self to allow async iteration over events."""
+        return self
+
+    async def __anext__(self) -> PlatformEvent:
+        """Get next event from the queue. Blocks until an event is available."""
+        return await self._event_queue.get()
 
     # --- Connection lifecycle (from ThenvoiAgent.start/stop/run) ---
 
@@ -191,32 +198,28 @@ class ThenvoiLink:
 
     # --- Event handlers (from ThenvoiAgent, unified into PlatformEvent) ---
 
-    async def _dispatch(self, event: PlatformEvent) -> None:
-        """Dispatch event via callback. Non-blocking via create_task."""
-        if self.on_event:
-            asyncio.create_task(self._safe_dispatch(event))
-
-    async def _safe_dispatch(self, event: PlatformEvent) -> None:
-        """Dispatch with exception handling."""
+    def _queue_event(self, event: PlatformEvent) -> None:
+        """Queue event for async iteration. Logs warning if queue is full."""
         try:
-            if self.on_event:
-                await self.on_event(event)
-        except Exception as e:
-            logger.error(f"Event handler error for {event.type}: {e}", exc_info=True)
+            self._event_queue.put_nowait(event)
+        except asyncio.QueueFull:
+            logger.warning(
+                f"Event queue full, dropping {event.type} event for room {event.room_id}"
+            )
 
     async def _on_room_added(self, payload: "RoomAddedPayload") -> None:
         """
         Handle room_added from WebSocket.
 
         From ThenvoiAgent._on_room_added() lines 619-630.
-        Now creates PlatformEvent instead of calling _subscribe_to_room/_create_session.
+        Now creates PlatformEvent and queues it for async iteration.
         """
         event = PlatformEvent(
             type="room_added",
             room_id=payload.id,
             payload=payload.model_dump(),
         )
-        await self._dispatch(event)
+        self._queue_event(event)
 
     async def _on_room_removed(self, payload: "RoomRemovedPayload") -> None:
         """
@@ -229,7 +232,7 @@ class ThenvoiLink:
             room_id=payload.id,
             payload=payload.model_dump(),
         )
-        await self._dispatch(event)
+        self._queue_event(event)
 
     async def _on_message_created(
         self, room_id: str, payload: "MessageCreatedPayload"
@@ -238,14 +241,14 @@ class ThenvoiLink:
         Handle message_created from WebSocket.
 
         From ThenvoiAgent._on_message_created() lines 645-682.
-        Now creates PlatformEvent instead of routing to session.
+        Now creates PlatformEvent and queues it for async iteration.
         """
         event = PlatformEvent(
             type="message_created",
             room_id=room_id,
             payload=payload.model_dump(),
         )
-        await self._dispatch(event)
+        self._queue_event(event)
 
     async def _on_participant_added(self, room_id: str, payload: dict) -> None:
         """
@@ -258,7 +261,7 @@ class ThenvoiLink:
             room_id=room_id,
             payload=payload if isinstance(payload, dict) else dict(payload),
         )
-        await self._dispatch(event)
+        self._queue_event(event)
 
     async def _on_participant_removed(self, room_id: str, payload: dict) -> None:
         """
@@ -271,7 +274,7 @@ class ThenvoiLink:
             room_id=room_id,
             payload=payload if isinstance(payload, dict) else dict(payload),
         )
-        await self._dispatch(event)
+        self._queue_event(event)
 
     # --- Message lifecycle (SDK internal operations) ---
 


### PR DESCRIPTION
## Summary
Refactors `ThenvoiLink` to use an async iterator pattern (`async for`) instead of callback-based event handling (`on_event`).

### Changes
- **Add asyncio.Queue for event buffering**: Events are now queued with a maxsize of 1000
- **Implement async iterator protocol**: Added `__aiter__()` and `__anext__()` methods
- **Replace callback dispatch**: Replaced `_dispatch()` and `_safe_dispatch()` with `_queue_event()` method
- **Update all event handlers**: All 5 event handlers now queue events instead of invoking callbacks
- **Clean up**: Removed `on_event` callback attribute and unused `Callable`/`Awaitable` imports
- **Update documentation**: Updated class docstring with new async for usage example

### New Usage Pattern
```python
link = ThenvoiLink(agent_id="...", api_key="...")
await link.connect()
await link.subscribe_agent_rooms(agent_id)

async for event in link:
    if event.is_message:
        print(f"Message: {event.payload['content']}")
    elif event.is_room_added:
        await link.subscribe_room(event.room_id)
```

### Benefits
- More Pythonic and idiomatic async code
- Simpler control flow (no callback registration needed)
- Better backpressure handling with bounded queue
- Cleaner separation of concerns