### PR TITLE
feat: add features param to SimpleAdapter and tool filtering helper (INT-294 Step 2)

### DIFF
--- a/src/thenvoi/core/exceptions.py
+++ b/src/thenvoi/core/exceptions.py
@@ -1,0 +1,19 @@
+"""Thenvoi SDK exception hierarchy."""
+
+from __future__ import annotations
+
+
+class ThenvoiError(Exception):
+    """Base for all SDK exceptions."""
+
+
+class ThenvoiConfigError(ThenvoiError):
+    """Configuration or setup problems. Actionable by developer."""
+
+
+class ThenvoiConnectionError(ThenvoiError):
+    """Transport failures (WebSocket, REST). Actionable by ops."""
+
+
+class ThenvoiToolError(ThenvoiError):
+    """Tool execution failures. Actionable by adapter/LLM."""

--- a/src/thenvoi/core/exceptions.py
+++ b/src/thenvoi/core/exceptions.py
@@ -2,13 +2,42 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 
 class ThenvoiError(Exception):
     """Base for all SDK exceptions."""
 
 
 class ThenvoiConfigError(ThenvoiError):
-    """Configuration or setup problems. Actionable by developer."""
+    """Configuration or setup problems. Actionable by developer.
+
+    Use ``with_suggestion`` to attach a "did you mean?" hint when the
+    user likely typoed a known parameter or capability name.
+    """
+
+    @classmethod
+    def with_suggestion(
+        cls,
+        message: str,
+        bad_name: str,
+        valid_names: Iterable[str],
+        *,
+        max_distance: int = 2,
+    ) -> "ThenvoiConfigError":
+        """Build an error message with a typo suggestion if one is close enough.
+
+        Args:
+            message: Base error message.
+            bad_name: The unknown / misspelled name the user supplied.
+            valid_names: Known-good names to compare against.
+            max_distance: Maximum Levenshtein distance to consider a match
+                (default 2 — catches single-char typos and small swaps).
+        """
+        suggestion = _closest_match(bad_name, valid_names, max_distance=max_distance)
+        if suggestion is not None:
+            return cls(f"{message} Did you mean {suggestion!r}?")
+        return cls(message)
 
 
 class ThenvoiConnectionError(ThenvoiError):
@@ -17,3 +46,42 @@ class ThenvoiConnectionError(ThenvoiError):
 
 class ThenvoiToolError(ThenvoiError):
     """Tool execution failures. Actionable by adapter/LLM."""
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Iterative Levenshtein distance. Pure Python, no dependencies."""
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+
+    previous = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        current = [i] + [0] * len(b)
+        for j, cb in enumerate(b, start=1):
+            insert = current[j - 1] + 1
+            delete = previous[j] + 1
+            substitute = previous[j - 1] + (0 if ca == cb else 1)
+            current[j] = min(insert, delete, substitute)
+        previous = current
+    return previous[-1]
+
+
+def _closest_match(
+    needle: str,
+    haystack: Iterable[str],
+    *,
+    max_distance: int = 2,
+) -> str | None:
+    """Return the closest name from haystack within max_distance, or None."""
+    needle_lower = needle.lower()
+    best: tuple[int, str] | None = None
+    for candidate in haystack:
+        distance = _levenshtein(needle_lower, candidate.lower())
+        if distance > max_distance:
+            continue
+        if best is None or distance < best[0]:
+            best = (distance, candidate)
+    return best[1] if best is not None else None

--- a/src/thenvoi/core/simple_adapter.py
+++ b/src/thenvoi/core/simple_adapter.py
@@ -46,6 +46,7 @@ class SimpleAdapter(Generic[H], ABC):
                 tools: AgentToolsProtocol,
                 history: list[ChatMessage],  # Fully typed!
                 participants_msg: str | None,
+                contacts_msg: str | None,
                 *,
                 is_session_bootstrap: bool,
                 room_id: str,

--- a/src/thenvoi/core/simple_adapter.py
+++ b/src/thenvoi/core/simple_adapter.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, ClassVar, Generic, TypeVar, cast
 
 from thenvoi.core.protocols import AgentToolsProtocol, HistoryConverter
-from thenvoi.core.types import AgentInput, PlatformMessage
+from thenvoi.core.types import (
+    AdapterFeatures,
+    AgentInput,
+    Capability,
+    Emit,
+    PlatformMessage,
+)
+
+logger = logging.getLogger(__name__)
 
 # Type variable for history type - bound by converter
 H = TypeVar("H")
@@ -19,8 +28,15 @@ class SimpleAdapter(Generic[H], ABC):
     Generic over H (history type) for full type safety.
     Users extend this and override on_message().
 
+    Subclasses should declare SUPPORTED_EMIT and SUPPORTED_CAPABILITIES
+    as class-level sets to document what they actually implement.
+    on_started() will warn if features request unsupported values.
+
     Example:
         class MyAdapter(SimpleAdapter[list[ChatMessage]]):
+            SUPPORTED_EMIT = frozenset({Emit.EXECUTION})
+            SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY})
+
             def __init__(self):
                 super().__init__(history_converter=MyHistoryConverter())
 
@@ -37,10 +53,14 @@ class SimpleAdapter(Generic[H], ABC):
                 ...
     """
 
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset()
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset()
+
     def __init__(
         self,
         *,
         history_converter: HistoryConverter[H] | None = None,
+        features: AdapterFeatures | None = None,
     ):
         """
         Initialize adapter.
@@ -48,8 +68,11 @@ class SimpleAdapter(Generic[H], ABC):
         Args:
             history_converter: Optional converter for automatic history conversion.
                               Pass via __init__ to avoid shared state issues.
+            features: Shared adapter feature settings (capabilities, emit, tool filters).
+                     Defaults to empty AdapterFeatures().
         """
         self.history_converter = history_converter
