### PR TITLE
INT-340: disable CrewAI tool cache + propagate AgentTools participant changes

### DIFF
--- a/src/thenvoi/adapters/crewai.py
+++ b/src/thenvoi/adapters/crewai.py
@@ -15,7 +15,7 @@ import logging
 import threading
 import warnings
 from contextvars import ContextVar
-from typing import ClassVar, Any, Coroutine, Literal, Type, TypeVar
+from typing import Callable, ClassVar, Any, Coroutine, Literal, Type, TypeVar
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -42,6 +42,19 @@ from thenvoi.runtime.tools import get_tool_description
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+def _never_cache(*_args: Any, **_kwargs: Any) -> bool:
+    """cache_function override for every Thenvoi CrewAI tool.
+
+    Thenvoi tools reach the current room via the _current_room_context
+    ContextVar, not via tool arguments. CrewAI's CacheHandler keys entries
+    by (tool_name, input_string) — room identity never enters the key —
+    so caching would leak results across rooms. Returning False here
+    disables CrewAI's per-tool cache write unconditionally.
+    """
+    return False
+
 
 # Module-level state for nest_asyncio patch.
 # See module docstring for important notes about global process impact.
@@ -461,6 +474,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
                     name: str = _tool_name  # type: ignore[misc]
                     description: str = _tool_desc  # type: ignore[misc]
                     args_schema: Type[BaseModel] = model
+                    cache_function: Callable = _never_cache
 
                     def _run(self, *_args: Any, **kwargs: Any) -> Any:
                         async def execute(_tools: AgentToolsProtocol) -> str:
@@ -667,6 +681,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_send_message"
             description: str = get_tool_description("thenvoi_send_message")
             args_schema: Type[BaseModel] = SendMessageInput
+            cache_function: Callable = _never_cache
 
             # *_args is required by BaseTool's _run signature even though we don't use it
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
@@ -696,6 +711,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_send_event"
             description: str = get_tool_description("thenvoi_send_event")
             args_schema: Type[BaseModel] = SendEventInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 content: str = kwargs.get("content", "")
@@ -713,6 +729,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_add_participant"
             description: str = get_tool_description("thenvoi_add_participant")
             args_schema: Type[BaseModel] = AddParticipantInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 participant_name: str = kwargs.get("participant_name", "")
@@ -736,6 +753,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_remove_participant"
             description: str = get_tool_description("thenvoi_remove_participant")
             args_schema: Type[BaseModel] = RemoveParticipantInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 participant_name: str = kwargs.get("participant_name", "")
@@ -758,6 +776,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_get_participants"
             description: str = get_tool_description("thenvoi_get_participants")
             args_schema: Type[BaseModel] = GetParticipantsInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **_kwargs: Any) -> Any:
                 async def execute(tools: AgentToolsProtocol) -> str:
@@ -790,6 +809,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_lookup_peers"
             description: str = get_tool_description("thenvoi_lookup_peers")
             args_schema: Type[BaseModel] = LookupPeersInput
+            cache_function: Callable = _never_cache
 
             # *_args is required by BaseTool's _run signature even though we don't use it
             def _run(self, *_args: Any, **_kwargs: Any) -> Any:
@@ -814,6 +834,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_create_chatroom"
             description: str = get_tool_description("thenvoi_create_chatroom")
             args_schema: Type[BaseModel] = CreateChatroomInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 task_id: str | None = kwargs.get("task_id")
@@ -840,6 +861,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_list_contacts"
             description: str = get_tool_description("thenvoi_list_contacts")
             args_schema: Type[BaseModel] = ListContactsInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 page: int = kwargs.get("page", 1)
@@ -863,6 +885,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_add_contact"
             description: str = get_tool_description("thenvoi_add_contact")
             args_schema: Type[BaseModel] = AddContactInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 handle: str = kwargs.get("handle", "")
@@ -886,6 +909,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_remove_contact"
             description: str = get_tool_description("thenvoi_remove_contact")
             args_schema: Type[BaseModel] = RemoveContactInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 handle: str | None = kwargs.get("handle")
