### PR TITLE
Add lazy imports and CI packaging verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,49 @@ jobs:
 
     - name: Run tests
       run: uv run pytest
+
+
+  packaging:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Build wheel
+      run: uv build --wheel
+
+    - name: Install from wheel (isolated, no extras)
+      run: |
+        uv venv /tmp/test-install
+        uv pip install dist/*.whl --python /tmp/test-install/bin/python
+
+    - name: Verify core imports (no extras)
+      run: |
+        /tmp/test-install/bin/python -c "
+        from thenvoi import Agent, ThenvoiLink, AgentRuntime
+        from thenvoi.config import load_agent_config
+        print('Core imports successful')
+        "
+
+    - name: Install with all extras
+      run: |
+        WHEEL=$(ls dist/*.whl)
+        uv pip install "${WHEEL}[dev]" --python /tmp/test-install/bin/python
+
+    - name: Verify all imports (with extras)
+      run: |
+        /tmp/test-install/bin/python -c "
+        from thenvoi import Agent, ThenvoiLink, AgentRuntime
+        from thenvoi.adapters import LangGraphAdapter, AnthropicAdapter, PydanticAIAdapter, ClaudeSDKAdapter
+        from thenvoi.converters import LangChainHistoryConverter, AnthropicHistoryConverter, PydanticAIHistoryConverter
+        from thenvoi.config import load_agent_config
+        print('All imports successful')
+        "

--- a/src/thenvoi/adapters/__init__.py
+++ b/src/thenvoi/adapters/__init__.py
@@ -1,9 +1,21 @@
-"""Built-in framework adapters."""
+"""Built-in framework adapters.
 
-from thenvoi.adapters.langgraph import LangGraphAdapter
-from thenvoi.adapters.anthropic import AnthropicAdapter
-from thenvoi.adapters.pydantic_ai import PydanticAIAdapter
-from thenvoi.adapters.claude_sdk import ClaudeSDKAdapter
+Adapters are lazily imported to avoid requiring all optional dependencies.
+Install the extra you need:
+    uv add thenvoi-sdk[langgraph]
+    uv add thenvoi-sdk[anthropic]
+    uv add thenvoi-sdk[pydantic_ai]
+    uv add thenvoi-sdk[claude_sdk]
+"""
+
+from typing import TYPE_CHECKING
+
+# Type-only imports for static analysis (pyrefly, mypy, etc.)
+if TYPE_CHECKING:
+    from thenvoi.adapters.langgraph import LangGraphAdapter as LangGraphAdapter
+    from thenvoi.adapters.anthropic import AnthropicAdapter as AnthropicAdapter
+    from thenvoi.adapters.pydantic_ai import PydanticAIAdapter as PydanticAIAdapter
+    from thenvoi.adapters.claude_sdk import ClaudeSDKAdapter as ClaudeSDKAdapter
 
 __all__ = [
     "LangGraphAdapter",
@@ -11,3 +23,24 @@ __all__ = [
     "PydanticAIAdapter",
     "ClaudeSDKAdapter",
 ]
+
+
+def __getattr__(name: str):
+    """Lazy import adapters to avoid loading optional dependencies."""
+    if name == "LangGraphAdapter":
+        from thenvoi.adapters.langgraph import LangGraphAdapter
+
+        return LangGraphAdapter
+    elif name == "AnthropicAdapter":
+        from thenvoi.adapters.anthropic import AnthropicAdapter
+
+        return AnthropicAdapter
+    elif name == "PydanticAIAdapter":
+        from thenvoi.adapters.pydantic_ai import PydanticAIAdapter
+
+        return PydanticAIAdapter
+    elif name == "ClaudeSDKAdapter":
+        from thenvoi.adapters.claude_sdk import ClaudeSDKAdapter
+
+        return ClaudeSDKAdapter
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/thenvoi/converters/__init__.py
+++ b/src/thenvoi/converters/__init__.py
@@ -1,12 +1,32 @@
-"""Built-in history converters."""
+"""Built-in history converters.
 
-from thenvoi.converters.langchain import LangChainHistoryConverter, LangChainMessages
-from thenvoi.converters.anthropic import AnthropicHistoryConverter, AnthropicMessages
-from thenvoi.converters.pydantic_ai import (
-    PydanticAIHistoryConverter,
-    PydanticAIMessages,
-)
-from thenvoi.converters.claude_sdk import ClaudeSDKHistoryConverter
+Converters are lazily imported to avoid requiring all optional dependencies.
+Install the extra you need:
+    uv add thenvoi-sdk[langgraph]
+    uv add thenvoi-sdk[anthropic]
+    uv add thenvoi-sdk[pydantic_ai]
+    uv add thenvoi-sdk[claude_sdk]
+"""
+
+from typing import TYPE_CHECKING
+
+# Type-only imports for static analysis (pyrefly, mypy, etc.)
+if TYPE_CHECKING:
+    from thenvoi.converters.langchain import (
+        LangChainHistoryConverter as LangChainHistoryConverter,
+        LangChainMessages as LangChainMessages,
+    )
+    from thenvoi.converters.anthropic import (
+        AnthropicHistoryConverter as AnthropicHistoryConverter,
+        AnthropicMessages as AnthropicMessages,
+    )
+    from thenvoi.converters.pydantic_ai import (
+        PydanticAIHistoryConverter as PydanticAIHistoryConverter,
+        PydanticAIMessages as PydanticAIMessages,
+    )
+    from thenvoi.converters.claude_sdk import (
+        ClaudeSDKHistoryConverter as ClaudeSDKHistoryConverter,
+    )
 
 __all__ = [
     "LangChainHistoryConverter",
@@ -17,3 +37,43 @@ __all__ = [
     "PydanticAIMessages",
     "ClaudeSDKHistoryConverter",
 ]
+
+
+def __getattr__(name: str):
+    """Lazy import converters to avoid loading optional dependencies."""
+    if name in ("LangChainHistoryConverter", "LangChainMessages"):
+        from thenvoi.converters.langchain import (
+            LangChainHistoryConverter,
+            LangChainMessages,
+        )
+
+        if name == "LangChainHistoryConverter":
+            return LangChainHistoryConverter
+        return LangChainMessages
+
+    elif name in ("AnthropicHistoryConverter", "AnthropicMessages"):
+        from thenvoi.converters.anthropic import (
+            AnthropicHistoryConverter,
+            AnthropicMessages,
+        )
+
+        if name == "AnthropicHistoryConverter":
+            return AnthropicHistoryConverter
+        return AnthropicMessages
+
+    elif name in ("PydanticAIHistoryConverter", "PydanticAIMessages"):
+        from thenvoi.converters.pydantic_ai import (
+            PydanticAIHistoryConverter,
+            PydanticAIMessages,
+        )
+
+        if name == "PydanticAIHistoryConverter":
+            return PydanticAIHistoryConverter
+        return PydanticAIMessages
+
+    elif name == "ClaudeSDKHistoryConverter":
+        from thenvoi.converters.claude_sdk import ClaudeSDKHistoryConverter
+
+        return ClaudeSDKHistoryConverter
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/thenvoi/converters/langchain.py
+++ b/src/thenvoi/converters/langchain.py
@@ -7,7 +7,13 @@ import logging
 import re
 from typing import Any
 
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+try:
+    from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+except ImportError as e:
+    raise ImportError(
+        "LangChain dependencies not installed. "
+        "Install with: uv add thenvoi-sdk[langgraph]"
+    ) from e
 
 from thenvoi.core.protocols import HistoryConverter
 

--- a/src/thenvoi/converters/pydantic_ai.py
+++ b/src/thenvoi/converters/pydantic_ai.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic_ai.messages import (
-    ModelRequest,
-    ModelResponse,
-    UserPromptPart,
-    TextPart,
-)
+try:
+    from pydantic_ai.messages import (
+        ModelRequest,
+        ModelResponse,
+        UserPromptPart,
+        TextPart,
+    )
+except ImportError as e:
+    raise ImportError(
+        "Pydantic AI dependencies not installed. "
+        "Install with: uv add thenvoi-sdk[pydantic_ai]"
+    ) from e
 
 from thenvoi.core.protocols import HistoryConverter
 


### PR DESCRIPTION
## Summary

- Convert `adapters/__init__.py` to use `__getattr__` for lazy loading - users can now install only the extras they need without getting import errors
- Convert `converters/__init__.py` to use `__getattr__` for lazy loading
- Add try/except with helpful error messages in converter modules pointing users to install commands
- Add CI job that builds wheel and verifies imports work:
  - Tests core imports without any extras (verifies lazy loading works)
  - Tests all imports with dev extras (verifies full functionality)
- Fix Claude SDK adapter tests to use direct imports instead of broken module mocking

## Problem Solved

Previously, `from thenvoi.adapters import LangGraphAdapter` would fail if anthropic, pydantic_ai, or claude_sdk weren't installed, because all adapters were eagerly imported in `__init__.py`.

Now users can install just the extra they need:
```bash
uv add thenvoi-sdk[langgraph]
```

And import just that adapter:
```python
from thenvoi.adapters import LangGraphAdapter  # Works!
```

## Test plan

- [x] All 510 unit tests pass locally
- [ ] CI packaging job passes - verifies core imports work without extras
- [ ] CI packaging job passes - verifies all imports work with extras