+        self.features = features or AdapterFeatures()
         self.agent_name: str = ""
         self.agent_description: str = ""
 
@@ -87,6 +110,22 @@ class SimpleAdapter(Generic[H], ABC):
         """Override for post-start setup."""
         self.agent_name = agent_name
         self.agent_description = agent_description
+
+        # Warn on unsupported feature values
+        unsupported_emit = self.features.emit - self.SUPPORTED_EMIT
+        if unsupported_emit:
+            logger.warning(
+                "%s does not support emit values: %s (they will have no effect)",
+                type(self).__name__,
+                unsupported_emit,
+            )
+        unsupported_caps = self.features.capabilities - self.SUPPORTED_CAPABILITIES
+        if unsupported_caps:
+            logger.warning(
+                "%s does not support capability values: %s (they will have no effect)",
+                type(self).__name__,
+                unsupported_caps,
+            )
 
         # Propagate agent name to converter if it supports it
         if self.history_converter and hasattr(self.history_converter, "set_agent_name"):

--- a/src/thenvoi/core/simple_adapter.py
+++ b/src/thenvoi/core/simple_adapter.py
@@ -118,14 +118,14 @@ class SimpleAdapter(Generic[H], ABC):
             logger.warning(
                 "%s does not support emit values: %s (they will have no effect)",
                 type(self).__name__,
-                unsupported_emit,
+                ", ".join(sorted(e.value for e in unsupported_emit)),
             )
         unsupported_caps = self.features.capabilities - self.SUPPORTED_CAPABILITIES
         if unsupported_caps:
             logger.warning(
                 "%s does not support capability values: %s (they will have no effect)",
                 type(self).__name__,
-                unsupported_caps,
+                ", ".join(sorted(c.value for c in unsupported_caps)),
             )
 
         # Propagate agent name to converter if it supports it

--- a/src/thenvoi/core/tool_filter.py
+++ b/src/thenvoi/core/tool_filter.py
@@ -1,0 +1,66 @@
+"""Shared tool-schema filtering helper.
+
+Single source of truth for applying include/exclude/category filters
+from AdapterFeatures to tool schema lists.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, TypeVar
+
+from thenvoi.core.types import AdapterFeatures
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def filter_tool_schemas(
+    schemas: list[T],
+    features: AdapterFeatures,
+    *,
+    get_name: Callable[[T], str],
+    get_category: Callable[[T], str | None] | None = None,
+) -> list[T]:
+    """Apply include/exclude/category filters from AdapterFeatures.
+
+    Args:
+        schemas: List of tool schemas (any type).
+        features: AdapterFeatures with filtering config.
+        get_name: Extracts the tool name from a schema object.
+        get_category: Extracts the category from a schema object.
+            If None, include_categories filtering is skipped with a warning.
+
+    Returns:
+        Filtered list of schemas.
+    """
+    available_names = {get_name(s) for s in schemas}
+    result = list(schemas)
+
+    if features.include_categories is not None:
+        if get_category is None:
+            logger.warning(
+                "include_categories is set but this adapter does not support "
+                "category filtering (ignored): %s",
+                features.include_categories,
+            )
+        else:
+            cats = set(features.include_categories)
+            result = [s for s in result if get_category(s) in cats]
+
+    if features.include_tools is not None:
+        names = set(features.include_tools)
+        unmatched = names - available_names
+        if unmatched:
+            logger.warning("include_tools contains unknown names: %s", unmatched)
+        result = [s for s in result if get_name(s) in names]
+
+    if features.exclude_tools is not None:
+        names = set(features.exclude_tools)
+        unmatched = names - available_names
+        if unmatched:
+            logger.warning("exclude_tools contains unknown names: %s", unmatched)
+        result = [s for s in result if get_name(s) not in names]
+
+    return result

--- a/src/thenvoi/core/tool_filter.py
+++ b/src/thenvoi/core/tool_filter.py
@@ -25,6 +25,17 @@ def filter_tool_schemas(
 ) -> list[T]:
     """Apply include/exclude/category filters from AdapterFeatures.
 
