### PR TITLE
fix: surface WS disconnect reason in Python SDK

### DIFF
--- a/src/thenvoi/client/streaming/__init__.py
+++ b/src/thenvoi/client/streaming/__init__.py
@@ -7,6 +7,7 @@ Usage:
 """
 
 from thenvoi.client.streaming.client import (
+    KNOWN_DISCONNECT_REASONS,
     WebSocketClient,
     MessageCreatedPayload,
     RoomAddedPayload,
@@ -20,9 +21,12 @@ from thenvoi.client.streaming.client import (
     ContactRequestUpdatedPayload,
     ContactAddedPayload,
     ContactRemovedPayload,
+    extract_disconnect_reason,
+    humanize_disconnect_reason,
 )
 
 __all__ = [
+    "KNOWN_DISCONNECT_REASONS",
     "WebSocketClient",
     "MessageCreatedPayload",
     "RoomAddedPayload",
@@ -36,4 +40,6 @@ __all__ = [
     "ContactRequestUpdatedPayload",
     "ContactAddedPayload",
     "ContactRemovedPayload",
+    "extract_disconnect_reason",
+    "humanize_disconnect_reason",
 ]

--- a/src/thenvoi/client/streaming/client.py
+++ b/src/thenvoi/client/streaming/client.py
@@ -10,6 +10,7 @@ from phoenix_channels_python_client.client import (
 )
 from phoenix_channels_python_client.phx_messages import PHXMessage
 from pydantic import BaseModel, ConfigDict, ValidationError
+from websockets.exceptions import ConnectionClosed
 
 logger = logging.getLogger(__name__)
 
@@ -17,8 +18,8 @@ logger = logging.getLogger(__name__)
 _PHX_CLOSE = "phx_close"
 _PHX_ERROR = "phx_error"
 
-# Callback type: (human_reason, raw_payload | None) -> None
-DisconnectCallback = Callable[[str, dict | None], Awaitable[None]]
+# Callback type: (human_reason, raw_payload | None, topic | None) -> None
+DisconnectCallback = Callable[[str, dict | None, str | None], Awaitable[None]]
 
 # Map well-known backend reason strings to human-readable messages.
 # Unknown reasons fall back to including the raw payload.
@@ -228,8 +229,8 @@ def humanize_disconnect_reason(reason: str, raw_payload: dict | None = None) -> 
     if reason in KNOWN_DISCONNECT_REASONS:
         return KNOWN_DISCONNECT_REASONS[reason]
     if raw_payload:
-        return "Disconnected: %s (raw: %s)" % (reason, raw_payload)
-    return "Disconnected: %s" % reason
+        return f"Disconnected: {reason} (raw: {raw_payload})"
+    return f"Disconnected: {reason}"
 
 
 def _extract_transport_reason(error: Exception | None) -> str:
@@ -241,11 +242,10 @@ def _extract_transport_reason(error: Exception | None) -> str:
     """
     if error is None:
         return "connection_closed"
-    # websockets.exceptions.ConnectionClosed has .reason and .code
-    if hasattr(error, "reason") and error.reason:
-        return str(error.reason)
-    if hasattr(error, "code"):
-        return "close_code_%s" % error.code
+    if isinstance(error, ConnectionClosed) and error.rcvd is not None:
+        if error.rcvd.reason:
+            return str(error.rcvd.reason)
+        return f"close_code_{error.rcvd.code}"
     return str(error)
 
 
@@ -303,7 +303,7 @@ class WebSocketClient:
         if self._on_disconnect:
             raw = {"error": str(error)} if error else None
             try:
-                await self._on_disconnect(human, raw)
+                await self._on_disconnect(human, raw, None)
             except Exception:  # noqa: BLE001
                 logger.exception("[WebSocket] Error in disconnect callback")
 
@@ -325,7 +325,7 @@ class WebSocketClient:
             )
             if self._on_disconnect:
                 try:
-                    await self._on_disconnect(human, message.payload)
+                    await self._on_disconnect(human, message.payload, message.topic)
                 except Exception:  # noqa: BLE001
                     logger.exception("[WebSocket] Error in disconnect callback")
             return

--- a/src/thenvoi/client/streaming/client.py
+++ b/src/thenvoi/client/streaming/client.py
@@ -13,6 +13,27 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 
 logger = logging.getLogger(__name__)
 
+# Phoenix protocol events that indicate channel/connection errors
+_PHX_CLOSE = "phx_close"
+_PHX_ERROR = "phx_error"
+
+# Callback type: (human_reason, raw_payload | None) -> None
+DisconnectCallback = Callable[[str, dict | None], Awaitable[None]]
+
+# Map well-known backend reason strings to human-readable messages.
+# Unknown reasons fall back to including the raw payload.
+KNOWN_DISCONNECT_REASONS: dict[str, str] = {
+    "replaced": (
+        "Another instance connected with the same agent ID "
+        "— only one connection per agent is allowed"
+    ),
+    "kicked": "Agent was removed by the platform",
+    "token_expired": "Authentication token expired or was revoked",
+    "invalid_token": "Authentication token is invalid",
+    "normal": "Server closed the connection normally",
+    "unauthorized": "Not authorized to join this channel",
+}
+
 
 # WebSocket message payloads (based on actual backend messages)
 # Using Pydantic for runtime validation
@@ -178,11 +199,68 @@ _PAYLOAD_MODELS: dict[str, type[BaseModel]] = {
 }
 
 
