### PR TITLE
Fix version mismatch and prepare for v0.1.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thenvoi-sdk"
-version = "0.0.2"
+version = "0.1.0"
 description = "A Python SDK for Thenvoi API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/thenvoi/__init__.py
+++ b/src/thenvoi/__init__.py
@@ -40,6 +40,8 @@ Example (Framework-light pattern):
     await link.run_forever()
 """
 
+from importlib.metadata import version as _get_version, PackageNotFoundError
+
 # Composition layer (new pattern)
 from .agent import Agent
 
@@ -100,4 +102,7 @@ __all__ = [
     "MessageRetryTracker",
 ]
 
-__version__ = "0.0.1"
+try:
+    __version__ = _get_version("thenvoi-sdk")
+except PackageNotFoundError:
+    __version__ = "0.1.0"  # Fallback for editable installs


### PR DESCRIPTION
## Summary

Fix version numbers out of sync (Issue #42):

| Source | Before | After |
|--------|--------|-------|
| `pyproject.toml` | `0.0.2` | `0.1.0` |
| `src/thenvoi/__init__.py` | `0.0.1` (static) | Dynamic via `importlib.metadata` |

## Changes

- **Single source of truth**: Version now only defined in `pyproject.toml`
- **Dynamic version lookup**: Uses `importlib.metadata.version()` at runtime
- **Fallback for dev**: Returns `0.1.0` if package not installed (editable installs)

## Why v0.1.0?

34+ PRs merged since v0.0.1 with major features:
- 4 adapters (LangGraph, PydanticAI, Anthropic, Claude SDK)
- SimpleAdapter pattern
- History converters
- Execution reporting

## Post-merge

After merging to `main`:
1. Create git tag: `git tag -a v0.1.0 -m "v0.1.0"`
2. Create GitHub Release

Closes #42