### PR TITLE
feat: normalize adapter constructors with AdapterFeatures (INT-294 Step 3)

### DIFF
--- a/examples/anthropic/01_basic_agent.py
+++ b/examples/anthropic/01_basic_agent.py
@@ -49,7 +49,7 @@ async def main() -> None:
     # Create adapter with framework-specific settings
     adapter = AnthropicAdapter(
         model="claude-sonnet-4-5-20250929",
-        custom_section="You are a helpful assistant. Be concise and friendly.",
+        prompt="You are a helpful assistant. Be concise and friendly.",
     )
 
     # Create and start agent

--- a/examples/anthropic/02_custom_instructions.py
+++ b/examples/anthropic/02_custom_instructions.py
@@ -27,6 +27,7 @@ from setup_logging import setup_logging
 from thenvoi import Agent
 from thenvoi.adapters import AnthropicAdapter
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -66,9 +67,9 @@ async def main() -> None:
     # Create adapter with custom instructions and execution reporting
     adapter = AnthropicAdapter(
         model="claude-sonnet-4-5-20250929",
-        custom_section=CUSTOM_PROMPT,
+        prompt=CUSTOM_PROMPT,
         # Enable execution reporting to see tool calls in the chat
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
     )
 
     # Create and start agent

--- a/examples/anthropic/03_tom_agent.py
+++ b/examples/anthropic/03_tom_agent.py
@@ -61,7 +61,7 @@ async def main() -> None:
     # Create adapter with Tom's character prompt
     adapter = AnthropicAdapter(
         model="claude-sonnet-4-5-20250929",
-        custom_section=generate_tom_prompt("Tom"),
+        prompt=generate_tom_prompt("Tom"),
     )
 
     # Create and start agent

--- a/examples/anthropic/04_jerry_agent.py
+++ b/examples/anthropic/04_jerry_agent.py
@@ -61,7 +61,7 @@ async def main() -> None:
     # Create adapter with Jerry's character prompt
     adapter = AnthropicAdapter(
         model="claude-sonnet-4-5-20250929",
-        custom_section=generate_jerry_prompt("Jerry"),
+        prompt=generate_jerry_prompt("Jerry"),
     )
 
     # Create and start agent

--- a/examples/anthropic/05_contact_management.py
+++ b/examples/anthropic/05_contact_management.py
@@ -58,7 +58,7 @@ async def main() -> None:
 
     adapter = AnthropicAdapter(
         model="claude-sonnet-4-5-20250929",
-        custom_section=(
+        prompt=(
             "You are a helpful assistant with contact management capabilities.\n"
             "You can list, add, and remove contacts, and manage contact requests.\n"
             "Incoming contact requests are auto-approved."

--- a/examples/claude_sdk/01_basic_agent.py
+++ b/examples/claude_sdk/01_basic_agent.py
@@ -41,6 +41,7 @@ from setup_logging import setup_logging
 from thenvoi import Agent
 from thenvoi.adapters import ClaudeSDKAdapter
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -65,7 +66,7 @@ async def main() -> None:
     adapter = ClaudeSDKAdapter(
         model="claude-sonnet-4-5-20250929",
         custom_section="You are a helpful assistant. Be concise and friendly.",
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
     )
 
     # Create and start agent

--- a/examples/claude_sdk/01_basic_agent.py
+++ b/examples/claude_sdk/01_basic_agent.py
@@ -66,7 +66,7 @@ async def main() -> None:
     adapter = ClaudeSDKAdapter(
         model="claude-sonnet-4-5-20250929",
         custom_section="You are a helpful assistant. Be concise and friendly.",
-        features=AdapterFeatures(emit={Emit.EXECUTION}),
+        features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
     )
 
     # Create and start agent

--- a/examples/claude_sdk/02_extended_thinking.py
+++ b/examples/claude_sdk/02_extended_thinking.py
@@ -47,6 +47,7 @@ from setup_logging import setup_logging
 from thenvoi import Agent
 from thenvoi.adapters import ClaudeSDKAdapter
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -77,7 +78,7 @@ complex problem-solving. When faced with challenging questions:
 3. Evaluate trade-offs
 4. Provide clear, well-reasoned answers""",
         max_thinking_tokens=10000,  # Enable extended thinking
-        enable_execution_reporting=True,  # Report thinking as events
+        features=AdapterFeatures(emit={Emit.EXECUTION}),  # Report thinking as events
     )
 
     # Create and start agent

--- a/examples/claude_sdk/02_extended_thinking.py
+++ b/examples/claude_sdk/02_extended_thinking.py
@@ -78,7 +78,9 @@ complex problem-solving. When faced with challenging questions:
 3. Evaluate trade-offs
 4. Provide clear, well-reasoned answers""",
         max_thinking_tokens=10000,  # Enable extended thinking
-        features=AdapterFeatures(emit={Emit.EXECUTION}),  # Report thinking as events
+        features=AdapterFeatures(
+            emit={Emit.EXECUTION, Emit.THOUGHTS}
+        ),  # Report execution and thinking as events
     )
 
     # Create and start agent

--- a/examples/claude_sdk/03_tom_agent.py
+++ b/examples/claude_sdk/03_tom_agent.py
@@ -65,7 +65,7 @@ async def main() -> None:
     adapter = ClaudeSDKAdapter(
         model="claude-sonnet-4-5-20250929",
         custom_section=generate_tom_prompt("Tom"),
-        features=AdapterFeatures(emit={Emit.EXECUTION}),
+        features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
     )
 
     # Create and start agent

--- a/examples/claude_sdk/03_tom_agent.py
+++ b/examples/claude_sdk/03_tom_agent.py
@@ -40,6 +40,7 @@ from setup_logging import setup_logging
 from thenvoi import Agent
 from thenvoi.adapters import ClaudeSDKAdapter
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -64,7 +65,7 @@ async def main() -> None:
     adapter = ClaudeSDKAdapter(
         model="claude-sonnet-4-5-20250929",
         custom_section=generate_tom_prompt("Tom"),
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
     )
 
     # Create and start agent

--- a/examples/claude_sdk/04_jerry_agent.py
+++ b/examples/claude_sdk/04_jerry_agent.py
@@ -40,6 +40,7 @@ from setup_logging import setup_logging
 from thenvoi import Agent
 from thenvoi.adapters import ClaudeSDKAdapter
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -64,7 +65,7 @@ async def main() -> None:
     adapter = ClaudeSDKAdapter(
         model="claude-sonnet-4-5-20250929",
         custom_section=generate_jerry_prompt("Jerry"),
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
     )
 
     # Create and start agent

--- a/examples/claude_sdk/04_jerry_agent.py
+++ b/examples/claude_sdk/04_jerry_agent.py
@@ -65,7 +65,7 @@ async def main() -> None:
     adapter = ClaudeSDKAdapter(
         model="claude-sonnet-4-5-20250929",
         custom_section=generate_jerry_prompt("Jerry"),
-        features=AdapterFeatures(emit={Emit.EXECUTION}),
+        features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
     )
 
     # Create and start agent

--- a/examples/claude_sdk_docker/runner.py
+++ b/examples/claude_sdk_docker/runner.py
@@ -240,7 +240,7 @@ async def main() -> None:
         model=model,
         custom_section=final_prompt,
         max_thinking_tokens=thinking_tokens,
-        features=AdapterFeatures(emit={Emit.EXECUTION}),
+        features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
         additional_tools=custom_tools if custom_tools else None,
         cwd=workspace,
     )

--- a/examples/claude_sdk_docker/runner.py
+++ b/examples/claude_sdk_docker/runner.py
@@ -29,6 +29,7 @@ from typing import Any
 import yaml
 
 from thenvoi.config.loader import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 # Global flag for graceful shutdown
 _shutdown_event: asyncio.Event | None = None
@@ -239,7 +240,7 @@ async def main() -> None:
         model=model,
         custom_section=final_prompt,
         max_thinking_tokens=thinking_tokens,
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
         additional_tools=custom_tools if custom_tools else None,
         cwd=workspace,
     )

--- a/examples/crewai/02_role_based_agent.py
+++ b/examples/crewai/02_role_based_agent.py
@@ -27,6 +27,7 @@ from setup_logging import setup_logging
 from thenvoi import Agent
 from thenvoi.adapters import CrewAIAdapter
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ async def main() -> None:
         analyzing data, and presenting findings in a clear, actionable format.
         You're known for your attention to detail and ability to connect disparate
         pieces of information into meaningful insights.""",
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
         verbose=True,
     )
 

--- a/examples/crewai/03_coordinator_agent.py
+++ b/examples/crewai/03_coordinator_agent.py
@@ -30,6 +30,7 @@ from setup_logging import setup_logging
 from thenvoi import Agent
 from thenvoi.adapters import CrewAIAdapter
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -76,7 +77,7 @@ When coordinating:
 6. Synthesize outputs from multiple agents
 7. Clean up by removing agents no longer needed
 """,
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
         verbose=True,
     )
 

--- a/examples/crewai/04_research_crew.py
+++ b/examples/crewai/04_research_crew.py
@@ -45,6 +45,7 @@ from setup_logging import setup_logging
 from thenvoi import Agent
 from thenvoi.adapters import CrewAIAdapter
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -163,7 +164,7 @@ async def main() -> None:
         goal=member["goal"],
         backstory=member["backstory"],
         custom_section=member["custom_section"],
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
     )
 
     # Create and start agent

--- a/examples/crewai/07_contact_and_memory_agent.py
+++ b/examples/crewai/07_contact_and_memory_agent.py
@@ -36,6 +36,7 @@ from thenvoi import Agent
 from thenvoi.adapters import CrewAIAdapter
 from thenvoi.config import load_agent_config
 from thenvoi.runtime.types import ContactEventConfig, ContactEventStrategy
+from thenvoi.core.types import AdapterFeatures, Capability
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -76,7 +77,7 @@ async def main() -> None:
             "When a system message reports that a contact was added or removed, "
             "treat it as fresh room context."
         ),
-        enable_memory_tools=True,
+        features=AdapterFeatures(capabilities={Capability.MEMORY}),
     )
 
     contact_config = ContactEventConfig(

--- a/examples/gemini/01_basic_agent.py
+++ b/examples/gemini/01_basic_agent.py
@@ -43,10 +43,10 @@ async def main() -> None:
     agent_id, api_key = load_agent_config("gemini_agent")
 
     # Create adapter with Gemini settings
-    # Requires GEMINI_API_KEY environment variable or pass gemini_api_key explicitly
+    # Requires GEMINI_API_KEY environment variable or pass api_key explicitly
     adapter = GeminiAdapter(
         model="gemini-2.5-flash",
-        custom_section="You are a helpful assistant. Be concise and friendly.",
+        prompt="You are a helpful assistant. Be concise and friendly.",
     )
 
     # Create and start agent

--- a/examples/google_adk/02_custom_instructions.py
+++ b/examples/google_adk/02_custom_instructions.py
@@ -33,6 +33,7 @@ from setup_logging import setup_logging
 from thenvoi import Agent
 from thenvoi.adapters import GoogleADKAdapter
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -58,7 +59,7 @@ async def main() -> None:
             "You are a research assistant specializing in summarizing information. "
             "Always provide sources when possible and be thorough but concise."
         ),
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
     )
 
     agent = Agent.create(

--- a/examples/google_adk/03_custom_tools.py
+++ b/examples/google_adk/03_custom_tools.py
@@ -36,6 +36,7 @@ from setup_logging import setup_logging
 from thenvoi import Agent
 from thenvoi.adapters import GoogleADKAdapter
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -106,7 +107,7 @@ async def main() -> None:
             "You are a helpful assistant with access to a calculator and "
             "weather tool in addition to the platform tools."
         ),
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
     )
 
     agent = Agent.create(

--- a/examples/mixed/01_strategy_coordinator.py
+++ b/examples/mixed/01_strategy_coordinator.py
@@ -30,6 +30,7 @@ from setup_logging import setup_logging
 from thenvoi import Agent
 from thenvoi.adapters import CrewAIAdapter
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 logger = logging.getLogger(__name__)
 CONFIG_PATH = Path(__file__).with_name("agents.yaml")
@@ -82,7 +83,7 @@ When a user posts a request:
 
 Keep messages short, explicit, and coordination-focused.
 """,
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
         verbose=True,
     )
 

--- a/examples/mixed/02_draft_writer.py
+++ b/examples/mixed/02_draft_writer.py
@@ -29,6 +29,7 @@ from setup_logging import setup_logging
 from thenvoi import Agent
 from thenvoi.adapters import CrewAIAdapter
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 logger = logging.getLogger(__name__)
 CONFIG_PATH = Path(__file__).with_name("agents.yaml")
@@ -72,7 +73,7 @@ When the room is active:
 
 Do not try to coordinate the room. Your job is to synthesize.
 """,
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
         verbose=True,
     )
 