+def extract_disconnect_reason(payload: dict) -> str:
+    """Extract a reason string from a phx_close / phx_error payload.
+
+    Tries common Phoenix payload shapes in order:
+      1. ``{"reason": "..."}``
+      2. ``{"response": {"reason": "..."}}``
+      3. ``{"message": "..."}``
+    Falls back to ``"unknown"`` if none match.
+    """
+    if "reason" in payload:
+        return str(payload["reason"])
+    response = payload.get("response")
+    if isinstance(response, dict) and "reason" in response:
+        return str(response["reason"])
+    if "message" in payload:
+        return str(payload["message"])
+    return "unknown"
+
+
+def humanize_disconnect_reason(reason: str, raw_payload: dict | None = None) -> str:
+    """Return a human-readable disconnect message.
+
+    If *reason* matches a well-known key the canned explanation is returned.
+    Otherwise the raw reason (and optionally the full payload) is included so
+    operators can diagnose unknown scenarios.
+    """
+    if reason in KNOWN_DISCONNECT_REASONS:
+        return KNOWN_DISCONNECT_REASONS[reason]
+    if raw_payload:
+        return "Disconnected: %s (raw: %s)" % (reason, raw_payload)
+    return "Disconnected: %s" % reason
+
+
+def _extract_transport_reason(error: Exception | None) -> str:
+    """Best-effort reason from a transport-level disconnect exception.
+
+    The ``websockets`` library raises ``ConnectionClosed`` subclasses that
+    carry ``.code`` and ``.reason`` attributes.  We surface those when
+    available; otherwise we fall back to ``str(error)``.
+    """
+    if error is None:
+        return "connection_closed"
+    # websockets.exceptions.ConnectionClosed has .reason and .code
+    if hasattr(error, "reason") and error.reason:
+        return str(error.reason)
+    if hasattr(error, "code"):
+        return "close_code_%s" % error.code
+    return str(error)
+
+
 class WebSocketClient:
-    def __init__(self, ws_url: str, api_key: str, agent_id: str | None = None):
+    def __init__(
+        self,
+        ws_url: str,
+        api_key: str,
+        agent_id: str | None = None,
+        on_disconnect: DisconnectCallback | None = None,
+    ):
         self.ws_url = ws_url
         self.api_key = api_key
         self.agent_id = agent_id
+        self._on_disconnect = on_disconnect
         self._validation_error_count: int = 0
 
     @property
@@ -205,6 +283,7 @@ class WebSocketClient:
             self.ws_url,
             self.api_key,
             protocol_version=PhoenixChannelsProtocolVersion.V2,
+            on_disconnect=self._on_transport_disconnect,
         )
         if self.agent_id:
             self.client.channel_socket_url += f"&agent_id={self.agent_id}"
@@ -216,9 +295,40 @@ class WebSocketClient:
         if self.client:
             await self.client.__aexit__(exc_type, exc_val, exc_tb)
 
+    async def _on_transport_disconnect(self, error: Exception | None) -> None:
+        """Handle transport-level disconnects from PHXChannelsClient."""
+        reason = _extract_transport_reason(error)
+        human = humanize_disconnect_reason(reason)
+        logger.warning("[WebSocket] Transport disconnected: %s", human)
+        if self._on_disconnect:
+            raw = {"error": str(error)} if error else None
+            try:
+                await self._on_disconnect(human, raw)
+            except Exception:  # noqa: BLE001
+                logger.exception("[WebSocket] Error in disconnect callback")
+
     async def _handle_events(self, message: PHXMessage, event_handlers: dict):
         """Generic async event handler that maps events to their corresponding async callbacks"""
         logger.debug("[WebSocket] Received event: %s", message.event)
+
+        # Intercept Phoenix close / error events before normal dispatch.
+        # These indicate the server is closing the channel (e.g. duplicate
+        # agent connection) and must be surfaced to the caller.
+        if message.event in (_PHX_CLOSE, _PHX_ERROR):
+            reason = extract_disconnect_reason(message.payload)
+            human = humanize_disconnect_reason(reason, message.payload)
+            logger.warning(
+                "[WebSocket] Channel %s on topic %s: %s",
+                message.event,
+                message.topic,
+                human,
+            )
+            if self._on_disconnect:
+                try:
+                    await self._on_disconnect(human, message.payload)
+                except Exception:  # noqa: BLE001
+                    logger.exception("[WebSocket] Error in disconnect callback")
+            return
 
         # Check if we have a handler for this event
         if message.event not in event_handlers:

--- a/src/thenvoi/platform/__init__.py
+++ b/src/thenvoi/platform/__init__.py
@@ -6,10 +6,11 @@ Components:
     PlatformEvent: Single event type for all platform events
 """
 
-from .event import PlatformEvent
+from .event import DisconnectedEvent, PlatformEvent
 from .link import ThenvoiLink
 
 __all__ = [
+    "DisconnectedEvent",
     "ThenvoiLink",
     "PlatformEvent",
 ]

--- a/src/thenvoi/platform/event.py
+++ b/src/thenvoi/platform/event.py
@@ -125,6 +125,22 @@ class ContactRemovedEvent:
     raw: dict[str, Any] | None = None
 
 
+@dataclass
+class DisconnectedEvent:
+    """WebSocket disconnected event with reason.
+
+    Fired when the platform closes the connection (e.g. another instance
+    connected with the same agent ID) or when a transport-level disconnect
+    is detected.  The ``reason`` field contains a human-readable explanation;
+    ``raw`` preserves the original payload for diagnostics.
+    """
+
+    type: Literal["disconnected"] = "disconnected"
+    room_id: str | None = None  # Always None — connection-level event
+    reason: str = "unknown"
+    raw: dict[str, Any] | None = None
+
+
 # Contact event union (for type narrowing)
 ContactEvent = (
     ContactRequestReceivedEvent
@@ -146,4 +162,5 @@ PlatformEvent = (
     | ContactRequestUpdatedEvent
     | ContactAddedEvent
     | ContactRemovedEvent
+    | DisconnectedEvent
 )

--- a/src/thenvoi/platform/link.py
+++ b/src/thenvoi/platform/link.py
@@ -28,6 +28,7 @@ from .event import (
     ContactRequestUpdatedEvent,
     ContactAddedEvent,
     ContactRemovedEvent,
+    DisconnectedEvent,
     PlatformEvent,
 )
 
@@ -122,7 +123,12 @@ class ThenvoiLink:
             logger.warning("Already connected")
             return
 
-        self._ws = WebSocketClient(self.ws_url, self.api_key, self.agent_id)
+        self._ws = WebSocketClient(
+            self.ws_url,
+            self.api_key,
+            self.agent_id,
+            on_disconnect=self._on_ws_disconnect,
+        )
         await self._ws.__aenter__()
         self._is_connected = True
         logger.info("Connected to platform")
@@ -249,6 +255,21 @@ class ThenvoiLink:
             await self._ws.leave_agent_contacts_channel(self.agent_id)
         except Exception as e:
             logger.warning("Error unsubscribing from agent_contacts: %s", e)
+
+    # --- Disconnect handling ---
+
+    async def _on_ws_disconnect(self, reason: str, raw: dict | None) -> None:
+        """Handle disconnect notifications from the WebSocket layer.
+
+        Called for both channel-level events (phx_close / phx_error) and
+        transport-level disconnects.  Logs a human-readable message and
+        queues a ``DisconnectedEvent`` so consumers (RoomPresence, adapters)
+        can react.
+        """
+        logger.warning("Platform connection lost: %s", reason)
+        self._is_connected = False
+        event = DisconnectedEvent(reason=reason, raw=raw)
+        self._queue_event(event)
 
     # --- Event handlers (from ThenvoiAgent, unified into PlatformEvent) ---
 

--- a/src/thenvoi/platform/link.py
+++ b/src/thenvoi/platform/link.py
@@ -258,7 +258,9 @@ class ThenvoiLink:
 
     # --- Disconnect handling ---
 
-    async def _on_ws_disconnect(self, reason: str, raw: dict | None) -> None:
+    async def _on_ws_disconnect(
+        self, reason: str, raw: dict | None, topic: str | None = None
+    ) -> None:
         """Handle disconnect notifications from the WebSocket layer.
 
         Called for both channel-level events (phx_close / phx_error) and
