### PR TITLE
fix: document mentions parameter as array in Claude SDK prompt (INT-325)

### DIFF
--- a/src/thenvoi/integrations/claude_sdk/prompts.py
+++ b/src/thenvoi/integrations/claude_sdk/prompts.py
@@ -95,11 +95,11 @@ Plain text responses will NOT be delivered. Always call the tool.
 {{
   "room_id": "abc-123-def",
   "content": "Your message here",
-  "mentions": "[]"
+  "mentions": []
 }}
 ```
-- `mentions`: JSON string of participant handles, e.g. `"[\\"@john\\"]"` or `"[\\"@john/weather-agent\\"]"`
-- Use `"[]"` for no mentions
+- `mentions`: Array of participant handles, e.g. `["@john"]` or `["@john/weather-agent"]`
+- Use `[]` for no mentions
 - Handles: @<username> for users, @<username>/<agent-name> for agents
 
 **mcp__thenvoi__thenvoi_lookup_peers** - Find users/agents to add
@@ -167,7 +167,7 @@ Example - mentioning user "john":
 {{
   "room_id": "abc-123-def",
   "content": "@john here is your answer...",
-  "mentions": "[\\"@john\\"]"
+  "mentions": ["@john"]
 }}
 ```
 
@@ -179,7 +179,7 @@ Input: [room_id: abc-123][Test User]: What's 2+2?
 Action: mcp__thenvoi__thenvoi_send_message
   room_id: "abc-123"
   content: "2 + 2 = 4"
-  mentions: "[]"
+  mentions: []
 ```
 
 **Asking another agent for help:**


### PR DESCRIPTION
## Summary
- Fix [INT-325](https://linear.app/thenvoi/issue/INT-325/update-mentions-parameter-documentation-to-use-array-format): the Claude SDK system prompt documented `mentions` as a JSON-encoded string (e.g. `"[\"@john\"]"`), but the tool schema defines `mentions: list[str]`. Claude followed the prompt and produced strings, Claude Code rejected them against the array schema, and agents got stuck in a retry loop.
- Updated the three `mentions` examples in `src/thenvoi/integrations/claude_sdk/prompts.py` to use native arrays, and changed the description from "JSON string of participant handles" to "Array of participant handles."

## Test plan
- [x] `uv run ruff check` and `uv run ruff format --check` on modified file
- [x] `uv run pyrefly check` on modified file
- [x] `uv run pytest tests/framework_conformance/test_tool_name_drift.py tests/test_capability_gating_e2e.py`
- [x] Confirm a Claude SDK agent no longer hits the retry loop when sending a message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
