### PR TITLE
feat: add config-driven agent creation

### DIFF
--- a/src/thenvoi/__init__.py
+++ b/src/thenvoi/__init__.py
@@ -16,17 +16,15 @@ from importlib.metadata import version as _get_version, PackageNotFoundError
 
 # Composition layer (new pattern)
 from .agent import Agent
+from .config import AgentConfig
 
 # Platform layer
 from .platform import ThenvoiLink, PlatformEvent
 
 # Runtime layer
-from .runtime import (
-    AgentConfig,
-    ConversationContext,
-    PlatformMessage,
-    SessionConfig,
-)
+from .runtime.execution import ExecutionContext
+from .runtime.runtime import AgentRuntime
+from .runtime.types import ConversationContext, PlatformMessage, SessionConfig
 
 __all__ = [
     # Composition
@@ -39,6 +37,8 @@ __all__ = [
     "AgentConfig",
     "SessionConfig",
     "ConversationContext",
+    "AgentRuntime",
+    "ExecutionContext",
 ]
 
 try:

--- a/src/thenvoi/agent.py
+++ b/src/thenvoi/agent.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 import logging
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _get_version
+from pathlib import Path
 from types import TracebackType
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
+from thenvoi.config import build_adapter_from_config, load_agent_config
+from thenvoi.core.exceptions import ThenvoiConfigError
 from thenvoi.core.protocols import FrameworkAdapter, Preprocessor
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.runtime.platform_runtime import PlatformRuntime
-from thenvoi.runtime.types import AgentConfig, ContactEventConfig, SessionConfig
 from thenvoi.preprocessing.default import DefaultPreprocessor
+from thenvoi.runtime.platform_runtime import PlatformRuntime
+from thenvoi.runtime.types import ContactEventConfig, SessionConfig
 
 if TYPE_CHECKING:
     from thenvoi.platform.event import PlatformEvent
@@ -93,10 +96,18 @@ class Agent:
         api_key: str,
         ws_url: str = "wss://app.thenvoi.com/api/v1/socket/websocket",
         rest_url: str = "https://app.thenvoi.com",
-        config: AgentConfig | None = None,
+        config: Any | None = None,
         session_config: SessionConfig | None = None,
         contact_config: ContactEventConfig | None = None,
         preprocessor: Preprocessor | None = None,
+        tools: list[Any] | None = None,
+        capabilities: list[str] | None = None,
+        include_categories: list[str] | None = None,
+        include_tools: list[str] | None = None,
+        exclude_tools: list[str] | None = None,
+        emit: list[str] | None = None,
+        prompt: str | None = None,
+        prompt_path: str | Path | None = None,
     ) -> "Agent":
         """
         Create agent with default runtime.
@@ -125,11 +136,156 @@ class Agent:
             session_config=session_config,
             contact_config=contact_config,
         )
+        cls._apply_composition_options(
+            adapter=adapter,
+            tools=tools,
+            capabilities=capabilities,
+            include_categories=include_categories,
+            include_tools=include_tools,
+            exclude_tools=exclude_tools,
+            emit=emit,
+            prompt=prompt,
+            prompt_path=prompt_path,
+        )
         return cls(
             runtime=runtime,
             adapter=adapter,
             preprocessor=preprocessor,
         )
+
+    @classmethod
+    def from_config(
+        cls,
+        name: str,
+        *,
+        adapter: FrameworkAdapter | SimpleAdapter | None = None,
+        config_path: str | Path | None = None,
+        ws_url: str = "wss://app.thenvoi.com/api/v1/socket/websocket",
+        rest_url: str = "https://app.thenvoi.com",
+        config: Any | None = None,
+        session_config: SessionConfig | None = None,
+        contact_config: ContactEventConfig | None = None,
+        preprocessor: Preprocessor | None = None,
+        tools: list[Any] | None = None,
+        capabilities: list[str] | None = None,
+        include_categories: list[str] | None = None,
+        include_tools: list[str] | None = None,
+        exclude_tools: list[str] | None = None,
+        emit: list[str] | None = None,
+        prompt: str | None = None,
+        prompt_path: str | Path | None = None,
+    ) -> "Agent":
+        loaded = load_agent_config(name, config_path=config_path)
+        loaded_adapter = adapter
+        if loaded_adapter is None and loaded.adapter is not None:
+            loaded_adapter = build_adapter_from_config(loaded.adapter)
+
+        if loaded_adapter is None:
+            raise ThenvoiConfigError(
+                f"No adapter configured for agent '{name}'. Pass adapter= to Agent.from_config() or add an adapter: section to agent_config.yaml."
+            )
+
+        merged_capabilities = cls._merge_lists(loaded.capabilities, capabilities)
+        merged_emit = cls._merge_lists(loaded.emit, emit)
+        merged_include_categories = cls._merge_lists(
+            loaded.include_categories, include_categories
+        )
+        merged_include_tools = cls._merge_lists(loaded.include_tools, include_tools)
+        merged_exclude_tools = cls._merge_lists(loaded.exclude_tools, exclude_tools)
+
+        resolved_prompt_path = prompt_path or loaded.prompt_path
+        resolved_prompt = loaded.prompt if prompt is None else prompt
+        resolved_prompt = cls._compose_prompt(
+            resolved_prompt_path,
+            loaded.prompt,
+            prompt,
+        )
+
+        return cls.create(
+            adapter=loaded_adapter,
+            agent_id=str(loaded.agent_id),
+            api_key=loaded.api_key,
+            ws_url=ws_url,
+            rest_url=rest_url,
+            config=config,
+            session_config=session_config,
+            contact_config=contact_config,
+            preprocessor=preprocessor,
+            tools=tools,
+            capabilities=merged_capabilities,
+            include_categories=merged_include_categories,
+            include_tools=merged_include_tools,
+            exclude_tools=merged_exclude_tools,
+            emit=merged_emit,
+            prompt=resolved_prompt,
+            prompt_path=resolved_prompt_path,
+        )
+
+    @staticmethod
+    def _merge_lists(
+        base: list[str] | None,
+        override: list[str] | None,
+    ) -> list[str] | None:
+        if base is None and override is None:
+            return None
+        merged: list[str] = []
+        for value in (base or []) + (override or []):
+            if value not in merged:
+                merged.append(value)
+        return merged
+
+    @staticmethod
+    def _compose_prompt(
+        loaded_prompt_path: str | Path | None,
+        loaded_prompt: str | None,
+        override_prompt: str | None,
+    ) -> str | None:
+        parts: list[str] = []
+        if loaded_prompt_path:
+            path = Path(loaded_prompt_path)
+            if not path.exists():
+                raise ThenvoiConfigError(
+                    f"Prompt file not found at {path}. Update prompt_path to a readable file."
+                )
+            parts.append(path.read_text(encoding="utf-8").strip())
+        if loaded_prompt:
+            parts.append(loaded_prompt.strip())
+        if override_prompt:
+            parts.append(override_prompt.strip())
+        if not parts:
+            return None
+        return "\n\n# Developer Instructions\n\n" + "\n\n".join(
+            part for part in parts if part
+        )
+
+    @staticmethod
+    def _apply_composition_options(
+        *,
+        adapter: FrameworkAdapter | SimpleAdapter,
+        tools: list[Any] | None,
+        capabilities: list[str] | None,
+        include_categories: list[str] | None,
+        include_tools: list[str] | None,
+        exclude_tools: list[str] | None,
+        emit: list[str] | None,
+        prompt: str | None,
+        prompt_path: str | Path | None,
+    ) -> None:
+        setattr(adapter, "custom_tools", tools or [])
+        setattr(adapter, "capabilities", capabilities or [])
+        setattr(adapter, "include_categories", include_categories)
+        setattr(adapter, "include_tools", include_tools)
+        setattr(adapter, "exclude_tools", exclude_tools)
+        setattr(adapter, "emit", emit or [])
+        if prompt is not None:
+            if hasattr(adapter, "custom_section"):
+                setattr(adapter, "custom_section", prompt)
+            elif hasattr(adapter, "config") and hasattr(
+                adapter.config, "custom_section"
+            ):
+                adapter.config.custom_section = prompt
+        if prompt_path is not None:
+            setattr(adapter, "prompt_path", Path(prompt_path))
 
     @property
     def runtime(self) -> PlatformRuntime:

--- a/src/thenvoi/config/__init__.py
+++ b/src/thenvoi/config/__init__.py
@@ -1,12 +1,12 @@
-"""
-Agent configuration utilities.
+"""Agent configuration utilities."""
 