@@ -268,12 +270,23 @@ class ThenvoiLink:
 
         Guarded so that only the first disconnect fires the event — a
         ``phx_close`` followed by a transport drop won't produce duplicates.
+
+        Note: the ``_is_connected`` guard is safe without a lock because both
+        channel-level and transport-level callbacks run on the same event loop.
         """
         if not self._is_connected:
             return
         logger.warning("Platform connection lost: %s", reason)
         self._is_connected = False
-        event = DisconnectedEvent(reason=reason, raw=raw)
+
+        # Parse room_id from channel topic (e.g. "chat_room:room-123")
+        room_id: str | None = None
+        if topic and ":" in topic:
+            prefix, _, entity_id = topic.partition(":")
+            if prefix == "chat_room":
+                room_id = entity_id
+
+        event = DisconnectedEvent(reason=reason, raw=raw, room_id=room_id)
         self._queue_event(event)
 
     # --- Event handlers (from ThenvoiAgent, unified into PlatformEvent) ---

--- a/src/thenvoi/platform/link.py
+++ b/src/thenvoi/platform/link.py
@@ -265,7 +265,12 @@ class ThenvoiLink:
         transport-level disconnects.  Logs a human-readable message and
         queues a ``DisconnectedEvent`` so consumers (RoomPresence, adapters)
         can react.
+
+        Guarded so that only the first disconnect fires the event — a
+        ``phx_close`` followed by a transport drop won't produce duplicates.
         """
+        if not self._is_connected:
+            return
         logger.warning("Platform connection lost: %s", reason)
         self._is_connected = False
         event = DisconnectedEvent(reason=reason, raw=raw)

--- a/src/thenvoi/platform/link.py
+++ b/src/thenvoi/platform/link.py
@@ -264,20 +264,29 @@ class ThenvoiLink:
         """Handle disconnect notifications from the WebSocket layer.
 
         Called for both channel-level events (phx_close / phx_error) and
-        transport-level disconnects.  Logs a human-readable message and
-        queues a ``DisconnectedEvent`` so consumers (RoomPresence, adapters)
-        can react.
+        transport-level disconnects.
 
-        Guarded so that only the first disconnect fires the event — a
-        ``phx_close`` followed by a transport drop won't produce duplicates.
+        Channel-level disconnects (topic is set) are always surfaced — each
+        carries distinct information about which channel was closed and why.
+        For example, the server may close ``chat_room:X`` (unauthorized) and
+        then ``agent_rooms:Y`` (replaced) before the transport drops.
+
+        Transport-level disconnects (topic is None) are deduped so only the
+        first fires, preventing a ``phx_close`` followed by a transport drop
+        from producing duplicate events.
 
         Note: the ``_is_connected`` guard is safe without a lock because both
         channel-level and transport-level callbacks run on the same event loop.
         """
-        if not self._is_connected:
-            return
-        logger.warning("Platform connection lost: %s", reason)
-        self._is_connected = False
+        if topic is None:
+            # Transport-level disconnect — dedup so only the first fires
+            if not self._is_connected:
+                return
+            self._is_connected = False
+            logger.warning("Platform connection lost: %s", reason)
+        else:
+            # Channel-level disconnect — always surface these
+            logger.warning("Channel disconnected (%s): %s", topic, reason)
 
         # Parse room_id from channel topic (e.g. "chat_room:room-123")
         room_id: str | None = None

--- a/src/thenvoi/runtime/presence.py
+++ b/src/thenvoi/runtime/presence.py
@@ -16,6 +16,7 @@ from thenvoi.platform.event import (
     RoomAddedEvent,
     RoomDeletedEvent,
     RoomRemovedEvent,
+    DisconnectedEvent,
     PlatformEvent,
     ContactEvent,
     ContactRequestReceivedEvent,
@@ -93,6 +94,7 @@ class RoomPresence:
             None
         )
         self.on_contact_event: ContactEventHandler | None = None
+        self.on_disconnected: Callable[[str], Awaitable[None]] | None = None
 
         # Internal task for consuming events from link
         self._event_task: asyncio.Task | None = None
@@ -170,6 +172,8 @@ class RoomPresence:
                 await self._handle_room_added(event)
             case RoomRemovedEvent() | RoomDeletedEvent():
                 await self._handle_room_left(event)
+            case DisconnectedEvent():
+                await self._handle_disconnected(event)
             case (
                 ContactRequestReceivedEvent()
                 | ContactRequestUpdatedEvent()
@@ -289,6 +293,19 @@ class RoomPresence:
                     e,
                     exc_info=True,
                 )
