### PR TITLE
feat(websocket): prefer is_remote payload fields [INT-345]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ RoomRemovedPayload:
   id, status?, type?, title?, removed_at?
 
 ParticipantAddedPayload:
-  id, name, type, is_remote?, is_external?
+  id, name, type, is_remote?, is_external? (legacy alias)
 
 ParticipantRemovedPayload:
   id
@@ -106,7 +106,7 @@ Each event has: `type` (literal), `room_id`, `payload`, `raw`
 |-------|----------------|
 | `contact_request_received` | `id`, `from_handle`, `from_name`, `message?`, `status`, `inserted_at` |
 | `contact_request_updated` | `id`, `status` |
-| `contact_added` | `id`, `handle`, `name`, `type`, `description?`, `is_remote?`, `is_external?` (legacy alias), `inserted_at` |
+| `contact_added` | `id`, `handle`, `name`, `type`, `description?`, `is_remote?`, `is_external?` (legacy alias; mirrors `is_remote`), `inserted_at` |
 | `contact_removed` | `id` |
 
 ## Contact Event Handling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ RoomRemovedPayload:
   id, status?, type?, title?, removed_at?
 
 ParticipantAddedPayload:
-  id, name, type
+  id, name, type, is_remote?, is_external?
 
 ParticipantRemovedPayload:
   id
@@ -106,7 +106,7 @@ Each event has: `type` (literal), `room_id`, `payload`, `raw`
 |-------|----------------|
 | `contact_request_received` | `id`, `from_handle`, `from_name`, `message?`, `status`, `inserted_at` |
 | `contact_request_updated` | `id`, `status` |