-Usage:
-    from thenvoi.config import load_agent_config
+from thenvoi.config.loader import get_config_path, load_agent_config
+from thenvoi.config.registry import build_adapter_from_config
+from thenvoi.config.types import AgentConfig
 
-    agent_id, api_key = load_agent_config("my_agent")
-"""
-
-from thenvoi.config.loader import load_agent_config, get_config_path
-
-__all__ = ["load_agent_config", "get_config_path"]
+__all__ = [
+    "AgentConfig",
+    "build_adapter_from_config",
+    "load_agent_config",
+    "get_config_path",
+]

--- a/src/thenvoi/config/loader.py
+++ b/src/thenvoi/config/loader.py
@@ -1,115 +1,213 @@
-"""
-Agent configuration management utilities.
-
-This module provides functions to load agent credentials from a YAML
-configuration file. Agents must be created manually on the platform
-as external agents before use.
-"""
+"""Agent configuration management utilities."""
 
 from __future__ import annotations
 
 import logging
 import os
+import re
 from pathlib import Path
+from typing import Any
+from uuid import UUID
 
 import yaml
 
+from thenvoi.config.types import AgentConfig
+from thenvoi.core.exceptions import ThenvoiConfigError
+
 logger = logging.getLogger(__name__)
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([A-Z0-9_]+)(?::-(.*?))?\}")
+_DEFAULT_CONFIG_FILENAMES = ("agent_config.yaml", "agents.yaml")
 
 
 def get_config_path() -> Path:
-    """
-    Get the path to the agent configuration file.
+    """Get the path to the agent configuration file."""
+    cwd = Path.cwd()
+    for filename in _DEFAULT_CONFIG_FILENAMES:
+        path = cwd / filename
+        if path.exists():
+            return path
+    return cwd / _DEFAULT_CONFIG_FILENAMES[0]
 