+
+    async def _handle_disconnected(self, event: DisconnectedEvent) -> None:
+        """Handle platform disconnect event.
+
+        Logs the reason and forwards to ``on_disconnected`` callback so
+        the runtime / adapter layer can react (e.g. stop processing).
+        """
+        logger.warning("Platform disconnected: %s", event.reason)
+        if self.on_disconnected:
+            try:
+                await self.on_disconnected(event.reason)
+            except Exception as e:
+                logger.error("on_disconnected callback error: %s", e, exc_info=True)
 
     async def _subscribe_to_existing_rooms(self) -> None:
         """

--- a/src/thenvoi/runtime/runtime.py
+++ b/src/thenvoi/runtime/runtime.py
@@ -187,16 +187,26 @@ class AgentRuntime:
             logger.warning("No execution for room %s, event dropped", room_id)
 
     async def _on_disconnected(self, reason: str) -> None:
-        """Handle platform disconnect — log and surface reason.
+        """Handle platform disconnect — cancel active executions.
 
-        TODO: cancel active executions and notify adapters so they don't
-        continue processing against a dead connection.
+        The connection is dead, so executions can't send results back.
+        Cancel them immediately (timeout=None) and run cleanup callbacks
+        so adapters can release resources.
         """
         logger.error(
             "Agent %s disconnected from platform: %s",
             self.agent_id,
             reason,
         )
+        for room_id in list(self.executions.keys()):
+            try:
+                await self._destroy_execution(room_id, timeout=None)
+            except Exception as e:
+                logger.error(
+                    "Failed to stop execution for room %s on disconnect: %s",
+                    room_id,
+                    e,
+                )
 
     # --- Execution management ---
 

--- a/src/thenvoi/runtime/runtime.py
+++ b/src/thenvoi/runtime/runtime.py
@@ -187,7 +187,11 @@ class AgentRuntime:
             logger.warning("No execution for room %s, event dropped", room_id)
 
     async def _on_disconnected(self, reason: str) -> None:
-        """Handle platform disconnect — log and surface reason."""
+        """Handle platform disconnect — log and surface reason.
+
+        TODO: cancel active executions and notify adapters so they don't
+        continue processing against a dead connection.
+        """
         logger.error(
             "Agent %s disconnected from platform: %s",
             self.agent_id,

--- a/src/thenvoi/runtime/runtime.py
+++ b/src/thenvoi/runtime/runtime.py
@@ -110,6 +110,7 @@ class AgentRuntime:
         self.presence.on_room_joined = self._on_room_joined
         self.presence.on_room_left = self._on_room_left
         self.presence.on_room_event = self._on_room_event
+        self.presence.on_disconnected = self._on_disconnected
 
     @property
     def active_sessions(self) -> dict[str, Execution]:
@@ -184,6 +185,14 @@ class AgentRuntime:
             await execution.on_event(event)
         else:
             logger.warning("No execution for room %s, event dropped", room_id)
+
+    async def _on_disconnected(self, reason: str) -> None:
+        """Handle platform disconnect — log and surface reason."""
+        logger.error(
+            "Agent %s disconnected from platform: %s",
+            self.agent_id,
+            reason,
+        )
 
     # --- Execution management ---
 

--- a/tests/platform/test_disconnect.py
+++ b/tests/platform/test_disconnect.py
@@ -21,8 +21,9 @@ from thenvoi.client.streaming.client import (
     WebSocketClient,
     extract_disconnect_reason,
     humanize_disconnect_reason,
-    _extract_transport_reason,
 )
+from websockets.exceptions import ConnectionClosedError
+from websockets.frames import Close
 from thenvoi.platform.event import DisconnectedEvent
 from thenvoi.platform.link import ThenvoiLink
 from thenvoi.runtime.presence import RoomPresence
@@ -100,34 +101,56 @@ class TestHumanizeDisconnectReason:
 
 
 # ---------------------------------------------------------------------------
-# _extract_transport_reason
+# Transport reason extraction (tested via _on_transport_disconnect)
 # ---------------------------------------------------------------------------
 
 
 class TestExtractTransportReason:
-    """Test transport-level disconnect reason extraction."""
+    """Test transport-level disconnect reason extraction via _on_transport_disconnect."""
 
-    def test_none_error(self):
-        assert _extract_transport_reason(None) == "connection_closed"
+    @pytest.mark.asyncio
+    async def test_none_error(self):
+        on_disconnect = AsyncMock()
+        client = WebSocketClient(
+            ws_url="wss://test.com/ws", api_key="key", on_disconnect=on_disconnect
+        )
+        await client._on_transport_disconnect(None)
+        human, _, _ = on_disconnect.call_args[0]
+        assert "connection_closed" in human
 
-    def test_error_with_reason_attr(self):
-        err = Exception("boom")
-        err.reason = "replaced"  # type: ignore[attr-defined]
-        assert _extract_transport_reason(err) == "replaced"
+    @pytest.mark.asyncio
+    async def test_connection_closed_with_reason(self):
+        on_disconnect = AsyncMock()
+        client = WebSocketClient(
+            ws_url="wss://test.com/ws", api_key="key", on_disconnect=on_disconnect
+        )
+        err = ConnectionClosedError(Close(4001, "replaced"), None)
+        assert err.rcvd is not None and err.rcvd.reason == "replaced"
+        await client._on_transport_disconnect(err)
+        human, _, _ = on_disconnect.call_args[0]
+        assert "same agent ID" in human
 
-    def test_error_with_code_attr(self):
-        err = Exception("boom")
-        err.code = 4001  # type: ignore[attr-defined]
-        assert _extract_transport_reason(err) == "close_code_4001"
+    @pytest.mark.asyncio
+    async def test_connection_closed_with_code_only(self):
+        on_disconnect = AsyncMock()
+        client = WebSocketClient(
+            ws_url="wss://test.com/ws", api_key="key", on_disconnect=on_disconnect
+        )
+        err = ConnectionClosedError(Close(4001, ""), None)
+        assert err.rcvd is not None and err.rcvd.reason == ""
+        await client._on_transport_disconnect(err)
+        human, _, _ = on_disconnect.call_args[0]
+        assert "4001" in human
 
-    def test_error_with_empty_reason_falls_to_code(self):
-        err = Exception("boom")
-        err.reason = ""  # type: ignore[attr-defined]
-        err.code = 4001  # type: ignore[attr-defined]
-        assert _extract_transport_reason(err) == "close_code_4001"
-
-    def test_generic_exception(self):
-        assert _extract_transport_reason(RuntimeError("oops")) == "oops"
+    @pytest.mark.asyncio
+    async def test_generic_exception(self):
+        on_disconnect = AsyncMock()
+        client = WebSocketClient(
+            ws_url="wss://test.com/ws", api_key="key", on_disconnect=on_disconnect
+        )
+        await client._on_transport_disconnect(RuntimeError("oops"))
+        human, _, _ = on_disconnect.call_args[0]
+        assert "oops" in human
 
 
 # ---------------------------------------------------------------------------
@@ -160,9 +183,10 @@ class TestWebSocketClientHandlePhxEvents:
         await client._handle_events(msg, {"room_added": AsyncMock()})  # type: ignore[arg-type]
 
         on_disconnect.assert_awaited_once()
-        human, raw = on_disconnect.call_args[0]
+        human, raw, topic = on_disconnect.call_args[0]
         assert "same agent ID" in human
         assert raw == {"reason": "replaced"}
+        assert topic == "agent_rooms:agent-1"
 
     @pytest.mark.asyncio
     async def test_phx_error_triggers_callback(self, ws_client):
@@ -175,8 +199,9 @@ class TestWebSocketClientHandlePhxEvents:
         await client._handle_events(msg, {})  # type: ignore[arg-type]
 
         on_disconnect.assert_awaited_once()
-        human, _ = on_disconnect.call_args[0]
+        human, _, topic = on_disconnect.call_args[0]
         assert "Not authorized" in human
+        assert topic == "chat_room:room-1"
 
     @pytest.mark.asyncio
     async def test_phx_close_unknown_reason_includes_raw(self, ws_client):
@@ -189,7 +214,7 @@ class TestWebSocketClientHandlePhxEvents:
         await client._handle_events(msg, {})  # type: ignore[arg-type]
 
         on_disconnect.assert_awaited_once()
-        human, raw = on_disconnect.call_args[0]
+        human, raw, _ = on_disconnect.call_args[0]
         assert "unknown" in human
         assert "weird_field" in str(raw)
 
@@ -252,14 +277,15 @@ class TestWebSocketClientTransportDisconnect:
             api_key="key",
             on_disconnect=on_disconnect,
         )
