### PR TITLE
Fix package build: include root package files in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thenvoi-sdk"
-version = "0.0.1"
+version = "0.0.2"
 description = "A Python SDK for Thenvoi API"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -77,7 +77,8 @@ dev = [
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["thenvoi.*"]
+include = ["thenvoi", "thenvoi.*"]
+namespaces = false
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
## Summary

- Fix wheel missing `thenvoi/__init__.py` and `thenvoi/agent.py`
- Bump version to 0.0.2

## Problem

Installing from git caused:
```
ImportError: cannot import name 'Agent' from 'thenvoi'
```

The wheel only included subpackages (`thenvoi/adapters/`, `thenvoi/runtime/`, etc.) but not the root package files.

## Root Cause

Two issues in `pyproject.toml`:
1. `include = ["thenvoi.*"]` only matched subpackages, not the root `thenvoi` package
2. Without `namespaces = false`, setuptools treated it as a namespace package (which have no `__init__.py`)

## Fix

```toml
[tool.setuptools.packages.find]
where = ["src"]
include = ["thenvoi", "thenvoi.*"]  # Added "thenvoi"
namespaces = false                   # Added
```

## Test Plan

- [x] Build wheel and verify root files included:
  ```
  uv build --wheel
  unzip -l dist/*.whl | grep "thenvoi/__init__.py"
  unzip -l dist/*.whl | grep "thenvoi/agent.py"
  ```
- [ ] Install from git and verify `from thenvoi import Agent` works