@@ -909,6 +933,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_list_contact_requests"
             description: str = get_tool_description("thenvoi_list_contact_requests")
             args_schema: Type[BaseModel] = ListContactRequestsInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 page: int = kwargs.get("page", 1)
@@ -939,6 +964,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_respond_contact_request"
             description: str = get_tool_description("thenvoi_respond_contact_request")
             args_schema: Type[BaseModel] = RespondContactRequestInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 action: str = kwargs.get("action", "")
@@ -966,6 +992,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_list_memories"
             description: str = get_tool_description("thenvoi_list_memories")
             args_schema: Type[BaseModel] = ListMemoriesInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 subject_id = kwargs.get("subject_id")
@@ -1013,6 +1040,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_store_memory"
             description: str = get_tool_description("thenvoi_store_memory")
             args_schema: Type[BaseModel] = StoreMemoryInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 content = kwargs.get("content", "")
@@ -1057,6 +1085,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_get_memory"
             description: str = get_tool_description("thenvoi_get_memory")
             args_schema: Type[BaseModel] = GetMemoryInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 memory_id = kwargs.get("memory_id", "")
@@ -1077,6 +1106,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_supersede_memory"
             description: str = get_tool_description("thenvoi_supersede_memory")
             args_schema: Type[BaseModel] = SupersedeMemoryInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 memory_id = kwargs.get("memory_id", "")
@@ -1097,6 +1127,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             name: str = "thenvoi_archive_memory"
             description: str = get_tool_description("thenvoi_archive_memory")
             args_schema: Type[BaseModel] = ArchiveMemoryInput
+            cache_function: Callable = _never_cache
 
             def _run(self, *_args: Any, **kwargs: Any) -> Any:
                 memory_id = kwargs.get("memory_id", "")

--- a/src/thenvoi/runtime/tools.py
+++ b/src/thenvoi/runtime/tools.py
@@ -521,6 +521,8 @@ class AgentTools(AgentToolsProtocol):
         room_id: str,
         rest: "AsyncRestClient",
         participants: list[dict[str, Any]] | None = None,
+        *,
+        ctx: "ExecutionContext | None" = None,
     ):
         """
         Initialize AgentTools for a specific room.
@@ -529,10 +531,15 @@ class AgentTools(AgentToolsProtocol):
             room_id: The room this tools instance is bound to
             rest: AsyncRestClient for API calls
             participants: Optional list of participants for mention resolution
+            ctx: Optional ExecutionContext backref. When provided, successful
+                add_participant / remove_participant calls also update
+                ctx._participants so the next preprocessing pass sees the
+                change before the WebSocket participant event arrives.
         """
         self.room_id = room_id
         self.rest = rest
         self._participants = participants or []
+        self._ctx = ctx
 
     @property
     def participants(self) -> list[dict[str, Any]]:
