### PR TITLE
Fix multi-agent history converters and centralize tool definitions

### DIFF
--- a/src/thenvoi/adapters/claude_sdk.py
+++ b/src/thenvoi/adapters/claude_sdk.py
@@ -40,6 +40,7 @@ from thenvoi.core.types import PlatformMessage
 from thenvoi.converters.claude_sdk import ClaudeSDKHistoryConverter
 from thenvoi.integrations.claude_sdk.session_manager import ClaudeSessionManager
 from thenvoi.integrations.claude_sdk.prompts import generate_claude_sdk_agent_prompt
+from thenvoi.runtime.tools import get_tool_description
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +168,7 @@ class ClaudeSDKAdapter(SimpleAdapter[str]):
 
         @tool(
             "send_message",
-            "Send a message to the Thenvoi chat room. Use this to respond to users. You MUST use this tool to communicate - text responses without this tool won't reach users.",
+            get_tool_description("send_message"),
             {
                 "room_id": str,
                 "content": str,
@@ -208,7 +209,7 @@ class ClaudeSDKAdapter(SimpleAdapter[str]):
 
         @tool(
             "send_event",
-            "Send an event (thought, tool_call, tool_result, error) to the chat room for transparency.",
+            get_tool_description("send_event"),
             {"room_id": str, "content": str, "message_type": str},
         )
         async def send_event(args: dict[str, Any]) -> dict[str, Any]:
@@ -232,7 +233,7 @@ class ClaudeSDKAdapter(SimpleAdapter[str]):
 
         @tool(
             "add_participant",
-            "Add a participant (user or agent) to the chat room by name.",
+            get_tool_description("add_participant"),
             {"room_id": str, "name": str, "role": str},
         )
         async def add_participant(args: dict[str, Any]) -> dict[str, Any]:
@@ -262,7 +263,7 @@ class ClaudeSDKAdapter(SimpleAdapter[str]):
 
         @tool(
             "remove_participant",
-            "Remove a participant from the chat room by name.",
+            get_tool_description("remove_participant"),
             {"room_id": str, "name": str},
         )
         async def remove_participant(args: dict[str, Any]) -> dict[str, Any]:
@@ -291,7 +292,7 @@ class ClaudeSDKAdapter(SimpleAdapter[str]):
 
         @tool(
             "get_participants",
-            "Get list of participants currently in the chat room.",
+            get_tool_description("get_participants"),
             {"room_id": str},
         )
         async def get_participants(args: dict[str, Any]) -> dict[str, Any]:
@@ -319,7 +320,7 @@ class ClaudeSDKAdapter(SimpleAdapter[str]):
 
         @tool(
             "lookup_peers",
-            "Look up available users and agents that can be added to the chat room.",
+            get_tool_description("lookup_peers"),
             {"room_id": str, "page": int, "page_size": int},
         )
         async def lookup_peers(args: dict[str, Any]) -> dict[str, Any]:

--- a/src/thenvoi/integrations/langgraph/langchain_tools.py
+++ b/src/thenvoi/integrations/langgraph/langchain_tools.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 from langchain_core.tools import StructuredTool
 
 from thenvoi.core.protocols import AgentToolsProtocol
+from thenvoi.runtime.tools import get_tool_description
 
 
 def agent_tools_to_langchain(tools: AgentToolsProtocol) -> list[Any]:
@@ -95,36 +96,36 @@ def agent_tools_to_langchain(tools: AgentToolsProtocol) -> list[Any]:
         StructuredTool.from_function(
             coroutine=send_message_wrapper,
             name="send_message",
-            description="Send a message to the chat room. Provide participant names in mentions array.",
+            description=get_tool_description("send_message"),
         ),
         StructuredTool.from_function(
             coroutine=add_participant_wrapper,
             name="add_participant",
-            description="Add a participant (agent or user) to the chat room by name. Use lookup_peers first to find available agents. Provide name and optionally role (owner/admin/member, default: member).",
+            description=get_tool_description("add_participant"),
         ),
         StructuredTool.from_function(
             coroutine=remove_participant_wrapper,
             name="remove_participant",
-            description="Remove a participant from the chat room by name.",
+            description=get_tool_description("remove_participant"),
         ),
         StructuredTool.from_function(
             coroutine=lookup_peers_wrapper,
             name="lookup_peers",
-            description="List available peers (agents and users) that can be added to this room. Automatically excludes peers already in the room. Supports pagination with page and page_size parameters. Returns dict with 'peers' list and 'metadata' (page, page_size, total_count, total_pages).",
+            description=get_tool_description("lookup_peers"),
         ),
         StructuredTool.from_function(
             coroutine=get_participants_wrapper,
             name="get_participants",
-            description="Get a list of all participants in the current chat room.",
+            description=get_tool_description("get_participants"),
         ),
         StructuredTool.from_function(
             coroutine=create_chatroom_wrapper,
             name="create_chatroom",
-            description="Create a new chat room for a specific task or conversation.",
+            description=get_tool_description("create_chatroom"),
         ),
         StructuredTool.from_function(
             coroutine=send_event_wrapper,
             name="send_event",
-            description="Send an event. Use 'thought' to share reasoning BEFORE actions, 'error' for problems, 'task' for progress updates. Always send a thought before complex actions.",
+            description=get_tool_description("send_event"),
         ),
     ]

--- a/src/thenvoi/runtime/prompts.py
+++ b/src/thenvoi/runtime/prompts.py
@@ -23,6 +23,18 @@ BASE_INSTRUCTIONS = """
 Multi-participant chat. Messages show sender: [Name]: content.
 Use `send_message(content, mentions)` to respond. Plain text output is not delivered.
 
+## CRITICAL: Delegate When You Cannot Help Directly
+
+You have NO internet access and NO real-time data. When asked about weather, news, stock prices,
+or any current information you cannot answer directly:
+
+1. Call `lookup_peers()` to find available specialized agents
+2. If a relevant agent exists (e.g., Weather Agent), call `add_participant(name)` to add them
+3. Ask that agent using `send_message(question, mentions=[agent_name])`
+4. Wait for their response and relay it back to the user
+
+NEVER say "I can't do that" without first checking if another agent can help via `lookup_peers()`.
+
 ## CRITICAL: Always Relay Information Back to the Requester
 
 When someone asks you to get information from another agent:
@@ -42,17 +54,24 @@ This is required so users can see your reasoning process.
 -> send_event("Simple arithmetic, answering directly.", message_type="thought")
 -> send_message("4", mentions=["John Doe"])
 
-### Delegating to another agent - MUST relay response back
-[John Doe]: Ask Weather Agent about Tokyo
--> send_event("Need weather info. Adding Weather Agent.", message_type="thought")
+### User asks about weather (you cannot answer directly)
+[John Doe]: What's the weather in Tokyo?
+-> send_event("I can't check weather directly. Looking for a Weather Agent.", message_type="thought")
 -> lookup_peers()
+-> send_event("Found Weather Agent. Adding to room.", message_type="thought")
 -> add_participant("Weather Agent")
--> send_event("Weather Agent added. Asking about Tokyo.", message_type="thought")
 -> send_message("What's the weather in Tokyo?", mentions=["Weather Agent"])
 
 [Weather Agent]: Tokyo is 15°C and cloudy.
 -> send_event("Got weather response. Relaying back to John Doe.", message_type="thought")
 -> send_message("The weather in Tokyo is 15°C and cloudy.", mentions=["John Doe"])
+
+### No suitable agent available
+[John Doe]: What's the stock price of AAPL?
+-> send_event("I can't check stock prices. Looking for a Stock Agent.", message_type="thought")
+-> lookup_peers()
+-> send_event("No stock agent available. Must inform user.", message_type="thought")
+-> send_message("I don't have access to stock prices, and there's no specialized agent available to help with that.", mentions=["John Doe"])
 
 ### Follow-up question in same conversation
 [John Doe]: What about London?

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -1,13 +1,65 @@
 """Tests for PydanticAIAdapter."""
 
 from datetime import datetime, timezone
+from typing import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic_ai import (
+    AgentRunResultEvent,
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+)
 from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
 
 from thenvoi.adapters.pydantic_ai import PydanticAIAdapter
 from thenvoi.core.types import PlatformMessage
+
+
+def make_stream_events(
+    result_messages: list | None = None,
+    tool_calls: list[tuple[str, dict, str]] | None = None,
+    tool_results: list[tuple[str, str, str]] | None = None,
+) -> AsyncIterator:
+    """Create a mock async iterator of stream events.
+
+    Args:
+        result_messages: Messages to return in AgentRunResultEvent
+        tool_calls: List of (tool_name, args, tool_call_id) tuples
+        tool_results: List of (tool_name, output, tool_call_id) tuples
+
+    Returns:
+        Async iterator of stream events
+    """
+
+    async def stream():
+        # Emit tool call events
+        if tool_calls:
+            for tool_name, args, tool_call_id in tool_calls:
+                event = MagicMock(spec=FunctionToolCallEvent)
+                event.part = MagicMock()
+                event.part.tool_name = tool_name
+                event.part.args = args
+                event.part.tool_call_id = tool_call_id
+                yield event
+
+        # Emit tool result events
+        if tool_results:
+            for tool_name, output, tool_call_id in tool_results:
+                event = MagicMock(spec=FunctionToolResultEvent)
+                event.result = MagicMock()
+                event.result.tool_name = tool_name  # tool_name is on result, not event
+                event.result.content = output
+                event.tool_call_id = tool_call_id
+                yield event
+
+        # Always emit final result event
+        result_event = MagicMock(spec=AgentRunResultEvent)
+        result_event.result = MagicMock()
+        result_event.result.all_messages.return_value = result_messages or []
+        yield result_event
+
+    return stream()
 
 
 @pytest.fixture
@@ -87,6 +139,21 @@ class TestInitialization:
         assert adapter.system_prompt == "You are a helpful bot."
         assert adapter.custom_section == "Be concise."
 
+    def test_enable_execution_reporting_default_false(self):
+        """Should default enable_execution_reporting to False."""
+        adapter = PydanticAIAdapter(model="openai:gpt-4o")
+
+        assert adapter.enable_execution_reporting is False
+
+    def test_enable_execution_reporting_can_be_enabled(self):
+        """Should accept enable_execution_reporting parameter."""
+        adapter = PydanticAIAdapter(
+            model="openai:gpt-4o",
+            enable_execution_reporting=True,
+        )
+
+        assert adapter.enable_execution_reporting is True
+
 
 class TestOnStarted:
     """Tests for on_started() method."""
@@ -158,11 +225,10 @@ class TestOnMessage:
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started("TestBot", "Test bot")
 
-        mock_result = MagicMock()
-        mock_result.all_messages.return_value = [
-            ModelRequest(parts=[UserPromptPart(content="test")])
-        ]
-        adapter._agent.run = AsyncMock(return_value=mock_result)
+        result_messages = [ModelRequest(parts=[UserPromptPart(content="test")])]
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(result_messages=result_messages)
+        )
 
         await adapter.on_message(
             msg=sample_message,
@@ -190,11 +256,12 @@ class TestOnMessage:
             ModelResponse(parts=[TextPart(content="Previous response")]),
         ]
 
-        mock_result = MagicMock()
-        mock_result.all_messages.return_value = existing_history + [
+        result_messages = existing_history + [
             ModelRequest(parts=[UserPromptPart(content="new")])
         ]
-        adapter._agent.run = AsyncMock(return_value=mock_result)
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(result_messages=result_messages)
+        )
 
         await adapter.on_message(
             msg=sample_message,
@@ -205,8 +272,8 @@ class TestOnMessage:
             room_id="room-123",
         )
 
-        # Verify history was passed to agent.run()
-        call_kwargs = adapter._agent.run.call_args.kwargs
+        # Verify history was passed to agent.run_stream_events()
+        call_kwargs = adapter._agent.run_stream_events.call_args.kwargs
         assert "message_history" in call_kwargs
         assert len(call_kwargs["message_history"]) == 2
 
@@ -220,9 +287,9 @@ class TestOnMessage:
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started("TestBot", "Test bot")
 
-        mock_result = MagicMock()
-        mock_result.all_messages.return_value = []
-        adapter._agent.run = AsyncMock(return_value=mock_result)
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(result_messages=[])
+        )
 
         await adapter.on_message(
             msg=sample_message,
@@ -234,7 +301,7 @@ class TestOnMessage:
         )
 
         # Check that participant message was added to history before run
-        call_kwargs = adapter._agent.run.call_args.kwargs
+        call_kwargs = adapter._agent.run_stream_events.call_args.kwargs
         message_history = call_kwargs.get("message_history", [])
         # First message should be the participant update
         if message_history:
@@ -256,9 +323,9 @@ class TestOnMessage:
 
         with patch.object(adapter, "_create_agent") as mock_create:
             mock_agent = MagicMock()
-            mock_result = MagicMock()
-            mock_result.all_messages.return_value = []
-            mock_agent.run = AsyncMock(return_value=mock_result)
+            mock_agent.run_stream_events = MagicMock(
+                return_value=make_stream_events(result_messages=[])
+            )
             mock_create.return_value = mock_agent
 
             await adapter.on_message(
@@ -318,9 +385,9 @@ class TestHistoryManagement:
             ModelResponse(parts=[TextPart(content="A1")]),
         ]
 
-        mock_result = MagicMock()
-        mock_result.all_messages.return_value = new_messages
-        adapter._agent.run = AsyncMock(return_value=mock_result)
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(result_messages=new_messages)
+        )
 
         await adapter.on_message(
             msg=sample_message,
@@ -343,9 +410,9 @@ class TestHistoryManagement:
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started("TestBot", "Test bot")
 
-        mock_result = MagicMock()
-        mock_result.all_messages.return_value = []
-        adapter._agent.run = AsyncMock(return_value=mock_result)
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(result_messages=[])
+        )
 
         await adapter.on_message(
             msg=sample_message,
@@ -358,3 +425,201 @@ class TestHistoryManagement:
 
         # Should have created empty history
         assert "new-room" in adapter._message_history
+
+
+class TestExecutionReporting:
+    """Tests for execution reporting (tool_call and tool_result events)."""
+
+    @pytest.mark.asyncio
+    async def test_emits_tool_call_events_when_enabled(
+        self, sample_message, mock_tools, mock_pydantic_agent
+    ):
+        """Should emit tool_call events when enable_execution_reporting=True."""
+        adapter = PydanticAIAdapter(
+            model="openai:gpt-4o",
+            enable_execution_reporting=True,
+        )
+
+        with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
+            await adapter.on_started("TestBot", "Test bot")
+
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(
+                result_messages=[],
+                tool_calls=[("send_message", {"content": "Hello"}, "call-123")],
+            )
+        )
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        # Verify send_event was called with tool_call
+        mock_tools.send_event.assert_any_call(
+            content='{"name": "send_message", "args": {"content": "Hello"}, "tool_call_id": "call-123"}',
+            message_type="tool_call",
+        )
+
+    @pytest.mark.asyncio
+    async def test_emits_tool_result_events_when_enabled(
+        self, sample_message, mock_tools, mock_pydantic_agent
+    ):
+        """Should emit tool_result events when enable_execution_reporting=True."""
+        adapter = PydanticAIAdapter(
+            model="openai:gpt-4o",
+            enable_execution_reporting=True,
+        )
+
+        with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
+            await adapter.on_started("TestBot", "Test bot")
+
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(
+                result_messages=[],
+                tool_results=[
+                    ("send_message", "Message sent successfully", "call-123")
+                ],
+            )
+        )
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        # Verify send_event was called with tool_result
+        mock_tools.send_event.assert_any_call(
+            content='{"name": "send_message", "output": "Message sent successfully", "tool_call_id": "call-123"}',
+            message_type="tool_result",
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_events_when_reporting_disabled(
+        self, sample_message, mock_tools, mock_pydantic_agent
+    ):
+        """Should NOT emit events when enable_execution_reporting=False (default)."""
+        adapter = PydanticAIAdapter(model="openai:gpt-4o")  # Default is False
+
+        with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
+            await adapter.on_started("TestBot", "Test bot")
+
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(
+                result_messages=[],
+                tool_calls=[("send_message", {"content": "Hello"}, "call-123")],
+                tool_results=[("send_message", "Message sent", "call-123")],
+            )
+        )
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        # Verify send_event was NOT called for tool_call or tool_result
+        for call in mock_tools.send_event.call_args_list:
+            _, kwargs = call
+            assert kwargs.get("message_type") not in ["tool_call", "tool_result"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_tool_calls_all_reported(
+        self, sample_message, mock_tools, mock_pydantic_agent
+    ):
+        """Should emit events for all tool calls in sequence."""
+        adapter = PydanticAIAdapter(
+            model="openai:gpt-4o",
+            enable_execution_reporting=True,
+        )
+
+        with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
+            await adapter.on_started("TestBot", "Test bot")
+
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(
+                result_messages=[],
+                tool_calls=[
+                    ("lookup_peers", {}, "call-1"),
+                    ("add_participant", {"name": "Helper"}, "call-2"),
+                    ("send_message", {"content": "Done"}, "call-3"),
+                ],
+                tool_results=[
+                    ("lookup_peers", "[{...}]", "call-1"),
+                    ("add_participant", "Added", "call-2"),
+                    ("send_message", "Sent", "call-3"),
+                ],
+            )
+        )
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        # Count tool_call and tool_result events
+        tool_call_count = sum(
+            1
+            for call in mock_tools.send_event.call_args_list
+            if call.kwargs.get("message_type") == "tool_call"
+        )
+        tool_result_count = sum(
+            1
+            for call in mock_tools.send_event.call_args_list
+            if call.kwargs.get("message_type") == "tool_result"
+        )
+
+        assert tool_call_count == 3
+        assert tool_result_count == 3
+
+    @pytest.mark.asyncio
+    async def test_event_failure_does_not_crash_run(
+        self, sample_message, mock_pydantic_agent
+    ):
+        """Should continue running if send_event fails."""
+        adapter = PydanticAIAdapter(
+            model="openai:gpt-4o",
+            enable_execution_reporting=True,
+        )
+
+        with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
+            await adapter.on_started("TestBot", "Test bot")
+
+        # Mock tools where send_event fails
+        failing_tools = AsyncMock()
+        failing_tools.send_event = AsyncMock(side_effect=Exception("Network error"))
+
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(
+                result_messages=[ModelRequest(parts=[UserPromptPart(content="test")])],
+                tool_calls=[("send_message", {"content": "Hello"}, "call-123")],
+            )
+        )
+
+        # Should not raise
+        await adapter.on_message(
+            msg=sample_message,
+            tools=failing_tools,
+            history=[],
+            participants_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        # History should still be updated
+        assert "room-123" in adapter._message_history


### PR DESCRIPTION
## Summary

- Fix history converters dropping other agents' messages in multi-agent rooms (LangChain, PydanticAI, Anthropic)
- Centralize tool descriptions in `runtime/tools.py` with `get_tool_description()` helper
- Add execution reporting (`tool_call`/`tool_result` events) to PydanticAI adapter
- Improve delegation prompts (check `lookup_peers()` before saying "I can't")

## Test plan

- [x] All 65 adapter tests pass
- [ ] Manual test with multi-agent room to verify history includes all participants
- [ ] Manual test PydanticAI execution reporting with `--streaming` flag