-    Looks for agent_config.yaml in the current working directory (project root).
-    """
-    return Path(os.getcwd()) / "agent_config.yaml"
+
+def _expand_env_var_in_string(value: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        default = match.group(2)
+        env_value = os.environ.get(name)
+        if env_value:
+            return env_value
+        if env_value == "" and default is not None:
+            return default
+        if env_value == "":
+            raise ThenvoiConfigError(
+                f"Environment variable '{name}' is empty. Set {name} or provide a default with ${{{name}:-value}}."
+            )
+        if default is not None:
+            return default
+        raise ThenvoiConfigError(
+            f"Environment variable '{name}' is not set. Set {name} or provide a default with ${{{name}:-value}}."
+        )
+
+    return _ENV_VAR_PATTERN.sub(replace, value)
+
+
+def _expand_env_vars(data: Any) -> Any:
+    if isinstance(data, dict):
+        return {key: _expand_env_vars(value) for key, value in data.items()}
+    if isinstance(data, list):
+        return [_expand_env_vars(item) for item in data]
+    if isinstance(data, str):
+        return _expand_env_var_in_string(data)
+    return data
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    try:
+        with open(path, encoding="utf-8") as file:
+            loaded = yaml.safe_load(file) or {}
+    except yaml.YAMLError as exc:
+        raise ThenvoiConfigError(
+            f"Invalid YAML in {path}. Fix the YAML syntax and try again."
+        ) from exc
+    except OSError as exc:
+        raise ThenvoiConfigError(
+            f"Could not read config file at {path}. Check that the file exists and is readable."
+        ) from exc
+
+    if not isinstance(loaded, dict):
+        raise ThenvoiConfigError(
+            f"Config file at {path} must contain a YAML mapping. Use key/value YAML at the top level."
+        )
+    return _expand_env_vars(loaded)
+
+
+def _select_agent_section(
+    config: dict[str, Any], agent_key: str, path: Path
+) -> dict[str, Any]:
+    agent_config = config.get(agent_key)
+    if agent_config is None and "agent_id" in config:
+        agent_config = config
+
+    if agent_config is None:
+        raise ThenvoiConfigError(
+            f"Agent '{agent_key}' was not found in {path}. Add that agent key to the config file or use the flat single-agent format."
+        )
+    if not isinstance(agent_config, dict):
+        raise ThenvoiConfigError(
+            f"Agent '{agent_key}' config must be a mapping. Use YAML key/value fields under that agent key."
+        )
+    return agent_config
+
+
+def _required_string(
+    agent_config: dict[str, Any], field_name: str, agent_key: str
+) -> str:
+    value = agent_config.get(field_name)
+    if not value:
+        raise ThenvoiConfigError(
+            f"Missing required field '{field_name}' for agent '{agent_key}'. Add {field_name} to the config entry."
+        )
+    if not isinstance(value, str):
+        raise ThenvoiConfigError(
+            f"Field '{field_name}' for agent '{agent_key}' must be a string. Update the config value to a string."
+        )
+    return value
+
+
+def _optional_string_list(
+    agent_config: dict[str, Any], field_name: str, *, default: list[str] | None = None
+) -> list[str] | None:
+    value = agent_config.get(field_name, default)
+    if value is None:
+        return None
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ThenvoiConfigError(
+            f"Field '{field_name}' must be a list of strings. Update {field_name} to a YAML list of strings."
+        )
+    return list(value)
+
+
+def _build_agent_config(
+    agent_key: str, agent_config: dict[str, Any], config_path: Path
+) -> AgentConfig:
+    agent_id = _required_string(agent_config, "agent_id", agent_key)
+    api_key = _required_string(agent_config, "api_key", agent_key)
+
+    try:
+        agent_uuid = UUID(agent_id)
+    except ValueError as exc:
+        raise ThenvoiConfigError(
+            f"Invalid agent_id for agent '{agent_key}'. Use a valid UUID string."
+        ) from exc
+
+    prompt_path_value = agent_config.get("prompt_path")
+    if prompt_path_value is not None and not isinstance(prompt_path_value, str):
+        raise ThenvoiConfigError(
+            "Field 'prompt_path' must be a string path. Set prompt_path to a relative or absolute file path."
+        )
+
+    prompt_path = Path(prompt_path_value) if prompt_path_value else None
+    if prompt_path is not None and not prompt_path.is_absolute():
+        prompt_path = (config_path.parent / prompt_path).resolve()
+
+    adapter = agent_config.get("adapter")
+    if adapter is not None and not isinstance(adapter, dict):
+        raise ThenvoiConfigError(
+            "Field 'adapter' must be a mapping. Put adapter options under adapter: in YAML."
+        )
+
+    known_fields = {
+        "agent_id",
+        "api_key",
+        "adapter",
+        "capabilities",
+        "include_categories",
+        "include_tools",
+        "exclude_tools",
+        "emit",
+        "prompt",
+        "prompt_path",
+    }
+
+    prompt = agent_config.get("prompt")
+    if prompt is not None and not isinstance(prompt, str):
+        raise ThenvoiConfigError(
+            "Field 'prompt' must be a string. Use a YAML string or block scalar for prompt."
+        )
+
+    return AgentConfig(
+        agent_id=agent_uuid,
+        api_key=api_key,
+        adapter=adapter,
+        capabilities=_optional_string_list(agent_config, "capabilities", default=[])
+        or [],
+        include_categories=_optional_string_list(agent_config, "include_categories"),
+        include_tools=_optional_string_list(agent_config, "include_tools"),
+        exclude_tools=_optional_string_list(agent_config, "exclude_tools"),
+        emit=_optional_string_list(agent_config, "emit", default=[]) or [],
+        prompt=prompt,
+        prompt_path=prompt_path,
+        extra={
+            key: value for key, value in agent_config.items() if key not in known_fields
+        },
+    )
 
 
 def load_agent_config(
     agent_key: str,
     *,
     config_path: str | Path | None = None,
-) -> tuple[str, str]:
-    """
-    Load agent credentials from a YAML configuration file.
-
-    Supports two formats:
-
-    1. **Keyed format** (``agent_config.yaml``)::
-
-           planner:
-             agent_id: "..."
-             api_key: "..."
-
-       Looked up via *agent_key*.
-
-    2. **Flat format** (Docker runner YAML)::
-
-           agent_id: "..."
-           api_key: "..."
-           role: planner
-
-       When *agent_key* is not found as a top-level key **and**
-       ``agent_id`` exists at the top level, the file is treated as
-       a flat single-agent config.
-
-    Args:
-        agent_key: The key identifying the agent in the config file.
-        config_path: Explicit path to the YAML file.  When *None*,
-            falls back to ``agent_config.yaml`` in the working directory.
-
-    Returns:
-        Tuple of (agent_id, api_key).
-
-    Raises:
-        FileNotFoundError: If the config file doesn't exist.
-        ValueError: If required fields (agent_id, api_key) are missing or empty.
-    """
+) -> AgentConfig:
+    """Load typed agent config from YAML."""
     path = Path(config_path) if config_path is not None else get_config_path()
     logger.debug("Loading config from: %s", path)
 
     if not path.exists():
-        raise FileNotFoundError(
-            f"Config file not found at {path}. "
-            "Copy agent_config.yaml.example to agent_config.yaml and configure your agents."
+        raise ThenvoiConfigError(
+            f"Config file not found at {path}. Copy agent_config.yaml.example to agent_config.yaml and configure your agent."
         )
 
-    try:
-        with open(path, encoding="utf-8") as f:
-            config = yaml.safe_load(f) or {}
-
-        # Try keyed lookup first
-        agent_config = config.get(agent_key, {})
-
-        # Fall back to flat format (Docker runner YAMLs put agent_id at top level)
-        if not agent_config and "agent_id" in config:
-            agent_config = config
-
-        if not agent_config:
-            raise ValueError(
-                f"Agent '{agent_key}' not found in {path}. "
-                "Please add the agent configuration."
-            )
-
-        # Require agent_id and api_key
-        agent_id = agent_config.get("agent_id")
-        api_key = agent_config.get("api_key")
-
-        missing_fields: list[str] = []
-        if not agent_id:
-            missing_fields.append("agent_id")
-        if not api_key:
-            missing_fields.append("api_key")
-
-        if missing_fields:
-            raise ValueError(
-                f"Missing required fields for agent '{agent_key}': {', '.join(missing_fields)}. "
-                f"Please create an external agent on the platform and add the credentials to {path}"
-            )
-
-        return agent_id, api_key
-    except (ValueError, FileNotFoundError):
-        raise
-    except Exception as e:
-        raise RuntimeError(f"Error loading agent config: {e}") from e
+    config = _read_yaml(path)
+    selected = _select_agent_section(config, agent_key, path)
+    return _build_agent_config(agent_key, selected, path)

--- a/src/thenvoi/config/registry.py
+++ b/src/thenvoi/config/registry.py
@@ -1,0 +1,146 @@
+"""Adapter registry for config-driven agent creation."""
+
+from __future__ import annotations
+
+from difflib import get_close_matches
+from enum import Enum
+from typing import Any
+
+from thenvoi.core.exceptions import ThenvoiConfigError
+
+
+def _normalize_enum_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _normalize_enum_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_normalize_enum_value(item) for item in value]
+    if isinstance(value, Enum):
+        return value
+    return value
+
+
+def _build_anthropic_adapter(config: dict[str, Any]) -> Any:
+    from thenvoi.adapters.anthropic import AnthropicAdapter
+
+    return AnthropicAdapter(**{k: _normalize_enum_value(v) for k, v in config.items()})
+
+
+def _build_gemini_adapter(config: dict[str, Any]) -> Any:
+    from thenvoi.adapters.gemini import GeminiAdapter
+
+    normalized = {k: _normalize_enum_value(v) for k, v in config.items()}
+    if "api_key" in normalized:
+        normalized["gemini_api_key"] = normalized.pop("api_key")
+    if "prompt" in normalized:
+        normalized["custom_section"] = normalized.pop("prompt")
+    if "max_tokens" in normalized:
+        normalized["max_output_tokens"] = normalized.pop("max_tokens")
+    return GeminiAdapter(**normalized)
+
+
+def _build_claude_sdk_adapter(config: dict[str, Any]) -> Any:
+    from thenvoi.adapters.claude_sdk import ClaudeSDKAdapter
+
+    normalized = {k: _normalize_enum_value(v) for k, v in config.items()}
+    if "prompt" in normalized:
+        normalized["custom_section"] = normalized.pop("prompt")
+    return ClaudeSDKAdapter(**normalized)
+
+
+def _build_codex_adapter(config: dict[str, Any]) -> Any:
+    from thenvoi.adapters.codex import CodexAdapter, CodexAdapterConfig
+
+    normalized = {k: _normalize_enum_value(v) for k, v in config.items()}
+    if "prompt" in normalized:
+        normalized["custom_section"] = normalized.pop("prompt")
+    if "adapter_config" in normalized:
+        raise ThenvoiConfigError(
+            "Nested adapter_config is not supported. Put Codex options directly under adapter:."
+        )
+    return CodexAdapter(config=CodexAdapterConfig(**normalized))
+
+
+def _build_langgraph_adapter(config: dict[str, Any]) -> Any:
+    raise ThenvoiConfigError(
+        "LangGraph requires a Python-built adapter. Pass adapter=LangGraphAdapter(...) to Agent.from_config()."
+    )
+
+
+def _build_crewai_adapter(config: dict[str, Any]) -> Any:
+    from thenvoi.adapters.crewai import CrewAIAdapter
+
+    normalized = {k: _normalize_enum_value(v) for k, v in config.items()}
+    if "prompt" in normalized:
+        normalized["custom_section"] = normalized.pop("prompt")
+    return CrewAIAdapter(**normalized)
+
+
+def _build_pydantic_ai_adapter(config: dict[str, Any]) -> Any:
+    from thenvoi.adapters.pydantic_ai import PydanticAIAdapter
+
+    normalized = {k: _normalize_enum_value(v) for k, v in config.items()}
+    if "prompt" in normalized:
+        normalized["custom_section"] = normalized.pop("prompt")
+    return PydanticAIAdapter(**normalized)
+
+
+def _build_google_adk_adapter(config: dict[str, Any]) -> Any:
+    from thenvoi.adapters.google_adk import GoogleADKAdapter
+
+    normalized = {k: _normalize_enum_value(v) for k, v in config.items()}
+    if "prompt" in normalized:
+        normalized["custom_section"] = normalized.pop("prompt")
+    return GoogleADKAdapter(**normalized)
+
+
+def _build_parlant_adapter(config: dict[str, Any]) -> Any:
+    from thenvoi.adapters.parlant import ParlantAdapter
+
+    normalized = {k: _normalize_enum_value(v) for k, v in config.items()}
+    if "prompt" in normalized:
+        normalized["custom_section"] = normalized.pop("prompt")
+    return ParlantAdapter(**normalized)
+
+
+def _build_letta_adapter(config: dict[str, Any]) -> Any:
+    from thenvoi.adapters.letta import LettaAdapter, LettaAdapterConfig
+
+    normalized = {k: _normalize_enum_value(v) for k, v in config.items()}
+    if "prompt" in normalized:
+        normalized["custom_section"] = normalized.pop("prompt")
+    return LettaAdapter(config=LettaAdapterConfig(**normalized))
+
+
+_ADAPTER_BUILDERS = {
+    "anthropic": _build_anthropic_adapter,
+    "gemini": _build_gemini_adapter,
+    "claude_sdk": _build_claude_sdk_adapter,
+    "codex": _build_codex_adapter,
+    "langgraph": _build_langgraph_adapter,
+    "crewai": _build_crewai_adapter,
+    "pydantic_ai": _build_pydantic_ai_adapter,
+    "google_adk": _build_google_adk_adapter,
+    "parlant": _build_parlant_adapter,
+    "letta": _build_letta_adapter,
+}
+
+
+def build_adapter_from_config(adapter_config: dict[str, Any]) -> Any:
+    """Build an adapter instance from YAML adapter config."""
+    adapter_type = adapter_config.get("type")
+    if not adapter_type:
+        raise ThenvoiConfigError(
+            "Missing adapter type. Add adapter.type to your config."
+        )
+
+    builder = _ADAPTER_BUILDERS.get(str(adapter_type))
+    if builder is None:
+        candidates = ", ".join(sorted(_ADAPTER_BUILDERS))
+        suggestion = get_close_matches(str(adapter_type), _ADAPTER_BUILDERS.keys(), n=1)
+        hint = f" Did you mean '{suggestion[0]}'?" if suggestion else ""
+        raise ThenvoiConfigError(
+            f"Unknown adapter type '{adapter_type}'. Use one of: {candidates}.{hint}"
+        )
+
+    kwargs = {k: v for k, v in adapter_config.items() if k != "type"}
+    return builder(kwargs)

--- a/src/thenvoi/config/types.py
+++ b/src/thenvoi/config/types.py
@@ -1,0 +1,49 @@
+"""Typed configuration models for config-driven agent creation."""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import UUID
+
+from thenvoi.core.exceptions import ThenvoiConfigError
+
+
+@dataclass
+class AgentConfig:
+    """Typed config loaded from YAML for config-driven agent creation."""
+
+    agent_id: UUID
+    api_key: str
+    adapter: dict[str, Any] | None = None
+    capabilities: list[str] = field(default_factory=list)
+    include_categories: list[str] | None = None
+    include_tools: list[str] | None = None
+    exclude_tools: list[str] | None = None
+    emit: list[str] = field(default_factory=list)
+    prompt: str | None = None
+    prompt_path: Path | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.agent_id, UUID):
+            try:
+                self.agent_id = UUID(str(self.agent_id))
+            except (TypeError, ValueError) as exc:
+                raise ThenvoiConfigError(
+                    "Invalid agent_id value. Use a valid UUID string in your config."
+                ) from exc
+
+        if self.prompt_path is not None and not isinstance(self.prompt_path, Path):
+            self.prompt_path = Path(self.prompt_path)
+
+    def __iter__(self) -> Iterator[str]:
+        warnings.warn(
+            "Tuple unpacking from load_agent_config() is deprecated. Use the returned AgentConfig object instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        yield str(self.agent_id)
+        yield self.api_key

--- a/src/thenvoi/core/__init__.py
+++ b/src/thenvoi/core/__init__.py
@@ -1,5 +1,6 @@
 """Core protocols and types for composition-based architecture."""
 
+from thenvoi.core.exceptions import ThenvoiConfigError, ThenvoiError
 from thenvoi.core.protocols import (
     AgentToolsProtocol,
     FrameworkAdapter,
@@ -18,4 +19,6 @@ __all__ = [
     "PlatformMessage",
     "Preprocessor",
     "SimpleAdapter",
+    "ThenvoiConfigError",
+    "ThenvoiError",
 ]

--- a/src/thenvoi/core/exceptions.py
+++ b/src/thenvoi/core/exceptions.py
@@ -1,0 +1,11 @@
+"""Public exception types for Thenvoi SDK boundaries."""
+
+from __future__ import annotations
+
+
+class ThenvoiError(Exception):
+    """Base exception for public Thenvoi SDK errors."""
+
+
+class ThenvoiConfigError(ThenvoiError):
+    """Raised when SDK configuration is missing, invalid, or inconsistent."""

--- a/src/thenvoi/platform/link.py
+++ b/src/thenvoi/platform/link.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING
 
 from thenvoi.client.rest import AsyncRestClient, DEFAULT_REQUEST_OPTIONS
 from thenvoi.client.streaming import WebSocketClient
-from thenvoi.runtime.types import PlatformMessage
 from thenvoi_rest.core.api_error import ApiError
 
 from .event import (
@@ -32,16 +31,17 @@ from .event import (
 
 if TYPE_CHECKING:
     from thenvoi.client.streaming import (
+        ContactAddedPayload,
+        ContactRemovedPayload,
+        ContactRequestReceivedPayload,
+        ContactRequestUpdatedPayload,
         MessageCreatedPayload,
         ParticipantAddedPayload,
         ParticipantRemovedPayload,
         RoomAddedPayload,
         RoomRemovedPayload,
-        ContactRequestReceivedPayload,
-        ContactRequestUpdatedPayload,
-        ContactAddedPayload,
-        ContactRemovedPayload,
     )
+    from thenvoi.runtime.types import PlatformMessage
 
 logger = logging.getLogger(__name__)
 
@@ -441,6 +441,8 @@ class ThenvoiLink:
             logger.warning("Failed to mark message %s as failed: %s", message_id, e)
 
     async def get_next_message(self, room_id: str) -> PlatformMessage | None:
+        from thenvoi.runtime.types import PlatformMessage
+
         """
         Get next unprocessed message for a room from the server.
 
