### PR TITLE
Fix Claude SDK history converter and sender name lookup

### DIFF
--- a/src/thenvoi/converters/claude_sdk.py
+++ b/src/thenvoi/converters/claude_sdk.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from thenvoi.core.protocols import HistoryConverter
+
+logger = logging.getLogger(__name__)
 
 
 class ClaudeSDKHistoryConverter(HistoryConverter[str]):
@@ -12,17 +15,39 @@ class ClaudeSDKHistoryConverter(HistoryConverter[str]):
     Converts platform history to Claude SDK text format.
 
     Claude SDK uses text context rather than structured messages.
-    This converter formats history as a human-readable text block
-    with sender names and room_id context.
+    This converter formats history as a text block for context injection.
 
-    Output: "Previous conversation history:\\n[room_id: xxx][Alice]: Hello\\n..."
+    Handles:
+    - Skipping this agent's text messages (redundant with tool events)
+    - Including other agents' text messages with [name]: prefix
+    - Including tool_call events as raw JSON (as stored by platform)
+    - Including tool_result events as raw JSON (as stored by platform)
 
-    Args:
-        room_id: Room ID to include in context prefix
+    Output example:
+        [Alice]: What's the weather?
+        {"name": "get_weather", "args": {"location": "NYC"}, "tool_call_id": "toolu_123"}
+        {"output": {"temperature": 72}, "tool_call_id": "toolu_123"}
+        [Other Agent]: I can help too!
     """
 
-    def __init__(self, room_id: str = ""):
-        self.room_id = room_id
+    def __init__(self, agent_name: str = ""):
+        """
+        Initialize converter.
+
+        Args:
+            agent_name: Name of this agent. Text messages from this agent
+                       are skipped (redundant with tool events).
+        """
+        self._agent_name = agent_name
+
+    def set_agent_name(self, name: str) -> None:
+        """
+        Set agent name so converter knows which messages to skip.
+
+        Args:
+            name: Name of this agent
+        """
+        self._agent_name = name
 
     def convert(self, raw: list[dict[str, Any]]) -> str:
         """Convert platform history to text format for Claude SDK."""
@@ -30,22 +55,30 @@ class ClaudeSDKHistoryConverter(HistoryConverter[str]):
             return ""
 
         lines: list[str] = []
-        room_context = f"[room_id: {self.room_id}]" if self.room_id else ""
 
         for hist in raw:
             message_type = hist.get("message_type", "text")
-
-            # Only include text messages in context
-            if message_type != "text":
-                continue
-
-            sender_name = hist.get("sender_name", "Unknown")
             content = hist.get("content", "")
+            role = hist.get("role", "user")
+            sender_name = hist.get("sender_name", "Unknown")
 
-            if content:
-                lines.append(f"{room_context}[{sender_name}]: {content}")
+            if message_type == "text":
+                # Skip own text (redundant with tool results)
+                if role == "assistant" and sender_name == self._agent_name:
+                    logger.debug(f"Skipping own message: {content[:50]}...")
+                    continue
+                # Include user and other agents' messages
+                if content:
+                    lines.append(f"[{sender_name}]: {content}")
 
-        if not lines:
-            return ""
+            elif message_type == "tool_call":
+                # Include raw tool_call JSON as-is
+                if content:
+                    lines.append(content)
 
-        return "Previous conversation history:\n" + "\n".join(lines)
+            elif message_type == "tool_result":
+                # Include raw tool_result JSON as-is
+                if content:
+                    lines.append(content)
+
+        return "\n".join(lines) if lines else ""

--- a/src/thenvoi/integrations/claude_sdk/session_manager.py
+++ b/src/thenvoi/integrations/claude_sdk/session_manager.py
@@ -3,12 +3,17 @@ Session manager for Claude Agent SDK clients.
 
 Maintains one ClaudeSDKClient instance per Thenvoi chat room to ensure
 conversation continuity within each room.
+
+Uses a dedicated background task for all session operations to ensure
+connect() and disconnect() are always called from the same task context.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Dict
+from dataclasses import dataclass
+from typing import Any
 
 try:
     from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
@@ -22,6 +27,16 @@ except ImportError as e:
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class _SessionCommand:
+    """Command to be processed by the session manager task."""
+
+    action: str  # "create", "cleanup", "cleanup_all", "stop"
+    room_id: str | None = None
+    resume_session_id: str | None = None
+    result_future: asyncio.Future[Any] | None = None
+
+
 class ClaudeSessionManager:
     """
     Manages ClaudeSDKClient instances per chat room.
@@ -33,9 +48,12 @@ class ClaudeSessionManager:
     - Lazy initialization (clients created on first message)
     - Session reuse (same client for all messages in a room)
     - Graceful cleanup on room leave/disconnect
+    - All session operations run in a single background task to avoid
+      cross-task asyncio issues with connect/disconnect
 
     Example:
         manager = ClaudeSessionManager(base_options)
+        await manager.start()  # Start background task
 
         # Get client for room (creates if doesn't exist)
         client = await manager.get_or_create_session("room-123")