-| `contact_added` | `id`, `handle`, `name`, `type`, `description?`, `is_external?`, `inserted_at` |
+| `contact_added` | `id`, `handle`, `name`, `type`, `description?`, `is_remote?`, `is_external?` (legacy alias), `inserted_at` |
 | `contact_removed` | `id` |
 
 ## Contact Event Handling

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -13,7 +13,7 @@ from phoenix_channels_python_client.client import (
 from phoenix_channels_python_client.client_types import ReconnectPolicy
 from phoenix_channels_python_client.exceptions import PHXConnectionError
 from phoenix_channels_python_client.phx_messages import PHXMessage
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
 
 from band.client.streaming.errors import classify_initial_upgrade_error
 
@@ -130,7 +130,15 @@ class ParticipantAddedPayload(BaseModel):
     name: str
     type: str
     is_remote: bool | None = None
-    is_external: bool | None = None
+    is_external: bool | None = None  # Legacy alias for is_remote
+
+    @model_validator(mode="after")
+    def _sync_remote_aliases(self) -> "ParticipantAddedPayload":
+        if self.is_remote is None and self.is_external is not None:
+            self.is_remote = self.is_external
+        if self.is_external is None and self.is_remote is not None:
+            self.is_external = self.is_remote
+        return self
 
 
 class ParticipantRemovedPayload(BaseModel):
@@ -177,8 +185,16 @@ class ContactAddedPayload(BaseModel):
     type: str
     description: str | None = None
     is_remote: bool | None = None
-    is_external: bool | None = None
+    is_external: bool | None = None  # Legacy alias for is_remote
     inserted_at: str
+
+    @model_validator(mode="after")
+    def _sync_remote_aliases(self) -> "ContactAddedPayload":
+        if self.is_remote is None and self.is_external is not None:
+            self.is_remote = self.is_external
+        if self.is_external is None and self.is_remote is not None:
+            self.is_external = self.is_remote
+        return self
 
 
 class ContactRemovedPayload(BaseModel):

--- a/src/band/client/streaming/client.py
+++ b/src/band/client/streaming/client.py
@@ -129,6 +129,8 @@ class ParticipantAddedPayload(BaseModel):
     id: str
     name: str
     type: str
+    is_remote: bool | None = None
+    is_external: bool | None = None
 
 
 class ParticipantRemovedPayload(BaseModel):
@@ -174,6 +176,7 @@ class ContactAddedPayload(BaseModel):
     name: str
     type: str
     description: str | None = None
+    is_remote: bool | None = None
     is_external: bool | None = None
     inserted_at: str
 

--- a/src/thenvoi/client/streaming/client.py
+++ b/src/thenvoi/client/streaming/client.py
@@ -9,7 +9,7 @@ from phoenix_channels_python_client.client import (
     PhoenixChannelsProtocolVersion,
 )
 from phoenix_channels_python_client.phx_messages import PHXMessage
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +108,15 @@ class ParticipantAddedPayload(BaseModel):
     name: str
     type: str
     is_remote: bool | None = None
-    is_external: bool | None = None
+    is_external: bool | None = None  # Legacy alias for is_remote
+
+    @model_validator(mode="after")
+    def _sync_remote_aliases(self) -> "ParticipantAddedPayload":
+        if self.is_remote is None and self.is_external is not None:
+            self.is_remote = self.is_external
+        if self.is_external is None and self.is_remote is not None:
+            self.is_external = self.is_remote
+        return self
 
 
 class ParticipantRemovedPayload(BaseModel):
@@ -155,8 +163,16 @@ class ContactAddedPayload(BaseModel):
     type: str
     description: str | None = None
     is_remote: bool | None = None
-    is_external: bool | None = None
+    is_external: bool | None = None  # Legacy alias for is_remote
     inserted_at: str
+
+    @model_validator(mode="after")
+    def _sync_remote_aliases(self) -> "ContactAddedPayload":
+        if self.is_remote is None and self.is_external is not None:
+            self.is_remote = self.is_external
+        if self.is_external is None and self.is_remote is not None:
+            self.is_external = self.is_remote
+        return self
 
 
 class ContactRemovedPayload(BaseModel):

--- a/src/thenvoi/client/streaming/client.py
+++ b/src/thenvoi/client/streaming/client.py
@@ -107,6 +107,8 @@ class ParticipantAddedPayload(BaseModel):
     id: str
     name: str
     type: str
+    is_remote: bool | None = None
+    is_external: bool | None = None
 
 
 class ParticipantRemovedPayload(BaseModel):
@@ -152,6 +154,7 @@ class ContactAddedPayload(BaseModel):
     name: str
     type: str
     description: str | None = None
+    is_remote: bool | None = None
     is_external: bool | None = None
     inserted_at: str
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,9 +125,16 @@ def make_participant_added_event(
     participant_id: str = "user-456",
     name: str = "Test User",
     type: str = "User",
+    **kwargs,
 ) -> ParticipantAddedEvent:
     """Create a ParticipantAddedEvent using SDK-native types."""
-    payload = ParticipantAddedPayload(id=participant_id, name=name, type=type)
+    payload = ParticipantAddedPayload(
+        id=participant_id,
+        name=name,
+        type=type,
+        is_remote=kwargs.get("is_remote"),
+        is_external=kwargs.get("is_external"),
+    )
     return ParticipantAddedEvent(room_id=room_id, payload=payload)
 
 
@@ -184,6 +191,7 @@ def make_contact_added_event(
         name=name,
         type=contact_type,
         description=kwargs.get("description"),
+        is_remote=kwargs.get("is_remote"),
         is_external=kwargs.get("is_external"),
         inserted_at=kwargs.get("inserted_at", "2026-01-01T00:00:00Z"),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,9 +128,16 @@ def make_participant_added_event(
     participant_id: str = "user-456",
     name: str = "Test User",
     type: str = "User",
+    **kwargs,
 ) -> ParticipantAddedEvent:
     """Create a ParticipantAddedEvent using SDK-native types."""
-    payload = ParticipantAddedPayload(id=participant_id, name=name, type=type)
+    payload = ParticipantAddedPayload(
+        id=participant_id,
+        name=name,
+        type=type,
+        is_remote=kwargs.get("is_remote"),
+        is_external=kwargs.get("is_external"),
+    )
     return ParticipantAddedEvent(room_id=room_id, payload=payload)
 
 
@@ -187,6 +194,7 @@ def make_contact_added_event(
         name=name,
         type=contact_type,
         description=kwargs.get("description"),
+        is_remote=kwargs.get("is_remote"),
         is_external=kwargs.get("is_external"),
         inserted_at=kwargs.get("inserted_at", "2026-01-01T00:00:00Z"),
     )

--- a/tests/platform/test_contact_events.py
+++ b/tests/platform/test_contact_events.py
@@ -108,11 +108,13 @@ class TestContactAddedEvent:
             name="Weather Bot",
             type="Agent",
             description="Weather forecasts",
+            is_remote=True,
             is_external=True,
             inserted_at="2026-02-09T10:35:00Z",
         )
         event = ContactAddedEvent(payload=payload)
         assert event.payload.type == "Agent"
+        assert event.payload.is_remote is True
         assert event.payload.is_external is True
 
 

--- a/tests/platform/test_contact_events.py
+++ b/tests/platform/test_contact_events.py
@@ -117,6 +117,20 @@ class TestContactAddedEvent:
         assert event.payload.is_remote is True
         assert event.payload.is_external is True
 
+    def test_legacy_contact_alias_still_populates_primary_field(self):
+        """Legacy contact payloads should hydrate is_remote for consumers."""
+        payload = ContactAddedPayload(
+            id="contact-legacy",
+            handle="weather-bot",
+            name="Weather Bot",
+            type="Agent",
+            is_external=True,
+            inserted_at="2026-02-09T10:35:00Z",
+        )
+        event = ContactAddedEvent(payload=payload)
+        assert event.payload.is_remote is True
+        assert event.payload.is_external is True
+
 
 class TestContactRemovedEvent:
     """Tests for ContactRemovedEvent."""

--- a/tests/platform/test_event.py
+++ b/tests/platform/test_event.py
@@ -215,6 +215,23 @@ class TestParticipantEvents:
         assert event.payload.is_remote is True
         assert event.payload.is_external is True
 
+    def test_construct_participant_added_event_from_legacy_alias(self):
+        """Legacy participant payloads should still expose is_remote."""
+        payload = ParticipantAddedPayload(
+            id="user-123",
+            name="Test User",
+            type="User",
+            is_external=False,
+        )
+
+        event = ParticipantAddedEvent(
+            room_id="room-123",
+            payload=payload,
+        )
+
+        assert event.payload.is_remote is False
+        assert event.payload.is_external is False
+
     def test_construct_participant_removed_event(self):
         """Construct a ParticipantRemovedEvent with typed payload."""
         payload = ParticipantRemovedPayload(id="user-123")

--- a/tests/platform/test_event.py
+++ b/tests/platform/test_event.py
@@ -199,6 +199,8 @@ class TestParticipantEvents:
             id="user-123",
             name="Test User",
             type="User",
+            is_remote=True,
+            is_external=True,
         )
 
         event = ParticipantAddedEvent(
@@ -210,6 +212,8 @@ class TestParticipantEvents:
         assert event.room_id == "room-123"
         assert event.payload.id == "user-123"
         assert event.payload.name == "Test User"
+        assert event.payload.is_remote is True
+        assert event.payload.is_external is True
 
     def test_construct_participant_removed_event(self):
         """Construct a ParticipantRemovedEvent with typed payload."""

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -329,12 +329,16 @@ async def test_accepts_valid_participant_added_payload():
             "id": "p-123",
             "name": "Test Agent",
             "type": "Agent",
+            "is_remote": True,
+            "is_external": True,
         }
 
     await client._handle_events(MockMessage(), {"participant_added": test_callback})
     assert isinstance(received_payload, ParticipantAddedPayload)
     assert received_payload.id == "p-123"
     assert received_payload.name == "Test Agent"