@@ -485,6 +487,8 @@ class ThenvoiLink:
     async def get_stale_processing_messages(
         self, room_id: str
     ) -> list[PlatformMessage]:
+        from thenvoi.runtime.types import PlatformMessage
+
         """
         Get messages stuck in 'processing' state for a room.
 

--- a/src/thenvoi/runtime/__init__.py
+++ b/src/thenvoi/runtime/__init__.py
@@ -1,76 +1,40 @@
-"""
-Thenvoi Runtime Layer - Agent execution and room management.
+"""Thenvoi Runtime Layer - Agent execution and room management."""
 
-Components:
-    RoomPresence: Cross-room lifecycle management
-    Execution: Per-room execution protocol
-    ExecutionContext: Default execution implementation (context accumulation)
-    AgentRuntime: Convenience wrapper combining presence + execution
-    AgentTools: Tool interface for LLM platform interaction
-
-Utilities:
-    formatters: Pure functions for message formatting
-    prompts: System prompt rendering
-    ParticipantTracker: Participant tracking with change detection
-    MessageRetryTracker: Message retry tracking
-
-Shutdown:
-    GracefulShutdown: Signal handler for graceful agent termination
-    run_with_graceful_shutdown: Convenience function to run agent with signal handling
-"""
-
-# Types
-from .types import (
-    AgentConfig,
-    ConversationContext,
-    MessageHandler,
-    PlatformMessage,
-    SessionConfig,
-)
-
-# Core runtime components
-from .presence import RoomPresence
 from .execution import Execution, ExecutionContext, ExecutionHandler
+from .formatters import (
+    build_participants_message,
+    format_history_for_llm,
+    format_message_for_llm,
+)
+from .participant_tracker import ParticipantTracker
+from .presence import RoomPresence
+from .prompts import BASE_INSTRUCTIONS, TEMPLATES, render_system_prompt
+from .retry_tracker import MessageRetryTracker
 from .runtime import AgentRuntime
-
-# Tools
+from .shutdown import GracefulShutdown, run_with_graceful_shutdown
 from .tools import (
-    AgentTools,
-    TOOL_MODELS,
     ALL_TOOL_NAMES,
     BASE_TOOL_NAMES,
     CHAT_TOOL_NAMES,
     CONTACT_TOOL_NAMES,
-    MEMORY_TOOL_NAMES,
     MCP_TOOL_PREFIX,
+    MEMORY_TOOL_NAMES,
+    TOOL_MODELS,
+    AgentTools,
     mcp_tool_names,
 )
-
-# Utilities
-from .formatters import (
-    format_message_for_llm,
-    format_history_for_llm,
-    build_participants_message,
-)
-from .prompts import render_system_prompt, BASE_INSTRUCTIONS, TEMPLATES
-from .participant_tracker import ParticipantTracker
-from .retry_tracker import MessageRetryTracker
-from .shutdown import GracefulShutdown, run_with_graceful_shutdown
+from .types import ConversationContext, MessageHandler, PlatformMessage, SessionConfig
 
 __all__ = [
-    # Types
-    "AgentConfig",
     "SessionConfig",
     "PlatformMessage",
     "ConversationContext",
     "MessageHandler",
-    # Core components
     "RoomPresence",
     "Execution",
     "ExecutionContext",
     "ExecutionHandler",
     "AgentRuntime",
-    # Tools
     "AgentTools",
     "TOOL_MODELS",
     "ALL_TOOL_NAMES",
@@ -80,18 +44,14 @@ __all__ = [
     "MEMORY_TOOL_NAMES",
     "MCP_TOOL_PREFIX",
     "mcp_tool_names",
-    # Formatters
     "format_message_for_llm",
     "format_history_for_llm",
     "build_participants_message",
-    # Prompts
     "render_system_prompt",
     "BASE_INSTRUCTIONS",
     "TEMPLATES",
-    # Trackers
     "ParticipantTracker",
     "MessageRetryTracker",
-    # Shutdown
     "GracefulShutdown",
     "run_with_graceful_shutdown",
 ]

--- a/src/thenvoi/runtime/mcp_server.py
+++ b/src/thenvoi/runtime/mcp_server.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel
 from thenvoi.core.protocols import AgentToolsProtocol
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import PlainTextResponse, Response
+from starlette.responses import PlainTextResponse
 from starlette.routing import Mount, Route
 import uvicorn
 
@@ -411,7 +411,7 @@ class LocalMCPServer:
                     with suppress(asyncio.CancelledError):
                         await http_task
 
-        async def sse_endpoint(request: Request) -> Response:
+        async def sse_endpoint(request: Request) -> None:
             async with sse_transport.connect_sse(
                 request.scope,
                 request.receive,
@@ -422,7 +422,6 @@ class LocalMCPServer:
                     streams[1],
                     initialization_options,
                 )
-            return Response()
 
         async def healthz(_: Request) -> PlainTextResponse:
             return PlainTextResponse("ok")

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,14 +1,19 @@
 """Tests for Agent compositor."""
 
+from __future__ import annotations
+
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from thenvoi.agent import Agent, DEFAULT_SHUTDOWN_TIMEOUT
+from thenvoi.config.types import AgentConfig as LoadedAgentConfig
+from thenvoi.core.exceptions import ThenvoiConfigError
 from thenvoi.core.simple_adapter import SimpleAdapter
 from thenvoi.core.types import AgentInput
-from thenvoi.runtime.types import AgentConfig, SessionConfig
 from thenvoi.preprocessing.default import DefaultPreprocessor
+from thenvoi.runtime.types import AgentConfig, SessionConfig
 
 
 @pytest.fixture
@@ -146,6 +151,140 @@ class TestCreateFactory:
             )
 
             assert agent._preprocessor is mock_preprocessor
+
+
+class TestFromConfig:
+    """Tests for Agent.from_config()."""
+
+    def test_from_config_uses_python_adapter_and_loaded_credentials(self, mock_adapter):
+        loaded = LoadedAgentConfig(
+            agent_id="11111111-1111-1111-1111-111111111111",
+            api_key="loaded-key",
+        )
+
+        with patch("thenvoi.agent.load_agent_config", return_value=loaded):
+            with patch.object(Agent, "create", return_value="created") as mock_create:
+                result = Agent.from_config("planner", adapter=mock_adapter)
+
+        assert result == "created"
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["adapter"] is mock_adapter
+        assert kwargs["agent_id"] == "11111111-1111-1111-1111-111111111111"
+        assert kwargs["api_key"] == "loaded-key"
+
+    def test_from_config_builds_adapter_from_yaml_when_not_overridden(self):
+        loaded = LoadedAgentConfig(
+            agent_id="11111111-1111-1111-1111-111111111111",
+            api_key="loaded-key",
+            adapter={"type": "anthropic", "model": "claude-sonnet-4-5"},
+        )
+        built_adapter = MagicMock()
+
+        with patch("thenvoi.agent.load_agent_config", return_value=loaded):
+            with patch(
+                "thenvoi.agent.build_adapter_from_config", return_value=built_adapter
+            ):
+                with patch.object(
+                    Agent, "create", return_value="created"
+                ) as mock_create:
+                    Agent.from_config("planner")
+
+        assert mock_create.call_args.kwargs["adapter"] is built_adapter
+
+    def test_from_config_python_adapter_ignores_yaml_adapter(self, mock_adapter):
+        loaded = LoadedAgentConfig(
+            agent_id="11111111-1111-1111-1111-111111111111",
+            api_key="loaded-key",
+            adapter={"type": "anthropic", "model": "claude-sonnet-4-5"},
+        )
+
+        with patch("thenvoi.agent.load_agent_config", return_value=loaded):
+            with patch("thenvoi.agent.build_adapter_from_config") as mock_builder:
+                with patch.object(
+                    Agent, "create", return_value="created"
+                ) as mock_create:
+                    Agent.from_config("planner", adapter=mock_adapter)
+
+        mock_builder.assert_not_called()
+        assert mock_create.call_args.kwargs["adapter"] is mock_adapter
+
+    def test_from_config_requires_adapter(self):
+        loaded = LoadedAgentConfig(
+            agent_id="11111111-1111-1111-1111-111111111111",
+            api_key="loaded-key",
+        )
+
+        with patch("thenvoi.agent.load_agent_config", return_value=loaded):
+            with pytest.raises(
+                ThenvoiConfigError, match="No adapter configured for agent 'planner'"
+            ):
+                Agent.from_config("planner")
+
+    def test_from_config_merges_list_options(self, mock_adapter):
+        loaded = LoadedAgentConfig(
+            agent_id="11111111-1111-1111-1111-111111111111",
+            api_key="loaded-key",
+            capabilities=["memory"],
+            include_tools=["thenvoi_send_message"],
+            emit=["thoughts"],
+        )
+
+        with patch("thenvoi.agent.load_agent_config", return_value=loaded):
+            with patch.object(Agent, "create", return_value="created") as mock_create:
+                Agent.from_config(
+                    "planner",
+                    adapter=mock_adapter,
+                    capabilities=["contacts", "memory"],
+                    include_tools=["thenvoi_lookup_peers"],
+                    emit=["tool_calls"],
+                )
+
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["capabilities"] == ["memory", "contacts"]
+        assert kwargs["include_tools"] == [
+            "thenvoi_send_message",
+            "thenvoi_lookup_peers",
+        ]
+        assert kwargs["emit"] == ["thoughts", "tool_calls"]
+
+    def test_from_config_composes_prompt_from_path_yaml_and_override(
+        self, tmp_path, mock_adapter
+    ):
+        prompt_file = tmp_path / "prompt.md"
+        prompt_file.write_text("Path prompt")
+        loaded = LoadedAgentConfig(
+            agent_id="11111111-1111-1111-1111-111111111111",
+            api_key="loaded-key",
+            prompt_path=prompt_file,
+            prompt="Inline prompt",
+        )
+
+        with patch("thenvoi.agent.load_agent_config", return_value=loaded):
+            with patch.object(Agent, "create", return_value="created") as mock_create:
+                Agent.from_config(
+                    "planner",
+                    adapter=mock_adapter,
+                    prompt="Override prompt",
+                )
+
+        prompt = mock_create.call_args.kwargs["prompt"]
+        assert prompt == (
+            "\n\n# Developer Instructions\n\n"
+            "Path prompt\n\nInline prompt\n\nOverride prompt"
+        )
+
+    def test_from_config_missing_prompt_path_raises(self, mock_adapter):
+        missing_path = Path("/tmp/does-not-exist-prompt.md")
+        loaded = LoadedAgentConfig(
+            agent_id="11111111-1111-1111-1111-111111111111",
+            api_key="loaded-key",
+            prompt_path=missing_path,
+        )
+
+        with patch("thenvoi.agent.load_agent_config", return_value=loaded):
+            with pytest.raises(ThenvoiConfigError, match="Prompt file not found"):
+                Agent.from_config("planner", adapter=mock_adapter)
 
 
 class TestProperties:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,229 +1,275 @@
-"""
-Config loading tests - verify agent configuration management.
-
-Tests cover all error paths and edge cases for loading agent credentials
-from YAML configuration files.
-"""
+"""Config loading tests for typed agent configuration."""
 
 from __future__ import annotations
 
+import warnings
+from uuid import UUID
+
 import pytest
-from thenvoi.config import load_agent_config
+
+from thenvoi.config import AgentConfig, build_adapter_from_config, load_agent_config
+from thenvoi.core.exceptions import ThenvoiConfigError
 
 
 @pytest.fixture
 def config_file(tmp_path, monkeypatch):
     """Provide a writable config path wired into the loader."""
     path = tmp_path / "agent_config.yaml"
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("thenvoi.config.loader.get_config_path", lambda: path)
     return path
 
 
-def test_load_valid_config_success(config_file):
-    """Should successfully load agent credentials from valid config."""
-    config_file.write_text("""
+def test_load_valid_config_success(config_file) -> None:
+    config_file.write_text(
+        """
 simple_agent:
-  agent_id: test-agent-123
+  agent_id: "11111111-1111-1111-1111-111111111111"
   api_key: test-key-abc
-    """)
+        """.strip()
+    )
 
-    agent_id, api_key = load_agent_config("simple_agent")
+    config = load_agent_config("simple_agent")
 
-    assert agent_id == "test-agent-123"
+    assert isinstance(config, AgentConfig)
+    assert config.agent_id == UUID("11111111-1111-1111-1111-111111111111")
+    assert config.api_key == "test-key-abc"
+
+
+def test_tuple_unpack_still_works_with_warning(config_file) -> None:
+    config_file.write_text(
+        """
+simple_agent:
+  agent_id: "11111111-1111-1111-1111-111111111111"
+  api_key: test-key-abc
+        """.strip()
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        agent_id, api_key = load_agent_config("simple_agent")
+
+    assert agent_id == "11111111-1111-1111-1111-111111111111"
     assert api_key == "test-key-abc"
+    assert any(item.category is DeprecationWarning for item in caught)
 
 
-def test_missing_config_file(tmp_path, monkeypatch):
-    """Should raise FileNotFoundError with helpful message when config missing."""
+def test_missing_config_file_raises_thenvoi_config_error(tmp_path, monkeypatch) -> None:
     non_existent = tmp_path / "does_not_exist.yaml"
     monkeypatch.setattr("thenvoi.config.loader.get_config_path", lambda: non_existent)
 
-    with pytest.raises(FileNotFoundError) as exc_info:
+    with pytest.raises(ThenvoiConfigError, match="Config file not found"):
         load_agent_config("any_agent")
 
-    assert "Config file not found" in str(exc_info.value)
-    assert "agent_config.yaml.example" in str(exc_info.value)
 
-
-def test_agent_key_not_in_config(config_file):
-    """Should raise ValueError when requested agent key doesn't exist."""
-    config_file.write_text("""
+def test_agent_key_not_in_config(config_file) -> None:
+    config_file.write_text(
+        """
 simple_agent:
-  agent_id: test-agent-123
+  agent_id: "11111111-1111-1111-1111-111111111111"
   api_key: test-key-abc
-    """)
+        """.strip()
+    )
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(
+        ThenvoiConfigError, match="Agent 'nonexistent_agent' was not found"
+    ):
         load_agent_config("nonexistent_agent")
 
