### PR TITLE
feat: Add Fern API validation to CI - WIP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,25 @@ on:
 
 jobs:
 
+  fern:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install Fern CLI
+      run: npm install -g fern-api
+
+    - name: Validate API definition
+      env:
+        FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+      run: fern check --warnings --strict-broken-links
+
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Add new `fern` job to CI workflow to validate API definitions
- Installs Fern CLI via npm and runs `fern check --warnings --strict-broken-links`
- Uses `FERN_TOKEN` secret for authentication

## Test plan
- [ ] Verify CI workflow runs the Fern check job on PR
- [ ] Ensure `FERN_TOKEN` secret is configured in repository settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)