### PR TITLE
Fix startup race condition: adapter.on_started before runtime.start

### DIFF
--- a/src/thenvoi/agent.py
+++ b/src/thenvoi/agent.py
@@ -94,13 +94,19 @@ class Agent:
 
     async def start(self) -> None:
         """Start agent."""
-        await self._runtime.start(
-            on_execute=self._on_execute,
-            on_cleanup=self._adapter.on_cleanup,
-        )
+        # 1. Initialize runtime (fetch metadata via REST, no WebSocket yet)
+        await self._runtime.initialize()
+
+        # 2. Initialize adapter with agent metadata BEFORE message processing
         await self._adapter.on_started(
             self._runtime.agent_name,
             self._runtime.agent_description,
+        )
+
+        # 3. NOW start message processing (connects WebSocket)
+        await self._runtime.start(
+            on_execute=self._on_execute,
+            on_cleanup=self._adapter.on_cleanup,
         )
 
     async def stop(self) -> None:


### PR DESCRIPTION
## Summary

- Fix agent not responding in NEW rooms due to race condition in startup sequence
- `adapter.on_started()` (sets system prompt) was called AFTER `runtime.start()` (begins processing messages)
- Messages arriving during this window had an empty system prompt

## Changes

- Add `PlatformRuntime.initialize()` to fetch metadata via REST without connecting WebSocket
- Reorder `Agent.start()` to: `initialize` → `on_started` → `start`
- Add `TestStartupRaceCondition` test to prevent regression

## Test plan

- [x] New test `TestStartupRaceCondition` passes
- [x] All 511 existing tests pass
- [ ] Manual test: agent responds in NEW rooms