### PR TITLE
refactor: rename THENVOI_REST_API_URL to THENVOI_REST_URL for consistency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 
 # Thenvoi Platform URLs (defaults to production)
 # Only change these if connecting to a different environment
-THENVOI_REST_API_URL=https://app.thenvoi.com/
+THENVOI_REST_URL=https://app.thenvoi.com/
 THENVOI_WS_URL=wss://app.thenvoi.com/api/v1/socket/websocket
 
 # OpenAI API key (required for LangGraph examples)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Git Workflow:
 
 Environment Variables:
 
-- THENVOI_REST_API_URL: REST API URL (default: https://api.thenvoi.com)
+- THENVOI_REST_URL: REST API URL (default: https://api.thenvoi.com)
 - THENVOI_WS_URL: WebSocket URL (default: wss://api.thenvoi.com/ws)
 - OPENAI_API_KEY: OpenAI API key (for LangGraph examples)
 - ANTHROPIC_API_KEY: Anthropic API key (for Anthropic/Claude SDK examples)

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ docker build -t thenvoi-sdk .
 # Run (load .env first)
 set -a && source .env && set +a
 docker run --rm \
-  -e THENVOI_REST_API_URL="${THENVOI_REST_API_URL}" \
+  -e THENVOI_REST_URL="${THENVOI_REST_URL}" \
   -e THENVOI_WS_URL="${THENVOI_WS_URL}" \
   -e OPENAI_API_KEY="${OPENAI_API_KEY}" \
   -v ./agent_config.yaml:/app/agent_config.yaml \
@@ -437,7 +437,7 @@ docker run --rm \
 
 ```bash
 # Platform URLs
-THENVOI_REST_API_URL=https://api.thenvoi.com
+THENVOI_REST_URL=https://api.thenvoi.com
 THENVOI_WS_URL=wss://api.thenvoi.com/ws
 
 # LLM API Keys

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # Shared configuration using YAML anchors
 x-common-env: &common-env
-  THENVOI_REST_API_URL: ${THENVOI_REST_API_URL}
+  THENVOI_REST_URL: ${THENVOI_REST_URL}
   THENVOI_WS_URL: ${THENVOI_WS_URL}
   OPENAI_API_KEY: ${OPENAI_API_KEY}
   # Note: Agent-specific API keys are in agent_config.yaml (mounted as volume)

--- a/examples/anthropic/01_basic_agent.py
+++ b/examples/anthropic/01_basic_agent.py
@@ -25,12 +25,12 @@ async def main():
     load_dotenv()
 
     ws_url = os.getenv("THENVOI_WS_URL")
-    rest_url = os.getenv("THENVOI_REST_API_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
 
     if not ws_url:
         raise ValueError("THENVOI_WS_URL environment variable is required")
     if not rest_url:
-        raise ValueError("THENVOI_REST_API_URL environment variable is required")
+        raise ValueError("THENVOI_REST_URL environment variable is required")
 
     # Load agent credentials from agent_config.yaml
     agent_id, api_key = load_agent_config("anthropic_agent")

--- a/examples/anthropic/02_custom_instructions.py
+++ b/examples/anthropic/02_custom_instructions.py
@@ -42,12 +42,12 @@ async def main():
     load_dotenv()
 
     ws_url = os.getenv("THENVOI_WS_URL")
-    rest_url = os.getenv("THENVOI_REST_API_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
 
     if not ws_url:
         raise ValueError("THENVOI_WS_URL environment variable is required")
     if not rest_url:
-        raise ValueError("THENVOI_REST_API_URL environment variable is required")
+        raise ValueError("THENVOI_REST_URL environment variable is required")
 
     # Load agent credentials from agent_config.yaml
     agent_id, api_key = load_agent_config("support_agent")

--- a/examples/claude_sdk/README.md
+++ b/examples/claude_sdk/README.md
@@ -169,7 +169,7 @@ docker run --rm \
   -e THENVOI_AGENT_ID="your-agent-id" \
   -e THENVOI_API_KEY="your-api-key" \
   -e ANTHROPIC_API_KEY="your-anthropic-api-key" \
-  -e THENVOI_REST_API_URL="${THENVOI_REST_API_URL:-}" \
+  -e THENVOI_REST_URL="${THENVOI_REST_URL:-}" \
   -e THENVOI_WS_URL="${THENVOI_WS_URL:-}" \
   claude-sdk-example
 

--- a/examples/langgraph/01_simple_agent.py
+++ b/examples/langgraph/01_simple_agent.py
@@ -23,12 +23,12 @@ async def main():
     load_dotenv()
 
     ws_url = os.getenv("THENVOI_WS_URL")
-    rest_url = os.getenv("THENVOI_REST_API_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
 
     if not ws_url:
         raise ValueError("THENVOI_WS_URL environment variable is required")
     if not rest_url:
-        raise ValueError("THENVOI_REST_API_URL environment variable is required")
+        raise ValueError("THENVOI_REST_URL environment variable is required")
 
     # Load agent credentials from agent_config.yaml
     agent_id, api_key = load_agent_config("simple_agent")

--- a/examples/langgraph/02_custom_tools.py
+++ b/examples/langgraph/02_custom_tools.py
@@ -66,12 +66,12 @@ async def main():
     load_dotenv()
 
     ws_url = os.getenv("THENVOI_WS_URL")
-    rest_url = os.getenv("THENVOI_REST_API_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
 
     if not ws_url:
         raise ValueError("THENVOI_WS_URL environment variable is required")
     if not rest_url:
-        raise ValueError("THENVOI_REST_API_URL environment variable is required")
+        raise ValueError("THENVOI_REST_URL environment variable is required")
 
     # Load agent credentials from agent_config.yaml
     agent_id, api_key = load_agent_config("custom_tools_agent")

--- a/examples/langgraph/03_custom_personality.py
+++ b/examples/langgraph/03_custom_personality.py
@@ -19,12 +19,12 @@ setup_logging()
 async def main():
     load_dotenv()
     ws_url = os.getenv("THENVOI_WS_URL")
-    rest_url = os.getenv("THENVOI_REST_API_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
 
     if not ws_url:
         raise ValueError("THENVOI_WS_URL environment variable is required")
     if not rest_url:
-        raise ValueError("THENVOI_REST_API_URL environment variable is required")
+        raise ValueError("THENVOI_REST_URL environment variable is required")
 
     # Load agent credentials from agent_config.yaml
     agent_id, api_key = load_agent_config("custom_personality_agent")

--- a/examples/langgraph/04_calculator_as_tool.py
+++ b/examples/langgraph/04_calculator_as_tool.py
@@ -32,12 +32,12 @@ logger = logging.getLogger(__name__)
 async def main():
     load_dotenv()
     ws_url = os.getenv("THENVOI_WS_URL")
-    rest_url = os.getenv("THENVOI_REST_API_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
 
     if not ws_url:
         raise ValueError("THENVOI_WS_URL environment variable is required")
     if not rest_url:
-        raise ValueError("THENVOI_REST_API_URL environment variable is required")
+        raise ValueError("THENVOI_REST_URL environment variable is required")
 
     # Load agent credentials from agent_config.yaml
     agent_id, api_key = load_agent_config("calculator_agent")

--- a/examples/langgraph/05_rag_as_tool.py
+++ b/examples/langgraph/05_rag_as_tool.py
@@ -41,12 +41,12 @@ logger = logging.getLogger(__name__)
 async def main():
     load_dotenv()
     ws_url = os.getenv("THENVOI_WS_URL")
-    rest_url = os.getenv("THENVOI_REST_API_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
 
     if not ws_url:
         raise ValueError("THENVOI_WS_URL environment variable is required")
     if not rest_url:
-        raise ValueError("THENVOI_REST_API_URL environment variable is required")
+        raise ValueError("THENVOI_REST_URL environment variable is required")
 
     # Load agent configuration from agent_config.yaml
     agent_id, api_key = load_agent_config("rag_agent")

--- a/examples/langgraph/06_delegate_to_sql_agent.py
+++ b/examples/langgraph/06_delegate_to_sql_agent.py
@@ -35,12 +35,12 @@ logger = logging.getLogger(__name__)
 async def main():
     load_dotenv()
     ws_url = os.getenv("THENVOI_WS_URL")
-    rest_url = os.getenv("THENVOI_REST_API_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
 
     if not ws_url:
         raise ValueError("THENVOI_WS_URL environment variable is required")
     if not rest_url:
-        raise ValueError("THENVOI_REST_API_URL environment variable is required")
+        raise ValueError("THENVOI_REST_URL environment variable is required")
 
     # Load agent configuration from agent_config.yaml
     agent_id, api_key = load_agent_config("sql_agent")

--- a/examples/pydantic_ai/01_basic_agent.py
+++ b/examples/pydantic_ai/01_basic_agent.py
@@ -25,12 +25,12 @@ async def main():
     load_dotenv()
 
     ws_url = os.getenv("THENVOI_WS_URL")
-    rest_url = os.getenv("THENVOI_REST_API_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
 
     if not ws_url:
         raise ValueError("THENVOI_WS_URL environment variable is required")
     if not rest_url:
-        raise ValueError("THENVOI_REST_API_URL environment variable is required")
+        raise ValueError("THENVOI_REST_URL environment variable is required")
 
     # Load agent credentials from agent_config.yaml
     agent_id, api_key = load_agent_config("pydantic_agent")

--- a/examples/pydantic_ai/02_custom_instructions.py
+++ b/examples/pydantic_ai/02_custom_instructions.py
@@ -41,12 +41,12 @@ async def main():
     load_dotenv()
 
     ws_url = os.getenv("THENVOI_WS_URL")
-    rest_url = os.getenv("THENVOI_REST_API_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
 
     if not ws_url:
         raise ValueError("THENVOI_WS_URL environment variable is required")
     if not rest_url:
-        raise ValueError("THENVOI_REST_API_URL environment variable is required")
+        raise ValueError("THENVOI_REST_URL environment variable is required")
 
     # Load agent credentials from agent_config.yaml
     agent_id, api_key = load_agent_config("support_agent")

--- a/examples/pydantic_ai/README.md
+++ b/examples/pydantic_ai/README.md
@@ -66,7 +66,7 @@ support_agent:
 Set environment variables:
 ```bash
 export THENVOI_WS_URL="wss://api.thenvoi.com/ws"
-export THENVOI_REST_API_URL="https://api.thenvoi.com"
+export THENVOI_REST_URL="https://api.thenvoi.com"
 export OPENAI_API_KEY="your-openai-key"  # for OpenAI models
 export ANTHROPIC_API_KEY="your-anthropic-key"  # for Anthropic models
 ```

--- a/examples/run_agent.py
+++ b/examples/run_agent.py
@@ -21,7 +21,7 @@ Configure agent in agent_config.yaml:
 
 Setup:
 1. Copy .env.example to .env and configure:
-   - THENVOI_REST_API_URL (default: production, change for local dev)
+   - THENVOI_REST_URL (default: production, change for local dev)
    - THENVOI_WS_URL (default: production, change for local dev)
    - OPENAI_API_KEY (required for langgraph/openai models)
    - ANTHROPIC_API_KEY (required for anthropic models)
@@ -257,11 +257,11 @@ Examples:
     logger = setup_logging(args.log_level)
 
     # Load URLs from environment
-    rest_url = os.getenv("THENVOI_REST_API_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
     ws_url = os.getenv("THENVOI_WS_URL")
 
     if not rest_url:
-        parser.error("THENVOI_REST_API_URL environment variable is required")
+        parser.error("THENVOI_REST_URL environment variable is required")
     if not ws_url:
         parser.error("THENVOI_WS_URL environment variable is required")
 


### PR DESCRIPTION
## Summary

Rename `THENVOI_REST_API_URL` environment variable to `THENVOI_REST_URL` for consistency with the WebSocket URL naming convention.

## Motivation

- **Consistency**: `THENVOI_WS_URL` and `THENVOI_REST_URL` now follow the same pattern
- **Redundancy**: "REST" already implies API, so "REST API URL" is redundant (similar to "ATM machine")

Before:
- `THENVOI_WS_URL`
- `THENVOI_REST_API_URL` ❌

After:
- `THENVOI_WS_URL`
- `THENVOI_REST_URL` ✓

## Changes

Updated 16 files:
- `CLAUDE.md` - Documentation
- `README.md` - Documentation  
- `docker-compose.yml` - Docker config
- `examples/run_agent.py` - Example runner
- `examples/anthropic/*.py` - Anthropic examples
- `examples/langgraph/*.py` - LangGraph examples
- `examples/pydantic_ai/*.py` - PydanticAI examples
- `examples/*/README.md` - Example documentation

## Breaking Change

⚠️ Users will need to update their environment variables from `THENVOI_REST_API_URL` to `THENVOI_REST_URL`.