### PR TITLE
Fix LangGraph rehydration: only reconstruct text messages

### DIFF
--- a/src/thenvoi/integrations/langgraph/agent.py
+++ b/src/thenvoi/integrations/langgraph/agent.py
@@ -180,9 +180,13 @@ class ThenvoiLangGraphAgent(BaseFrameworkAgent):
                 logger.info(f"Room {room_id}: Sending system prompt (first message)")
             logger.debug(f"System prompt:\n{self._system_prompt}")
 
-            # Inject historical messages
+            # Inject historical messages (only text messages, skip events)
             if history:
                 for hist in history:
+                    # Only rebuild text messages, not events (thought, error, task, etc.)
+                    if hist["message_type"] != "text":
+                        continue
+
                     role = hist["role"]
                     content = hist["content"]
                     sender_name = hist["sender_name"]

--- a/src/thenvoi/runtime/execution.py
+++ b/src/thenvoi/runtime/execution.py
@@ -339,19 +339,19 @@ class ExecutionContext:
 
             messages = []
             if context_response.data:
+                # context_response.data is List[ChatMessage] from thenvoi_rest
+                # ChatMessage has required fields: id, content, message_type, sender_id, sender_type
+                # and optional: sender_name, inserted_at, metadata, etc.
                 for item in context_response.data:
-                    sender_name = getattr(item, "sender_name", None) or getattr(
-                        item, "name", None
-                    )
                     messages.append(
                         {
                             "id": item.id,
-                            "content": getattr(item, "content", ""),
-                            "sender_id": getattr(item, "sender_id", ""),
-                            "sender_type": getattr(item, "sender_type", ""),
-                            "sender_name": sender_name,
-                            "message_type": getattr(item, "message_type", "text"),
-                            "created_at": getattr(item, "inserted_at", None),
+                            "content": item.content,
+                            "sender_id": item.sender_id,
+                            "sender_type": item.sender_type,
+                            "sender_name": item.sender_name,
+                            "message_type": item.message_type,
+                            "created_at": item.inserted_at,
                         }
                     )
 

--- a/src/thenvoi/runtime/formatters.py
+++ b/src/thenvoi/runtime/formatters.py
@@ -8,19 +8,20 @@ def format_message_for_llm(msg: dict) -> dict:
     Map platform message to LLM format.
 
     Args:
-        msg: Platform message dict with sender_type, content, sender_name
+        msg: Platform message dict from hydration (ChatMessage fields)
 
     Returns:
