### PR TITLE
fix: add target-branch to release-please configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           token: ${{ steps.app_token_generator.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: main
 
       - name: Set up Python
         if: steps.release.outputs.release_created == 'true'


### PR DESCRIPTION
## Summary
- Add `target-branch: main` to release-please action configuration
- Fixes release-please creating PRs against dev (default branch) instead of main
- PR #76 was affected by this issue - it released from dev instead of main

## Test plan
- [ ] Verify next release-please PR targets main branch
- [ ] Confirm workflow triggers correctly on main branch pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)