-        err = Exception("connection reset")
-        err.reason = "replaced"  # type: ignore[attr-defined]
+        err = ConnectionClosedError(Close(4001, "replaced"), None)
+        assert err.rcvd is not None and err.rcvd.reason == "replaced"
         await client._on_transport_disconnect(err)
 
         on_disconnect.assert_awaited_once()
-        human, raw = on_disconnect.call_args[0]
+        human, raw, topic = on_disconnect.call_args[0]
         assert "same agent ID" in human
         assert raw is not None
+        assert topic is None  # transport-level has no topic
 
     @pytest.mark.asyncio
     async def test_transport_disconnect_none_error(self):
@@ -272,9 +298,10 @@ class TestWebSocketClientTransportDisconnect:
         await client._on_transport_disconnect(None)
 
         on_disconnect.assert_awaited_once()
-        human, raw = on_disconnect.call_args[0]
+        human, raw, topic = on_disconnect.call_args[0]
         assert "connection_closed" in human
         assert raw is None
+        assert topic is None
 
 
 # ---------------------------------------------------------------------------
@@ -286,7 +313,7 @@ class TestThenvoiLinkDisconnect:
     """Test ThenvoiLink queues DisconnectedEvent on disconnect."""
 
     @pytest.mark.asyncio
-    async def test_queues_disconnected_event(self):
+    async def test_queues_disconnected_event_without_topic(self):
         link = ThenvoiLink(agent_id="agent-1", api_key="key")
         link._is_connected = True
 
@@ -299,6 +326,31 @@ class TestThenvoiLinkDisconnect:
         assert event.reason == "Server closed normally"
         assert event.raw == {"reason": "normal"}
         assert event.room_id is None
+
+    @pytest.mark.asyncio
+    async def test_queues_disconnected_event_with_chat_room_topic(self):
+        link = ThenvoiLink(agent_id="agent-1", api_key="key")
+        link._is_connected = True
+
+        await link._on_ws_disconnect(
+            "Not authorized",
+            {"response": {"reason": "unauthorized"}},
+            "chat_room:room-42",
+        )
+
+        event = link._event_queue.get_nowait()
+        assert isinstance(event, DisconnectedEvent)
+        assert event.room_id == "room-42"
+
+    @pytest.mark.asyncio
+    async def test_queues_disconnected_event_with_non_chat_topic(self):
+        link = ThenvoiLink(agent_id="agent-1", api_key="key")
+        link._is_connected = True
+
+        await link._on_ws_disconnect("replaced", None, "agent_rooms:agent-1")
+
+        event = link._event_queue.get_nowait()
+        assert event.room_id is None  # agent_rooms topic doesn't map to room_id
 
     @pytest.mark.asyncio
     async def test_disconnect_sets_is_connected_false(self):

--- a/tests/platform/test_disconnect.py
+++ b/tests/platform/test_disconnect.py
@@ -362,18 +362,166 @@ class TestThenvoiLinkDisconnect:
         assert link._is_connected is False
 
     @pytest.mark.asyncio
-    async def test_second_disconnect_is_ignored(self):
-        """Only the first disconnect should queue an event."""
+    async def test_second_transport_disconnect_is_deduped(self):
+        """Only the first transport-level disconnect should queue an event."""
         link = ThenvoiLink(agent_id="agent-1", api_key="key")
         link._is_connected = True
 
         await link._on_ws_disconnect("replaced", {"reason": "replaced"})
         await link._on_ws_disconnect("transport closed", None)
 
-        # Only one event should be queued
+        # Only one event should be queued (both are transport-level, no topic)
         assert link._event_queue.qsize() == 1
         event = link._event_queue.get_nowait()
         assert event.reason == "replaced"
