### PR TITLE
feat: add foundation types for SDK normalization (INT-294 Step 1)

### DIFF
--- a/src/thenvoi/core/exceptions.py
+++ b/src/thenvoi/core/exceptions.py
@@ -1,0 +1,19 @@
+"""Thenvoi SDK exception hierarchy."""
+
+from __future__ import annotations
+
+
+class ThenvoiError(Exception):
+    """Base for all SDK exceptions."""
+
+
+class ThenvoiConfigError(ThenvoiError):
+    """Configuration or setup problems. Actionable by developer."""
+
+
+class ThenvoiConnectionError(ThenvoiError):
+    """Transport failures (WebSocket, REST). Actionable by ops."""
+
+
+class ThenvoiToolError(ThenvoiError):
+    """Tool execution failures. Actionable by adapter/LLM."""

--- a/src/thenvoi/core/exceptions.py
+++ b/src/thenvoi/core/exceptions.py
@@ -2,13 +2,42 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 
 class ThenvoiError(Exception):
     """Base for all SDK exceptions."""
 
 
 class ThenvoiConfigError(ThenvoiError):
-    """Configuration or setup problems. Actionable by developer."""
+    """Configuration or setup problems. Actionable by developer.
+
+    Use ``with_suggestion`` to attach a "did you mean?" hint when the
+    user likely typoed a known parameter or capability name.
+    """
+
+    @classmethod
+    def with_suggestion(
+        cls,
+        message: str,
+        bad_name: str,
+        valid_names: Iterable[str],
+        *,
+        max_distance: int = 2,
+    ) -> "ThenvoiConfigError":
+        """Build an error message with a typo suggestion if one is close enough.
+
+        Args:
+            message: Base error message.
+            bad_name: The unknown / misspelled name the user supplied.
+            valid_names: Known-good names to compare against.
+            max_distance: Maximum Levenshtein distance to consider a match
+                (default 2 — catches single-char typos and small swaps).
+        """
+        suggestion = _closest_match(bad_name, valid_names, max_distance=max_distance)
+        if suggestion is not None:
+            return cls(f"{message} Did you mean {suggestion!r}?")
+        return cls(message)
 
 
 class ThenvoiConnectionError(ThenvoiError):
