### PR TITLE
feat: publish package under both thenvoi-sdk and band-sdk names (INT-303)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,24 @@ jobs:
         if: steps.release.outputs.release_created == 'true'
         run: uv build
 
-      - name: Publish to PyPI
+      - name: Publish thenvoi-sdk to PyPI
         if: steps.release.outputs.release_created == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Rebuild as band-sdk
+        if: steps.release.outputs.release_created == 'true'
+        run: |
+          sed -i 's/^name = "thenvoi-sdk"/name = "band-sdk"/' pyproject.toml
+          rm -rf dist/
+          uv build
+
+      - name: Publish band-sdk to PyPI
+        if: steps.release.outputs.release_created == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Restore pyproject.toml
+        if: steps.release.outputs.release_created == 'true'
+        run: git checkout pyproject.toml
 
       - name: Publish release summary
         if: steps.release.outputs.release_created == 'true'


### PR DESCRIPTION
## Summary
- Add CI steps to publish the package under both `thenvoi-sdk` and `band-sdk` names on PyPI
- After publishing `thenvoi-sdk`, the workflow swaps the name in `pyproject.toml`, rebuilds, and publishes as `band-sdk`
- `pyproject.toml` is restored after the second publish

## Prerequisites (manual PyPI steps)
- [x] Transfer `thenvoi-sdk` to the band org on PyPI
- [ ] Register `band-sdk` as a trusted publisher on PyPI (owner: `thenvoi`, repo: `thenvoi-sdk-python`, workflow: `release.yml`, environment: `release`)

## Test plan
- [ ] Verify trusted publisher is configured for `band-sdk` on PyPI
- [ ] Trigger a release and verify both `thenvoi-sdk` and `band-sdk` are published
- [ ] Verify `uv add band-sdk` installs the package correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)