### PR TITLE
Fix prompt teaching model to output text instead of tool calls

### DIFF
--- a/src/thenvoi/runtime/prompts.py
+++ b/src/thenvoi/runtime/prompts.py
@@ -21,7 +21,7 @@ BASE_INSTRUCTIONS = """
 ## Environment
 
 Multi-participant chat. Messages show sender: [Name]: content.
-Use `send_message(content, mentions)` to respond. Plain text output is not delivered.
+You have tools available to interact. Plain text output is not delivered - you MUST use the send_message tool to respond.
 
 ## CRITICAL: Always Relay Information Back to the Requester
 
@@ -32,36 +32,32 @@ When someone asks you to get information from another agent:
 
 ## IMPORTANT: Always Share Your Thinking
 
-You MUST call `send_event(content, message_type="thought")` BEFORE every action.
+BEFORE every action, use the send_event tool with message_type="thought" to share your reasoning.
 This is required so users can see your reasoning process.
 
-## Examples
+## Workflow Examples
 
 ### Simple question - answer directly
-[John Doe]: What's 2+2?
--> send_event("Simple arithmetic, answering directly.", message_type="thought")
--> send_message("4", mentions=["John Doe"])
+User asks: "What's 2+2?"
+Your workflow:
+1. Use send_event tool to share your thought: "Simple arithmetic, answering directly."
+2. Use send_message tool to reply with "4", mentioning the user
 
 ### Delegating to another agent - MUST relay response back
-[John Doe]: Ask Weather Agent about Tokyo
--> send_event("Need weather info. Adding Weather Agent.", message_type="thought")
--> lookup_peers()
--> add_participant("Weather Agent")
--> send_event("Weather Agent added. Asking about Tokyo.", message_type="thought")
--> send_message("What's the weather in Tokyo?", mentions=["Weather Agent"])
+User asks: "Ask Weather Agent about Tokyo"
+Your workflow:
+1. Use send_event tool to share your thought: "Need weather info. Adding Weather Agent."
+2. Use lookup_peers tool to find available agents
+3. Use add_participant tool to add "Weather Agent"
+4. Use send_event tool: "Weather Agent added. Asking about Tokyo."
+5. Use send_message tool to ask Weather Agent about Tokyo weather
 
-[Weather Agent]: Tokyo is 15°C and cloudy.
--> send_event("Got weather response. Relaying back to John Doe.", message_type="thought")
--> send_message("The weather in Tokyo is 15°C and cloudy.", mentions=["John Doe"])
+When Weather Agent responds with the weather info:
+1. Use send_event tool: "Got weather response. Relaying back to the user."
+2. Use send_message tool to relay the weather info back to the ORIGINAL user who asked
 
-### Follow-up question in same conversation
-[John Doe]: What about London?
--> send_event("Follow-up weather question. Asking Weather Agent.", message_type="thought")
--> send_message("What's the weather in London?", mentions=["Weather Agent"])
-
-[Weather Agent]: London is 8°C and rainy.
--> send_event("Got London weather. Relaying to John Doe.", message_type="thought")
--> send_message("London is 8°C and rainy.", mentions=["John Doe"])
+### Follow-up questions
+For follow-ups, continue the same pattern - always relay responses back to whoever originally asked.
 """
 
 # Single default template - agent identity + custom section + base instructions


### PR DESCRIPTION
## Summary

- Fixed system prompt examples that were teaching the model to output function calls as text instead of making actual tool calls
- Changed from literal syntax (`-> send_event(...)`) to natural language workflow descriptions

## Root Cause

The original prompt showed examples like:
```
[John Doe]: What's 2+2?
-> send_event("Simple arithmetic, answering directly.", message_type="thought")
-> send_message("4", mentions=["John Doe"])
```

This taught the model to **output** `send_event(...)` as literal text instead of invoking the actual tools. The fix uses natural language descriptions:
```
User asks: "What's 2+2?"
Your workflow:
1. Use send_event tool to share your thought: "Simple arithmetic, answering directly."
2. Use send_message tool to reply with "4", mentioning the user
```

## Note on History Rehydration

This PR builds on top of the history rehydration fix in `refactor/migrate-to-agent-api`. While that fix correctly reconstructs `AIMessage` objects with `tool_calls` arrays from stored `tool_call`/`tool_result` events, there's a known limitation:

**The agent's final response after each turn is not fully reconstructed.**

In a normal LangGraph ReAct loop, the final message is an `AIMessage` with `content` (not just `tool_calls`) - this is what signals the loop to stop. The platform doesnt store real agent's final response because it was originally thought to be redundant (agent is sending text messages that one of them could represent its final response via tools but it is prompt based, not code logic).
This means the reconstructed graph state ends with:
```
HumanMessage → AIMessage(tool_calls=[...]) → ToolMessage
```

Instead of the original:
```
HumanMessage → AIMessage(tool_calls=[...]) → ToolMessage → AIMessage(content="Done!")
```

**Why it still works:** LangGraph sees the last message is a `ToolMessage` and re-runs the model, which then produces a new response. Functionally equivalent, but the agent loses visibility into its own previous final responses.

This is acceptable for now but worth noting for future improvements if agent behavior depends on seeing its own response history.

## Test plan

- [x] Tested with `uv run --extra langgraph examples/langgraph/01_simple_agent.py`
- [x] Verified agent makes actual tool calls (not text output)
- [x] Verified tool calls work correctly after agent restart with history rehydration