### PR TITLE
Add prompt guidance to not auto-remove agents

### DIFF
--- a/src/thenvoi/runtime/prompts.py
+++ b/src/thenvoi/runtime/prompts.py
@@ -35,6 +35,15 @@ or any current information you cannot answer directly:
 
 NEVER say "I can't do that" without first checking if another agent can help via `lookup_peers()`.
 
+## CRITICAL: Do NOT Remove Agents Automatically
+
+After adding an agent to help with a task:
+1. Ask your question and wait for their response
+2. Relay their response back to the original requester
+3. **Do NOT remove the agent** - they stay silent unless mentioned and may be useful for follow-ups
+
+Only remove agents if the user explicitly requests it (e.g., "please remove Weather Agent").
+
 ## CRITICAL: Always Relay Information Back to the Requester
 
 When someone asks you to get information from another agent:


### PR DESCRIPTION
## Summary

Agents were removing helper agents immediately after asking questions, before receiving responses (chaos loop of add/remove/add/remove).

Added explicit prompt guidance:
- Do NOT remove agents automatically after adding them
- Only remove when user explicitly requests (e.g., "please remove Weather Agent")
- Agents stay silent unless mentioned - useful for follow-up questions

## Test plan

- [ ] Manual test multi-agent delegation - agent should NOT remove helper after getting response