### PR TITLE
Fix CI to trigger on PRs to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [dev]
+    branches: [dev, main]
 
 jobs:
 


### PR DESCRIPTION
## Summary

CI workflow was only triggering on PRs to `dev`, not `main`.

This meant PR #44 (Release v0.1.0: dev → main) had no CI checks.

## Fix

```yaml
on:
  pull_request:
    branches: [dev, main]  # Added main
```

## Note

After merging this to dev, PR #44 should show CI running.