### PR TITLE
fix(ci): skip PR title validation for dependabot

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,6 +11,8 @@ jobs:
   validate:
     name: Validate PR Title
     runs-on: ubuntu-latest
+    # Skip validation for dependabot PRs
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Validate Conventional Commits format
         uses: amannn/action-semantic-pull-request@v5


### PR DESCRIPTION
## Summary

Skip the PR title validation workflow for dependabot PRs by adding an `if` condition that checks `github.actor != 'dependabot[bot]'`.

## Why

Dependabot PRs use titles like "Bump X from Y to Z" which don't follow conventional commit format. The `ignoreLabels` option alone isn't reliable because:
1. Labels may not be applied before the check runs
2. Re-running workflows uses the cached workflow file

## Changes

- Added `if: github.actor != 'dependabot[bot]'` condition to the validate job

This matches the fix applied to thenvoi-mcp in PR #61.