@@ -17,3 +46,42 @@ class ThenvoiConnectionError(ThenvoiError):
 
 class ThenvoiToolError(ThenvoiError):
     """Tool execution failures. Actionable by adapter/LLM."""
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Iterative Levenshtein distance. Pure Python, no dependencies."""
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        current = [i] + [0] * len(b)
+        for j, cb in enumerate(b, start=1):
+            insert = current[j - 1] + 1
+            delete = previous[j] + 1
+            substitute = previous[j - 1] + (0 if ca == cb else 1)
+            current[j] = min(insert, delete, substitute)
+        previous = current
+    return previous[-1]
+
+
+def _closest_match(
+    needle: str,
+    haystack: Iterable[str],
+    *,
+    max_distance: int = 2,
+) -> str | None:
+    """Return the closest name from haystack within max_distance, or None."""
+    needle_lower = needle.lower()
+    best: tuple[int, str] | None = None
+    for candidate in haystack:
+        distance = _levenshtein(needle_lower, candidate.lower())
+        if distance > max_distance:
+            continue
+        if best is None or distance < best[0]:
+            best = (distance, candidate)
+    return best[1] if best is not None else None

--- a/src/thenvoi/core/types.py
+++ b/src/thenvoi/core/types.py
@@ -4,12 +4,64 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
     from thenvoi.core.protocols import AgentToolsProtocol, HistoryConverter
 
 T = TypeVar("T")
+
+
+class Capability(str, Enum):
+    """Platform tool categories an adapter can expose to the LLM.
+
+    These control tool-schema inclusion only -- they do NOT affect
+    runtime event routing (WebSocket subscriptions, contact-event
+    strategies, hub-room creation).  Those remain under
+    ContactEventConfig / ContactEventStrategy in runtime/types.py.
+    """
+
+    MEMORY = "memory"
+    CONTACTS = "contacts"
+
+
+class Emit(str, Enum):
+    """Event types an adapter can emit to the platform."""
+
+    EXECUTION = "execution"
+    THOUGHTS = "thoughts"
+    TASK_EVENTS = "task_events"
+
+
+@dataclass(frozen=True)
+class AdapterFeatures:
+    """Shared adapter feature settings. Framework-agnostic knobs only.
+
+    Custom tools are NOT included -- they are adapter-local because each
+    framework has its own tool type.
+
+    Accepts list/set inputs for convenience; normalizes to frozen types
+    internally.
+    """
+
+    capabilities: frozenset[Capability] = frozenset()
+    emit: frozenset[Emit] = frozenset()
+    include_tools: tuple[str, ...] | None = None
+    exclude_tools: tuple[str, ...] | None = None
+    include_categories: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "capabilities", frozenset(self.capabilities))
+        object.__setattr__(self, "emit", frozenset(self.emit))
+        if self.include_tools is not None:
+            object.__setattr__(self, "include_tools", tuple(self.include_tools))
+        if self.exclude_tools is not None:
+            object.__setattr__(self, "exclude_tools", tuple(self.exclude_tools))
+        if self.include_categories is not None:
+            object.__setattr__(
+                self, "include_categories", tuple(self.include_categories)
+            )
 
 
 @dataclass(frozen=True)

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -1,0 +1,32 @@
+"""Tests for Thenvoi exception hierarchy."""
+
+from __future__ import annotations
+
+from thenvoi.core.exceptions import (
+    ThenvoiConfigError,
+    ThenvoiConnectionError,
+    ThenvoiError,
+    ThenvoiToolError,
+)
+
+
+class TestExceptionHierarchy:
+    def test_all_inherit_from_thenvoi_error(self) -> None:
+        assert issubclass(ThenvoiConfigError, ThenvoiError)
+        assert issubclass(ThenvoiConnectionError, ThenvoiError)
+        assert issubclass(ThenvoiToolError, ThenvoiError)
+
+    def test_thenvoi_error_inherits_from_exception(self) -> None:
+        assert issubclass(ThenvoiError, Exception)
+
+    def test_can_catch_with_base_class(self) -> None:
+        with __import__("pytest").raises(ThenvoiError):
+            raise ThenvoiConfigError("bad config")
+
+    def test_message_preserved(self) -> None:
+        err = ThenvoiToolError("send_message failed: 403")
+        assert str(err) == "send_message failed: 403"
+
+    def test_config_error_not_tool_error(self) -> None:
+        assert not issubclass(ThenvoiConfigError, ThenvoiToolError)
+        assert not issubclass(ThenvoiToolError, ThenvoiConfigError)

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from thenvoi.core.exceptions import (
     ThenvoiConfigError,
     ThenvoiConnectionError,
@@ -20,7 +22,7 @@ class TestExceptionHierarchy:
         assert issubclass(ThenvoiError, Exception)
 
     def test_can_catch_with_base_class(self) -> None:
-        with __import__("pytest").raises(ThenvoiError):
+        with pytest.raises(ThenvoiError):
             raise ThenvoiConfigError("bad config")
 
     def test_message_preserved(self) -> None:
@@ -30,3 +32,67 @@ class TestExceptionHierarchy:
     def test_config_error_not_tool_error(self) -> None:
         assert not issubclass(ThenvoiConfigError, ThenvoiToolError)
         assert not issubclass(ThenvoiToolError, ThenvoiConfigError)
+
+
+class TestConfigErrorWithSuggestion:
+    """Tests for ThenvoiConfigError.with_suggestion()."""
+
+    def test_suggests_close_match(self) -> None:
+        err = ThenvoiConfigError.with_suggestion(
+            "Unknown capability 'memry'.",
+            "memry",
+            ["memory", "contacts"],
+        )
+        assert "Did you mean 'memory'?" in str(err)
+
+    def test_suggests_case_insensitive(self) -> None:
+        err = ThenvoiConfigError.with_suggestion(
+            "Unknown emit value 'EXEUCTION'.",
+            "EXEUCTION",
+            ["execution", "thoughts", "task_events"],
+        )
+        assert "Did you mean 'execution'?" in str(err)
+
+    def test_no_suggestion_when_too_far(self) -> None:
+        err = ThenvoiConfigError.with_suggestion(
+            "Unknown capability 'completely_different'.",
+            "completely_different",
+            ["memory", "contacts"],
+        )
+        assert "Did you mean" not in str(err)
+        assert "Unknown capability 'completely_different'." in str(err)
+
+    def test_picks_closest_among_candidates(self) -> None:
+        err = ThenvoiConfigError.with_suggestion(
+            "Unknown param 'enabel_memory'.",
+            "enabel_memory",
+            ["enable_memory", "enable_contacts", "memory"],
+        )
+        assert "Did you mean 'enable_memory'?" in str(err)
+
+    def test_max_distance_respected(self) -> None:
+        # 'memo' -> 'memory' is distance 2
+        err_default = ThenvoiConfigError.with_suggestion(
+            "Bad name 'memo'.",
+            "memo",
+            ["memory"],
+        )
+        assert "Did you mean 'memory'?" in str(err_default)
+
+        # With max_distance=1, 'memo' -> 'memory' is too far
+        err_strict = ThenvoiConfigError.with_suggestion(
+            "Bad name 'memo'.",
+            "memo",
+            ["memory"],
+            max_distance=1,
+        )
+        assert "Did you mean" not in str(err_strict)
+
+    def test_returns_thenvoi_config_error(self) -> None:
+        err = ThenvoiConfigError.with_suggestion("msg", "x", ["y"], max_distance=5)
+        assert isinstance(err, ThenvoiConfigError)
+        assert isinstance(err, ThenvoiError)
+
+    def test_empty_haystack_no_suggestion(self) -> None:
+        err = ThenvoiConfigError.with_suggestion("Bad name.", "anything", [])
+        assert "Did you mean" not in str(err)

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -1,0 +1,86 @@
+"""Tests for Capability, Emit enums and AdapterFeatures dataclass."""
+
+from __future__ import annotations
+
+import pytest
+
+from thenvoi.core.types import AdapterFeatures, Capability, Emit
+
+
+class TestCapabilityEnum:
+    def test_values(self) -> None:
+        assert Capability.MEMORY == "memory"
+        assert Capability.CONTACTS == "contacts"
+
+    def test_is_str_enum(self) -> None:
+        assert isinstance(Capability.MEMORY, str)
+
+
+class TestEmitEnum:
+    def test_values(self) -> None:
+        assert Emit.EXECUTION == "execution"
+        assert Emit.THOUGHTS == "thoughts"
+        assert Emit.TASK_EVENTS == "task_events"
+
+    def test_is_str_enum(self) -> None:
+        assert isinstance(Emit.EXECUTION, str)
+
+
+class TestAdapterFeatures:
+    def test_empty_defaults(self) -> None:
+        f = AdapterFeatures()
+        assert f.capabilities == frozenset()
+        assert f.emit == frozenset()
+        assert f.include_tools is None
+        assert f.exclude_tools is None
+        assert f.include_categories is None
+
+    def test_set_literal_normalized_to_frozenset(self) -> None:
+        f = AdapterFeatures(
+            capabilities={Capability.MEMORY},
+            emit={Emit.EXECUTION, Emit.THOUGHTS},
+        )
+        assert isinstance(f.capabilities, frozenset)
+        assert isinstance(f.emit, frozenset)
+        assert Capability.MEMORY in f.capabilities
+        assert Emit.EXECUTION in f.emit
+        assert Emit.THOUGHTS in f.emit
+
+    def test_list_normalized_to_frozenset(self) -> None:
+        f = AdapterFeatures(
+            capabilities=[Capability.MEMORY, Capability.CONTACTS],
+        )
+        assert isinstance(f.capabilities, frozenset)
+        assert len(f.capabilities) == 2
+
+    def test_include_tools_normalized_to_tuple(self) -> None:
+        f = AdapterFeatures(
+            include_tools=["thenvoi_send_message", "thenvoi_lookup_peers"]
+        )
+        assert isinstance(f.include_tools, tuple)
+        assert f.include_tools == ("thenvoi_send_message", "thenvoi_lookup_peers")
+
+    def test_exclude_tools_normalized_to_tuple(self) -> None:
+        f = AdapterFeatures(exclude_tools=["thenvoi_store_memory"])
+        assert isinstance(f.exclude_tools, tuple)
+
+    def test_include_categories_normalized_to_tuple(self) -> None:
+        f = AdapterFeatures(include_categories=["chat", "memory"])
+        assert isinstance(f.include_categories, tuple)
+        assert f.include_categories == ("chat", "memory")
+
+    def test_frozen_raises_on_assignment(self) -> None:
+        f = AdapterFeatures()
+        with pytest.raises(AttributeError):
+            f.capabilities = frozenset({Capability.MEMORY})  # type: ignore[misc]
+
+    def test_hashable(self) -> None:
+        f1 = AdapterFeatures(capabilities={Capability.MEMORY})
+        f2 = AdapterFeatures(capabilities={Capability.MEMORY})
+        assert hash(f1) == hash(f2)
+        assert f1 == f2
+
+    def test_different_features_not_equal(self) -> None:
+        f1 = AdapterFeatures(capabilities={Capability.MEMORY})
+        f2 = AdapterFeatures(capabilities={Capability.CONTACTS})
+        assert f1 != f2


### PR DESCRIPTION
## Summary
- Add `Capability` and `Emit` string enums to `core/types.py`
- Add `AdapterFeatures` frozen dataclass with frozenset/tuple normalization
- Add `ThenvoiError` exception hierarchy in `core/exceptions.py`

**Part 1 of 6** for INT-294 SDK Cleanup & Normalization.

## Changes
| File | Change |
|------|--------|
| `src/thenvoi/core/types.py` | `Capability`, `Emit` enums + `AdapterFeatures` dataclass |
| `src/thenvoi/core/exceptions.py` | New: `ThenvoiError`, `ThenvoiConfigError`, `ThenvoiConnectionError`, `ThenvoiToolError` |
| `tests/core/test_types.py` | 13 tests for enums and AdapterFeatures |
| `tests/core/test_exceptions.py` | 5 tests for exception hierarchy |

## Test plan
- [x] `uv run pytest tests/core/test_types.py tests/core/test_exceptions.py -v` — 18/18 pass
- [x] Full suite: 2453 passed, same pre-existing failures only
- [x] `uv run ruff check . && uv run ruff format .` — clean
- [x] `uv run pyrefly check` — clean