-    assert "nonexistent_agent" in str(exc_info.value)
-    assert "not found" in str(exc_info.value)
 
-
-def test_missing_agent_id_field(config_file):
-    """Should raise ValueError when agent_id field is missing."""
-    config_file.write_text("""
+def test_missing_required_fields(config_file) -> None:
+    config_file.write_text(
+        """
 simple_agent:
   api_key: test-key-abc
-    """)
+        """.strip()
+    )
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ThenvoiConfigError, match="Missing required field 'agent_id'"):
         load_agent_config("simple_agent")
 
-    assert "agent_id" in str(exc_info.value)
-    assert "Missing required fields" in str(exc_info.value)
 
-
-def test_missing_api_key_field(config_file):
-    """Should raise ValueError when api_key field is missing."""
-    config_file.write_text("""
+def test_invalid_uuid_raises_thenvoi_config_error(config_file) -> None:
+    config_file.write_text(
+        """
 simple_agent:
-  agent_id: test-agent-123
-    """)
-
-    with pytest.raises(ValueError) as exc_info:
-        load_agent_config("simple_agent")
-
-    assert "api_key" in str(exc_info.value)
-    assert "Missing required fields" in str(exc_info.value)
-
-
-def test_missing_both_fields(config_file):
-    """Should raise ValueError listing both missing fields."""
-    config_file.write_text("""
-simple_agent:
-  some_other_field: value
-    """)
-
-    with pytest.raises(ValueError) as exc_info:
-        load_agent_config("simple_agent")
-
-    error_msg = str(exc_info.value)
-    assert "agent_id" in error_msg
-    assert "api_key" in error_msg
-    assert "Missing required fields" in error_msg
-
-
-def test_empty_agent_id(config_file):
-    """Should raise ValueError when agent_id is empty string."""
-    config_file.write_text("""
-simple_agent:
-  agent_id: ""
+  agent_id: not-a-uuid
   api_key: test-key-abc
-    """)
+        """.strip()
+    )
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ThenvoiConfigError, match="Invalid agent_id"):
         load_agent_config("simple_agent")
 