-        Dict with role, content, sender_name, sender_type
+        Dict with role, content, sender_name, sender_type, message_type
     """
-    sender_type = msg.get("sender_type", "")
-    sender_name = msg.get("sender_name") or msg.get("name") or sender_type
+    sender_type = msg["sender_type"]
+    sender_name = msg["sender_name"] or sender_type
 
     return {
         "role": "assistant" if sender_type == "Agent" else "user",
-        "content": msg.get("content", ""),
+        "content": msg["content"],
         "sender_name": sender_name,
         "sender_type": sender_type,
+        "message_type": msg["message_type"],
     }
 
 

--- a/tests/runtime/test_formatters.py
+++ b/tests/runtime/test_formatters.py
@@ -9,49 +9,86 @@ from thenvoi.runtime.formatters import (
 
 class TestFormatMessageForLlm:
     def test_agent_sender_maps_to_assistant(self):
-        msg = {"sender_type": "Agent", "content": "Hello", "sender_name": "Bot"}
+        msg = {
+            "sender_type": "Agent",
+            "content": "Hello",
+            "sender_name": "Bot",
+            "message_type": "text",
+        }
         result = format_message_for_llm(msg)
         assert result["role"] == "assistant"
         assert result["content"] == "Hello"
         assert result["sender_name"] == "Bot"
+        assert result["message_type"] == "text"
 
     def test_user_sender_maps_to_user(self):
-        msg = {"sender_type": "User", "content": "Hi", "sender_name": "Alice"}
+        msg = {
+            "sender_type": "User",
+            "content": "Hi",
+            "sender_name": "Alice",
+            "message_type": "text",
+        }
         result = format_message_for_llm(msg)
         assert result["role"] == "user"
 
     def test_unknown_sender_maps_to_user(self):
-        msg = {"sender_type": "", "content": "Test"}
+        msg = {
+            "sender_type": "",
+            "content": "Test",
+            "sender_name": None,
+            "message_type": "text",
+        }
         result = format_message_for_llm(msg)
         assert result["role"] == "user"
 
     def test_fallback_sender_name_to_type(self):
-        # Falls back to sender_type if no name
-        msg = {"sender_type": "Agent", "content": ""}
+        # Falls back to sender_type if sender_name is None
+        msg = {
+            "sender_type": "Agent",
+            "content": "",
+            "sender_name": None,
+            "message_type": "text",
+        }
         result = format_message_for_llm(msg)
         assert result["sender_name"] == "Agent"
 
-    def test_fallback_sender_name_to_name_field(self):
-        # Falls back to "name" field if sender_name missing
-        msg = {"sender_type": "User", "content": "Hi", "name": "Bob"}
-        result = format_message_for_llm(msg)
-        assert result["sender_name"] == "Bob"
-
     def test_includes_sender_type(self):
-        msg = {"sender_type": "Agent", "content": "Test", "sender_name": "Bot"}
+        msg = {
+            "sender_type": "Agent",
+            "content": "Test",
+            "sender_name": "Bot",
+            "message_type": "text",
+        }
         result = format_message_for_llm(msg)
         assert result["sender_type"] == "Agent"
+
+    def test_includes_message_type(self):
+        msg = {
+            "sender_type": "Agent",
+            "content": "Thinking...",
+            "sender_name": "Bot",
+            "message_type": "thought",
+        }
+        result = format_message_for_llm(msg)
+        assert result["message_type"] == "thought"
 
 
 class TestFormatHistoryForLlm:
     def test_formats_multiple_messages(self):
         messages = [
-            {"id": "1", "sender_type": "User", "content": "Hi", "sender_name": "Alice"},
+            {
+                "id": "1",
+                "sender_type": "User",
+                "content": "Hi",
+                "sender_name": "Alice",
+                "message_type": "text",
+            },
             {
                 "id": "2",
                 "sender_type": "Agent",
                 "content": "Hello",
                 "sender_name": "Bot",
+                "message_type": "text",
             },
         ]
         result = format_history_for_llm(messages)
@@ -61,8 +98,20 @@ class TestFormatHistoryForLlm:
 
     def test_excludes_message_by_id(self):
         messages = [
-            {"id": "1", "content": "First", "sender_type": "User"},
-            {"id": "2", "content": "Second", "sender_type": "User"},
+            {
+                "id": "1",
+                "content": "First",
+                "sender_type": "User",
+                "sender_name": "Alice",
+                "message_type": "text",
+            },
+            {
+                "id": "2",
+                "content": "Second",
+                "sender_type": "User",
+                "sender_name": "Bob",
+                "message_type": "text",
+            },
         ]
         result = format_history_for_llm(messages, exclude_id="1")
         assert len(result) == 1
@@ -74,8 +123,20 @@ class TestFormatHistoryForLlm:
 
     def test_none_exclude_id_includes_all(self):
         messages = [
-            {"id": "1", "content": "First", "sender_type": "User"},
-            {"id": "2", "content": "Second", "sender_type": "User"},
+            {
+                "id": "1",
+                "content": "First",
+                "sender_type": "User",
+                "sender_name": "Alice",
+                "message_type": "text",
+            },
+            {
+                "id": "2",
+                "content": "Second",
+                "sender_type": "User",
+                "sender_name": "Bob",
+                "message_type": "text",
+            },
         ]
         result = format_history_for_llm(messages, exclude_id=None)
         assert len(result) == 2


### PR DESCRIPTION
## LangGraph Rehydration Issue

### The Problem

When the agent reconnects, the graph state becomes corrupted:

**Fresh session:**
```
[2] HumanMessage: @simple agent hello
[3] AIMessage + tool_calls: [{'name': 'send_message', ...}]
[4] ToolMessage (tool_call_id: call_xyz)
[5] AIMessage: (empty)
```

**After reconnect (current behavior):**
```
[2] AIMessage: {"event": "on_tool_start", "data": ...}   ← raw JSON as text
[3] AIMessage: Hello! How can I assist you?
[4] AIMessage: {"event": "on_tool_end", "data": ...}     ← raw JSON as text
[5] AIMessage: Checking the number of participants...    ← thought as text
```

All Thenvoi message types (`tool_call`, `tool_result`, `thought`, `text`) are being injected as plain AIMessage strings.

### This PR

A middle-ground fix: only reconstruct `text` messages, skip events. The agent gets a clean summary of what was said, without the corrupted state.

### Future: Full State Reconstruction

To properly rebuild the LangGraph state, we would need to:
1. Store `tool_call_id` in Thenvoi's `tool_call` and `tool_result` messages
2. Store the final AIMessage response (currently not visible in Thenvoi)
3. During rehydration, build proper LangChain `ToolMessage` objects with `tool_call_id` references
4. Skip reconstructing agent `text` messages (they're already captured in the tool results from `send_message`)

This would give the agent full conversation continuity including tool execution history.