@@ -552,7 +559,7 @@ class AgentTools(AgentToolsProtocol):
         Returns:
             AgentTools instance bound to the context's room
         """
-        return cls(ctx.room_id, ctx.link.rest, ctx.participants)
+        return cls(ctx.room_id, ctx.link.rest, ctx.participants, ctx=ctx)
 
     # --- Tool methods ---
 
@@ -741,6 +748,15 @@ class AgentTools(AgentToolsProtocol):
             "type": getattr(participant, "type", "Agent"),
             "handle": getattr(participant, "handle", None),
         }
+        # Propagate to ExecutionContext if we have a backref, so the next
+        # preprocessing pass (which rebuilds AgentTools from ctx.participants)
+        # sees the peer before the WebSocket participant_added event arrives.
+        # ExecutionContext.add_participant is idempotent, so WS re-delivery is safe.
+        # Out of scope: the "already_in_room" early-return above does not sync
+        # ctx — if ctx._participants is stale while the server already has the
+        # peer, WS is still the recovery path.
+        if self._ctx is not None:
+            self._ctx.add_participant(new_participant)
         self._participants.append(new_participant)
         logger.debug(
             "Updated participant cache: added %s, total=%s",
@@ -799,6 +815,10 @@ class AgentTools(AgentToolsProtocol):
         # Update internal participant cache
         # NOTE: WebSocket will eventually deliver participant_removed event, but this
         # prevents @mentions to the removed participant immediately after removal.
+        # Propagate to ExecutionContext if we have a backref; remove_participant
+        # is idempotent (filters by id), so WS re-delivery is safe.
+        if self._ctx is not None:
+            self._ctx.remove_participant(participant_id)
         self._participants = [
             p for p in self._participants if p.get("id") != participant_id
         ]

--- a/tests/adapters/test_crewai_cache.py
+++ b/tests/adapters/test_crewai_cache.py
@@ -1,0 +1,134 @@
+"""Regression tests for CrewAI tool caching behavior (INT-340).
+
+These tests intentionally bypass the mocked `crewai.tools.BaseTool` fixture in
+tests/adapters/test_crewai_adapter.py and exercise the **real** CrewAI SDK.
+CrewAI's CacheHandler keys cached tool outputs by (tool_name, input_string).
+Thenvoi tools are room-scoped via a ContextVar, not via arguments, so caching
+would silently serve room A's result back in room B. Every Thenvoi-supplied
+CrewAI tool (including the dynamic CustomCrewAITool) must opt out by returning
+False from cache_function.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+from pydantic import BaseModel, Field
+
+from thenvoi.core.types import AdapterFeatures, Capability
+
+
+class CustomToolInput(BaseModel):
+    """A custom tool for exercising the CustomCrewAITool cache override."""
+
+    query: str = Field(..., description="Query string")
+
+
+def _handler(validated: CustomToolInput) -> str:
+    return f"got {validated.query}"
+
+
+@pytest.fixture
+def crewai_adapter_cls():
+    """Import CrewAIAdapter against the real CrewAI SDK.
+
+    tests/adapters/test_crewai_adapter.py installs a mocked `crewai.tools`
+    in sys.modules and pops `thenvoi.adapters.crewai` during teardown — which
+    leaves Pydantic unable to resolve forward refs on any previously-imported
+    adapter class. Re-importing here guarantees we get a module bound to the
+    real `crewai.tools.BaseTool`, not the mock.
+    """
+    sys.modules.pop("thenvoi.adapters.crewai", None)
+    module = importlib.import_module("thenvoi.adapters.crewai")
+    return module.CrewAIAdapter
+
+
+@pytest.fixture
+def adapter_with_memory_and_custom_tool(crewai_adapter_cls):
+    """Adapter with all tools enabled: platform + memory + one custom tool."""
+    return crewai_adapter_cls(
+        model="gpt-4o-mini",
+        additional_tools=[(CustomToolInput, _handler)],
+        features=AdapterFeatures(
+            emit=frozenset(),
+            capabilities=frozenset({Capability.MEMORY}),
+        ),
+    )
+
+
+class TestToolCaching:
+    """CrewAI tools must never be cached — their context is a ContextVar."""
+
+    def test_every_platform_and_memory_tool_disables_cache(
+        self, adapter_with_memory_and_custom_tool
+    ) -> None:
+        """cache_function must return False for every Thenvoi tool."""
+        tools = adapter_with_memory_and_custom_tool._create_crewai_tools()
+
+        # Sanity check: full set = 12 platform + 5 memory + 1 custom = 18
+        tool_names = [t.name for t in tools]
+        assert len(tools) == 18, (
+            f"Expected 18 tools (12 platform + 5 memory + 1 custom), "
+            f"got {len(tools)}: {tool_names}"
+        )
+
+        for tool in tools:
+            # CrewAI calls cache_function(calling.arguments, result); the exact
+            # args don't matter — our override ignores them.
+            assert tool.cache_function({"any": "input"}, "any output") is False, (
+                f"Tool {tool.name!r} did NOT disable caching — "
+                "CrewAI will leak results across rooms."
+            )
+
+    def test_custom_tool_disables_cache(
+        self, adapter_with_memory_and_custom_tool
+    ) -> None:
+        """The dynamic CustomCrewAITool factory must also opt out of caching."""
+        tools = adapter_with_memory_and_custom_tool._create_crewai_tools()
+
+        platform_names = {
+            "thenvoi_send_message",
+            "thenvoi_send_event",
+            "thenvoi_add_participant",
+            "thenvoi_remove_participant",
+            "thenvoi_get_participants",
+            "thenvoi_lookup_peers",
+            "thenvoi_create_chatroom",
+            "thenvoi_list_contacts",
+            "thenvoi_add_contact",
+            "thenvoi_remove_contact",
+            "thenvoi_list_contact_requests",
+            "thenvoi_respond_contact_request",
+            "thenvoi_list_memories",
+            "thenvoi_store_memory",
+            "thenvoi_get_memory",
+            "thenvoi_supersede_memory",
+            "thenvoi_archive_memory",
+        }
+        custom_tools = [t for t in tools if t.name not in platform_names]
+        assert len(custom_tools) == 1, (
+            f"Expected exactly one CustomCrewAITool, got: {[t.name for t in custom_tools]}"
+        )
+        assert custom_tools[0].cache_function({"query": "x"}, "any output") is False
+
+    def test_cache_override_is_not_the_crewai_default(
+        self, adapter_with_memory_and_custom_tool
+    ) -> None:
+        """Guard against regression to CrewAI's default (always-True) cache_function."""
+        from crewai.tools import BaseTool
+
+        default_cf = BaseTool.model_fields["cache_function"].default
+        assert default_cf(None, None) is True, (
+            "CrewAI's BaseTool default cache_function should return True — "
+            "if this fails, CrewAI's upstream behavior changed and this test "
+            "suite's assumptions need re-verification."
+        )
+
+        tools = adapter_with_memory_and_custom_tool._create_crewai_tools()
+        for tool in tools:
+            assert tool.cache_function is not default_cf, (
+                f"Tool {tool.name!r} still references CrewAI's default "
+                "cache_function — override did not land."
+            )

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -161,6 +161,23 @@ class TestAgentToolsFromContext:
         assert tools.rest is mock_rest_client
         assert tools._participants == participants
 