-    assert "agent_id" in str(exc_info.value)
-    assert "Missing required fields" in str(exc_info.value)
 
-
-def test_empty_api_key(config_file):
-    """Should raise ValueError when api_key is empty string."""
-    config_file.write_text("""
+def test_invalid_yaml_syntax(config_file) -> None:
+    config_file.write_text(
+        """
 simple_agent:
-  agent_id: test-agent-123
-  api_key: ""
-    """)
+  agent_id: [unclosed
+        """.strip()
+    )
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ThenvoiConfigError, match="Invalid YAML"):
         load_agent_config("simple_agent")
 
-    assert "api_key" in str(exc_info.value)
-    assert "Missing required fields" in str(exc_info.value)
 
-
-def test_empty_yaml_file(config_file):
-    """Should raise ValueError when YAML file is empty."""
-    config_file.write_text("")
-
-    with pytest.raises(ValueError) as exc_info:
-        load_agent_config("simple_agent")
-
-    assert "simple_agent" in str(exc_info.value)
-    assert "not found" in str(exc_info.value)
-
-
-def test_invalid_yaml_syntax(config_file):
-    """Should raise RuntimeError when YAML is malformed."""
-    config_file.write_text("""
-simple_agent:
-  agent_id: test-agent-123
-  api_key: [unclosed bracket
-    """)
-
-    with pytest.raises(RuntimeError) as exc_info:
-        load_agent_config("simple_agent")
-
-    assert "Error loading agent config" in str(exc_info.value)
-
-
-def test_load_multiple_agents_from_same_file(config_file):
-    """Should successfully load different agents from same config file."""
-    config_file.write_text("""
+def test_load_multiple_agents_from_same_file(config_file) -> None:
+    config_file.write_text(
+        """
 agent_one:
-  agent_id: agent-1-id
+  agent_id: "11111111-1111-1111-1111-111111111111"
   api_key: agent-1-key
 
 agent_two:
-  agent_id: agent-2-id
+  agent_id: "22222222-2222-2222-2222-222222222222"
   api_key: agent-2-key
-    """)
+        """.strip()
+    )
 