+
+    @pytest.mark.asyncio
+    async def test_channel_disconnect_does_not_flip_is_connected(self):
+        """Channel-level disconnects should not change _is_connected."""
+        link = ThenvoiLink(agent_id="agent-1", api_key="key")
+        link._is_connected = True
+
+        await link._on_ws_disconnect("unauthorized", None, "chat_room:room-1")
+
+        assert link._is_connected is True
+        assert link._event_queue.qsize() == 1
+
+    @pytest.mark.asyncio
+    async def test_multiple_channel_disconnects_all_surface(self):
+        """Each channel-level disconnect should produce an event."""
+        link = ThenvoiLink(agent_id="agent-1", api_key="key")
+        link._is_connected = True
+
+        await link._on_ws_disconnect("Not authorized", None, "chat_room:room-1")
+        await link._on_ws_disconnect(
+            "Another instance connected", None, "agent_rooms:agent-1"
+        )
+
+        assert link._event_queue.qsize() == 2
+        e1 = link._event_queue.get_nowait()
+        e2 = link._event_queue.get_nowait()
+        assert e1.reason == "Not authorized"
+        assert e1.room_id == "room-1"
+        assert e2.reason == "Another instance connected"
+        assert e2.room_id is None  # agent_rooms doesn't map to room_id
+
+    @pytest.mark.asyncio
+    async def test_channel_then_transport_produces_two_events(self):
+        """A channel close followed by transport drop should both fire."""
+        link = ThenvoiLink(agent_id="agent-1", api_key="key")
+        link._is_connected = True
+
+        # Channel-level phx_close (with topic)
+        await link._on_ws_disconnect(
+            "Another instance connected", {"reason": "replaced"}, "agent_rooms:agent-1"
+        )
+        # Transport-level disconnect (no topic)
+        await link._on_ws_disconnect("connection_closed", None)
+
+        assert link._event_queue.qsize() == 2
+        assert link._is_connected is False
+
+
+# ---------------------------------------------------------------------------
+# AgentRuntime — execution cleanup on disconnect
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeDisconnect:
+    """Test that AgentRuntime cancels executions on disconnect."""
+
+    @pytest.fixture
+    def mock_link(self):
+        link = MagicMock()
+        link.agent_id = "agent-1"
+        link.is_connected = True
+        link.connect = AsyncMock()
+        link.subscribe_agent_rooms = AsyncMock()
+        link.subscribe_room = AsyncMock()
+        link.unsubscribe_room = AsyncMock()
+        link.run_forever = AsyncMock()
+        link.rest = MagicMock()
+        link.rest.agent_api_chats = MagicMock()
+        link.rest.agent_api_chats.list_agent_chats = AsyncMock(
+            return_value=MagicMock(data=[])
+        )
+        return link
+
+    @pytest.mark.asyncio
+    async def test_on_disconnected_cancels_executions(self, mock_link):
+        from thenvoi.runtime.runtime import AgentRuntime
+
+        runtime = AgentRuntime(
+            link=mock_link, agent_id="agent-1", on_execute=AsyncMock()
+        )
+
+        # Add mock executions
+        exec1 = MagicMock()
+        exec1.stop = AsyncMock(return_value=True)
+        exec2 = MagicMock()
+        exec2.stop = AsyncMock(return_value=True)
+        runtime.executions["room-1"] = exec1
+        runtime.executions["room-2"] = exec2
+
+        await runtime._on_disconnected("replaced")
+
+        # Both executions should have been stopped with timeout=None (immediate)
+        exec1.stop.assert_awaited_once_with(timeout=None)
+        exec2.stop.assert_awaited_once_with(timeout=None)
+        assert len(runtime.executions) == 0
+
+    @pytest.mark.asyncio
+    async def test_on_disconnected_handles_stop_errors(self, mock_link):
+        from thenvoi.runtime.runtime import AgentRuntime
+
+        runtime = AgentRuntime(
+            link=mock_link, agent_id="agent-1", on_execute=AsyncMock()
+        )
+
+        # First execution raises on stop, second should still be stopped
+        exec1 = MagicMock()
+        exec1.stop = AsyncMock(side_effect=RuntimeError("boom"))
+        exec2 = MagicMock()
+        exec2.stop = AsyncMock(return_value=True)
+        runtime.executions["room-1"] = exec1
+        runtime.executions["room-2"] = exec2
+
+        # Should not raise
+        await runtime._on_disconnected("replaced")
+
+        exec1.stop.assert_awaited_once()
+        exec2.stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_on_disconnected_calls_session_cleanup(self, mock_link):
+        from thenvoi.runtime.runtime import AgentRuntime
+
+        cleanup = AsyncMock()
+        runtime = AgentRuntime(
+            link=mock_link,
+            agent_id="agent-1",
+            on_execute=AsyncMock(),
+            on_session_cleanup=cleanup,
+        )
+
+        exec1 = MagicMock()
+        exec1.stop = AsyncMock(return_value=True)
+        runtime.executions["room-1"] = exec1
+
+        await runtime._on_disconnected("replaced")
+
+        cleanup.assert_awaited_once_with("room-1")
+
+    @pytest.mark.asyncio
+    async def test_on_disconnected_no_executions(self, mock_link):
+        """Should handle empty executions gracefully."""
+        from thenvoi.runtime.runtime import AgentRuntime
+
+        runtime = AgentRuntime(
+            link=mock_link, agent_id="agent-1", on_execute=AsyncMock()
+        )
+
+        await runtime._on_disconnected("replaced")  # Should not raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/platform/test_disconnect.py
+++ b/tests/platform/test_disconnect.py
@@ -309,6 +309,20 @@ class TestThenvoiLinkDisconnect:
 
         assert link._is_connected is False
 
+    @pytest.mark.asyncio
+    async def test_second_disconnect_is_ignored(self):
+        """Only the first disconnect should queue an event."""
+        link = ThenvoiLink(agent_id="agent-1", api_key="key")
+        link._is_connected = True
+
+        await link._on_ws_disconnect("replaced", {"reason": "replaced"})
+        await link._on_ws_disconnect("transport closed", None)
+
+        # Only one event should be queued
+        assert link._event_queue.qsize() == 1
+        event = link._event_queue.get_nowait()
+        assert event.reason == "replaced"
+
 
 # ---------------------------------------------------------------------------
 # RoomPresence — DisconnectedEvent routing

