### PR TITLE
fix(websocket): include threadId in interrupt payload [INT-323]

### DIFF
--- a/src/thenvoi/adapters/codex.py
+++ b/src/thenvoi/adapters/codex.py
@@ -557,7 +557,8 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                 if turn_id:
                     try:
                         await self._client.request(
-                            "turn/interrupt", {"turnId": turn_id}
+                            "turn/interrupt",
+                            {"threadId": thread_id, "turnId": turn_id},
                         )
                     except Exception:
                         logger.warning(

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -1571,11 +1571,13 @@ class TestCodexAdapter:
             room_id="room-1",
         )
 
-        # Adapter should have sent turn/interrupt.
+        # Adapter should have sent turn/interrupt with both identifiers.
         interrupt_requests = [
             (m, p) for m, p in fake_client.requests if m == "turn/interrupt"
         ]
-        assert len(interrupt_requests) == 1
+        assert interrupt_requests == [
+            ("turn/interrupt", {"threadId": "thr-1", "turnId": "turn-1"})
+        ]
 
         # Adapter should send a user-facing message about stopping.
         assert any("stopped" in msg["content"].lower() for msg in tools.messages_sent)


### PR DESCRIPTION
## Summary
- include `threadId` alongside `turnId` when the Codex adapter sends `turn/interrupt` after a timeout
- tighten the timeout regression so it asserts the exact JSON-RPC interrupt payload

## Test plan
- [x] `uv run pytest tests/adapters/test_codex_adapter.py -k \"test_turn_timeout_sends_interrupt_and_clean_error\"`