--- a/examples/opencode/01_basic_agent.py
+++ b/examples/opencode/01_basic_agent.py
@@ -34,6 +34,7 @@ from setup_logging import setup_logging  # pyrefly: ignore[missing-import]
 from thenvoi import Agent
 from thenvoi.adapters.opencode import OpencodeAdapter, OpencodeAdapterConfig
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -60,7 +61,7 @@ async def main() -> None:
             agent=os.getenv("OPENCODE_AGENT") or None,
             custom_section="You are a helpful assistant. Keep replies concise.",
             approval_mode=os.getenv("OPENCODE_APPROVAL_MODE", "manual"),  # type: ignore[arg-type]  # env var is str; invalid values fall through to manual mode
-            enable_execution_reporting=True,
+            features=AdapterFeatures(emit={Emit.EXECUTION}),
         )
     )
 

--- a/examples/run_agent.py
+++ b/examples/run_agent.py
@@ -68,6 +68,7 @@ from dotenv import load_dotenv
 
 from thenvoi import Agent
 from thenvoi.config import load_agent_config
+from thenvoi.core.types import AdapterFeatures, Emit
 from thenvoi.platform.event import ContactRequestReceivedEvent, ContactEvent
 from thenvoi.runtime.contact_tools import ContactTools
 from thenvoi.runtime.types import ContactEventConfig, ContactEventStrategy