--- a/tests/platform/test_disconnect.py
+++ b/tests/platform/test_disconnect.py
@@ -1,0 +1,363 @@
+"""Tests for WebSocket disconnect reason surfacing.
+
+Covers:
+- phx_close / phx_error parsing in WebSocketClient
+- Reason extraction from various payload shapes
+- Human-readable reason mapping (known + unknown)
+- Transport-level disconnect reason extraction
+- DisconnectedEvent propagation through ThenvoiLink
+- DisconnectedEvent routing in RoomPresence
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from thenvoi.client.streaming.client import (
+    KNOWN_DISCONNECT_REASONS,
+    WebSocketClient,
+    extract_disconnect_reason,
+    humanize_disconnect_reason,
+    _extract_transport_reason,
+)
+from thenvoi.platform.event import DisconnectedEvent
+from thenvoi.platform.link import ThenvoiLink
+from thenvoi.runtime.presence import RoomPresence
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FakePHXMessage:
+    """Minimal stand-in for phoenix_channels_python_client.phx_messages.PHXMessage."""
+
+    event: str
+    topic: str
+    payload: dict
+    ref: str | None = None
+    join_ref: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# extract_disconnect_reason
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDisconnectReason:
+    """Test reason extraction from various Phoenix payload shapes."""
+
+    def test_reason_field(self):
+        assert extract_disconnect_reason({"reason": "replaced"}) == "replaced"
+
+    def test_nested_response_reason(self):
+        payload = {"response": {"reason": "kicked"}}
+        assert extract_disconnect_reason(payload) == "kicked"
+
+    def test_message_field(self):
+        assert extract_disconnect_reason({"message": "bye"}) == "bye"
+
+    def test_empty_payload(self):
+        assert extract_disconnect_reason({}) == "unknown"
+
+    def test_prefers_reason_over_message(self):
+        payload = {"reason": "replaced", "message": "other"}
+        assert extract_disconnect_reason(payload) == "replaced"
+
+    def test_non_string_reason_coerced(self):
+        assert extract_disconnect_reason({"reason": 42}) == "42"
+
+
+# ---------------------------------------------------------------------------
+# humanize_disconnect_reason
+# ---------------------------------------------------------------------------
+
+
+class TestHumanizeDisconnectReason:
+    """Test human-readable message generation."""
+
+    def test_known_reason(self):
+        result = humanize_disconnect_reason("replaced")
+        assert "same agent ID" in result
+
+    def test_all_known_reasons_produce_output(self):
+        for key in KNOWN_DISCONNECT_REASONS:
+            assert humanize_disconnect_reason(key)
+
+    def test_unknown_reason_with_raw_payload(self):
+        result = humanize_disconnect_reason("custom_err", {"code": 99})
+        assert "custom_err" in result
+        assert "99" in result
+
+    def test_unknown_reason_without_payload(self):
+        result = humanize_disconnect_reason("custom_err")
+        assert result == "Disconnected: custom_err"
+
+
+# ---------------------------------------------------------------------------
+# _extract_transport_reason
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTransportReason:
+    """Test transport-level disconnect reason extraction."""
+
+    def test_none_error(self):
+        assert _extract_transport_reason(None) == "connection_closed"
+
+    def test_error_with_reason_attr(self):
+        err = Exception("boom")
+        err.reason = "replaced"  # type: ignore[attr-defined]
+        assert _extract_transport_reason(err) == "replaced"
+
+    def test_error_with_code_attr(self):
+        err = Exception("boom")
+        err.code = 4001  # type: ignore[attr-defined]
+        assert _extract_transport_reason(err) == "close_code_4001"
+
+    def test_error_with_empty_reason_falls_to_code(self):
+        err = Exception("boom")
+        err.reason = ""  # type: ignore[attr-defined]
+        err.code = 4001  # type: ignore[attr-defined]
+        assert _extract_transport_reason(err) == "close_code_4001"
+
+    def test_generic_exception(self):
+        assert _extract_transport_reason(RuntimeError("oops")) == "oops"
+
+
+# ---------------------------------------------------------------------------
+# WebSocketClient._handle_events — phx_close / phx_error interception
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocketClientHandlePhxEvents:
+    """Test that phx_close and phx_error are intercepted in _handle_events."""
+
+    @pytest.fixture
+    def ws_client(self):
+        on_disconnect = AsyncMock()
+        client = WebSocketClient(
+            ws_url="wss://test.com/ws",
+            api_key="key",
+            agent_id="agent-1",
+            on_disconnect=on_disconnect,
+        )
+        return client, on_disconnect
+
+    @pytest.mark.asyncio
+    async def test_phx_close_triggers_callback(self, ws_client):
+        client, on_disconnect = ws_client
+        msg = FakePHXMessage(
+            event="phx_close",
+            topic="agent_rooms:agent-1",
+            payload={"reason": "replaced"},
+        )
+        await client._handle_events(msg, {"room_added": AsyncMock()})  # type: ignore[arg-type]
+
+        on_disconnect.assert_awaited_once()
+        human, raw = on_disconnect.call_args[0]
+        assert "same agent ID" in human
+        assert raw == {"reason": "replaced"}
+
+    @pytest.mark.asyncio
+    async def test_phx_error_triggers_callback(self, ws_client):
+        client, on_disconnect = ws_client
+        msg = FakePHXMessage(
+            event="phx_error",
+            topic="chat_room:room-1",
+            payload={"response": {"reason": "unauthorized"}},
+        )
+        await client._handle_events(msg, {})  # type: ignore[arg-type]
+
+        on_disconnect.assert_awaited_once()
+        human, _ = on_disconnect.call_args[0]
+        assert "Not authorized" in human
+
+    @pytest.mark.asyncio
+    async def test_phx_close_unknown_reason_includes_raw(self, ws_client):
+        client, on_disconnect = ws_client
+        msg = FakePHXMessage(
+            event="phx_close",
+            topic="agent_rooms:agent-1",
+            payload={"weird_field": "data"},
+        )
+        await client._handle_events(msg, {})  # type: ignore[arg-type]
+
+        on_disconnect.assert_awaited_once()
+        human, raw = on_disconnect.call_args[0]
+        assert "unknown" in human
+        assert "weird_field" in str(raw)
+
+    @pytest.mark.asyncio
+    async def test_phx_close_does_not_call_event_handlers(self, ws_client):
+        """phx_close should be intercepted before event handler dispatch."""
+        client, _ = ws_client
+        handler = AsyncMock()
+        msg = FakePHXMessage(
+            event="phx_close",
+            topic="agent_rooms:agent-1",
+            payload={"reason": "replaced"},
+        )
+        await client._handle_events(msg, {"phx_close": handler})  # type: ignore[arg-type]
+
+        handler.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_callback_does_not_raise(self):
+        """If on_disconnect is None, phx_close should still be handled gracefully."""
+        client = WebSocketClient(
+            ws_url="wss://test.com/ws",
+            api_key="key",
+        )
+        msg = FakePHXMessage(
+            event="phx_close",
+            topic="agent_rooms:agent-1",
+            payload={"reason": "replaced"},
+        )
+        # Should not raise
+        await client._handle_events(msg, {})  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_callback_error_is_swallowed(self, ws_client):
+        """Errors in the disconnect callback must not propagate."""
+        client, on_disconnect = ws_client
+        on_disconnect.side_effect = RuntimeError("boom")
+        msg = FakePHXMessage(
+            event="phx_close",
+            topic="agent_rooms:agent-1",
+            payload={"reason": "replaced"},
+        )
+        # Should not raise
+        await client._handle_events(msg, {})  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# WebSocketClient — transport disconnect handler
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocketClientTransportDisconnect:
+    """Test _on_transport_disconnect handler."""
+
+    @pytest.mark.asyncio
+    async def test_transport_disconnect_calls_callback(self):
+        on_disconnect = AsyncMock()
+        client = WebSocketClient(
+            ws_url="wss://test.com/ws",
+            api_key="key",
+            on_disconnect=on_disconnect,
+        )
+        err = Exception("connection reset")
+        err.reason = "replaced"  # type: ignore[attr-defined]
+        await client._on_transport_disconnect(err)
+
+        on_disconnect.assert_awaited_once()
+        human, raw = on_disconnect.call_args[0]
+        assert "same agent ID" in human
+        assert raw is not None
+
+    @pytest.mark.asyncio
+    async def test_transport_disconnect_none_error(self):
+        on_disconnect = AsyncMock()
+        client = WebSocketClient(
+            ws_url="wss://test.com/ws",
+            api_key="key",
+            on_disconnect=on_disconnect,
+        )
+        await client._on_transport_disconnect(None)
+
+        on_disconnect.assert_awaited_once()
+        human, raw = on_disconnect.call_args[0]
+        assert "connection_closed" in human
+        assert raw is None
+
+
+# ---------------------------------------------------------------------------
+# ThenvoiLink._on_ws_disconnect
+# ---------------------------------------------------------------------------
+
+
+class TestThenvoiLinkDisconnect:
+    """Test ThenvoiLink queues DisconnectedEvent on disconnect."""
+
+    @pytest.mark.asyncio
+    async def test_queues_disconnected_event(self):
+        link = ThenvoiLink(agent_id="agent-1", api_key="key")
+        link._is_connected = True
+
+        await link._on_ws_disconnect("Server closed normally", {"reason": "normal"})
+
+        assert link._is_connected is False
+        assert not link._event_queue.empty()
+        event = link._event_queue.get_nowait()
+        assert isinstance(event, DisconnectedEvent)
+        assert event.reason == "Server closed normally"
+        assert event.raw == {"reason": "normal"}
+        assert event.room_id is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect_sets_is_connected_false(self):
+        link = ThenvoiLink(agent_id="agent-1", api_key="key")
+        link._is_connected = True
+
+        await link._on_ws_disconnect("replaced", None)
+
+        assert link._is_connected is False
+
+
+# ---------------------------------------------------------------------------
+# RoomPresence — DisconnectedEvent routing
+# ---------------------------------------------------------------------------
+
+
+class TestPresenceDisconnectedEvent:
+    """Test that DisconnectedEvent is routed to on_disconnected callback."""
+
+    @pytest.fixture
+    def mock_link(self):
+        link = MagicMock()
+        link.agent_id = "agent-123"
+        link.is_connected = True
+        link.connect = AsyncMock()
+        link.subscribe_agent_rooms = AsyncMock()
+        link.subscribe_room = AsyncMock()
+        link.unsubscribe_room = AsyncMock()
+        link.rest = MagicMock()
+        link.rest.agent_api_chats = MagicMock()
+        link.rest.agent_api_chats.list_agent_chats = AsyncMock(
+            return_value=MagicMock(data=[])
+        )
+        return link
+
+    @pytest.mark.asyncio
+    async def test_disconnected_event_calls_callback(self, mock_link):
+        presence = RoomPresence(mock_link)
+        callback = AsyncMock()
+        presence.on_disconnected = callback
+
+        event = DisconnectedEvent(reason="replaced by another connection")
+        await presence._on_platform_event(event)
+
+        callback.assert_awaited_once_with("replaced by another connection")
+
+    @pytest.mark.asyncio
+    async def test_disconnected_event_no_callback(self, mock_link):
+        """Should not raise if no callback is set."""
+        presence = RoomPresence(mock_link)
+        event = DisconnectedEvent(reason="test")
+        await presence._on_platform_event(event)  # No error
+
+    @pytest.mark.asyncio
+    async def test_disconnected_event_callback_error_swallowed(self, mock_link):
+        """Errors in on_disconnected must not propagate."""
+        presence = RoomPresence(mock_link)
+        callback = AsyncMock(side_effect=RuntimeError("boom"))
+        presence.on_disconnected = callback
+
+        event = DisconnectedEvent(reason="test")
+        await presence._on_platform_event(event)  # Should not raise

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -95,7 +95,12 @@ class TestThenvoiLinkConnection:
         link = ThenvoiLink(agent_id="agent-123", api_key="test-key")
         await link.connect()
 
-        mock_ws_class.assert_called_once_with(link.ws_url, link.api_key, link.agent_id)
+        mock_ws_class.assert_called_once_with(
+            link.ws_url,
+            link.api_key,
+            link.agent_id,
+            on_disconnect=link._on_ws_disconnect,
+        )
         mock_ws_client.__aenter__.assert_called_once()
         assert link.is_connected is True
 


### PR DESCRIPTION
## Summary

- Parse Phoenix `phx_close` / `phx_error` events in the WebSocket client and propagate the disconnect reason through the connection lifecycle to runtime and adapters
- Map well-known disconnect reasons (`replaced`, `kicked`, `token_expired`, etc.) to human-readable messages; unknown reasons include the raw payload for diagnostics
- Add `DisconnectedEvent` to the platform event union, routed through `ThenvoiLink` → `RoomPresence` → `AgentRuntime` with logging at every level

Fixes INT-330

## Test plan

- [x] 28 new unit tests in `tests/platform/test_disconnect.py`
- [x] All 485 platform + runtime tests pass
- [x] All 340 framework conformance tests pass
- [x] Ruff check, ruff format, pyrefly check all clean
- [ ] Manual: start two processes with the same `agent_id` — the displaced one should log a clear "Another instance connected with the same agent ID" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)