-    agent_id_1, api_key_1 = load_agent_config("agent_one")
-    assert agent_id_1 == "agent-1-id"
-    assert api_key_1 == "agent-1-key"
+    first = load_agent_config("agent_one")
+    second = load_agent_config("agent_two")
 
-    agent_id_2, api_key_2 = load_agent_config("agent_two")
-    assert agent_id_2 == "agent-2-id"
-    assert api_key_2 == "agent-2-key"
+    assert first.api_key == "agent-1-key"
+    assert second.api_key == "agent-2-key"
 
 
-def test_config_with_extra_fields_ignored(config_file):
-    """Should ignore extra fields and only return agent_id and api_key."""
-    config_file.write_text("""
+def test_config_with_extra_fields_preserved(config_file) -> None:
+    config_file.write_text(
+        """
 simple_agent:
-  agent_id: test-agent-123
+  agent_id: "11111111-1111-1111-1111-111111111111"
   api_key: test-key-abc
-  description: "This is a test agent"
-  extra_field: "should be ignored"
-  version: 2
-    """)
+  description: This is a test agent
+        """.strip()
+    )
 
-    agent_id, api_key = load_agent_config("simple_agent")
+    config = load_agent_config("simple_agent")
 
-    assert agent_id == "test-agent-123"
-    assert api_key == "test-key-abc"
-    assert isinstance((agent_id, api_key), tuple)
-    assert len((agent_id, api_key)) == 2
+    assert config.extra["description"] == "This is a test agent"
 
 
-def test_load_with_explicit_config_path(tmp_path):
-    """Should load keyed config when config_path is passed explicitly."""
+def test_load_with_explicit_config_path(tmp_path) -> None:
     config_path = tmp_path / "custom_config.yaml"