+    def test_from_context_stores_ctx_backref(self, mock_rest_client, participants):
+        """from_context() should store a backref to the ExecutionContext."""
+        mock_ctx = MagicMock()
+        mock_ctx.room_id = "room-456"
+        mock_ctx.link = MagicMock()
+        mock_ctx.link.rest = mock_rest_client
+        mock_ctx.participants = participants
+
+        tools = AgentTools.from_context(mock_ctx)
+
+        assert tools._ctx is mock_ctx
+
+    def test_direct_construction_has_no_ctx(self, mock_rest_client):
+        """Direct construction without ctx kwarg defaults to None (backward-compat)."""
+        tools = AgentTools("room-123", mock_rest_client)
+        assert tools._ctx is None
+
 
 class TestAgentToolsSendMessage:
     """Test send_message tool."""
@@ -271,6 +288,31 @@ class TestAgentToolsAddParticipant:
         with pytest.raises(ValueError, match="Participant 'Unknown' not found"):
             await tools.add_participant("Unknown")
 
+    async def test_add_participant_updates_ctx_participants(self, mock_rest_client):
+        """add_participant() should also push to ExecutionContext when ctx is set."""
+        mock_ctx = MagicMock()
+        tools = AgentTools("room-123", mock_rest_client, ctx=mock_ctx)
+
+        result = await tools.add_participant("Agent Two", role="member")
+
+        assert result["id"] == "agent-2"
+        # ctx.add_participant called once with the resolved participant dict
+        mock_ctx.add_participant.assert_called_once()
+        pushed = mock_ctx.add_participant.call_args.args[0]
+        assert pushed["id"] == "agent-2"
+        assert pushed["name"] == "Agent Two"
+        assert pushed["type"] == "Agent"
+
+    async def test_add_participant_without_ctx_does_not_crash(self, mock_rest_client):
+        """add_participant() must still work when ctx is None (direct construction)."""
+        tools = AgentTools("room-123", mock_rest_client)  # no ctx
+
+        result = await tools.add_participant("Agent Two", role="member")
+
+        assert result["id"] == "agent-2"
+        # Per-instance cache still updated
+        assert any(p["id"] == "agent-2" for p in tools._participants)
+
 
 class TestAgentToolsRemoveParticipant:
     """Test remove_participant tool."""