@@ -47,6 +65,7 @@ class ClaudeSessionManager:
 
         # Cleanup when done
         await manager.cleanup_session("room-123")
+        await manager.stop()  # Stop background task
     """
 
     def __init__(self, base_options: ClaudeAgentOptions):
@@ -58,27 +77,119 @@ class ClaudeSessionManager:
                           These options are shared across all room sessions.
         """
         self.base_options = base_options
-        self._sessions: Dict[str, ClaudeSDKClient] = {}
+        self._sessions: dict[str, ClaudeSDKClient] = {}
+        self._command_queue: asyncio.Queue[_SessionCommand] = asyncio.Queue()
+        self._task: asyncio.Task[None] | None = None
+        self._started = False
         logger.info("ClaudeSessionManager initialized")
 
-    async def get_or_create_session(self, room_id: str) -> ClaudeSDKClient:
-        """
-        Get existing ClaudeSDKClient for room or create new one.
+    async def start(self) -> None:
+        """Start the background task that manages all sessions."""
+        if self._started:
+            return
 
-        This method is idempotent - calling it multiple times for the same
-        room_id returns the same client instance.
+        self._task = asyncio.create_task(self._run_session_loop())
+        self._started = True
+        logger.info("ClaudeSessionManager background task started")
 
-        Args:
-            room_id: Thenvoi chat room ID (UUID)
+    async def stop(self) -> None:
+        """Stop the background task and cleanup all sessions."""
+        if not self._started:
+            return
 
-        Returns:
-            ClaudeSDKClient instance for this room
-        """
+        # Send stop command
+        stop_future: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        await self._command_queue.put(
+            _SessionCommand(action="stop", result_future=stop_future)
+        )
+
+        # Wait for cleanup to complete
+        await stop_future
+
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+        self._started = False
+        logger.info("ClaudeSessionManager background task stopped")
+
+    async def _run_session_loop(self) -> None:
+        """Background task that processes all session commands."""
+        logger.debug("Session loop started")
+
+        while True:
+            cmd: _SessionCommand | None = None
+            try:
+                cmd = await self._command_queue.get()
+
+                if cmd.action == "create":
+                    client = await self._do_create_session(
+                        cmd.room_id, cmd.resume_session_id
+                    )
+                    if cmd.result_future:
+                        cmd.result_future.set_result(client)
+
+                elif cmd.action == "cleanup":
+                    await self._do_cleanup_session(cmd.room_id)
+                    if cmd.result_future:
+                        cmd.result_future.set_result(None)
+
+                elif cmd.action == "cleanup_all":
+                    await self._do_cleanup_all()
+                    if cmd.result_future:
+                        cmd.result_future.set_result(None)
+
+                elif cmd.action == "stop":
+                    await self._do_cleanup_all()
+                    if cmd.result_future:
+                        cmd.result_future.set_result(None)
+                    break
+
+                self._command_queue.task_done()
+
+            except asyncio.CancelledError:
+                logger.debug("Session loop cancelled")
+                break
+            except Exception as e:
+                logger.error(f"Error in session loop: {e}", exc_info=True)
+                if cmd and cmd.result_future and not cmd.result_future.done():
+                    cmd.result_future.set_exception(e)
+
+        logger.debug("Session loop exited")
+
+    async def _do_create_session(
+        self, room_id: str | None, resume_session_id: str | None
+    ) -> ClaudeSDKClient:
+        """Create or get session (runs in background task)."""
+        if not room_id:
+            raise ValueError("room_id is required")
+
         if room_id not in self._sessions:
-            logger.info(f"Creating new ClaudeSDKClient session for room: {room_id}")
+            # Build options, optionally with resume
+            if resume_session_id:
+                logger.info(f"Resuming session {resume_session_id} for room: {room_id}")
+                # Create options with resume set
+                options = ClaudeAgentOptions(
+                    model=self.base_options.model,
+                    system_prompt=self.base_options.system_prompt,
+                    mcp_servers=self.base_options.mcp_servers,
+                    allowed_tools=self.base_options.allowed_tools,
+                    permission_mode=self.base_options.permission_mode,
+                    resume=resume_session_id,
+                )
+                # Copy max_thinking_tokens if set
+                if hasattr(self.base_options, "max_thinking_tokens"):
+                    options.max_thinking_tokens = self.base_options.max_thinking_tokens
+            else:
+                logger.info(f"Creating new ClaudeSDKClient session for room: {room_id}")
+                options = self.base_options
 
-            # Create new client with base options
-            client = ClaudeSDKClient(options=self.base_options)
+            # Create new client with options
+            client = ClaudeSDKClient(options=options)
 
             # Connect the client (establishes session with Claude)
             await client.connect()
@@ -95,6 +206,70 @@ class ClaudeSessionManager:
 
         return self._sessions[room_id]
 