+    assert received_payload.is_remote is True
+    assert received_payload.is_external is True
 
 
 async def test_accepts_valid_participant_removed_payload():

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -597,12 +597,16 @@ async def test_accepts_valid_participant_added_payload():
             "id": "p-123",
             "name": "Test Agent",
             "type": "Agent",
+            "is_remote": True,
+            "is_external": True,
         }
 
     await client._handle_events(MockMessage(), {"participant_added": test_callback})
     assert isinstance(received_payload, ParticipantAddedPayload)
     assert received_payload.id == "p-123"
     assert received_payload.name == "Test Agent"
+    assert received_payload.is_remote is True
+    assert received_payload.is_external is True
 
 
 async def test_accepts_valid_participant_removed_payload():

--- a/tests/websocket/test_contact_payloads.py
+++ b/tests/websocket/test_contact_payloads.py
@@ -123,6 +123,32 @@ class TestContactAddedPayload:
         assert payload.is_remote is True
         assert payload.is_external is True
 
+    def test_legacy_is_external_populates_is_remote(self):
+        """Legacy payloads should still expose the new primary field."""
+        payload = ContactAddedPayload(
+            id="contact-legacy",
+            handle="legacy-agent",
+            name="Legacy Agent",
+            type="Agent",
+            is_external=True,
+            inserted_at="2026-02-09T10:35:00Z",
+        )
+        assert payload.is_remote is True
+        assert payload.is_external is True
+
+    def test_is_remote_populates_legacy_alias(self):
+        """New payloads should keep the legacy alias populated too."""
+        payload = ContactAddedPayload(
+            id="contact-new",
+            handle="new-agent",
+            name="New Agent",
+            type="Agent",
+            is_remote=False,
+            inserted_at="2026-02-09T10:35:00Z",
+        )
+        assert payload.is_remote is False
+        assert payload.is_external is False
+
     def test_internal_agent_contact(self):
         """Should accept internal agent contact."""
         payload = ContactAddedPayload(

--- a/tests/websocket/test_contact_payloads.py
+++ b/tests/websocket/test_contact_payloads.py
@@ -103,6 +103,7 @@ class TestContactAddedPayload:
         assert payload.id == "contact-123"
         assert payload.type == "User"
         assert payload.description is None
+        assert payload.is_remote is None
         assert payload.is_external is None
 
     def test_agent_contact(self):
@@ -113,11 +114,13 @@ class TestContactAddedPayload:
             name="Weather Bot",
             type="Agent",
             description="Provides weather forecasts",
+            is_remote=True,
             is_external=True,
             inserted_at="2026-02-09T10:35:00Z",
         )
         assert payload.type == "Agent"
         assert payload.description == "Provides weather forecasts"
+        assert payload.is_remote is True
         assert payload.is_external is True
 
     def test_internal_agent_contact(self):
@@ -127,9 +130,11 @@ class TestContactAddedPayload:
             handle="my-agent",
             name="My Agent",
             type="Agent",
+            is_remote=False,
             is_external=False,
             inserted_at="2026-02-09T10:35:00Z",
         )
+        assert payload.is_remote is False
         assert payload.is_external is False
 
     def test_missing_required_field(self):


### PR DESCRIPTION
## Summary
- add `is_remote` as the primary typed field on participant and contact websocket payloads while keeping `is_external` as the legacy alias
- update fixtures and websocket/platform tests to cover the new field ordering and aliases
- refresh the Python SDK payload docs in `AGENTS.md`

## Test plan
- [x] `uv run --extra dev python -m pytest tests/websocket/test_contact_payloads.py tests/platform/test_contact_events.py tests/platform/test_event.py tests/websocket/test_client.py`