@@ -296,6 +338,27 @@ class TestAgentToolsRemoveParticipant:
 
         with pytest.raises(ValueError, match="not found in this room"):
             await tools.remove_participant("Unknown")
+
+    async def test_remove_participant_updates_ctx_participants(self, mock_rest_client):
+        """remove_participant() should also remove from ExecutionContext when ctx is set."""
+        mock_ctx = MagicMock()
+        tools = AgentTools("room-123", mock_rest_client, ctx=mock_ctx)
+
+        result = await tools.remove_participant("User One")
+
+        assert result["id"] == "user-1"
+        mock_ctx.remove_participant.assert_called_once_with("user-1")
+
+    async def test_remove_participant_without_ctx_does_not_crash(
+        self, mock_rest_client
+    ):
+        """remove_participant() must still work when ctx is None."""
+        tools = AgentTools("room-123", mock_rest_client)  # no ctx
+
+        result = await tools.remove_participant("User One")
+
+        assert result["id"] == "user-1"
+        assert not any(p.get("id") == "user-1" for p in tools._participants)
 
 
 class TestAgentToolsLookupPeers:


### PR DESCRIPTION
## Summary
- Override `cache_function` on all 17 Thenvoi CrewAI tool classes plus the dynamic `CustomCrewAITool` wrapper so CrewAI's `CacheHandler` no longer memoizes outputs of room-scoped tools (ContextVar-based room identity never enters the cache key, so caching silently leaked results across rooms).
- Add an optional `ctx` backref to `AgentTools` so `add_participant` / `remove_participant` propagate to `ExecutionContext._participants`, keeping the next preprocessing pass in sync before the WebSocket `participant_added` event arrives.

## Linear issue
INT-340 — https://linear.app/thenvoi/issue/INT-340/crewaiadapter-tools-are-cached-by-crewai-cache-function-unset-stateful

## Changes
- `src/thenvoi/adapters/crewai.py` — new module-level `_never_cache` helper; `cache_function: Callable = _never_cache` set on `CustomCrewAITool`, `SendMessageTool`, `SendEventTool`, `AddParticipantTool`, `RemoveParticipantTool`, `GetParticipantsTool`, `LookupPeersTool`, `CreateChatroomTool`, `ListContactsTool`, `AddContactTool`, `RemoveContactTool`, `ListContactRequestsTool`, `RespondContactRequestTool`, `ListMemoriesTool`, `StoreMemoryTool`, `GetMemoryTool`, `SupersedeMemoryTool`, `ArchiveMemoryTool`.
- `src/thenvoi/runtime/tools.py` — `AgentTools.__init__` accepts keyword-only `ctx: ExecutionContext | None`; `from_context` threads the ctx backref; `add_participant` / `remove_participant` call `ctx.add_participant` / `ctx.remove_participant` (idempotent, so WebSocket re-delivery is safe).
- `tests/adapters/test_crewai_cache.py` — new regression suite exercising the **real** CrewAI SDK (bypasses the mocked `BaseTool` fixture used elsewhere): asserts every tool's `cache_function` returns `False`, the custom tool wrapper disables caching, and the override is not CrewAI's always-true default.
- `tests/runtime/test_tools.py` — 5 new tests covering ctx backref storage, ctx propagation on add/remove, and graceful no-op when ctx is absent.

## Test results
- Scoped verification: `uv run pytest tests/adapters/test_crewai_cache.py tests/runtime/test_tools.py tests/adapters/test_crewai_adapter.py tests/framework_conformance/ tests/framework_configs/ --no-cov -q` — **473 passed, 32 skipped**.
- Full unit suite: **2561 passed, 139 skipped**.
- `uv run ruff check .` and `uv run pyrefly check` both clean.

## Limitations
- The existing "already_in_room" early-return in `AgentTools.add_participant` does not sync ctx when `self._participants` already contains the peer but `ctx._participants` is stale; WebSocket `participant_added` remains the recovery path for that edge case. Out of scope for this fix per plan.