### PR TITLE
fix: make MessageMetadata.status optional for websocket compatibility

### DIFF
--- a/src/thenvoi/client/streaming/client.py
+++ b/src/thenvoi/client/streaming/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from phoenix_channels_python_client.client import (
     PHXChannelsClient,
     PhoenixChannelsProtocolVersion,
@@ -25,7 +27,7 @@ class MessageMetadata(BaseModel):
     """Metadata within message_created payload."""
 
     mentions: list[Mention]
-    status: str
+    status: str | None = None
 
 
 class MessageCreatedPayload(BaseModel):

--- a/tests/platform/test_event.py
+++ b/tests/platform/test_event.py
@@ -47,6 +47,27 @@ class TestMessageEvent:
         assert event.payload.id == "msg-456"
         assert event.raw is None
 
+    def test_message_metadata_without_status(self):
+        """MessageMetadata.status is optional (websocket may omit it)."""
+        # INT-84: WebSocket API doesn't always include status field
+        metadata = MessageMetadata(mentions=[])
+        assert metadata.status is None
+
+        payload = MessageCreatedPayload(
+            id="msg-no-status",
+            content="Hello without status",
+            message_type="text",
+            sender_id="user-789",
+            sender_type="User",
+            chat_room_id="room-123",
+            inserted_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+            metadata=metadata,
+        )
+
+        event = MessageEvent(room_id="room-123", payload=payload)
+        assert event.payload.metadata.status is None
+
     def test_message_event_isinstance(self):
         """Test isinstance check for MessageEvent."""
         payload = MessageCreatedPayload(


### PR DESCRIPTION
## Summary
- Make `MessageMetadata.status` field optional with default `None`
- WebSocket API doesn't consistently include `status` in message payloads, causing Pydantic validation errors
- Add `from __future__ import annotations` import per coding standards

## Test plan
- [x] Added test `test_message_metadata_without_status` to verify optional status
- [x] All existing tests pass
- [x] Linting and type checking pass

Fixes INT-84
Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)