-    config_path.write_text("""
+    config_path.write_text(
+        """
 reviewer:
-  agent_id: reviewer-123
+  agent_id: "33333333-3333-3333-3333-333333333333"
   api_key: reviewer-key
-    """)
+        """.strip()
+    )
 
-    agent_id, api_key = load_agent_config("reviewer", config_path=config_path)
+    config = load_agent_config("reviewer", config_path=config_path)
 
-    assert agent_id == "reviewer-123"
-    assert api_key == "reviewer-key"
+    assert config.agent_id == UUID("33333333-3333-3333-3333-333333333333")
+    assert config.api_key == "reviewer-key"
 
 
-def test_flat_format_fallback_with_explicit_config_path(tmp_path):
-    """Should fall back to flat YAML format when agent key is absent."""
+def test_flat_format_fallback_with_explicit_config_path(tmp_path) -> None:
     config_path = tmp_path / "single_agent.yaml"
-    config_path.write_text("""
-agent_id: flat-agent-123
+    config_path.write_text(
+        """
+agent_id: "44444444-4444-4444-4444-444444444444"
 api_key: flat-key-abc
 role: planner
-    """)
+        """.strip()
+    )
 
-    agent_id, api_key = load_agent_config("any_key", config_path=config_path)
+    config = load_agent_config("any_key", config_path=config_path)
 
-    assert agent_id == "flat-agent-123"
-    assert api_key == "flat-key-abc"
+    assert config.agent_id == UUID("44444444-4444-4444-4444-444444444444")
+    assert config.api_key == "flat-key-abc"
+    assert config.extra["role"] == "planner"
+
+
+def test_env_expansion_and_defaults(config_file, monkeypatch) -> None:
+    monkeypatch.setenv("THENVOI_API_KEY", "expanded-key")
+    config_file.write_text(
+        """
+planner:
+  agent_id: "55555555-5555-5555-5555-555555555555"
+  api_key: "${THENVOI_API_KEY}"
+  prompt: "${MISSING_PROMPT:-fallback prompt}"
+        """.strip()
+    )
+
+    config = load_agent_config("planner")
+
+    assert config.api_key == "expanded-key"
+    assert config.prompt == "fallback prompt"
+
+
+def test_unresolved_env_var_raises(config_file) -> None:
+    config_file.write_text(
+        """
+planner:
+  agent_id: "55555555-5555-5555-5555-555555555555"
+  api_key: "${MISSING_API_KEY}"
+        """.strip()
+    )
+
+    with pytest.raises(
+        ThenvoiConfigError, match="Environment variable 'MISSING_API_KEY' is not set"
+    ):
+        load_agent_config("planner")
+
+
+def test_prompt_path_is_resolved_relative_to_config(tmp_path) -> None:
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    prompt_file = prompt_dir / "planner.md"
+    prompt_file.write_text("Be concise.")
+    config_path = tmp_path / "agent_config.yaml"
+    config_path.write_text(
+        """
+planner:
+  agent_id: "66666666-6666-6666-6666-666666666666"
+  api_key: test-key
+  prompt_path: prompts/planner.md
+        """.strip()
+    )
+
+    config = load_agent_config("planner", config_path=config_path)
+
+    assert config.prompt_path == prompt_file.resolve()
+
+
+def test_search_order_prefers_agent_config_yaml(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    agent_config = tmp_path / "agent_config.yaml"
+    agents_config = tmp_path / "agents.yaml"
+    agent_config.write_text(
+        """
+planner:
+  agent_id: "77777777-7777-7777-7777-777777777777"
+  api_key: first-key
+        """.strip()
+    )
+    agents_config.write_text(
+        """
+planner:
+  agent_id: "88888888-8888-8888-8888-888888888888"
+  api_key: second-key
+        """.strip()
+    )
+
+    config = load_agent_config("planner")
+
+    assert config.api_key == "first-key"
+
+
+def test_build_adapter_from_config_unknown_type_suggests_match() -> None:
+    with pytest.raises(ThenvoiConfigError, match="Did you mean 'anthropic'\?"):
+        build_adapter_from_config({"type": "anthopic"})
+
+
+def test_build_adapter_from_config_requires_type() -> None:
+    with pytest.raises(ThenvoiConfigError, match="Missing adapter type"):
+        build_adapter_from_config({})
+
+
+def test_build_adapter_from_config_rejects_langgraph_yaml() -> None:
+    with pytest.raises(
+        ThenvoiConfigError, match="LangGraph requires a Python-built adapter"
+    ):
+        build_adapter_from_config({"type": "langgraph"})

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -33,6 +33,13 @@ def test_runtime_symbols_remain_importable_from_runtime() -> None:
     assert ExecutionContext is not None
 
 
+def test_typed_config_is_importable_from_thenvoi_config() -> None:
+    """Verify config-driven API types are importable."""
+    from thenvoi.config import AgentConfig as ConfigAgentConfig
+
+    assert ConfigAgentConfig is not None
+
+
 def test_can_import_letta_adapter_from_lazy_surface() -> None:
     """Verify Letta lazy exports are available."""
     from thenvoi.adapters import LettaAdapter, LettaAdapterConfig


### PR DESCRIPTION
## Summary
- add typed config loading with `thenvoi.config.AgentConfig`, env var expansion, config search order, and better `ThenvoiConfigError` messages
- add an adapter registry plus `Agent.from_config()` so YAML config and Python overrides can build agents cleanly from a stacked branch base
- preserve legacy tuple unpacking with a deprecation warning and extend tests around prompt composition, adapter selection, and config parsing

## Test plan
- [x] `uv run --project /Users/pp/thenvoi/.worktrees/thenvoi-sdk-python-pr2 ruff check /Users/pp/thenvoi/.worktrees/thenvoi-sdk-python-pr2`
- [x] `uv run --project /Users/pp/thenvoi/.worktrees/thenvoi-sdk-python-pr2 ruff format --check /Users/pp/thenvoi/.worktrees/thenvoi-sdk-python-pr2`
- [x] `uv run --project /Users/pp/thenvoi/.worktrees/thenvoi-sdk-python-pr2 pyrefly check`
- [x] `uv run --project /Users/pp/thenvoi/.worktrees/thenvoi-sdk-python-pr2 pytest /Users/pp/thenvoi/.worktrees/thenvoi-sdk-python-pr2/tests --ignore=/Users/pp/thenvoi/.worktrees/thenvoi-sdk-python-pr2/tests/integration --ignore=/Users/pp/thenvoi/.worktrees/thenvoi-sdk-python-pr2/tests/e2e -q`