+    async def _do_cleanup_session(self, room_id: str | None) -> None:
+        """Cleanup single session (runs in background task)."""
+        if not room_id or room_id not in self._sessions:
+            logger.debug(f"No session to cleanup for room: {room_id}")
+            return
+
+        logger.info(f"Cleaning up session for room: {room_id}")
+
+        try:
+            await self._sessions[room_id].disconnect()
+            logger.debug(f"Disconnected client for room {room_id}")
+        except Exception as e:
+            logger.warning(f"Error disconnecting session for room {room_id}: {e}")
+
+        del self._sessions[room_id]
+
+        logger.info(
+            f"Session cleaned up for room {room_id} "
+            f"(remaining sessions: {len(self._sessions)})"
+        )
+
+    async def _do_cleanup_all(self) -> None:
+        """Cleanup all sessions (runs in background task)."""
+        logger.info(f"Cleaning up all sessions (count: {len(self._sessions)})")
+
+        room_ids = list(self._sessions.keys())
+        for room_id in room_ids:
+            await self._do_cleanup_session(room_id)
+
+        logger.info("All sessions cleaned up")
+
+    async def get_or_create_session(
+        self, room_id: str, resume_session_id: str | None = None
+    ) -> ClaudeSDKClient:
+        """
+        Get existing ClaudeSDKClient for room or create new one.
+
+        This method is idempotent - calling it multiple times for the same
+        room_id returns the same client instance.
+
+        Args:
+            room_id: Thenvoi chat room ID (UUID)
+            resume_session_id: Optional session ID to resume from a previous
+                              session. Only used when creating a new session.
+
+        Returns:
+            ClaudeSDKClient instance for this room
+        """
+        if not self._started:
+            await self.start()
+
+        result_future: asyncio.Future[ClaudeSDKClient] = (
+            asyncio.get_event_loop().create_future()
+        )
+        await self._command_queue.put(
+            _SessionCommand(
+                action="create",
+                room_id=room_id,
+                resume_session_id=resume_session_id,
+                result_future=result_future,
+            )
+        )
+        return await result_future
+
     async def cleanup_session(self, room_id: str) -> None:
         """
         Disconnect and remove session for a room.
@@ -107,26 +282,18 @@ class ClaudeSessionManager:
         Args:
             room_id: Thenvoi chat room ID
         """
-        if room_id in self._sessions:
-            logger.info(f"Cleaning up session for room: {room_id}")
+        if not self._started:
+            return
 
-            try:
-                await self._sessions[room_id].disconnect()
-                logger.debug(f"Disconnected client for room {room_id}")
-            except Exception as e:
-                logger.error(
-                    f"Error disconnecting session for room {room_id}: {e}",
-                    exc_info=True,
-                )
-
-            del self._sessions[room_id]
-
-            logger.info(
-                f"Session cleaned up for room {room_id} "
-                f"(remaining sessions: {len(self._sessions)})"
+        result_future: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        await self._command_queue.put(
+            _SessionCommand(
+                action="cleanup",
+                room_id=room_id,
+                result_future=result_future,
             )
-        else:
-            logger.debug(f"No session to cleanup for room: {room_id}")
+        )
+        await result_future
 
     async def cleanup_all(self) -> None:
         """
@@ -135,15 +302,17 @@ class ClaudeSessionManager:
         This should be called when the adapter is shutting down to ensure
         all Claude SDK clients are properly disconnected.
         """
-        logger.info(f"Cleaning up all sessions (count: {len(self._sessions)})")
+        if not self._started:
+            return
 
-        # Get list of room IDs to avoid modifying dict during iteration
-        room_ids = list(self._sessions.keys())
-
-        for room_id in room_ids:
-            await self.cleanup_session(room_id)
-
-        logger.info("All sessions cleaned up")
+        result_future: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        await self._command_queue.put(
+            _SessionCommand(
+                action="cleanup_all",
+                result_future=result_future,
+            )
+        )
+        await result_future
 
     def has_session(self, room_id: str) -> bool:
         """Check if session exists for room."""

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -144,7 +144,7 @@ class TestCleanupAll:
 
     @pytest.mark.asyncio
     async def test_cleans_up_all_sessions(self):
-        """Should cleanup all sessions and clear room tools."""
+        """Should stop session manager and clear room tools."""
         adapter = ClaudeSDKAdapter()
 
         mock_session_manager = AsyncMock()
@@ -154,7 +154,7 @@ class TestCleanupAll:
 
         await adapter.cleanup_all()
 
-        mock_session_manager.cleanup_all.assert_awaited_once()
+        mock_session_manager.stop.assert_awaited_once()
         assert len(adapter._room_tools) == 0
 
 


### PR DESCRIPTION
## Summary

- Fix sender_name lookup from participants list in preprocessor (WebSocket doesn't include sender_name)
- Update ClaudeSDKHistoryConverter with agent_name tracking to skip own messages
- Include raw JSON for tool_call/tool_result events (as stored by platform)
- Add background task pattern to session manager for proper connect/disconnect lifecycle
- Fix Anthropic adapter execution reporting format

## Changes

- `preprocessing/default.py`: Lookup sender_name from participants by sender_id
- `converters/claude_sdk.py`: Add agent_name, skip own text, raw JSON for tool events
- `session_manager.py`: Background task pattern to avoid cross-task asyncio issues
- `adapters/claude_sdk.py`: Various fixes for tool event reporting
- Updated tests