### PR TITLE
chore: add .a5c/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ uv.toml
 
 # Scripts config (contains local paths)
 scripts/config.yaml
+.a5c/


### PR DESCRIPTION
## Summary\n\nAdds `.a5c/` to `.gitignore` to prevent accidental commits of locally-generated tooling artifacts.\n\nThe `.a5c/` directory is created by local development tools and contains machine-specific configuration that should not be tracked in version control. Without this entry, contributors risk committing these files, which can cause merge conflicts and pollute the repository history.\n\n## Test plan\n- [x] Verify `.a5c/` directories are ignored by git after this change