### PR TITLE
fix: harden graceful shutdown against signal races and task cancellation (INT-327)

### DIFF
--- a/src/thenvoi/runtime/shutdown.py
+++ b/src/thenvoi/runtime/shutdown.py
@@ -190,6 +190,17 @@ class GracefulShutdown:
             signum: The signal number received.
         """
         sig_name = signal.Signals(signum).name
+
+        # Guard FIRST — before any side effects. The documented contract is
+        # "subsequent signals are ignored", and user-provided on_signal callbacks
+        # (e.g. paging/alerting) may not be idempotent.
+        if self._shutting_down or self._shutdown_task is not None:
+            logger.debug(
+                "Received %s but shutdown already in progress, ignoring", sig_name
+            )
+            return
+        self._shutting_down = True
+
         logger.info("Received %s, initiating graceful shutdown...", sig_name)
 
         # Call user callback if provided
@@ -202,13 +213,6 @@ class GracefulShutdown:
         # Set shutdown event to unblock any waiters
         if self._shutdown_event:
             self._shutdown_event.set()
-
-        # Guard against multiple signals triggering multiple shutdown tasks
-        # Use flag to prevent race between check and task creation
-        if self._shutting_down or self._shutdown_task is not None:
-            logger.debug("Shutdown already in progress, ignoring signal")
-            return
-        self._shutting_down = True
 
         # Schedule the shutdown coroutine.
         # Note: We store the reference to prevent garbage collection, but this task
@@ -227,11 +231,33 @@ class GracefulShutdown:
         logger.info("Shutting down agent (timeout: %ss)...", self.timeout)
 
         try:
-            graceful = await self.agent.stop(timeout=self.timeout)
+            # Shield agent.stop() so event-loop teardown cancelling pending tasks
+            # doesn't interrupt cleanup mid-flight (WebSocket unsubscribe, state
+            # persistence, etc.). _shutdown_task itself is not awaited, so
+            # asyncio.run() will cancel it on exit without the shield.
+            graceful = await asyncio.shield(self.agent.stop(timeout=self.timeout))
             if graceful:
                 logger.info("Agent shut down gracefully")
             else:
                 logger.warning("Agent shut down with processing interrupted")
+        except asyncio.CancelledError:
+            # CancelledError inherits from BaseException (Py3.8+) so the generic
+            # Exception handler below doesn't catch it. Without this branch, a
+            # cancelled shutdown surfaces only as a task-exception warning and
+            # leaves partial cleanup state. Try a best-effort quick stop so
+            # resources are released even when the loop is tearing down.
+            logger.warning(
+                "Shutdown was cancelled; attempting best-effort quick cleanup"
+            )
+            try:
+                await self.agent.stop(timeout=0.0)
+            except Exception as cleanup_err:
+                logger.error(
+                    "Quick-cleanup after cancellation failed: %s",
+                    cleanup_err,
+                    exc_info=True,
+                )
+            raise
         except Exception as e:
             logger.error("Error during shutdown: %s", e, exc_info=True)
 

--- a/src/thenvoi/runtime/shutdown.py
+++ b/src/thenvoi/runtime/shutdown.py
@@ -193,8 +193,10 @@ class GracefulShutdown:
 
         # Guard FIRST — before any side effects. The documented contract is
         # "subsequent signals are ignored", and user-provided on_signal callbacks
-        # (e.g. paging/alerting) may not be idempotent.
-        if self._shutting_down or self._shutdown_task is not None:
+        # (e.g. paging/alerting) may not be idempotent. _handle_signal runs in
+        # event-loop callback context and never yields between the flag set and
+        # create_task below, so checking the flag alone is sufficient.
+        if self._shutting_down:
             logger.debug(
                 "Received %s but shutdown already in progress, ignoring", sig_name
             )
@@ -241,22 +243,15 @@ class GracefulShutdown:
             else:
                 logger.warning("Agent shut down with processing interrupted")
         except asyncio.CancelledError:
-            # CancelledError inherits from BaseException (Py3.8+) so the generic
-            # Exception handler below doesn't catch it. Without this branch, a
-            # cancelled shutdown surfaces only as a task-exception warning and
-            # leaves partial cleanup state. Try a best-effort quick stop so
-            # resources are released even when the loop is tearing down.
+            # CancelledError inherits from BaseException (Py3.8+), so the
+            # generic Exception handler below doesn't catch it. asyncio.shield
+            # keeps the inner agent.stop() running in the background, so we do
+            # NOT kick off a second concurrent stop here: AgentRuntime.stop
+            # iterates executions.keys() with no in-flight guard, and two
+            # concurrent stops would race on per-room teardown.
             logger.warning(
-                "Shutdown was cancelled; attempting best-effort quick cleanup"
+                "Shutdown was cancelled; shielded agent.stop continues in background"
             )
-            try:
-                await self.agent.stop(timeout=0.0)
-            except Exception as cleanup_err:
-                logger.error(
-                    "Quick-cleanup after cancellation failed: %s",
-                    cleanup_err,
-                    exc_info=True,
-                )
             raise
         except Exception as e:
             logger.error("Error during shutdown: %s", e, exc_info=True)

--- a/src/thenvoi/runtime/shutdown.py
+++ b/src/thenvoi/runtime/shutdown.py
@@ -233,10 +233,13 @@ class GracefulShutdown:
         logger.info("Shutting down agent (timeout: %ss)...", self.timeout)
 
         try:
-            # Shield agent.stop() so event-loop teardown cancelling pending tasks
-            # doesn't interrupt cleanup mid-flight (WebSocket unsubscribe, state
-            # persistence, etc.). _shutdown_task itself is not awaited, so
-            # asyncio.run() will cancel it on exit without the shield.
+            # Shield agent.stop() so a cancellation propagating through the
+            # outer task (e.g. a parent run() being cancelled) doesn't interrupt
+            # cleanup mid-flight (WebSocket unsubscribe, state persistence, etc.).
+            # Caveat: asyncio.run() teardown calls _cancel_all_tasks(), which
+            # cancels the inner shielded task too — shield protects from the
+            # outer awaiter, not full loop teardown. Use the context-manager or
+            # await-stop patterns for guaranteed completion on process exit.
             graceful = await asyncio.shield(self.agent.stop(timeout=self.timeout))
             if graceful:
                 logger.info("Agent shut down gracefully")
@@ -250,7 +253,9 @@ class GracefulShutdown:
             # iterates executions.keys() with no in-flight guard, and two
             # concurrent stops would race on per-room teardown.
             logger.warning(
-                "Shutdown was cancelled; shielded agent.stop continues in background"
+                "Shutdown was cancelled (timeout=%ss); shielded agent.stop "
+                "continues in background",
+                self.timeout,
             )
             raise
         except Exception as e:

--- a/tests/runtime/test_shutdown.py
+++ b/tests/runtime/test_shutdown.py
@@ -221,17 +221,13 @@ class TestGracefulShutdownHandler:
             "agent.stop was cancelled mid-flight; asyncio.shield is missing"
         )
 
-    async def test_shutdown_handles_cancelled_error(self, mock_agent):
-        """_shutdown should log and run best-effort cleanup when cancelled."""
+    async def test_shutdown_reraises_cancelled_error(self, mock_agent):
+        """_shutdown should log and re-raise CancelledError without a second stop."""
         stop_calls: list[float] = []
 
         async def tracking_stop(*, timeout):
             stop_calls.append(timeout)
-            # First call (the shielded one) raises CancelledError to simulate
-            # the shield being bypassed; second call is the best-effort cleanup.
-            if len(stop_calls) == 1:
-                raise asyncio.CancelledError()
-            return True
+            raise asyncio.CancelledError()
 
         mock_agent.stop = AsyncMock(side_effect=tracking_stop)
         shutdown = GracefulShutdown(mock_agent, timeout=5.0)
@@ -239,8 +235,10 @@ class TestGracefulShutdownHandler:
         with pytest.raises(asyncio.CancelledError):
             await shutdown._shutdown()
 
-        # First call uses the configured timeout, second is the best-effort quick stop.
-        assert stop_calls == [5.0, 0.0]
+        # Only one call — asyncio.shield keeps the original agent.stop running
+        # in the background on real cancellation; starting a concurrent second
+        # stop would race on AgentRuntime's per-room executions teardown.
+        assert stop_calls == [5.0]
 
 
 class TestGracefulShutdownWaitForShutdown:

--- a/tests/runtime/test_shutdown.py
+++ b/tests/runtime/test_shutdown.py
@@ -233,9 +233,10 @@ class TestGracefulShutdownHandler:
         with pytest.raises(asyncio.CancelledError):
             await shutdown._shutdown()
 
-        # Only one call — asyncio.shield keeps the original agent.stop running
-        # in the background on real cancellation; starting a concurrent second
-        # stop would race on AgentRuntime's per-room executions teardown.
+        # Only one call — the except CancelledError branch must not kick off a
+        # second concurrent agent.stop. (Here agent.stop raises directly, so
+        # no background task exists; the shield's keep-running-in-background
+        # behavior is covered by test_shutdown_shields_agent_stop_from_cancellation.)
         assert stop_calls == [5.0]
 
 

--- a/tests/runtime/test_shutdown.py
+++ b/tests/runtime/test_shutdown.py
@@ -152,6 +152,96 @@ class TestGracefulShutdownHandler:
         # Should not raise
         await shutdown._shutdown()
 
+    async def test_handle_signal_guards_before_callback(self, mock_agent):
+        """Second signal during shutdown must not re-invoke on_signal or re-set event."""
+        callback = MagicMock()
+        shutdown = GracefulShutdown(mock_agent, on_signal=callback)
+        shutdown._shutdown_event = asyncio.Event()
+
+        with patch("asyncio.create_task") as mock_create_task:
+            # Simulate create_task returning a sentinel so _shutdown_task is set.
+            sentinel_task = MagicMock()
+            mock_create_task.return_value = sentinel_task
+
+            # First signal: callback fires, event is set, task is scheduled.
+            shutdown._handle_signal(signal.SIGINT)
+            assert callback.call_count == 1
+            assert shutdown._shutdown_event.is_set()
+            assert mock_create_task.call_count == 1
+
+            # Reset event so we can detect if the guard lets the second signal
+            # re-set it (it must not).
+            shutdown._shutdown_event.clear()
+
+            # Second signal during shutdown: everything must be skipped.
+            shutdown._handle_signal(signal.SIGTERM)
+            assert callback.call_count == 1, (
+                "on_signal should not fire for duplicate signals"
+            )
+            assert not shutdown._shutdown_event.is_set(), (
+                "shutdown event must not be re-set for duplicate signals"
+            )
+            assert mock_create_task.call_count == 1, (
+                "no additional shutdown task should be created"
+            )
+
+    async def test_shutdown_shields_agent_stop_from_cancellation(self, mock_agent):
+        """_shutdown should let agent.stop finish even when the task is cancelled."""
+        stop_started = asyncio.Event()
+        stop_finished = asyncio.Event()
+
+        async def slow_stop(*, timeout):  # noqa: ARG001
+            stop_started.set()
+            # Multiple small sleeps give the cancellation a chance to arrive
+            # while agent.stop is mid-flight, which is the scenario under test.
+            for _ in range(5):
+                await asyncio.sleep(0.01)
+            stop_finished.set()
+            return True
+
+        mock_agent.stop = AsyncMock(side_effect=slow_stop)
+        shutdown = GracefulShutdown(mock_agent, timeout=1.0)
+
+        task = asyncio.create_task(shutdown._shutdown())
+        await stop_started.wait()
+
+        # Cancel the outer shutdown task mid-stop. Shielded agent.stop should
+        # still run to completion.
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Give shielded stop a moment to finish after the outer task was cancelled.
+        for _ in range(50):
+            if stop_finished.is_set():
+                break
+            await asyncio.sleep(0.01)
+
+        assert stop_finished.is_set(), (
+            "agent.stop was cancelled mid-flight; asyncio.shield is missing"
+        )
+
+    async def test_shutdown_handles_cancelled_error(self, mock_agent):
+        """_shutdown should log and run best-effort cleanup when cancelled."""
+        stop_calls: list[float] = []
+
+        async def tracking_stop(*, timeout):
+            stop_calls.append(timeout)
+            # First call (the shielded one) raises CancelledError to simulate
+            # the shield being bypassed; second call is the best-effort cleanup.
+            if len(stop_calls) == 1:
+                raise asyncio.CancelledError()
+            return True
+
+        mock_agent.stop = AsyncMock(side_effect=tracking_stop)
+        shutdown = GracefulShutdown(mock_agent, timeout=5.0)
+
+        with pytest.raises(asyncio.CancelledError):
+            await shutdown._shutdown()
+
+        # First call uses the configured timeout, second is the best-effort quick stop.
+        assert stop_calls == [5.0, 0.0]
+
 
 class TestGracefulShutdownWaitForShutdown:
     """Test wait_for_shutdown behavior."""

--- a/tests/runtime/test_shutdown.py
+++ b/tests/runtime/test_shutdown.py
@@ -211,15 +211,13 @@ class TestGracefulShutdownHandler:
         with pytest.raises(asyncio.CancelledError):
             await task
 
-        # Give shielded stop a moment to finish after the outer task was cancelled.
-        for _ in range(50):
-            if stop_finished.is_set():
-                break
-            await asyncio.sleep(0.01)
-
-        assert stop_finished.is_set(), (
-            "agent.stop was cancelled mid-flight; asyncio.shield is missing"
-        )
+        # Shielded stop should complete shortly after the outer task was cancelled.
+        try:
+            await asyncio.wait_for(stop_finished.wait(), timeout=1.0)
+        except asyncio.TimeoutError:
+            pytest.fail(
+                "agent.stop was cancelled mid-flight; asyncio.shield is missing"
+            )
 
     async def test_shutdown_reraises_cancelled_error(self, mock_agent):
         """_shutdown should log and re-raise CancelledError without a second stop."""


### PR DESCRIPTION
## Summary

Closes [INT-327](https://linear.app/thenvoi/issue/INT-327/fix-harden-graceful-shutdown-against-signal-races-and-task). Fixes three robustness gaps in `runtime/shutdown.py` surfaced during audit of closed PR #98 (Letta adapter). General runtime fixes, not Letta-specific.

- **Signal guard runs too late:** Moved the `_shutting_down` / `_shutdown_task` guard to the top of `_handle_signal`, before the `on_signal` callback and `_shutdown_event.set()`. Honors the documented "subsequent signals are ignored" contract and prevents non-idempotent user callbacks (e.g. alerting) from firing twice.
- **`agent.stop()` not shielded from outer-task cancellation:** Wrapped with `asyncio.shield(...)` so a cancellation propagating through the outer awaiter (e.g. a parent `run()` being cancelled) doesn't interrupt cleanup mid-flight. Caveat: `asyncio.run()` teardown calls `_cancel_all_tasks()` which cancels the inner shielded task too — shield protects from the outer awaiter, not full loop teardown. The context-manager / await-stop patterns remain the correct choice for guaranteed completion on process exit.
- **`CancelledError` not caught in `_shutdown()`:** `except Exception` misses `CancelledError` (it inherits from `BaseException` in Py3.8+), so cancelled shutdowns surfaced only as unraisable task-exception warnings. Added an explicit `except asyncio.CancelledError` branch that logs and re-raises. It deliberately does **not** kick off a second concurrent `agent.stop` — `AgentRuntime.stop` iterates `executions.keys()` with no in-flight guard, and two concurrent stops would race on per-room teardown. The shielded inner `agent.stop` continues running in the background.

## Test plan

- [x] New: second signal during shutdown does not re-invoke `on_signal` and does not re-set the shutdown event
- [x] New: cancelling `_shutdown` mid-flight lets `agent.stop()` complete (shield verification, via `asyncio.wait_for`)
- [x] New: `CancelledError` in `_shutdown` is logged and re-raised exactly once (no second concurrent stop)
- [x] All 23 tests in `tests/runtime/test_shutdown.py` pass
- [x] `uv run ruff check .` clean on modified files
- [x] `uv run ruff format .` clean on modified files
- [x] `uv run pyrefly check src/thenvoi/runtime/shutdown.py` clean (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)