### PR TITLE
Add openai dependency to pydantic-ai optional group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 [project.optional-dependencies]
 pydantic-ai = [
     "pydantic-ai-slim>=1.0.0",
+    "openai>=1.0.0",
 ]
 anthropic = [
     "anthropic>=0.75.0",


### PR DESCRIPTION
## Summary
- Adds `openai>=1.0.0` to the `pydantic-ai` optional dependency group

The pydantic-ai adapter uses `openai:gpt-4o` by default, which requires the openai package. Without it, running the pydantic_ai example fails with `ModuleNotFoundError: No module named 'openai'`.

## Test plan
- [x] Run `uv sync --extra pydantic-ai`
- [x] Run `uv run python examples/run_agent.py --example pydantic_ai`
- [x] Verify agent starts successfully