+    Filters are applied in strict precedence order:
+
+    1. **include_categories** — keep only schemas whose category is in the set.
+    2. **include_tools** — keep only schemas whose name is in the set.
+    3. **exclude_tools** — drop schemas whose name is in the set.
+
+    Each stage narrows the result of the previous one, so
+    ``include_categories=["chat"]`` + ``include_tools=["thenvoi_store_memory"]``
+    yields an empty list when ``thenvoi_store_memory`` is not in the ``"chat"``
+    category.
+
     Args:
         schemas: List of tool schemas (any type).
         features: AdapterFeatures with filtering config.
@@ -53,14 +64,20 @@ def filter_tool_schemas(
         names = set(features.include_tools)
         unmatched = names - available_names
         if unmatched:
-            logger.warning("include_tools contains unknown names: %s", unmatched)
+            logger.warning(
+                "include_tools contains unknown names: %s",
+                ", ".join(sorted(unmatched)),
+            )
         result = [s for s in result if get_name(s) in names]
 
     if features.exclude_tools is not None:
         names = set(features.exclude_tools)
         unmatched = names - available_names
         if unmatched:
-            logger.warning("exclude_tools contains unknown names: %s", unmatched)
+            logger.warning(
+                "exclude_tools contains unknown names: %s",
+                ", ".join(sorted(unmatched)),
+            )
         result = [s for s in result if get_name(s) not in names]
 
     return result

--- a/src/thenvoi/core/types.py
+++ b/src/thenvoi/core/types.py
@@ -4,12 +4,64 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
     from thenvoi.core.protocols import AgentToolsProtocol, HistoryConverter
 
 T = TypeVar("T")
+
+
+class Capability(str, Enum):
+    """Platform tool categories an adapter can expose to the LLM.
+
+    These control tool-schema inclusion only -- they do NOT affect
+    runtime event routing (WebSocket subscriptions, contact-event
+    strategies, hub-room creation).  Those remain under
+    ContactEventConfig / ContactEventStrategy in runtime/types.py.
+    """
+
+    MEMORY = "memory"
+    CONTACTS = "contacts"
+
+
+class Emit(str, Enum):
+    """Event types an adapter can emit to the platform."""
+
+    EXECUTION = "execution"
+    THOUGHTS = "thoughts"
+    TASK_EVENTS = "task_events"
+
+
+@dataclass(frozen=True)
+class AdapterFeatures:
+    """Shared adapter feature settings. Framework-agnostic knobs only.
+
+    Custom tools are NOT included -- they are adapter-local because each
+    framework has its own tool type.
+
+    Accepts list/set inputs for convenience; normalizes to frozen types
+    internally.
+    """
+
+    capabilities: frozenset[Capability] = frozenset()
+    emit: frozenset[Emit] = frozenset()
+    include_tools: tuple[str, ...] | None = None
+    exclude_tools: tuple[str, ...] | None = None
+    include_categories: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "capabilities", frozenset(self.capabilities))
+        object.__setattr__(self, "emit", frozenset(self.emit))
+        if self.include_tools is not None:
+            object.__setattr__(self, "include_tools", tuple(self.include_tools))
+        if self.exclude_tools is not None:
+            object.__setattr__(self, "exclude_tools", tuple(self.exclude_tools))
+        if self.include_categories is not None:
+            object.__setattr__(
+                self, "include_categories", tuple(self.include_categories)
+            )
 
 
 @dataclass(frozen=True)

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -1,0 +1,32 @@
+"""Tests for Thenvoi exception hierarchy."""
+
+from __future__ import annotations
+
+from thenvoi.core.exceptions import (
+    ThenvoiConfigError,
+    ThenvoiConnectionError,
+    ThenvoiError,
+    ThenvoiToolError,
+)
+
+
+class TestExceptionHierarchy:
+    def test_all_inherit_from_thenvoi_error(self) -> None:
+        assert issubclass(ThenvoiConfigError, ThenvoiError)
+        assert issubclass(ThenvoiConnectionError, ThenvoiError)
+        assert issubclass(ThenvoiToolError, ThenvoiError)
+
+    def test_thenvoi_error_inherits_from_exception(self) -> None:
+        assert issubclass(ThenvoiError, Exception)
+
+    def test_can_catch_with_base_class(self) -> None:
+        with __import__("pytest").raises(ThenvoiError):
+            raise ThenvoiConfigError("bad config")
+
+    def test_message_preserved(self) -> None:
+        err = ThenvoiToolError("send_message failed: 403")
+        assert str(err) == "send_message failed: 403"
+
+    def test_config_error_not_tool_error(self) -> None:
+        assert not issubclass(ThenvoiConfigError, ThenvoiToolError)
+        assert not issubclass(ThenvoiToolError, ThenvoiConfigError)

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from thenvoi.core.exceptions import (
     ThenvoiConfigError,
     ThenvoiConnectionError,
@@ -20,7 +22,7 @@ class TestExceptionHierarchy:
         assert issubclass(ThenvoiError, Exception)
 
     def test_can_catch_with_base_class(self) -> None:
-        with __import__("pytest").raises(ThenvoiError):
+        with pytest.raises(ThenvoiError):
             raise ThenvoiConfigError("bad config")
 
     def test_message_preserved(self) -> None:
@@ -30,3 +32,67 @@ class TestExceptionHierarchy:
     def test_config_error_not_tool_error(self) -> None:
         assert not issubclass(ThenvoiConfigError, ThenvoiToolError)
         assert not issubclass(ThenvoiToolError, ThenvoiConfigError)
+
+
+class TestConfigErrorWithSuggestion:
+    """Tests for ThenvoiConfigError.with_suggestion()."""
+
+    def test_suggests_close_match(self) -> None:
+        err = ThenvoiConfigError.with_suggestion(
+            "Unknown capability 'memry'.",
+            "memry",
+            ["memory", "contacts"],
+        )
+        assert "Did you mean 'memory'?" in str(err)
+
+    def test_suggests_case_insensitive(self) -> None:
+        err = ThenvoiConfigError.with_suggestion(
+            "Unknown emit value 'EXEUCTION'.",
+            "EXEUCTION",
+            ["execution", "thoughts", "task_events"],
+        )
+        assert "Did you mean 'execution'?" in str(err)
+
+    def test_no_suggestion_when_too_far(self) -> None:
+        err = ThenvoiConfigError.with_suggestion(
+            "Unknown capability 'completely_different'.",
+            "completely_different",
+            ["memory", "contacts"],
+        )
+        assert "Did you mean" not in str(err)
+        assert "Unknown capability 'completely_different'." in str(err)
+
+    def test_picks_closest_among_candidates(self) -> None:
+        err = ThenvoiConfigError.with_suggestion(
+            "Unknown param 'enabel_memory'.",
+            "enabel_memory",
+            ["enable_memory", "enable_contacts", "memory"],
+        )
+        assert "Did you mean 'enable_memory'?" in str(err)
+
+    def test_max_distance_respected(self) -> None:
+        # 'memo' -> 'memory' is distance 2
+        err_default = ThenvoiConfigError.with_suggestion(
+            "Bad name 'memo'.",
+            "memo",
+            ["memory"],
+        )
+        assert "Did you mean 'memory'?" in str(err_default)
+
+        # With max_distance=1, 'memo' -> 'memory' is too far
+        err_strict = ThenvoiConfigError.with_suggestion(
+            "Bad name 'memo'.",
+            "memo",
+            ["memory"],
+            max_distance=1,
+        )
+        assert "Did you mean" not in str(err_strict)
+
+    def test_returns_thenvoi_config_error(self) -> None:
+        err = ThenvoiConfigError.with_suggestion("msg", "x", ["y"], max_distance=5)
+        assert isinstance(err, ThenvoiConfigError)
+        assert isinstance(err, ThenvoiError)
+
+    def test_empty_haystack_no_suggestion(self) -> None:
+        err = ThenvoiConfigError.with_suggestion("Bad name.", "anything", [])
+        assert "Did you mean" not in str(err)

--- a/tests/core/test_simple_adapter_features.py
+++ b/tests/core/test_simple_adapter_features.py
@@ -1,0 +1,124 @@
+"""Tests for SimpleAdapter features param and unsupported-value warnings."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from thenvoi.core.protocols import AgentToolsProtocol
+from thenvoi.core.simple_adapter import SimpleAdapter
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
+
+
+class _TestAdapter(SimpleAdapter[list[Any]]):
+    """Minimal concrete adapter for testing."""
+
+    SUPPORTED_EMIT = frozenset({Emit.EXECUTION})
+    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY})
+
+    async def on_message(
+        self,
+        msg: PlatformMessage,
+        tools: AgentToolsProtocol,
+        history: list[Any],
+        participants_msg: str | None,
+        contacts_msg: str | None,
+        *,
+        is_session_bootstrap: bool,
+        room_id: str,
+    ) -> None:
+        pass
+
+
+class _BareAdapter(SimpleAdapter[list[Any]]):
+    """Adapter that declares no SUPPORTED_* (like a direct FrameworkAdapter impl)."""
+
+    async def on_message(
+        self,
+        msg: PlatformMessage,
+        tools: AgentToolsProtocol,
+        history: list[Any],
+        participants_msg: str | None,
+        contacts_msg: str | None,
+        *,
+        is_session_bootstrap: bool,
+        room_id: str,
+    ) -> None:
+        pass
+
+
+class TestSimpleAdapterFeatures:
+    def test_defaults_to_empty_features(self) -> None:
+        adapter = _TestAdapter()
+        assert adapter.features == AdapterFeatures()
+
+    def test_accepts_features_param(self) -> None:
+        f = AdapterFeatures(
+            capabilities={Capability.MEMORY},
+            emit={Emit.EXECUTION},
+        )
+        adapter = _TestAdapter(features=f)
+        assert adapter.features is f
+
+    @pytest.mark.asyncio
+    async def test_warns_on_unsupported_emit(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        adapter = _TestAdapter(
+            features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
+        )
+        with caplog.at_level(logging.WARNING):
+            await adapter.on_started("test-agent", "A test agent")
+        assert "does not support emit values" in caplog.text
+        assert "THOUGHTS" in caplog.text or "thoughts" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_warns_on_unsupported_capabilities(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        adapter = _TestAdapter(
+            features=AdapterFeatures(
+                capabilities={Capability.MEMORY, Capability.CONTACTS}
+            ),
+        )
+        with caplog.at_level(logging.WARNING):
+            await adapter.on_started("test-agent", "A test agent")
+        assert "does not support capability values" in caplog.text
+        assert "CONTACTS" in caplog.text or "contacts" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_supported(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        adapter = _TestAdapter(
+            features=AdapterFeatures(
+                capabilities={Capability.MEMORY}, emit={Emit.EXECUTION}
+            ),
+        )
+        with caplog.at_level(logging.WARNING):
+            await adapter.on_started("test-agent", "A test agent")
+        assert "does not support" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_no_warning_on_empty_features(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        adapter = _TestAdapter()
+        with caplog.at_level(logging.WARNING):
+            await adapter.on_started("test-agent", "A test agent")
+        assert "does not support" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_bare_adapter_no_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Adapter with no SUPPORTED_* declarations warns on any non-empty features."""
+        adapter = _BareAdapter(
+            features=AdapterFeatures(emit={Emit.EXECUTION}),
+        )
+        with caplog.at_level(logging.WARNING):
+            await adapter.on_started("test-agent", "A test agent")
+        # _BareAdapter has empty SUPPORTED_EMIT, so EXECUTION is unsupported
+        assert "does not support emit values" in caplog.text

--- a/tests/core/test_tool_filter.py
+++ b/tests/core/test_tool_filter.py
@@ -1,0 +1,101 @@
+"""Tests for filter_tool_schemas helper."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import pytest
+
+from thenvoi.core.tool_filter import filter_tool_schemas
+from thenvoi.core.types import AdapterFeatures
+
+
+@dataclass
+class _FakeTool:
+    name: str
+    category: str | None = None
+
+
+def _get_name(t: _FakeTool) -> str:
+    return t.name
+
+
+def _get_category(t: _FakeTool) -> str | None:
+    return t.category
+
+
+SAMPLE_TOOLS = [
+    _FakeTool("thenvoi_send_message", "chat"),
+    _FakeTool("thenvoi_lookup_peers", "chat"),
+    _FakeTool("thenvoi_store_memory", "memory"),
+    _FakeTool("thenvoi_list_contacts", "contact"),
+]
+
+
+class TestFilterToolSchemas:
+    def test_empty_features_passes_everything(self) -> None:
+        result = filter_tool_schemas(
+            SAMPLE_TOOLS, AdapterFeatures(), get_name=_get_name
+        )
+        assert result == SAMPLE_TOOLS
+
+    def test_include_tools_filters(self) -> None:
+        f = AdapterFeatures(include_tools=["thenvoi_send_message"])
+        result = filter_tool_schemas(SAMPLE_TOOLS, f, get_name=_get_name)
+        assert len(result) == 1
+        assert result[0].name == "thenvoi_send_message"
+
+    def test_exclude_tools_filters(self) -> None:
+        f = AdapterFeatures(exclude_tools=["thenvoi_store_memory"])
+        result = filter_tool_schemas(SAMPLE_TOOLS, f, get_name=_get_name)
+        assert len(result) == 3
+        assert all(t.name != "thenvoi_store_memory" for t in result)
+
+    def test_include_categories_filters(self) -> None:
+        f = AdapterFeatures(include_categories=["chat"])
+        result = filter_tool_schemas(
+            SAMPLE_TOOLS, f, get_name=_get_name, get_category=_get_category
+        )
+        assert len(result) == 2
+        assert all(t.category == "chat" for t in result)
+
+    def test_include_categories_without_getter_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        f = AdapterFeatures(include_categories=["chat"])
+        with caplog.at_level(logging.WARNING):
+            result = filter_tool_schemas(SAMPLE_TOOLS, f, get_name=_get_name)
+        assert "does not support category filtering" in caplog.text
+        # All tools pass through when category filtering is unsupported
+        assert len(result) == 4
+
+    def test_unknown_include_tool_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        f = AdapterFeatures(
+            include_tools=["thenvoi_nonexistent", "thenvoi_send_message"]
+        )
+        with caplog.at_level(logging.WARNING):
+            result = filter_tool_schemas(SAMPLE_TOOLS, f, get_name=_get_name)
+        assert "unknown names" in caplog.text
+        assert len(result) == 1
+
+    def test_unknown_exclude_tool_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        f = AdapterFeatures(exclude_tools=["thenvoi_nonexistent"])
+        with caplog.at_level(logging.WARNING):
+            result = filter_tool_schemas(SAMPLE_TOOLS, f, get_name=_get_name)
+        assert "unknown names" in caplog.text
+        assert len(result) == 4
+
+    def test_include_and_exclude_combined(self) -> None:
+        f = AdapterFeatures(
+            include_tools=["thenvoi_send_message", "thenvoi_lookup_peers"],
+            exclude_tools=["thenvoi_lookup_peers"],
+        )
+        result = filter_tool_schemas(SAMPLE_TOOLS, f, get_name=_get_name)
+        assert len(result) == 1
+        assert result[0].name == "thenvoi_send_message"
+
+    def test_empty_schemas_returns_empty(self) -> None:
+        f = AdapterFeatures(include_tools=["thenvoi_send_message"])
+        result = filter_tool_schemas([], f, get_name=_get_name)
+        assert result == []

--- a/tests/core/test_tool_filter.py
+++ b/tests/core/test_tool_filter.py
@@ -99,3 +99,16 @@ class TestFilterToolSchemas:
         f = AdapterFeatures(include_tools=["thenvoi_send_message"])
         result = filter_tool_schemas([], f, get_name=_get_name)
         assert result == []
+
+    def test_category_then_include_precedence_yields_empty(self) -> None:
+        """Categories filter first, so include_tools on a tool outside that
+        category still produces an empty result."""
+        f = AdapterFeatures(
+            include_categories=["chat"],
+            include_tools=["thenvoi_store_memory"],
+        )
+        result = filter_tool_schemas(
+            SAMPLE_TOOLS, f, get_name=_get_name, get_category=_get_category
+        )
+        # thenvoi_store_memory is category "memory", excluded by categories step
+        assert result == []

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -1,0 +1,86 @@
+"""Tests for Capability, Emit enums and AdapterFeatures dataclass."""
+
+from __future__ import annotations
+
+import pytest
+
+from thenvoi.core.types import AdapterFeatures, Capability, Emit
+
+
+class TestCapabilityEnum:
+    def test_values(self) -> None:
+        assert Capability.MEMORY == "memory"
+        assert Capability.CONTACTS == "contacts"
+
+    def test_is_str_enum(self) -> None:
+        assert isinstance(Capability.MEMORY, str)
+
+
+class TestEmitEnum:
+    def test_values(self) -> None:
+        assert Emit.EXECUTION == "execution"
+        assert Emit.THOUGHTS == "thoughts"
+        assert Emit.TASK_EVENTS == "task_events"
+
+    def test_is_str_enum(self) -> None:
+        assert isinstance(Emit.EXECUTION, str)
+
+
+class TestAdapterFeatures:
+    def test_empty_defaults(self) -> None:
+        f = AdapterFeatures()
+        assert f.capabilities == frozenset()
+        assert f.emit == frozenset()
+        assert f.include_tools is None
+        assert f.exclude_tools is None
+        assert f.include_categories is None
+
+    def test_set_literal_normalized_to_frozenset(self) -> None:
+        f = AdapterFeatures(
+            capabilities={Capability.MEMORY},
+            emit={Emit.EXECUTION, Emit.THOUGHTS},
+        )
+        assert isinstance(f.capabilities, frozenset)
+        assert isinstance(f.emit, frozenset)
+        assert Capability.MEMORY in f.capabilities
+        assert Emit.EXECUTION in f.emit
+        assert Emit.THOUGHTS in f.emit
+
+    def test_list_normalized_to_frozenset(self) -> None:
+        f = AdapterFeatures(
+            capabilities=[Capability.MEMORY, Capability.CONTACTS],
+        )
+        assert isinstance(f.capabilities, frozenset)
+        assert len(f.capabilities) == 2
+
+    def test_include_tools_normalized_to_tuple(self) -> None:
+        f = AdapterFeatures(
+            include_tools=["thenvoi_send_message", "thenvoi_lookup_peers"]
+        )
+        assert isinstance(f.include_tools, tuple)
+        assert f.include_tools == ("thenvoi_send_message", "thenvoi_lookup_peers")
+
+    def test_exclude_tools_normalized_to_tuple(self) -> None:
+        f = AdapterFeatures(exclude_tools=["thenvoi_store_memory"])
+        assert isinstance(f.exclude_tools, tuple)
+
+    def test_include_categories_normalized_to_tuple(self) -> None:
+        f = AdapterFeatures(include_categories=["chat", "memory"])
+        assert isinstance(f.include_categories, tuple)
+        assert f.include_categories == ("chat", "memory")
+
+    def test_frozen_raises_on_assignment(self) -> None:
+        f = AdapterFeatures()
+        with pytest.raises(AttributeError):
+            f.capabilities = frozenset({Capability.MEMORY})  # type: ignore[misc]
+
+    def test_hashable(self) -> None:
+        f1 = AdapterFeatures(capabilities={Capability.MEMORY})
+        f2 = AdapterFeatures(capabilities={Capability.MEMORY})
+        assert hash(f1) == hash(f2)
+        assert f1 == f2
+
+    def test_different_features_not_equal(self) -> None:
+        f1 = AdapterFeatures(capabilities={Capability.MEMORY})
+        f2 = AdapterFeatures(capabilities={Capability.CONTACTS})
+        assert f1 != f2


### PR DESCRIPTION
## Summary
- `SimpleAdapter` gains `features: AdapterFeatures` param (defaults to empty)
- Class-level `SUPPORTED_EMIT` / `SUPPORTED_CAPABILITIES` for subclass declarations
- `on_started()` warns when features request unsupported emit/capability values
- New `core/tool_filter.py`: `filter_tool_schemas()` with include/exclude/category support

**Part 2 of 6** for INT-294 SDK Cleanup & Normalization.
**Depends on:** Step 1 (#211)

## Test plan
- [x] 16 new tests (7 SimpleAdapter features + 9 tool_filter)
- [x] 833 existing adapter/conformance tests still pass
- [x] Lint/format/pyrefly clean