@@ -280,7 +281,7 @@ async def run_pydantic_ai_agent(
     adapter = PydanticAIAdapter(
         model=model,
         custom_section=section,
-        enable_execution_reporting=enable_streaming,
+        features=AdapterFeatures(emit={Emit.EXECUTION}) if enable_streaming else None,
     )
 
     agent = Agent.create(
@@ -323,8 +324,8 @@ async def run_anthropic_agent(
 
     adapter = AnthropicAdapter(
         model=model,
-        custom_section=custom_section,
-        enable_execution_reporting=enable_streaming,
+        prompt=custom_section,
+        features=AdapterFeatures(emit={Emit.EXECUTION}) if enable_streaming else None,
     )
 
     agent = Agent.create(
@@ -368,7 +369,7 @@ async def run_claude_sdk_agent(
         model=model,
         custom_section=custom_section,
         max_thinking_tokens=10000 if enable_thinking else None,
-        enable_execution_reporting=enable_streaming,
+        features=AdapterFeatures(emit={Emit.EXECUTION}) if enable_streaming else None,
     )
 
     agent = Agent.create(
@@ -409,7 +410,7 @@ async def run_parlant_agent(
         model=model,
         custom_section=custom_section,
         guidelines=PARLANT_GUIDELINES,
-        enable_execution_reporting=enable_streaming,
+        features=AdapterFeatures(emit={Emit.EXECUTION}) if enable_streaming else None,
     )
 
     agent = Agent.create(
@@ -443,7 +444,7 @@ async def run_crewai_agent(
         goal=CREWAI_DEFAULTS["goal"],
         backstory=CREWAI_DEFAULTS["backstory"],
         custom_section=custom_section,
-        enable_execution_reporting=enable_streaming,
+        features=AdapterFeatures(emit={Emit.EXECUTION}) if enable_streaming else None,
     )
 
     agent = Agent.create(
@@ -541,7 +542,7 @@ async def run_pydantic_ai_contacts_agent(
     adapter = PydanticAIAdapter(
         model=model,
         custom_section=CONTACTS_INSTRUCTIONS,
-        enable_execution_reporting=True,  # Show tool calls
+        features=AdapterFeatures(emit={Emit.EXECUTION}),  # Show tool calls
     )
 
     agent = Agent.create(
@@ -596,7 +597,7 @@ async def run_contacts_auto_agent(
         model=model,
         custom_section="""You are a helpful assistant. Contact requests are handled automatically.
 When you see system messages about new contacts, acknowledge them to the user.""",
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
     )
 
     agent = Agent.create(
@@ -655,7 +656,7 @@ Actions available:
 - thenvoi_respond_contact_request(action="approve", handle="...")
 - thenvoi_respond_contact_request(action="reject", handle="...")
 """,
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
     )
 
     agent = Agent.create(
@@ -705,7 +706,7 @@ You will receive system messages when contacts are added or removed.
 These appear as "[Contacts]: @handle (name) is now a contact" or similar.
 Acknowledge these updates to the user when you see them.
 """,
-        enable_execution_reporting=True,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
     )
 
     agent = Agent.create(

--- a/src/thenvoi/adapters/anthropic.py
+++ b/src/thenvoi/adapters/anthropic.py
@@ -56,7 +56,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
     """
 
     SUPPORTED_EMIT = frozenset({Emit.EXECUTION})
-    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY})
+    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY, Capability.CONTACTS})
 
     def __init__(
         self,

--- a/src/thenvoi/adapters/anthropic.py
+++ b/src/thenvoi/adapters/anthropic.py
@@ -8,14 +8,21 @@ from __future__ import annotations
 
 import json
 import logging
+import warnings
 from typing import Any, cast
 
 from anthropic import AsyncAnthropic
 from anthropic.types import Message, MessageParam, ToolParam, ToolUseBlock
 
+from thenvoi.core.exceptions import ThenvoiConfigError
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+)
 from thenvoi.converters.anthropic import AnthropicHistoryConverter, AnthropicMessages
 from thenvoi.runtime.custom_tools import (
     CustomToolDef,
@@ -38,37 +45,94 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
     Example:
         adapter = AnthropicAdapter(
             model="claude-sonnet-4-5-20250929",
-            custom_section="You are a helpful assistant.",
+            prompt="You are a helpful assistant.",
+            features=AdapterFeatures(
+                capabilities={Capability.MEMORY},
+                emit={Emit.EXECUTION},
+            ),
         )
         agent = Agent.create(adapter=adapter, agent_id="...", api_key="...")
         await agent.run()
     """
 
+    SUPPORTED_EMIT = frozenset({Emit.EXECUTION})
+    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY})
+
     def __init__(
         self,
         model: str = "claude-sonnet-4-5-20250929",
-        anthropic_api_key: str | None = None,
+        api_key: str | None = None,
         system_prompt: str | None = None,
-        custom_section: str | None = None,
+        prompt: str | None = None,
         max_tokens: int = 4096,
-        enable_execution_reporting: bool = False,
-        enable_memory_tools: bool = False,
         history_converter: AnthropicHistoryConverter | None = None,
         additional_tools: list[CustomToolDef] | None = None,
+        features: AdapterFeatures | None = None,
+        include_base_instructions: bool = True,
+        # --- Deprecated (one release, then remove) ---
+        anthropic_api_key: str | None = None,
+        custom_section: str | None = None,
+        enable_execution_reporting: bool = False,
+        enable_memory_tools: bool = False,
     ):
+        # --- Selective: api_key rename ---
+        if anthropic_api_key is not None:
+            warnings.warn(
+                "anthropic_api_key is deprecated, use api_key instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if api_key is not None:
+                raise ThenvoiConfigError(
+                    "Cannot pass both api_key and anthropic_api_key"
+                )
+            api_key = anthropic_api_key
+
+        # --- Selective: prompt rename ---
+        if custom_section is not None:
+            warnings.warn(
+                "custom_section is deprecated, use prompt instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if prompt is not None:
+                raise ThenvoiConfigError("Cannot pass both prompt and custom_section")
+            prompt = custom_section
+
+        # --- Universal: boolean → AdapterFeatures migration ---
+        if enable_memory_tools or enable_execution_reporting:
+            if features is not None:
+                raise ThenvoiConfigError(
+                    "Cannot pass both features= and legacy boolean params "
+                    "(enable_memory_tools, enable_execution_reporting)"
+                )
+            warnings.warn(
+                "enable_memory_tools/enable_execution_reporting are deprecated, "
+                "use features=AdapterFeatures(...) instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            caps: frozenset[Capability] = frozenset()
+            emit: frozenset[Emit] = frozenset()
+            if enable_memory_tools:
+                caps = caps | frozenset({Capability.MEMORY})
+            if enable_execution_reporting:
+                emit = emit | frozenset({Emit.EXECUTION})
+            features = AdapterFeatures(capabilities=caps, emit=emit)
+
         super().__init__(
-            history_converter=history_converter or AnthropicHistoryConverter()
+            history_converter=history_converter or AnthropicHistoryConverter(),
+            features=features,
         )
 
         self.model = model
         self.system_prompt = system_prompt
-        self.custom_section = custom_section
+        self._prompt = prompt
+        self._include_base_instructions = include_base_instructions
         self.max_tokens = max_tokens
-        self.enable_execution_reporting = enable_execution_reporting
-        self.enable_memory_tools = enable_memory_tools
 
         # Anthropic client (uses ANTHROPIC_API_KEY env var if not provided)
-        self.client = AsyncAnthropic(api_key=anthropic_api_key)
+        self.client = AsyncAnthropic(api_key=api_key)
 
         # Per-room conversation history (Anthropic SDK is stateless)
         self._message_history: dict[str, list[dict[str, Any]]] = {}
@@ -84,7 +148,8 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
         self._system_prompt = self.system_prompt or render_system_prompt(
             agent_name=agent_name,
             agent_description=agent_description,
-            custom_section=self.custom_section or "",
+            custom_section=self._prompt or "",
+            include_base_instructions=self._include_base_instructions,
         )
         logger.info("Anthropic adapter started for agent: %s", agent_name)
 
@@ -168,9 +233,8 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
         )
 
         # Get tool schemas in Anthropic format (typed helper)
-        tool_schemas = tools.get_anthropic_tool_schemas(
-            include_memory=self.enable_memory_tools
-        )
+        include_memory = Capability.MEMORY in self.features.capabilities
+        tool_schemas = tools.get_anthropic_tool_schemas(include_memory=include_memory)
         # Merge custom tool schemas
         if self._custom_tools:
             tool_schemas = list(tool_schemas)  # Make mutable copy
@@ -329,7 +393,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
 
             # Report tool call if enabled (JSON format with tool_call_id for linking)
             # Best-effort: event reporting must never crash tool execution
-            if self.enable_execution_reporting:
+            if Emit.EXECUTION in self.features.emit:
                 try:
                     await tools.send_event(
                         content=json.dumps(
@@ -367,7 +431,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
 
             # Report tool result if enabled (JSON format with tool_call_id for linking)
             # Best-effort: event reporting must never crash tool execution
-            if self.enable_execution_reporting:
+            if Emit.EXECUTION in self.features.emit:
                 try:
                     await tools.send_event(
                         content=json.dumps(

--- a/src/thenvoi/adapters/anthropic.py
+++ b/src/thenvoi/adapters/anthropic.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import warnings
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 from anthropic import AsyncAnthropic
 from anthropic.types import Message, MessageParam, ToolParam, ToolUseBlock
@@ -55,8 +55,10 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
         await agent.run()
     """
 
-    SUPPORTED_EMIT = frozenset({Emit.EXECUTION})
-    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY, Capability.CONTACTS})
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY, Capability.CONTACTS}
+    )
 
     def __init__(
         self,

--- a/src/thenvoi/adapters/claude_sdk.py
+++ b/src/thenvoi/adapters/claude_sdk.py
@@ -18,7 +18,7 @@ import warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 try:
     from claude_agent_sdk import (
@@ -165,8 +165,12 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
 
     PermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions"]
 
-    SUPPORTED_EMIT = frozenset({Emit.EXECUTION, Emit.THOUGHTS})
-    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY, Capability.CONTACTS})
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset(
+        {Emit.EXECUTION, Emit.THOUGHTS}
+    )
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY, Capability.CONTACTS}
+    )
 
     def __init__(
         self,

--- a/src/thenvoi/adapters/claude_sdk.py
+++ b/src/thenvoi/adapters/claude_sdk.py
@@ -166,7 +166,7 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
     PermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions"]
 
     SUPPORTED_EMIT = frozenset({Emit.EXECUTION, Emit.THOUGHTS})
-    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY})
+    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY, Capability.CONTACTS})
 
     def __init__(
         self,

--- a/src/thenvoi/adapters/claude_sdk.py
+++ b/src/thenvoi/adapters/claude_sdk.py
@@ -49,9 +49,10 @@ except ImportError as e:
         "Or: uv add claude-agent-sdk"
     ) from e
 
+from thenvoi.core.exceptions import ThenvoiConfigError
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from thenvoi.converters.claude_sdk import (
     ClaudeSDKHistoryConverter,
     ClaudeSDKSessionState,
@@ -164,6 +165,9 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
 
     PermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions"]
 
+    SUPPORTED_EMIT = frozenset({Emit.EXECUTION, Emit.THOUGHTS})
+    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY})
+
     def __init__(
         self,
         model: str = "claude-sonnet-4-5-20250929",
@@ -182,6 +186,7 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         approval_timeout_decision: ApprovalDecision = "decline",
         max_pending_approvals_per_room: int = 50,
         approval_authorized_senders: set[str] | None = None,
+        features: AdapterFeatures | None = None,
     ):
         """
         Initialize the Claude SDK adapter.
@@ -191,16 +196,19 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
             custom_section: Custom instructions added to system prompt
             max_thinking_tokens: Max tokens for extended thinking (optional)
             permission_mode: SDK permission mode
-            enable_execution_reporting: If True, emit tool_call/tool_result events
-            enable_memory_tools: If True, includes memory management tools (enterprise only).
-                Defaults to False.
+            enable_execution_reporting: Deprecated. Use
+                ``features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS})``.
+                If True, emit tool_call/tool_result *and* thought events.
+            enable_memory_tools: Deprecated. Use
+                ``features=AdapterFeatures(capabilities={Capability.MEMORY})``.
+                If True, includes memory management tools (enterprise only).
             history_converter: Optional custom history converter
             additional_tools: Optional list of custom tools as (PydanticModel, callable)
                 tuples. These are converted to MCP tools internally.
             cwd: Working directory for Claude Code sessions. If set, Claude Code
                 will operate in this directory (e.g., a mounted git repo).
             approval_mode: Chat-based approval mode.  ``None`` (default) disables
-                chat-based approval — the SDK's ``permission_mode`` controls
+                chat-based approval -- the SDK's ``permission_mode`` controls
                 approvals entirely.  Set to ``"manual"`` to route approval
                 requests to the chat room (``/approve``, ``/decline``),
                 ``"auto_accept"`` to approve everything, or ``"auto_decline"``
@@ -217,17 +225,57 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                 issue ``/approve`` and ``/decline`` commands.  When ``None``
                 (default), any room participant can approve.  ``/approvals``
                 and ``/status`` are always available to all participants.
+            features: Unified adapter feature settings. When provided alongside
+                deprecated ``enable_execution_reporting`` or ``enable_memory_tools``,
+                raises ``ThenvoiConfigError``.
         """
+        # --- Shim deprecated params into features -------------------------
+        _has_legacy = enable_execution_reporting or enable_memory_tools
+        if _has_legacy and features is not None:
+            raise ThenvoiConfigError(
+                "Cannot combine 'features' with deprecated "
+                "'enable_execution_reporting' / 'enable_memory_tools'. "
+                "Use AdapterFeatures exclusively."
+            )
+
+        if _has_legacy:
+            _emit: set[Emit] = set()
+            _caps: set[Capability] = set()
+
+            if enable_execution_reporting:
+                warnings.warn(
+                    "enable_execution_reporting is deprecated. "
+                    "Use features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}).",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                # ClaudeSDK historically emitted both execution AND thought
+                # events under this single flag.
+                _emit.update({Emit.EXECUTION, Emit.THOUGHTS})
+
+            if enable_memory_tools:
+                warnings.warn(
+                    "enable_memory_tools is deprecated. "
+                    "Use features=AdapterFeatures(capabilities={Capability.MEMORY}).",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                _caps.add(Capability.MEMORY)
+
+            features = AdapterFeatures(
+                capabilities=frozenset(_caps),
+                emit=frozenset(_emit),
+            )
+
         super().__init__(
-            history_converter=history_converter or ClaudeSDKHistoryConverter()
+            history_converter=history_converter or ClaudeSDKHistoryConverter(),
+            features=features,
         )
 
         self.model = model
         self.custom_section = custom_section
         self.max_thinking_tokens = max_thinking_tokens
         self.permission_mode: ClaudeSDKAdapter.PermissionMode = permission_mode
-        self.enable_execution_reporting = enable_execution_reporting
-        self.enable_memory_tools = enable_memory_tools
         if cwd and not Path(cwd).is_dir():
             raise ValueError(f"cwd does not exist or is not a directory: {cwd}")
         self.cwd = cwd
@@ -328,9 +376,8 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
 
     async def _create_mcp_backend(self) -> ThenvoiMCPBackend:
         """Create shared MCP backend that uses stored room tools."""
-        tool_definitions = list(
-            iter_tool_definitions(include_memory=self.enable_memory_tools)
-        )
+        include_memory = Capability.MEMORY in self.features.capabilities
+        tool_definitions = list(iter_tool_definitions(include_memory=include_memory))
         backend = await create_thenvoi_mcp_backend(
             kind="sdk",
             tool_definitions=tool_definitions,
@@ -534,7 +581,7 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                                 block.thinking[:100],
                             )
                             # Report thinking as event if enabled
-                            if self.enable_execution_reporting:
+                            if Emit.THOUGHTS in self.features.emit:
                                 try:
                                     await tools.send_event(
                                         content=block.thinking,
@@ -552,7 +599,7 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                             block.name,
                             str(block.input)[:100],
                         )
-                        if self.enable_execution_reporting:
+                        if Emit.EXECUTION in self.features.emit:
                             try:
                                 await tools.send_event(
                                     content=json.dumps(
@@ -574,7 +621,7 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                             block.tool_use_id[:20],
                             block.is_error,
                         )
-                        if self.enable_execution_reporting:
+                        if Emit.EXECUTION in self.features.emit:
                             try:
                                 await tools.send_event(
                                     content=json.dumps(

--- a/src/thenvoi/adapters/codex.py
+++ b/src/thenvoi/adapters/codex.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import time as _time
+import warnings
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -14,6 +15,7 @@ from typing import ClassVar, Any, Callable, Literal, Protocol
 from pydantic import BaseModel, Field, ValidationError
 
 from thenvoi.converters.codex import CodexHistoryConverter
+from thenvoi.core.exceptions import ThenvoiConfigError
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
 from thenvoi.core.types import (
@@ -203,8 +205,31 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
     ) -> None:
         self._config = config or CodexAdapterConfig()
 
+        # --- Deprecation shim: boolean → features migration ---
+        # Only trigger for non-default booleans (enable_task_events defaults
+        # to True, so it doesn't count as "legacy usage").
+        _has_legacy_booleans = (
+            self._config.enable_execution_reporting or self._config.emit_thought_events
+        )
+        if _has_legacy_booleans and features is not None:
+            raise ThenvoiConfigError(
+                "Cannot pass both legacy boolean flags in CodexAdapterConfig "
+                "(enable_execution_reporting / emit_thought_events) "
+                "and 'features'. "
+                "Use features=AdapterFeatures(...) instead."
+            )
+
         # Build features from config booleans when not explicitly provided.
         if features is None:
+            if _has_legacy_booleans:
+                warnings.warn(
+                    "enable_execution_reporting and emit_thought_events in "
+                    "CodexAdapterConfig are deprecated. "
+                    "Use features=AdapterFeatures(emit={Emit.EXECUTION, "
+                    "Emit.THOUGHTS}) instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             emit: frozenset[Emit] = frozenset()
             if self._config.enable_execution_reporting:
                 emit = emit | frozenset({Emit.EXECUTION})

--- a/src/thenvoi/adapters/codex.py
+++ b/src/thenvoi/adapters/codex.py
@@ -191,7 +191,9 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset(
         {Emit.EXECUTION, Emit.THOUGHTS, Emit.TASK_EVENTS}
     )
-    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset()
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY, Capability.CONTACTS}
+    )
 
     def __init__(
         self,

--- a/src/thenvoi/adapters/codex.py
+++ b/src/thenvoi/adapters/codex.py
@@ -9,14 +9,20 @@ import time as _time
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Callable, Literal, Protocol
+from typing import ClassVar, Any, Callable, Literal, Protocol
 
 from pydantic import BaseModel, Field, ValidationError
 
 from thenvoi.converters.codex import CodexHistoryConverter
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import AgentInput, PlatformMessage
+from thenvoi.core.types import (
+    AdapterFeatures,
+    AgentInput,
+    Capability,
+    Emit,
+    PlatformMessage,
+)
 from thenvoi.integrations.codex import (
     CodexJsonRpcError,
     CodexStdioClient,
@@ -180,6 +186,11 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
     events metadata and restored via CodexHistoryConverter on bootstrap.
     """
 
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset(
+        {Emit.EXECUTION, Emit.THOUGHTS, Emit.TASK_EVENTS}
+    )
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset()
+
     def __init__(
         self,
         config: CodexAdapterConfig | None = None,
@@ -188,9 +199,26 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         history_converter: CodexHistoryConverter | None = None,
         client_factory: Callable[[CodexAdapterConfig], _CodexClientProtocol]
         | None = None,
+        features: AdapterFeatures | None = None,
     ) -> None:
-        super().__init__(history_converter=history_converter or CodexHistoryConverter())
-        self.config = config or CodexAdapterConfig()
+        self._config = config or CodexAdapterConfig()
+
+        # Build features from config booleans when not explicitly provided.
+        if features is None:
+            emit: frozenset[Emit] = frozenset()
+            if self._config.enable_execution_reporting:
+                emit = emit | frozenset({Emit.EXECUTION})
+            if self._config.emit_thought_events:
+                emit = emit | frozenset({Emit.THOUGHTS})
+            if self._config.enable_task_events:
+                emit = emit | frozenset({Emit.TASK_EVENTS})
+            features = AdapterFeatures(capabilities=frozenset(), emit=emit)
+
+        super().__init__(
+            history_converter=history_converter or CodexHistoryConverter(),
+            features=features,
+        )
+        self.config = self._config
         self._custom_tools: list[CustomToolDef] = list(additional_tools or [])
         if self.config.enable_self_config_tools:
             self._custom_tools.extend(self._build_self_config_tools())
@@ -362,7 +390,10 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             turn = turn_started.get("turn") if isinstance(turn_started, dict) else {}
             turn_id = str((turn or {}).get("id") or "")
 
-            if self.config.enable_task_events and self.config.emit_turn_task_markers:
+            if (
+                Emit.TASK_EVENTS in self.features.emit
+                and self.config.emit_turn_task_markers
+            ):
                 await tools.send_event(
                     content=self._build_task_event_content(
                         task_id=turn_id or None,
@@ -629,7 +660,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 if thread_id:
                     self._room_threads[room_id] = thread_id
                     self._raw_history_by_room.pop(room_id, None)
-                    if self.config.enable_task_events:
+                    if Emit.TASK_EVENTS in self.features.emit:
                         await tools.send_event(
                             content=self._build_task_event_content(
                                 task_id=thread_id,
@@ -676,7 +707,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
 
         self._room_threads[room_id] = thread_id
 
-        if self.config.enable_task_events:
+        if Emit.TASK_EVENTS in self.features.emit:
             await tools.send_event(
                 content=self._build_task_event_content(
                     task_id=thread_id,
@@ -850,7 +881,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             # Don't emit reporting for platform tools that already produce
             # visible output (messages/events) — reporting them is redundant.
             should_report = (
-                self.config.enable_execution_reporting
+                Emit.EXECUTION in self.features.emit
                 and tool_name not in _SILENT_REPORTING_TOOLS
             )
 
@@ -989,7 +1020,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 except Exception:
                     logger.exception("Failed to send approval policy notification")
 
-            if self.config.emit_thought_events:
+            if Emit.THOUGHTS in self.features.emit:
                 try:
                     await tools.send_event(
                         content=f"Codex approval request handled automatically ({decision}).",
@@ -1020,7 +1051,10 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         final_text: str,
         saw_send_message_tool: bool,
     ) -> None:
-        if self.config.enable_task_events and self.config.emit_turn_task_markers:
+        if (
+            Emit.TASK_EVENTS in self.features.emit
+            and self.config.emit_turn_task_markers
+        ):
             summary = f"Thread: {thread_id}"
             if turn_error:
                 summary += f" | Error: {turn_error}"
@@ -1123,7 +1157,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             "imageView",
             "collabAgentToolCall",
         }:
-            if not self.config.enable_execution_reporting:
+            if Emit.EXECUTION not in self.features.emit:
                 return
             name, args, output = self._extract_tool_item(item_type, item)
             await tools.send_event(
@@ -1150,7 +1184,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             "enteredReviewMode",
             "exitedReviewMode",
         }:
-            if not self.config.emit_thought_events:
+            if Emit.THOUGHTS not in self.features.emit:
                 return
             text = self._extract_thought_text(item_type, item)
             await tools.send_event(
@@ -1336,7 +1370,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         method: str,
         params: dict[str, Any],
     ) -> None:
-        if not self.config.enable_task_events:
+        if Emit.TASK_EVENTS not in self.features.emit:
             return
 
         is_started = method == "codex/event/task_started"

--- a/src/thenvoi/adapters/crewai.py
+++ b/src/thenvoi/adapters/crewai.py
@@ -175,7 +175,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY}
+        {Capability.MEMORY, Capability.CONTACTS}
     )
 
     def __init__(
@@ -245,6 +245,10 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
                 DeprecationWarning,
                 stacklevel=2,
             )
+            # NOTE: unlike ClaudeSDK, CrewAI's legacy enable_execution_reporting
+            # maps to {Emit.EXECUTION} only (no THOUGHTS). CrewAI had no native
+            # thought emission under this flag, so migrating to THOUGHTS would
+            # turn on a new behavior, not preserve existing behavior.
             features = AdapterFeatures(
                 emit=frozenset({Emit.EXECUTION})
                 if enable_execution_reporting

--- a/src/thenvoi/adapters/crewai.py
+++ b/src/thenvoi/adapters/crewai.py
@@ -15,7 +15,7 @@ import logging
 import threading
 import warnings
 from contextvars import ContextVar
-from typing import Any, Coroutine, Literal, Type, TypeVar
+from typing import ClassVar, Any, Coroutine, Literal, Type, TypeVar
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -31,9 +31,10 @@ except ImportError as e:
         "Or: uv add crewai nest-asyncio"
     ) from e
 
+from thenvoi.core.exceptions import ThenvoiConfigError
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from thenvoi.converters.crewai import CrewAIHistoryConverter, CrewAIMessages
 from thenvoi.runtime.custom_tools import CustomToolDef, get_custom_tool_name
 from thenvoi.runtime.tools import get_tool_description
@@ -172,6 +173,11 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         the CrewAI LLM class (e.g., OPENAI_API_KEY, ANTHROPIC_API_KEY).
     """
 
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY}
+    )
+
     def __init__(
         self,
         model: str = "gpt-4o",
@@ -188,6 +194,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         history_converter: CrewAIHistoryConverter | None = None,
         additional_tools: list[CustomToolDef] | None = None,
         system_prompt: str | None = None,  # Deprecated
+        features: AdapterFeatures | None = None,
     ):
         """Initialize the CrewAI adapter.
 
@@ -221,8 +228,35 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             if backstory is None:
                 backstory = system_prompt
 
+        # --- Deprecation shim: boolean → features migration ---
+        _has_legacy_booleans = enable_execution_reporting or enable_memory_tools
+        if _has_legacy_booleans and features is not None:
+            raise ThenvoiConfigError(
+                "Cannot pass both legacy boolean flags "
+                "(enable_execution_reporting / enable_memory_tools) and 'features'. "
+                "Use features=AdapterFeatures(...) instead."
+            )
+
+        if _has_legacy_booleans:
+            warnings.warn(
+                "enable_execution_reporting and enable_memory_tools are deprecated. "
+                "Use features=AdapterFeatures(emit={Emit.EXECUTION}, "
+                "capabilities={Capability.MEMORY}) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            features = AdapterFeatures(
+                emit=frozenset({Emit.EXECUTION})
+                if enable_execution_reporting
+                else frozenset(),
+                capabilities=frozenset({Capability.MEMORY})
+                if enable_memory_tools
+                else frozenset(),
+            )
+
         super().__init__(
-            history_converter=history_converter or CrewAIHistoryConverter()
+            history_converter=history_converter or CrewAIHistoryConverter(),
+            features=features,
         )
 
         self.model = model
@@ -230,8 +264,6 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         self.goal = goal
         self.backstory = backstory
         self.custom_section = custom_section
-        self.enable_execution_reporting = enable_execution_reporting
-        self.enable_memory_tools = enable_memory_tools
         self.verbose = verbose
         self.max_iter = max_iter
         self.max_rpm = max_rpm
@@ -343,7 +375,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
 
         Best-effort: event reporting must never crash tool execution.
         """
-        if self.enable_execution_reporting:
+        if Emit.EXECUTION in self.features.emit:
             try:
                 await tools.send_event(
                     content=json.dumps({"tool": tool_name, "input": input_data}),
@@ -366,7 +398,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
 
         Best-effort: event reporting must never crash tool execution.
         """
-        if self.enable_execution_reporting:
+        if Emit.EXECUTION in self.features.emit:
             try:
                 key = "error" if is_error else "result"
                 await tools.send_event(
@@ -1080,7 +1112,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         ]
 
         # Memory management tools (enterprise only - opt-in)
-        if self.enable_memory_tools:
+        if Capability.MEMORY in self.features.capabilities:
             platform_tools.extend(
                 [
                     ListMemoriesTool(),

--- a/src/thenvoi/adapters/gemini.py
+++ b/src/thenvoi/adapters/gemini.py
@@ -63,7 +63,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
     """
 
     SUPPORTED_EMIT = frozenset({Emit.EXECUTION})
-    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY})
+    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY, Capability.CONTACTS})
 
     def __init__(
         self,

--- a/src/thenvoi/adapters/gemini.py
+++ b/src/thenvoi/adapters/gemini.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import warnings
 from typing import Any, cast
 
 import httpx
@@ -21,9 +22,15 @@ except ImportError as e:
         "Or: uv add google-genai"
     ) from e
 
+from thenvoi.core.exceptions import ThenvoiConfigError
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+)
 from thenvoi.converters.gemini import GeminiHistoryConverter, GeminiMessages
 from thenvoi.runtime.custom_tools import (
     CustomToolDef,
@@ -41,42 +48,105 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
     Gemini SDK adapter using SimpleAdapter pattern.
 
     Uses the official google-genai Python SDK with explicit tool-loop control.
+
+    Example:
+        adapter = GeminiAdapter(
+            model="gemini-2.5-flash",
+            prompt="You are a helpful assistant.",
+            features=AdapterFeatures(
+                capabilities={Capability.MEMORY},
+                emit={Emit.EXECUTION},
+            ),
+        )
+        agent = Agent.create(adapter=adapter, agent_id="...", api_key="...")
+        await agent.run()
     """
+
+    SUPPORTED_EMIT = frozenset({Emit.EXECUTION})
+    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY})
 
     def __init__(
         self,
         model: str = "gemini-2.5-flash",
-        gemini_api_key: str | None = None,
+        api_key: str | None = None,
         system_prompt: str | None = None,
-        custom_section: str | None = None,
+        prompt: str | None = None,
         max_output_tokens: int | None = None,
         temperature: float | None = None,
-        enable_execution_reporting: bool = False,
-        enable_memory_tools: bool = False,
         max_tool_rounds: int = 20,
         max_retries: int = 2,
         retry_base_delay_s: float = 1.0,
         max_history_messages: int = 200,
         history_converter: GeminiHistoryConverter | None = None,
         additional_tools: list[CustomToolDef] | None = None,
+        features: AdapterFeatures | None = None,
+        include_base_instructions: bool = True,
+        # --- Deprecated (one release, then remove) ---
+        gemini_api_key: str | None = None,
+        custom_section: str | None = None,
+        enable_execution_reporting: bool = False,
+        enable_memory_tools: bool = False,
     ) -> None:
+        # --- Selective: api_key rename ---
+        if gemini_api_key is not None:
+            warnings.warn(
+                "gemini_api_key is deprecated, use api_key instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if api_key is not None:
+                raise ThenvoiConfigError("Cannot pass both api_key and gemini_api_key")
+            api_key = gemini_api_key
+
+        # --- Selective: prompt rename ---
+        if custom_section is not None:
+            warnings.warn(
+                "custom_section is deprecated, use prompt instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if prompt is not None:
+                raise ThenvoiConfigError("Cannot pass both prompt and custom_section")
+            prompt = custom_section
+
+        # --- Universal: boolean → AdapterFeatures migration ---
+        if enable_memory_tools or enable_execution_reporting:
+            if features is not None:
+                raise ThenvoiConfigError(
+                    "Cannot pass both features= and legacy boolean params "
+                    "(enable_memory_tools, enable_execution_reporting)"
+                )
+            warnings.warn(
+                "enable_memory_tools/enable_execution_reporting are deprecated, "
+                "use features=AdapterFeatures(...) instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            caps: frozenset[Capability] = frozenset()
+            emit: frozenset[Emit] = frozenset()
+            if enable_memory_tools:
+                caps = caps | frozenset({Capability.MEMORY})
+            if enable_execution_reporting:
+                emit = emit | frozenset({Emit.EXECUTION})
+            features = AdapterFeatures(capabilities=caps, emit=emit)
+
         super().__init__(
-            history_converter=history_converter or GeminiHistoryConverter()
+            history_converter=history_converter or GeminiHistoryConverter(),
+            features=features,
         )
 
         self.model = model
         self.system_prompt = system_prompt
-        self.custom_section = custom_section
+        self._prompt = prompt
+        self._include_base_instructions = include_base_instructions
         self.max_output_tokens = max_output_tokens
         self.temperature = temperature
-        self.enable_execution_reporting = enable_execution_reporting
-        self.enable_memory_tools = enable_memory_tools
         self.max_tool_rounds = max_tool_rounds
         self.max_retries = max_retries
         self.retry_base_delay_s = retry_base_delay_s
         self.max_history_messages = max_history_messages
 
-        self._gemini_api_key = gemini_api_key
+        self._api_key = api_key
         self.client: genai.Client | None = None
         self._message_history: dict[str, GeminiMessages] = {}
         self._system_prompt: str = ""
@@ -88,7 +158,8 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
         self._system_prompt = self.system_prompt or render_system_prompt(
             agent_name=agent_name,
             agent_description=agent_description,
-            custom_section=self.custom_section or "",
+            custom_section=self._prompt or "",
+            include_base_instructions=self._include_base_instructions,
         )
         logger.info("Gemini adapter started for agent: %s", agent_name)
 
@@ -251,11 +322,11 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
             return self.client
 
         try:
-            self.client = genai.Client(api_key=self._gemini_api_key)
+            self.client = genai.Client(api_key=self._api_key)
         except ValueError as e:
             raise ValueError(
                 "Gemini client initialization failed. Provide GEMINI_API_KEY or "
-                "pass gemini_api_key explicitly."
+                "pass api_key explicitly."
             ) from e
         return self.client
 
@@ -308,7 +379,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
         declarations: list[types.FunctionDeclaration] = []
 
         openai_schemas = tools.get_openai_tool_schemas(
-            include_memory=self.enable_memory_tools
+            include_memory=Capability.MEMORY in self.features.capabilities
         )
         for schema in openai_schemas:
             function = schema.get("function", {})
@@ -380,7 +451,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
             tool_input = dict(function_call.args or {})
             tool_call_id = function_call.id or f"gemini_tool_call_{index}"
 
-            if self.enable_execution_reporting:
+            if Emit.EXECUTION in self.features.emit:
                 try:
                     await tools.send_event(
                         content=json.dumps(
@@ -420,7 +491,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                 is_error = True
                 logger.exception("Tool %s failed: %s", tool_name, e)
 
-            if self.enable_execution_reporting:
+            if Emit.EXECUTION in self.features.emit:
                 try:
                     await tools.send_event(
                         content=json.dumps(

--- a/src/thenvoi/adapters/gemini.py
+++ b/src/thenvoi/adapters/gemini.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import logging
 import warnings
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import httpx
 from pydantic import ValidationError
@@ -62,8 +62,10 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
         await agent.run()
     """
 
-    SUPPORTED_EMIT = frozenset({Emit.EXECUTION})
-    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY, Capability.CONTACTS})
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY, Capability.CONTACTS}
+    )
 
     def __init__(
         self,

--- a/src/thenvoi/adapters/google_adk.py
+++ b/src/thenvoi/adapters/google_adk.py
@@ -12,13 +12,15 @@ import functools
 import json
 import logging
 import uuid
-from typing import TYPE_CHECKING, Any
+import warnings
+from typing import ClassVar, TYPE_CHECKING, Any
 
 from pydantic import ValidationError
 
+from thenvoi.core.exceptions import ThenvoiConfigError
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from thenvoi.converters.google_adk import GoogleADKHistoryConverter, GoogleADKMessages
 from thenvoi.runtime.custom_tools import (
     CustomToolDef,
@@ -282,6 +284,11 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
         await agent.run()
     """
 
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY}
+    )
+
     def __init__(
         self,
         model: str = "gemini-2.5-flash",
@@ -293,19 +300,45 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
         additional_tools: list[CustomToolDef] | None = None,
         max_history_messages: int = _DEFAULT_MAX_HISTORY_MESSAGES,
         max_transcript_chars: int = _DEFAULT_MAX_TRANSCRIPT_CHARS,
+        features: AdapterFeatures | None = None,
     ):
         # Validate google-adk is installed early (cached, so cheap on repeat).
         _require_adk()
 
+        # --- Deprecation shim: boolean → features migration ---
+        _has_legacy_booleans = enable_execution_reporting or enable_memory_tools
+        if _has_legacy_booleans and features is not None:
+            raise ThenvoiConfigError(
+                "Cannot pass both legacy boolean flags "
+                "(enable_execution_reporting / enable_memory_tools) and 'features'. "
+                "Use features=AdapterFeatures(...) instead."
+            )
+
+        if _has_legacy_booleans:
+            warnings.warn(
+                "enable_execution_reporting and enable_memory_tools are deprecated. "
+                "Use features=AdapterFeatures(emit={Emit.EXECUTION}, "
+                "capabilities={Capability.MEMORY}) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            features = AdapterFeatures(
+                emit=frozenset({Emit.EXECUTION})
+                if enable_execution_reporting
+                else frozenset(),
+                capabilities=frozenset({Capability.MEMORY})
+                if enable_memory_tools
+                else frozenset(),
+            )
+
         super().__init__(
-            history_converter=history_converter or GoogleADKHistoryConverter()
+            history_converter=history_converter or GoogleADKHistoryConverter(),
+            features=features,
         )
 
         self.model = model
         self._system_prompt_override = system_prompt
         self.custom_section = custom_section
-        self.enable_execution_reporting = enable_execution_reporting
-        self.enable_memory_tools = enable_memory_tools
         self.max_history_messages = max_history_messages
         self.max_transcript_chars = max_transcript_chars
 
@@ -341,7 +374,7 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
         """Build ADK tool bridges from Thenvoi tool schemas."""
         ToolBridge = _get_tool_bridge_class()
         openai_schemas = tools.get_openai_tool_schemas(
-            include_memory=self.enable_memory_tools
+            include_memory=Capability.MEMORY in self.features.capabilities
         )
 
         adk_tools: list[Any] = []
@@ -506,7 +539,7 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
                 new_message=user_content,
             ):
                 # Report tool calls/results if enabled
-                if self.enable_execution_reporting:
+                if Emit.EXECUTION in self.features.emit:
                     try:
                         await self._report_event(event, tools)
                     except Exception as e:

--- a/src/thenvoi/adapters/google_adk.py
+++ b/src/thenvoi/adapters/google_adk.py
@@ -286,7 +286,7 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY}
+        {Capability.MEMORY, Capability.CONTACTS}
     )
 
     def __init__(

--- a/src/thenvoi/adapters/langgraph.py
+++ b/src/thenvoi/adapters/langgraph.py
@@ -59,7 +59,7 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset()
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY}
+        {Capability.MEMORY, Capability.CONTACTS}
     )
 
     def __init__(

--- a/src/thenvoi/adapters/langgraph.py
+++ b/src/thenvoi/adapters/langgraph.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Callable, List
+import warnings
+from typing import ClassVar, TYPE_CHECKING, Any, Callable, List
 
 from langgraph.pregel import Pregel
 
+from thenvoi.core.exceptions import ThenvoiConfigError
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from thenvoi.converters.langchain import LangChainHistoryConverter, LangChainMessages
 from thenvoi.runtime.prompts import render_system_prompt
 
@@ -55,6 +57,11 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
         await agent.run()
     """
 
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset()
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY}
+    )
+
     def __init__(
         self,
         # Simple pattern: just provide llm and checkpointer
@@ -70,10 +77,28 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
         enable_memory_tools: bool = False,
         history_converter: LangChainHistoryConverter | None = None,
         recursion_limit: int = 50,
+        features: AdapterFeatures | None = None,
     ):
+        # --- Deprecation shim: boolean → features migration ---
+        if enable_memory_tools and features is not None:
+            raise ThenvoiConfigError(
+                "Cannot pass both 'enable_memory_tools' and 'features'. "
+                "Use features=AdapterFeatures(capabilities={Capability.MEMORY}) instead."
+            )
+
+        if enable_memory_tools:
+            warnings.warn(
+                "enable_memory_tools is deprecated. "
+                "Use features=AdapterFeatures(capabilities={Capability.MEMORY}) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            features = AdapterFeatures(capabilities=frozenset({Capability.MEMORY}))
+
         # Use default LangChain converter if not provided
         super().__init__(
-            history_converter=history_converter or LangChainHistoryConverter()
+            history_converter=history_converter or LangChainHistoryConverter(),
+            features=features,
         )
 
         # Simple pattern: create graph_factory from llm + checkpointer
@@ -105,7 +130,6 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
         self.prompt_template = prompt_template
         self.custom_section = custom_section
         self.additional_tools = additional_tools or []
-        self.enable_memory_tools = enable_memory_tools
         self.recursion_limit = recursion_limit
         self._system_prompt: str = ""
         # Track rooms that have already been bootstrapped to avoid injecting
@@ -145,7 +169,8 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
         # Get LangChain tools
         langchain_tools = (
             agent_tools_to_langchain(
-                tools, include_memory_tools=self.enable_memory_tools
+                tools,
+                include_memory_tools=Capability.MEMORY in self.features.capabilities,
             )
             + self.additional_tools
         )

--- a/src/thenvoi/adapters/letta.py
+++ b/src/thenvoi/adapters/letta.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import warnings
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import ClassVar, Any, Literal
 
 from thenvoi.converters.letta import LettaHistoryConverter, LettaSessionState
+from thenvoi.core.exceptions import ThenvoiConfigError
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
 from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
@@ -156,8 +158,32 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
     ) -> None:
         self._config = config or LettaAdapterConfig()
 
+        # Detect non-default legacy booleans (enable_task_events defaults to
+        # True, so only enable_memory_tools and enable_execution_reporting
+        # count as "legacy usage").
+        _has_legacy_booleans = (
+            self._config.enable_memory_tools or self._config.enable_execution_reporting
+        )
+
+        if _has_legacy_booleans and features is not None:
+            raise ThenvoiConfigError(
+                "Cannot pass both legacy boolean flags in LettaAdapterConfig "
+                "(enable_memory_tools / enable_execution_reporting) "
+                "and 'features'. "
+                "Use features=AdapterFeatures(...) instead."
+            )
+
         # Build features from config booleans when not explicitly provided.
         if features is None:
+            if _has_legacy_booleans:
+                warnings.warn(
+                    "enable_memory_tools and enable_execution_reporting in "
+                    "LettaAdapterConfig are deprecated. "
+                    "Use features=AdapterFeatures(capabilities={Capability.MEMORY}, "
+                    "emit={Emit.EXECUTION}) instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             caps: frozenset[Capability] = frozenset()
             emit: frozenset[Emit] = frozenset()
             if self._config.enable_memory_tools:

--- a/src/thenvoi/adapters/letta.py
+++ b/src/thenvoi/adapters/letta.py
@@ -7,12 +7,12 @@ import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Literal
+from typing import ClassVar, Any, Literal
 
 from thenvoi.converters.letta import LettaHistoryConverter, LettaSessionState
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from thenvoi.runtime.prompts import render_system_prompt
 
 logger = logging.getLogger(__name__)
@@ -140,13 +140,39 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         await agent.run()
     """
 
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset(
+        {Emit.EXECUTION, Emit.TASK_EVENTS}
+    )
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY}
+    )
+
     def __init__(
         self,
         config: LettaAdapterConfig | None = None,
         history_converter: LettaHistoryConverter | None = None,
+        *,
+        features: AdapterFeatures | None = None,
     ) -> None:
-        super().__init__(history_converter=history_converter or LettaHistoryConverter())
-        self.config = config or LettaAdapterConfig()
+        self._config = config or LettaAdapterConfig()
+
+        # Build features from config booleans when not explicitly provided.
+        if features is None:
+            caps: frozenset[Capability] = frozenset()
+            emit: frozenset[Emit] = frozenset()
+            if self._config.enable_memory_tools:
+                caps = caps | frozenset({Capability.MEMORY})
+            if self._config.enable_execution_reporting:
+                emit = emit | frozenset({Emit.EXECUTION})
+            if self._config.enable_task_events:
+                emit = emit | frozenset({Emit.TASK_EVENTS})
+            features = AdapterFeatures(capabilities=caps, emit=emit)
+
+        super().__init__(
+            history_converter=history_converter or LettaHistoryConverter(),
+            features=features,
+        )
+        self.config = self._config
 
         # Letta SDK async client (shared across rooms)
         self._client: Any = None
@@ -450,7 +476,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                 if tool_name == "thenvoi_send_message":
                     used_send_message = True
 
-                if self.config.enable_execution_reporting:
+                if Emit.EXECUTION in self.features.emit:
                     if tool_name not in _SILENT_REPORTING_TOOLS:
                         await tools.send_event(
                             content=json.dumps(
@@ -466,7 +492,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
 
             elif msg_type == "tool_return_message":
                 # MCP tool result — observe for reporting
-                if self.config.enable_execution_reporting:
+                if Emit.EXECUTION in self.features.emit:
                     tool_name = getattr(resp_msg, "tool_name", "unknown")
                     if tool_name not in _SILENT_REPORTING_TOOLS:
                         await tools.send_event(
@@ -756,7 +782,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         conversation_id: str | None = None,
     ) -> None:
         """Emit a task event with agent/room mapping metadata."""
-        if not self.config.enable_task_events:
+        if Emit.TASK_EVENTS not in self.features.emit:
             return
         try:
             if conversation_id is None:

--- a/src/thenvoi/adapters/letta.py
+++ b/src/thenvoi/adapters/letta.py
@@ -146,7 +146,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         {Emit.EXECUTION, Emit.TASK_EVENTS}
     )
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY}
+        {Capability.MEMORY, Capability.CONTACTS}
     )
 
     def __init__(

--- a/src/thenvoi/adapters/opencode.py
+++ b/src/thenvoi/adapters/opencode.py
@@ -134,7 +134,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         {Emit.EXECUTION, Emit.TASK_EVENTS}
     )
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY}
+        {Capability.MEMORY, Capability.CONTACTS}
     )
 
     def __init__(

--- a/src/thenvoi/adapters/opencode.py
+++ b/src/thenvoi/adapters/opencode.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import warnings
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -15,6 +16,7 @@ import httpx
 
 from thenvoi.converters._utils import optional_str
 from thenvoi.converters.opencode import OpencodeHistoryConverter
+from thenvoi.core.exceptions import ThenvoiConfigError
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
 from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
@@ -147,8 +149,32 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
     ) -> None:
         self._config = config or OpencodeAdapterConfig()
 
+        # Detect non-default legacy booleans (enable_task_events defaults to
+        # True, so only enable_memory_tools and enable_execution_reporting
+        # count as "legacy usage").
+        _has_legacy_booleans = (
+            self._config.enable_memory_tools or self._config.enable_execution_reporting
+        )
+
+        if _has_legacy_booleans and features is not None:
+            raise ThenvoiConfigError(
+                "Cannot pass both legacy boolean flags in OpencodeAdapterConfig "
+                "(enable_memory_tools / enable_execution_reporting) "
+                "and 'features'. "
+                "Use features=AdapterFeatures(...) instead."
+            )
+
         # Build features from config booleans when not explicitly provided.
         if features is None:
+            if _has_legacy_booleans:
+                warnings.warn(
+                    "enable_memory_tools and enable_execution_reporting in "
+                    "OpencodeAdapterConfig are deprecated. "
+                    "Use features=AdapterFeatures(capabilities={Capability.MEMORY}, "
+                    "emit={Emit.EXECUTION}) instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             caps: frozenset[Capability] = frozenset()
             emit: frozenset[Emit] = frozenset()
             if self._config.enable_memory_tools:

--- a/src/thenvoi/adapters/opencode.py
+++ b/src/thenvoi/adapters/opencode.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Literal
+from typing import ClassVar, Any, Literal
 
 import httpx
 
@@ -17,7 +17,7 @@ from thenvoi.converters._utils import optional_str
 from thenvoi.converters.opencode import OpencodeHistoryConverter
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from thenvoi.integrations.mcp.backends import (
     ThenvoiMCPBackend,
     create_thenvoi_mcp_backend,
@@ -128,6 +128,13 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
       * ``auto_reject`` -- questions are rejected immediately.
     """
 
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset(
+        {Emit.EXECUTION, Emit.TASK_EVENTS}
+    )
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY}
+    )
+
     def __init__(
         self,
         config: OpencodeAdapterConfig | None = None,
@@ -136,11 +143,27 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         history_converter: OpencodeHistoryConverter | None = None,
         client_factory: Callable[[OpencodeAdapterConfig], OpencodeClientProtocol]
         | None = None,
+        features: AdapterFeatures | None = None,
     ) -> None:
+        self._config = config or OpencodeAdapterConfig()
+
+        # Build features from config booleans when not explicitly provided.
+        if features is None:
+            caps: frozenset[Capability] = frozenset()
+            emit: frozenset[Emit] = frozenset()
+            if self._config.enable_memory_tools:
+                caps = caps | frozenset({Capability.MEMORY})
+            if self._config.enable_execution_reporting:
+                emit = emit | frozenset({Emit.EXECUTION})
+            if self._config.enable_task_events:
+                emit = emit | frozenset({Emit.TASK_EVENTS})
+            features = AdapterFeatures(capabilities=caps, emit=emit)
+
         super().__init__(
-            history_converter=history_converter or OpencodeHistoryConverter()
+            history_converter=history_converter or OpencodeHistoryConverter(),
+            features=features,
         )
-        self.config = config or OpencodeAdapterConfig()
+        self.config = self._config
         self._custom_tools: list[CustomToolDef] = list(additional_tools or [])
         self._client_factory = client_factory or self._default_client_factory
         self._client: OpencodeClientProtocol | None = None
@@ -217,7 +240,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
             session_id, created, restored_missing_session = await self._ensure_session(
                 room_state, history
             )
-            if self.config.enable_task_events and (
+            if Emit.TASK_EVENTS in self.features.emit and (
                 room_state.persisted_session_id != session_id or is_session_bootstrap
             ):
                 await self._emit_session_task_event(
@@ -346,7 +369,9 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
             return self._mcp_backend
 
         tool_definitions = list(
-            iter_tool_definitions(include_memory=self.config.enable_memory_tools)
+            iter_tool_definitions(
+                include_memory=Capability.MEMORY in self.features.capabilities
+            )
         )
         backend = await create_thenvoi_mcp_backend(
             kind="sse",
@@ -552,7 +577,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
             room_state.assistant_part_types[part_id] = "reasoning"
             return
 
-        if part_type != "tool" or not self.config.enable_execution_reporting:
+        if part_type != "tool" or Emit.EXECUTION not in self.features.emit:
             return
 
         state = part.get("state") or {}

--- a/src/thenvoi/adapters/parlant.py
+++ b/src/thenvoi/adapters/parlant.py
@@ -8,11 +8,11 @@ with the Thenvoi platform.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import ClassVar, TYPE_CHECKING, Any
 
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from thenvoi.converters.parlant import ParlantHistoryConverter, ParlantMessages
 from thenvoi.integrations.parlant.tools import set_session_tools, was_message_sent
 from thenvoi.runtime.custom_tools import CustomToolDef
@@ -58,6 +58,9 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
             await thenvoi_agent.run()
     """
 
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset()
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset()
+
     def __init__(
         self,
         server: p.Server,
@@ -66,6 +69,7 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
         custom_section: str | None = None,
         history_converter: ParlantHistoryConverter | None = None,
         additional_tools: list[CustomToolDef] | None = None,
+        features: AdapterFeatures | None = None,
     ):
         """
         Initialize the Parlant SDK adapter.
@@ -77,9 +81,11 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
             custom_section: Custom instructions appended to agent description
             history_converter: Custom history converter (optional)
             additional_tools: List of custom tools as (InputModel, callable) tuples
+            features: Shared adapter feature settings (capabilities, emit, tool filters).
         """
         super().__init__(
-            history_converter=history_converter or ParlantHistoryConverter()
+            history_converter=history_converter or ParlantHistoryConverter(),
+            features=features,
         )
 
         self._server = server

--- a/src/thenvoi/adapters/parlant.py
+++ b/src/thenvoi/adapters/parlant.py
@@ -59,7 +59,9 @@ class ParlantAdapter(SimpleAdapter[ParlantMessages]):
     """
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset()
-    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset()
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY, Capability.CONTACTS}
+    )
 
     def __init__(
         self,

--- a/src/thenvoi/adapters/pydantic_ai.py
+++ b/src/thenvoi/adapters/pydantic_ai.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Callable
+import warnings
+from typing import ClassVar, Any, Callable
 
 from pydantic_ai import (
     Agent,
@@ -22,9 +23,10 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 
+from thenvoi.core.exceptions import ThenvoiConfigError
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from thenvoi.converters.pydantic_ai import (
     PydanticAIHistoryConverter,
     PydanticAIMessages,
@@ -51,6 +53,11 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         await agent.run()
     """
 
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY}
+    )
+
     def __init__(
         self,
         model: str,
@@ -60,6 +67,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         enable_memory_tools: bool = False,
         history_converter: PydanticAIHistoryConverter | None = None,
         additional_tools: list[Callable[..., Any]] | None = None,
+        features: AdapterFeatures | None = None,
     ):
         """
         Initialize the Pydantic AI adapter.
@@ -68,26 +76,49 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             model: Pydantic AI model string (e.g., "openai:gpt-4o", "anthropic:claude-3-5-sonnet-latest")
             system_prompt: Optional custom system prompt (overrides default)
             custom_section: Optional custom section added to default system prompt
-            enable_execution_reporting: If True, emit tool_call and tool_result events
-                to the platform for real-time visibility into agent activity.
-                Defaults to False for backwards compatibility.
-            enable_memory_tools: If True, includes memory management tools (enterprise only).
-                Defaults to False.
+            enable_execution_reporting: Deprecated. Use features=AdapterFeatures(emit={Emit.EXECUTION}).
+            enable_memory_tools: Deprecated. Use features=AdapterFeatures(capabilities={Capability.MEMORY}).
             history_converter: Optional custom history converter
             additional_tools: Optional list of PydanticAI-compatible tool functions.
                 Each function should follow PydanticAI's tool signature:
                 `def my_tool(ctx: RunContext[AgentToolsProtocol], arg1: str, ...) -> T`
                 These are registered via agent.tool() alongside platform tools.
+            features: Shared adapter feature settings (capabilities, emit, tool filters).
         """
+        # --- Deprecation shim: boolean → features migration ---
+        _has_legacy_booleans = enable_execution_reporting or enable_memory_tools
+        if _has_legacy_booleans and features is not None:
+            raise ThenvoiConfigError(
+                "Cannot pass both legacy boolean flags "
+                "(enable_execution_reporting / enable_memory_tools) and 'features'. "
+                "Use features=AdapterFeatures(...) instead."
+            )
+
+        if _has_legacy_booleans:
+            warnings.warn(
+                "enable_execution_reporting and enable_memory_tools are deprecated. "
+                "Use features=AdapterFeatures(emit={Emit.EXECUTION}, "
+                "capabilities={Capability.MEMORY}) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            features = AdapterFeatures(
+                emit=frozenset({Emit.EXECUTION})
+                if enable_execution_reporting
+                else frozenset(),
+                capabilities=frozenset({Capability.MEMORY})
+                if enable_memory_tools
+                else frozenset(),
+            )
+
         super().__init__(
-            history_converter=history_converter or PydanticAIHistoryConverter()
+            history_converter=history_converter or PydanticAIHistoryConverter(),
+            features=features,
         )
 
         self.model = model
         self.system_prompt = system_prompt
         self.custom_section = custom_section
-        self.enable_execution_reporting = enable_execution_reporting
-        self.enable_memory_tools = enable_memory_tools
 
         self._agent: Agent[AgentToolsProtocol, None] | None = None
         # Conversation history per room (Pydantic AI is stateless, we maintain state)
@@ -310,7 +341,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         agent.tool(thenvoi_respond_contact_request)
 
         # Memory management tools (enterprise only - opt-in)
-        if self.enable_memory_tools:
+        if Capability.MEMORY in self.features.capabilities:
 
             async def thenvoi_list_memories(
                 ctx: RunContext[AgentToolsProtocol],
@@ -483,7 +514,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             message_history=self._message_history[room_id],
         ):
             if isinstance(event, FunctionToolCallEvent):
-                if self.enable_execution_reporting:
+                if Emit.EXECUTION in self.features.emit:
                     try:
                         await tools.send_event(
                             content=json.dumps(
@@ -498,7 +529,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                     except Exception as e:
                         logger.warning("Failed to send tool_call event: %s", e)
             elif isinstance(event, FunctionToolResultEvent):
-                if self.enable_execution_reporting:
+                if Emit.EXECUTION in self.features.emit:
                     try:
                         await tools.send_event(
                             content=json.dumps(

--- a/src/thenvoi/adapters/pydantic_ai.py
+++ b/src/thenvoi/adapters/pydantic_ai.py
@@ -55,7 +55,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
-        {Capability.MEMORY}
+        {Capability.MEMORY, Capability.CONTACTS}
     )
 
     def __init__(

--- a/src/thenvoi/integrations/a2a/adapter.py
+++ b/src/thenvoi/integrations/a2a/adapter.py
@@ -25,7 +25,7 @@ from a2a.utils import get_message_text
 from thenvoi.converters.a2a import A2AHistoryConverter
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import Capability, Emit, PlatformMessage
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from thenvoi.integrations.a2a.types import A2AAuth, A2ASessionState
 
 logger = logging.getLogger(__name__)
@@ -108,6 +108,7 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
         remote_url: str,
         auth: A2AAuth | None = None,
         streaming: bool = True,
+        features: AdapterFeatures | None = None,
     ) -> None:
         """Initialize A2A adapter.
 
@@ -116,7 +117,10 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
             auth: Optional authentication configuration.
             streaming: Whether to use streaming mode (SSE) for responses.
         """
-        super().__init__(history_converter=A2AHistoryConverter())
+        super().__init__(
+            history_converter=A2AHistoryConverter(),
+            features=features,
+        )
         self.remote_url = remote_url
         self.auth = auth
         self.streaming = streaming

--- a/src/thenvoi/integrations/a2a/adapter.py
+++ b/src/thenvoi/integrations/a2a/adapter.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import ClassVar, Any
 from uuid import uuid4
 
 from a2a.client import Client, ClientConfig, ClientFactory
@@ -25,7 +25,7 @@ from a2a.utils import get_message_text
 from thenvoi.converters.a2a import A2AHistoryConverter
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import Capability, Emit, PlatformMessage
 from thenvoi.integrations.a2a.types import A2AAuth, A2ASessionState
 
 logger = logging.getLogger(__name__)
@@ -99,6 +99,9 @@ class A2AAdapter(SimpleAdapter[A2ASessionState]):
         )
         await agent.run()
     """
+
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset()
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset()
 
     def __init__(
         self,

--- a/src/thenvoi/integrations/a2a/gateway/adapter.py
+++ b/src/thenvoi/integrations/a2a/gateway/adapter.py
@@ -33,7 +33,7 @@ from thenvoi.client.rest import (
 from thenvoi.converters.a2a_gateway import GatewayHistoryConverter
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import Capability, Emit, PlatformMessage
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from thenvoi.integrations.a2a.gateway.server import GatewayServer
 from thenvoi.integrations.a2a.gateway.types import GatewaySessionState, PendingA2ATask
 from thenvoi_rest import Peer
@@ -101,6 +101,7 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         api_key: str = "",
         gateway_url: str = "http://localhost:10000",
         port: int = 10000,
+        features: AdapterFeatures | None = None,
     ) -> None:
         """Initialize gateway adapter.
 
@@ -110,7 +111,10 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
             gateway_url: Base URL for A2A endpoints exposed by this gateway.
             port: Port for HTTP server to listen on.
         """
-        super().__init__(history_converter=GatewayHistoryConverter())
+        super().__init__(
+            history_converter=GatewayHistoryConverter(),
+            features=features,
+        )
         self.gateway_url = gateway_url
         self.port = port
 

--- a/src/thenvoi/integrations/a2a/gateway/adapter.py
+++ b/src/thenvoi/integrations/a2a/gateway/adapter.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import re
 from collections.abc import AsyncIterator
+from typing import ClassVar
 from uuid import uuid4
 
 from a2a.types import (
@@ -32,7 +33,7 @@ from thenvoi.client.rest import (
 from thenvoi.converters.a2a_gateway import GatewayHistoryConverter
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import Capability, Emit, PlatformMessage
 from thenvoi.integrations.a2a.gateway.server import GatewayServer
 from thenvoi.integrations.a2a.gateway.types import GatewaySessionState, PendingA2ATask
 from thenvoi_rest import Peer
@@ -90,6 +91,9 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         )
         await agent.run()
     """
+
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset()
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset()
 
     def __init__(
         self,

--- a/src/thenvoi/integrations/acp/client_adapter.py
+++ b/src/thenvoi/integrations/acp/client_adapter.py
@@ -7,7 +7,7 @@ import logging
 import os
 from collections.abc import Awaitable, Callable
 from contextlib import AbstractAsyncContextManager
-from typing import Any, Literal, Protocol, cast
+from typing import ClassVar, Any, Literal, Protocol, cast
 
 from acp import spawn_agent_process, text_block
 from acp.schema import HttpMcpServer, SseMcpServer
@@ -15,7 +15,7 @@ from acp.schema import HttpMcpServer, SseMcpServer
 from thenvoi.converters.acp_client import ACPClientHistoryConverter
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import PlatformMessage
+from thenvoi.core.types import Capability, Emit, PlatformMessage
 from thenvoi.integrations.acp.client_types import (
     ACPClientSessionState,
     ThenvoiACPClient,
@@ -96,6 +96,9 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
         )
         await agent.run()
     """
+
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset()
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset()
 
     def __init__(
         self,

--- a/src/thenvoi/integrations/acp/client_adapter.py
+++ b/src/thenvoi/integrations/acp/client_adapter.py
@@ -15,7 +15,7 @@ from acp.schema import HttpMcpServer, SseMcpServer
 from thenvoi.converters.acp_client import ACPClientHistoryConverter
 from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import Capability, Emit, PlatformMessage
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from thenvoi.integrations.acp.client_types import (
     ACPClientSessionState,
     ThenvoiACPClient,
@@ -110,6 +110,7 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
         rest_url: str | None = None,
         inject_thenvoi_tools: bool = True,
         auth_method: str | None = None,
+        features: AdapterFeatures | None = None,
     ) -> None:
         """Initialize ACP client adapter.
 
@@ -129,7 +130,10 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
                          Required for agents that need auth (e.g., "cursor_login"
                          for Cursor). Set to None to skip authentication.
         """
-        super().__init__(history_converter=ACPClientHistoryConverter())
+        super().__init__(
+            history_converter=ACPClientHistoryConverter(),
+            features=features,
+        )
         self._command = command if isinstance(command, list) else [command]
         self._env = env
         self._cwd = os.path.abspath(cwd or ".")

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -62,16 +62,20 @@ class TestInitialization:
     """Tests for adapter initialization (memory tools specific)."""
 
     def test_default_initialization(self):
-        """Should initialize with enable_memory_tools=False by default."""
+        """Should initialize with no memory capability by default."""
         adapter = ClaudeSDKAdapter()
 
-        assert adapter.enable_memory_tools is False
+        from thenvoi.core.types import Capability
+
+        assert Capability.MEMORY not in adapter.features.capabilities
 
     def test_enable_memory_tools(self):
-        """Should accept enable_memory_tools parameter."""
+        """Should accept enable_memory_tools parameter (deprecated)."""
         adapter = ClaudeSDKAdapter(enable_memory_tools=True)
 
-        assert adapter.enable_memory_tools is True
+        from thenvoi.core.types import Capability
+
+        assert Capability.MEMORY in adapter.features.capabilities
 
 
 class TestOnStarted:

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -1017,8 +1017,10 @@ class TestExecutionReporting:
         adapter_enabled = CrewAIAdapter(enable_execution_reporting=True)
         adapter_disabled = CrewAIAdapter(enable_execution_reporting=False)
 
-        assert adapter_enabled.enable_execution_reporting is True
-        assert adapter_disabled.enable_execution_reporting is False
+        from thenvoi.core.types import Emit
+
+        assert Emit.EXECUTION in adapter_enabled.features.emit
+        assert Emit.EXECUTION not in adapter_disabled.features.emit
 
     def test_reports_tool_call_when_enabled(
         self, CrewAIAdapter, crewai_mocks, mock_tools, room_context

--- a/tests/adapters/test_deprecation_shims.py
+++ b/tests/adapters/test_deprecation_shims.py
@@ -1,0 +1,118 @@
+"""Tests pinning the deprecation-shim contract for adapter constructors.
+
+These tests guarantee that the legacy boolean / api-key / prompt parameters
+still work for one release with a clear DeprecationWarning. When the shims
+are eventually removed, these tests should be deleted in the same commit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from thenvoi.core.exceptions import ThenvoiConfigError
+from thenvoi.core.types import AdapterFeatures, Capability, Emit
+
+
+class TestUniversalBooleanShims:
+    """Every adapter with legacy booleans must shim them with DeprecationWarning."""
+
+    def test_anthropic_enable_memory_tools_warns(self) -> None:
+        from thenvoi.adapters.anthropic import AnthropicAdapter
+
+        with pytest.warns(DeprecationWarning, match="enable_memory_tools"):
+            adapter = AnthropicAdapter(enable_memory_tools=True)
+        assert Capability.MEMORY in adapter.features.capabilities
+
+    def test_anthropic_enable_execution_reporting_warns(self) -> None:
+        from thenvoi.adapters.anthropic import AnthropicAdapter
+
+        with pytest.warns(DeprecationWarning, match="enable_execution_reporting"):
+            adapter = AnthropicAdapter(enable_execution_reporting=True)
+        assert Emit.EXECUTION in adapter.features.emit
+
+    def test_anthropic_both_booleans_and_features_raises(self) -> None:
+        from thenvoi.adapters.anthropic import AnthropicAdapter
+
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
+            AnthropicAdapter(
+                enable_memory_tools=True,
+                features=AdapterFeatures(capabilities={Capability.MEMORY}),
+            )
+
+    def test_gemini_enable_memory_tools_warns(self) -> None:
+        from thenvoi.adapters.gemini import GeminiAdapter
+
+        with pytest.warns(DeprecationWarning, match="enable_memory_tools"):
+            adapter = GeminiAdapter(enable_memory_tools=True)
+        assert Capability.MEMORY in adapter.features.capabilities
+
+    def test_langgraph_enable_memory_tools_warns(self) -> None:
+        from unittest.mock import MagicMock
+
+        from thenvoi.adapters.langgraph import LangGraphAdapter
+
+        with pytest.warns(DeprecationWarning, match="enable_memory_tools"):
+            adapter = LangGraphAdapter(
+                llm=MagicMock(), checkpointer=MagicMock(), enable_memory_tools=True
+            )
+        assert Capability.MEMORY in adapter.features.capabilities
+
+    def test_pydantic_ai_enable_execution_reporting_warns(self) -> None:
+        from thenvoi.adapters.pydantic_ai import PydanticAIAdapter
+
+        with pytest.warns(DeprecationWarning, match="enable_execution_reporting"):
+            adapter = PydanticAIAdapter(
+                model="openai:gpt-4o", enable_execution_reporting=True
+            )
+        assert Emit.EXECUTION in adapter.features.emit
+
+    def test_claude_sdk_enable_execution_reporting_maps_to_execution_and_thoughts(
+        self,
+    ) -> None:
+        """ClaudeSDK historically emitted thoughts under enable_execution_reporting."""
+        from thenvoi.adapters.claude_sdk import ClaudeSDKAdapter
+
+        with pytest.warns(DeprecationWarning, match="enable_execution_reporting"):
+            adapter = ClaudeSDKAdapter(enable_execution_reporting=True)
+        assert Emit.EXECUTION in adapter.features.emit
+        assert Emit.THOUGHTS in adapter.features.emit
+
+
+class TestSelectiveRenameShims:
+    """Anthropic and Gemini get the api_key/prompt selective renames."""
+
+    def test_anthropic_anthropic_api_key_warns(self) -> None:
+        from thenvoi.adapters.anthropic import AnthropicAdapter
+
+        with pytest.warns(DeprecationWarning, match="anthropic_api_key"):
+            AnthropicAdapter(anthropic_api_key="sk-test-key")
+
+    def test_anthropic_custom_section_warns(self) -> None:
+        from thenvoi.adapters.anthropic import AnthropicAdapter
+
+        with pytest.warns(DeprecationWarning, match="custom_section"):
+            AnthropicAdapter(custom_section="Be helpful.")
+
+    def test_anthropic_api_key_and_anthropic_api_key_conflict(self) -> None:
+        from thenvoi.adapters.anthropic import AnthropicAdapter
+
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
+            AnthropicAdapter(api_key="sk-new", anthropic_api_key="sk-old")
+
+    def test_anthropic_prompt_and_custom_section_conflict(self) -> None:
+        from thenvoi.adapters.anthropic import AnthropicAdapter
+
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
+            AnthropicAdapter(prompt="new", custom_section="old")
+
+    def test_gemini_gemini_api_key_warns(self) -> None:
+        from thenvoi.adapters.gemini import GeminiAdapter
+
+        with pytest.warns(DeprecationWarning, match="gemini_api_key"):
+            GeminiAdapter(gemini_api_key="AIza-test-key")
+
+    def test_gemini_custom_section_warns(self) -> None:
+        from thenvoi.adapters.gemini import GeminiAdapter
+
+        with pytest.warns(DeprecationWarning, match="custom_section"):
+            GeminiAdapter(custom_section="Be concise.")

--- a/tests/adapters/test_deprecation_shims.py
+++ b/tests/adapters/test_deprecation_shims.py
@@ -232,3 +232,65 @@ class TestSelectiveRenameShims:
 
         with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
             GeminiAdapter(prompt="new", custom_section="old")
+
+
+class TestOpencodeDeprecationShims:
+    """Opencode config booleans must warn when non-default."""
+
+    def test_enable_execution_reporting_warns(self) -> None:
+        from thenvoi.adapters.opencode import OpencodeAdapter, OpencodeAdapterConfig
+
+        config = OpencodeAdapterConfig(enable_execution_reporting=True)
+        with pytest.warns(
+            DeprecationWarning,
+            match="enable_memory_tools and enable_execution_reporting",
+        ):
+            OpencodeAdapter(config=config)
+
+    def test_enable_memory_tools_warns(self) -> None:
+        from thenvoi.adapters.opencode import OpencodeAdapter, OpencodeAdapterConfig
+
+        config = OpencodeAdapterConfig(enable_memory_tools=True)
+        with pytest.warns(
+            DeprecationWarning,
+            match="enable_memory_tools and enable_execution_reporting",
+        ):
+            OpencodeAdapter(config=config)
+
+    def test_conflict_raises(self) -> None:
+        from thenvoi.adapters.opencode import OpencodeAdapter, OpencodeAdapterConfig
+
+        config = OpencodeAdapterConfig(enable_execution_reporting=True)
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
+            OpencodeAdapter(config=config, features=AdapterFeatures())
+
+
+class TestLettaDeprecationShims:
+    """Letta config booleans must warn when non-default."""
+
+    def test_enable_execution_reporting_warns(self) -> None:
+        from thenvoi.adapters.letta import LettaAdapter, LettaAdapterConfig
+
+        config = LettaAdapterConfig(enable_execution_reporting=True)
+        with pytest.warns(
+            DeprecationWarning,
+            match="enable_memory_tools and enable_execution_reporting",
+        ):
+            LettaAdapter(config=config)
+
+    def test_enable_memory_tools_warns(self) -> None:
+        from thenvoi.adapters.letta import LettaAdapter, LettaAdapterConfig
+
+        config = LettaAdapterConfig(enable_memory_tools=True)
+        with pytest.warns(
+            DeprecationWarning,
+            match="enable_memory_tools and enable_execution_reporting",
+        ):
+            LettaAdapter(config=config)
+
+    def test_conflict_raises(self) -> None:
+        from thenvoi.adapters.letta import LettaAdapter, LettaAdapterConfig
+
+        config = LettaAdapterConfig(enable_memory_tools=True)
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
+            LettaAdapter(config=config, features=AdapterFeatures())

--- a/tests/adapters/test_deprecation_shims.py
+++ b/tests/adapters/test_deprecation_shims.py
@@ -46,6 +46,24 @@ class TestUniversalBooleanShims:
             adapter = GeminiAdapter(enable_memory_tools=True)
         assert Capability.MEMORY in adapter.features.capabilities
 
+    def test_gemini_enable_execution_reporting_warns(self) -> None:
+        from thenvoi.adapters.gemini import GeminiAdapter
+
+        with pytest.warns(
+            DeprecationWarning, match="enable_memory_tools|enable_execution_reporting"
+        ):
+            adapter = GeminiAdapter(enable_execution_reporting=True)
+        assert Emit.EXECUTION in adapter.features.emit
+
+    def test_gemini_both_booleans_and_features_raises(self) -> None:
+        from thenvoi.adapters.gemini import GeminiAdapter
+
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
+            GeminiAdapter(
+                enable_memory_tools=True,
+                features=AdapterFeatures(capabilities={Capability.MEMORY}),
+            )
+
     def test_langgraph_enable_memory_tools_warns(self) -> None:
         from unittest.mock import MagicMock
 
@@ -76,6 +94,92 @@ class TestUniversalBooleanShims:
             adapter = ClaudeSDKAdapter(enable_execution_reporting=True)
         assert Emit.EXECUTION in adapter.features.emit
         assert Emit.THOUGHTS in adapter.features.emit
+
+    def test_crewai_enable_execution_reporting_warns(self) -> None:
+        from thenvoi.adapters.crewai import CrewAIAdapter
+
+        with pytest.warns(
+            DeprecationWarning, match="enable_execution_reporting|enable_memory_tools"
+        ):
+            adapter = CrewAIAdapter(enable_execution_reporting=True)
+        assert Emit.EXECUTION in adapter.features.emit
+
+    def test_crewai_enable_memory_tools_warns(self) -> None:
+        from thenvoi.adapters.crewai import CrewAIAdapter
+
+        with pytest.warns(
+            DeprecationWarning, match="enable_execution_reporting|enable_memory_tools"
+        ):
+            adapter = CrewAIAdapter(enable_memory_tools=True)
+        assert Capability.MEMORY in adapter.features.capabilities
+
+    def test_crewai_both_booleans_and_features_raises(self) -> None:
+        from thenvoi.adapters.crewai import CrewAIAdapter
+
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
+            CrewAIAdapter(
+                enable_memory_tools=True,
+                features=AdapterFeatures(capabilities={Capability.MEMORY}),
+            )
+
+    def test_crewai_system_prompt_warns(self) -> None:
+        from thenvoi.adapters.crewai import CrewAIAdapter
+
+        with pytest.warns(DeprecationWarning, match="system_prompt.*deprecated"):
+            CrewAIAdapter(system_prompt="Be a helpful agent.")
+
+    def test_google_adk_enable_execution_reporting_warns(self) -> None:
+        from thenvoi.adapters.google_adk import GoogleADKAdapter
+
+        with pytest.warns(
+            DeprecationWarning, match="enable_execution_reporting|enable_memory_tools"
+        ):
+            adapter = GoogleADKAdapter(enable_execution_reporting=True)
+        assert Emit.EXECUTION in adapter.features.emit
+
+    def test_google_adk_enable_memory_tools_warns(self) -> None:
+        from thenvoi.adapters.google_adk import GoogleADKAdapter
+
+        with pytest.warns(
+            DeprecationWarning, match="enable_execution_reporting|enable_memory_tools"
+        ):
+            adapter = GoogleADKAdapter(enable_memory_tools=True)
+        assert Capability.MEMORY in adapter.features.capabilities
+
+    def test_google_adk_both_booleans_and_features_raises(self) -> None:
+        from thenvoi.adapters.google_adk import GoogleADKAdapter
+
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
+            GoogleADKAdapter(
+                enable_execution_reporting=True,
+                features=AdapterFeatures(emit={Emit.EXECUTION}),
+            )
+
+    def test_codex_enable_execution_reporting_warns(self) -> None:
+        from thenvoi.adapters.codex import CodexAdapter, CodexAdapterConfig
+
+        config = CodexAdapterConfig(enable_execution_reporting=True)
+        with pytest.warns(DeprecationWarning, match="enable_execution_reporting"):
+            adapter = CodexAdapter(config=config)
+        assert Emit.EXECUTION in adapter.features.emit
+
+    def test_codex_emit_thought_events_warns(self) -> None:
+        from thenvoi.adapters.codex import CodexAdapter, CodexAdapterConfig
+
+        config = CodexAdapterConfig(emit_thought_events=True)
+        with pytest.warns(DeprecationWarning, match="emit_thought_events"):
+            adapter = CodexAdapter(config=config)
+        assert Emit.THOUGHTS in adapter.features.emit
+
+    def test_codex_config_booleans_and_features_raises(self) -> None:
+        from thenvoi.adapters.codex import CodexAdapter, CodexAdapterConfig
+
+        config = CodexAdapterConfig(enable_execution_reporting=True)
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
+            CodexAdapter(
+                config=config,
+                features=AdapterFeatures(emit={Emit.EXECUTION}),
+            )
 
 
 class TestSelectiveRenameShims:
@@ -116,3 +220,15 @@ class TestSelectiveRenameShims:
 
         with pytest.warns(DeprecationWarning, match="custom_section"):
             GeminiAdapter(custom_section="Be concise.")
+
+    def test_gemini_api_key_and_gemini_api_key_conflict(self) -> None:
+        from thenvoi.adapters.gemini import GeminiAdapter
+
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
+            GeminiAdapter(api_key="AIza-new", gemini_api_key="AIza-old")
+
+    def test_gemini_prompt_and_custom_section_conflict(self) -> None:
+        from thenvoi.adapters.gemini import GeminiAdapter
+
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
+            GeminiAdapter(prompt="new", custom_section="old")

--- a/tests/adapters/test_google_adk_adapter.py
+++ b/tests/adapters/test_google_adk_adapter.py
@@ -102,13 +102,17 @@ class TestInitialization:
 
     def test_execution_reporting_default(self):
         """Should default execution reporting to False."""
+        from thenvoi.core.types import Emit
+
         adapter = GoogleADKAdapter()
-        assert adapter.enable_execution_reporting is False
+        assert Emit.EXECUTION not in adapter.features.emit
 
     def test_memory_tools_default(self):
         """Should default memory tools to False."""
+        from thenvoi.core.types import Capability
+
         adapter = GoogleADKAdapter()
-        assert adapter.enable_memory_tools is False
+        assert Capability.MEMORY not in adapter.features.capabilities
 
     def test_empty_custom_tools(self):
         """Should default to empty custom tools list."""

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -293,21 +293,16 @@ def _build_anthropic_config() -> AdapterConfig:
         expected_initial_values={
             "model": _default_from_init(AnthropicAdapter, "model"),
             "max_tokens": _default_from_init(AnthropicAdapter, "max_tokens"),
-            "enable_execution_reporting": _default_from_init(
-                AnthropicAdapter, "enable_execution_reporting"
-            ),
         },
         custom_kwargs={
             "model": "claude-opus-4-20250514",
             "max_tokens": 8192,
-            "custom_section": "Be helpful.",
-            "enable_execution_reporting": True,
+            "prompt": "Be helpful.",
         },
         custom_expected={
             "model": "claude-opus-4-20250514",
             "max_tokens": 8192,
-            "custom_section": "Be helpful.",
-            "enable_execution_reporting": True,
+            "_prompt": "Be helpful.",
         },
     )
 
@@ -347,9 +342,6 @@ def _build_crewai_config() -> AdapterConfig:
             "role": _default_from_init(crewai_cls, "role"),
             "goal": _default_from_init(crewai_cls, "goal"),
             "backstory": _default_from_init(crewai_cls, "backstory"),
-            "enable_execution_reporting": _default_from_init(
-                crewai_cls, "enable_execution_reporting"
-            ),
             "verbose": _default_from_init(crewai_cls, "verbose"),
             "max_iter": _default_from_init(crewai_cls, "max_iter"),
             "allow_delegation": _default_from_init(crewai_cls, "allow_delegation"),
@@ -360,7 +352,6 @@ def _build_crewai_config() -> AdapterConfig:
             "goal": "Find and analyze information",
             "backstory": "Expert researcher",
             "custom_section": "Be thorough.",
-            "enable_execution_reporting": True,
             "verbose": True,
             "max_iter": 30,
             "max_rpm": 10,
@@ -372,7 +363,6 @@ def _build_crewai_config() -> AdapterConfig:
             "goal": "Find and analyze information",
             "backstory": "Expert researcher",
             "custom_section": "Be thorough.",
-            "enable_execution_reporting": True,
             "verbose": True,
             "max_iter": 30,
             "max_rpm": 10,
@@ -395,23 +385,18 @@ def _build_claude_sdk_config() -> AdapterConfig:
                 ClaudeSDKAdapter, "max_thinking_tokens"
             ),
             "permission_mode": _default_from_init(ClaudeSDKAdapter, "permission_mode"),
-            "enable_execution_reporting": _default_from_init(
-                ClaudeSDKAdapter, "enable_execution_reporting"
-            ),
         },
         custom_kwargs={
             "model": "claude-opus-4-20250514",
             "custom_section": "Be helpful.",
             "max_thinking_tokens": 10000,
             "permission_mode": "bypassPermissions",
-            "enable_execution_reporting": True,
         },
         custom_expected={
             "model": "claude-opus-4-20250514",
             "custom_section": "Be helpful.",
             "max_thinking_tokens": 10000,
             "permission_mode": "bypassPermissions",
-            "enable_execution_reporting": True,
         },
         skip_on_started_conformance=True,  # on_started creates real MCP server + ClaudeSessionManager; tested in test_claude_sdk_adapter
     )
@@ -430,21 +415,16 @@ def _build_pydantic_ai_config() -> AdapterConfig:
             "model": _PYDANTIC_AI_INJECTED_MODEL,
             "system_prompt": _default_from_init(PydanticAIAdapter, "system_prompt"),
             "custom_section": _default_from_init(PydanticAIAdapter, "custom_section"),
-            "enable_execution_reporting": _default_from_init(
-                PydanticAIAdapter, "enable_execution_reporting"
-            ),
         },
         custom_kwargs={
             "model": "anthropic:claude-sonnet-4-5-20250929",
             "system_prompt": "You are a helpful bot.",
             "custom_section": "Be concise.",
-            "enable_execution_reporting": True,
         },
         custom_expected={
             "model": "anthropic:claude-sonnet-4-5-20250929",
             "system_prompt": "You are a helpful bot.",
             "custom_section": "Be concise.",
-            "enable_execution_reporting": True,
         },
         skip_on_started_conformance=True,  # on_started creates real OpenAI client; tested in test_pydantic_ai_adapter
     )
@@ -567,22 +547,16 @@ def _build_gemini_config() -> AdapterConfig:
         expected_initial_values={
             "model": _default_from_init(GeminiAdapter, "model"),
             "system_prompt": _default_from_init(GeminiAdapter, "system_prompt"),
-            "custom_section": _default_from_init(GeminiAdapter, "custom_section"),
-            "enable_execution_reporting": _default_from_init(
-                GeminiAdapter, "enable_execution_reporting"
-            ),
         },
         custom_kwargs={
             "model": "gemini-2.5-flash",
             "system_prompt": "You are a helpful bot.",
-            "custom_section": "Be concise.",
-            "enable_execution_reporting": True,
+            "prompt": "Be concise.",
         },
         custom_expected={
             "model": "gemini-2.5-flash",
             "system_prompt": "You are a helpful bot.",
-            "custom_section": "Be concise.",
-            "enable_execution_reporting": True,
+            "_prompt": "Be concise.",
         },
     )
 
@@ -605,12 +579,6 @@ def _build_google_adk_config() -> AdapterConfig:
         adapter_factory=_google_adk_factory,
         expected_initial_values={
             "model": _default_from_init(GoogleADKAdapter, "model"),
-            "enable_execution_reporting": _default_from_init(
-                GoogleADKAdapter, "enable_execution_reporting"
-            ),
-            "enable_memory_tools": _default_from_init(
-                GoogleADKAdapter, "enable_memory_tools"
-            ),
             "custom_section": _default_from_init(GoogleADKAdapter, "custom_section"),
             "max_history_messages": _default_from_init(
                 GoogleADKAdapter, "max_history_messages"
@@ -622,12 +590,10 @@ def _build_google_adk_config() -> AdapterConfig:
         custom_kwargs={
             "model": "gemini-2.5-pro",
             "custom_section": "Be helpful.",
-            "enable_execution_reporting": True,
         },
         custom_expected={
             "model": "gemini-2.5-pro",
             "custom_section": "Be helpful.",
-            "enable_execution_reporting": True,
         },
         skip_on_started_conformance=False,
     )

--- a/tests/framework_conformance/test_adapter_conformance.py
+++ b/tests/framework_conformance/test_adapter_conformance.py
@@ -149,3 +149,62 @@ class TestAdapterCleanup:
 
         # Should not raise
         await adapter.on_cleanup("nonexistent-room")
+
+
+class TestAdapterFeaturesContract:
+    """Every adapter must declare its supported emit/capability set.
+
+    Catches regressions where a new adapter is added without declaring
+    SUPPORTED_EMIT or SUPPORTED_CAPABILITIES — which would break the
+    feature warning mechanism in SimpleAdapter.on_started().
+    """
+
+    def test_supported_emit_declared(self, adapter_config):
+        """Every adapter class must define SUPPORTED_EMIT as a frozenset."""
+        from thenvoi.core.types import Emit
+
+        adapter = adapter_config.adapter_factory()
+        cls = type(adapter)
+        assert hasattr(cls, "SUPPORTED_EMIT"), (
+            f"{adapter_config.display_name}: missing SUPPORTED_EMIT class var. "
+            f"Declare it as `SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({{...}})`."
+        )
+        supported = cls.SUPPORTED_EMIT
+        assert isinstance(supported, frozenset), (
+            f"{adapter_config.display_name}.SUPPORTED_EMIT must be a frozenset, "
+            f"got {type(supported).__name__}"
+        )
+        for value in supported:
+            assert isinstance(value, Emit), (
+                f"{adapter_config.display_name}.SUPPORTED_EMIT contains non-Emit "
+                f"value: {value!r}"
+            )
+
+    def test_supported_capabilities_declared(self, adapter_config):
+        """Every adapter class must define SUPPORTED_CAPABILITIES as a frozenset."""
+        from thenvoi.core.types import Capability
+
+        adapter = adapter_config.adapter_factory()
+        cls = type(adapter)
+        assert hasattr(cls, "SUPPORTED_CAPABILITIES"), (
+            f"{adapter_config.display_name}: missing SUPPORTED_CAPABILITIES class var. "
+            f"Declare it as "
+            f"`SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset({{...}})`."
+        )
+        supported = cls.SUPPORTED_CAPABILITIES
+        assert isinstance(supported, frozenset), (
+            f"{adapter_config.display_name}.SUPPORTED_CAPABILITIES must be a frozenset, "
+            f"got {type(supported).__name__}"
+        )
+        for value in supported:
+            assert isinstance(value, Capability), (
+                f"{adapter_config.display_name}.SUPPORTED_CAPABILITIES contains "
+                f"non-Capability value: {value!r}"
+            )
+
+    def test_features_param_accepted(self, adapter_config):
+        """Every adapter constructor must accept features=AdapterFeatures(...)."""
+        from thenvoi.core.types import AdapterFeatures
+
+        adapter = adapter_config.adapter_factory(features=AdapterFeatures())
+        assert adapter.features == AdapterFeatures()


### PR DESCRIPTION
## Summary
Normalize all 14 adapter constructors to use the shared `AdapterFeatures` vocabulary.

### Universal changes (all 14 adapters)
- Declare `SUPPORTED_EMIT` and `SUPPORTED_CAPABILITIES` as `ClassVar` sets
- Accept `features=AdapterFeatures()` via `SimpleAdapter`
- Config-based adapters (Codex, Opencode, Letta) auto-build features from config booleans

### Boolean deprecation (11 adapters)
- `enable_memory_tools` / `enable_execution_reporting` emit `DeprecationWarning`
- Passing both booleans and `features=` raises `ThenvoiConfigError`
- Internal reads migrated from booleans to `features` membership checks

### Selective renames (Anthropic + Gemini only)
- `anthropic_api_key` -> `api_key`, `gemini_api_key` -> `api_key`
- `custom_section` -> `prompt`
- New `include_base_instructions` param
- Old names accepted with `DeprecationWarning` for one release

**Part 3 of 6** for INT-294 SDK Cleanup & Normalization.
**Depends on:** Step 2 (#212)

## Test plan
- [x] 2472 tests pass (34 new from Steps 1-3)
- [x] Conformance configs updated for new attribute names
- [x] All pre-commit hooks pass (ruff check, ruff format, pyrefly)
- [ ] Verify deprecated boolean paths still work (covered by existing tests using old params)
- [ ] Verify `ThenvoiConfigError` on conflicting params