### PR TITLE
feat: add HumanTools and ToolDefinition.surface field (INT-349)

### DIFF
--- a/src/thenvoi/runtime/__init__.py
+++ b/src/thenvoi/runtime/__init__.py
@@ -36,6 +36,7 @@ from .runtime import AgentRuntime
 # Tools
 from .tools import (
     AgentTools,
+    HumanTools,
     TOOL_MODELS,
     ALL_TOOL_NAMES,
     BASE_TOOL_NAMES,
@@ -72,6 +73,7 @@ __all__ = [
     "AgentRuntime",
     # Tools
     "AgentTools",
+    "HumanTools",
     "TOOL_MODELS",
     "ALL_TOOL_NAMES",
     "BASE_TOOL_NAMES",

--- a/src/thenvoi/runtime/mcp_server.py
+++ b/src/thenvoi/runtime/mcp_server.py
@@ -68,6 +68,31 @@ class MCPToolRegistration:
         )
 
 
+def _filter_to_agent_surface(
+    definitions: Sequence[ToolDefinition],
+) -> list[ToolDefinition]:
+    """Drop non-agent definitions and log a warning for each discarded entry.
+
+    ``build_*_tool_registrations`` wire their execution path through
+    ``AgentTools``; a ``surface="human"`` definition in the list would
+    ``AttributeError`` at call time because ``AgentTools`` has no
+    ``HumanTools`` methods. Rather than propagate the error, quietly filter
+    and warn so a regression in a caller is observable but not fatal.
+    """
+    filtered: list[ToolDefinition] = []
+    for definition in definitions:
+        if definition.surface != "agent":
+            logger.warning(
+                "Dropping non-agent tool definition %r (surface=%r) from MCP "
+                "registrations; LocalMCPServer is agent-only.",
+                definition.name,
+                definition.surface,
+            )
+            continue
+        filtered.append(definition)
+    return filtered
+
+
 def build_thenvoi_mcp_tool_registrations(
     agent_tools: AgentToolsProtocol,
     *,
@@ -80,7 +105,7 @@ def build_thenvoi_mcp_tool_registrations(
     # so a human tool added to the registry never leaks into an adapter
     # expecting only agent tools. Widening is deferred to a future ticket.
     definitions = (
-        list(tool_definitions)
+        _filter_to_agent_surface(list(tool_definitions))
         if tool_definitions is not None
         else [
             definition
@@ -110,7 +135,7 @@ def build_resolved_thenvoi_mcp_tool_registrations(
     """Build MCP registrations that resolve room-scoped tools at call time."""
     # LocalMCPServer stays agent-only — see build_thenvoi_mcp_tool_registrations.
     definitions = (
-        list(tool_definitions)
+        _filter_to_agent_surface(list(tool_definitions))
         if tool_definitions is not None
         else [
             definition

--- a/src/thenvoi/runtime/mcp_server.py
+++ b/src/thenvoi/runtime/mcp_server.py
@@ -76,12 +76,17 @@ def build_thenvoi_mcp_tool_registrations(
     tool_definitions: Sequence[ToolDefinition] | None = None,
 ) -> list[MCPToolRegistration]:
     """Build MCP tool registrations for Thenvoi tools and custom tools."""
+    # LocalMCPServer stays agent-only in Phase 1 of INT-338. Pin surface
+    # so a human tool added to the registry never leaks into an adapter
+    # expecting only agent tools. Widening is deferred to a future ticket.
     definitions = (
         list(tool_definitions)
         if tool_definitions is not None
         else [
             definition
-            for definition in iter_tool_definitions(include_memory=include_memory)
+            for definition in iter_tool_definitions(
+                surface="agent", include_memory=include_memory
+            )
         ]
     )
     registrations = [
@@ -103,12 +108,15 @@ def build_resolved_thenvoi_mcp_tool_registrations(
     tool_definitions: Sequence[ToolDefinition] | None = None,
 ) -> list[MCPToolRegistration]:
     """Build MCP registrations that resolve room-scoped tools at call time."""
+    # LocalMCPServer stays agent-only — see build_thenvoi_mcp_tool_registrations.
     definitions = (
         list(tool_definitions)
         if tool_definitions is not None
         else [
             definition
-            for definition in iter_tool_definitions(include_memory=include_memory)
+            for definition in iter_tool_definitions(
+                surface="agent", include_memory=include_memory
+            )
         ]
     )
     registrations = [

--- a/src/thenvoi/runtime/tools.py
+++ b/src/thenvoi/runtime/tools.py
@@ -70,6 +70,7 @@ class ToolDefinition:
     name: str
     input_model: type[BaseModel]
     method_name: str
+    surface: Literal["agent", "human"] = "agent"
 
 
 # --- Tool input models (single source of truth for schemas) ---
@@ -324,6 +325,325 @@ class ArchiveMemoryInput(BaseModel):
     memory_id: str = Field(..., description="Memory ID (UUID)")
 
 
+# --- Human-tool input models (copied from thenvoi-mcp/src/thenvoi_mcp/tools/human/*.py) ---
+#
+# These models mirror the current thenvoi-mcp human tool handler signatures
+# field-for-field. They are the canonical contract preserved by Phase 1 of
+# INT-338: the observable tool surface stays identical to today's MCP
+# behavior. Widening to full Fern parity is out of scope for this ticket.
+
+
+# human_agents.py
+
+
+class ListMyAgentsInput(BaseModel):
+    """List agents owned by the user."""
+
+    page: int | None = Field(None, description="Page number (optional).")
+    page_size: int | None = Field(None, description="Items per page (optional).")
+
+
+class RegisterMyAgentInput(BaseModel):
+    """Register a new external agent.
+
+    Returns the agent details including API key. Save the API key - it's only shown once!
+    """
+
+    name: str = Field(..., description="Agent name (required).")
+    description: str = Field(..., description="Agent description (required).")
+
+
+class DeleteMyAgentInput(BaseModel):
+    """Delete an agent owned by the user."""
+
+    agent_id: str = Field(..., description="ID of the agent to delete (required).")
+    force: bool | None = Field(
+        None, description="If true, force deletion even when the agent is active."
+    )
+
+
+# human_chats.py
+
+
+class ListMyChatsInput(BaseModel):
+    """List chat rooms where the user is a participant."""
+
+    page: int | None = Field(None, description="Page number (optional).")
+    page_size: int | None = Field(None, description="Items per page (optional).")
+
+
+class GetMyChatRoomInput(BaseModel):
+    """Get a specific chat room by ID."""
+
+    chat_id: str = Field(..., description="The chat room ID (required).")
+
+
+class CreateMyChatRoomInput(BaseModel):
+    """Create a new chat room with the user as owner."""
+
+    task_id: str | None = Field(
+        None, description="Optional task ID to associate with the chat."
+    )
+
+
+# human_contacts.py
+
+
+class ListMyContactsInput(BaseModel):
+    """List the user's contacts.
+
+    Returns active contacts with their details including handle, email, and type.
+    """
+
+    page: int | None = Field(None, description="Page number for pagination (optional).")
+    page_size: int | None = Field(
+        None, description="Number of items per page (optional)."
+    )
+
+
+class CreateContactRequestInput(BaseModel):
+    """Send a contact request to another user."""
+
+    recipient_handle: str = Field(
+        ...,
+        description="Handle of the user to add (with or without @ prefix, required).",
+    )
+    message: str | None = Field(
+        None,
+        description="Optional message to include with the request (max 500 chars).",
+    )
+
+
+class ListReceivedContactRequestsInput(BaseModel):
+    """List contact requests received by the user.
+
+    Returns pending contact requests that need approval or rejection.
+    """
+
+    page: int | None = Field(None, description="Page number for pagination (optional).")
+    page_size: int | None = Field(
+        None, description="Number of items per page (optional)."
+    )
+
+
+class ListSentContactRequestsInput(BaseModel):
+    """List contact requests sent by the user."""
+
+    status: Literal["pending", "approved", "rejected", "cancelled", "all"] | None = (
+        Field(
+            None,
+            description=(
+                "Filter by status: 'pending', 'approved', 'rejected', "
+                "'cancelled', or 'all' (optional)."
+            ),
+        )
+    )
+    page: int | None = Field(None, description="Page number for pagination (optional).")
+    page_size: int | None = Field(
+        None, description="Number of items per page (optional)."
+    )
+
+
+class ApproveContactRequestInput(BaseModel):
+    """Approve a received contact request."""
+
+    request_id: str = Field(
+        ..., description="The contact request ID to approve (required)."
+    )
+
+
+class RejectContactRequestInput(BaseModel):
+    """Reject a received contact request."""
+
+    request_id: str = Field(
+        ..., description="The contact request ID to reject (required)."
+    )
+
+
+class CancelContactRequestInput(BaseModel):
+    """Cancel a sent contact request."""
+
+    request_id: str = Field(
+        ..., description="The contact request ID to cancel (required)."
+    )
+
+
+class ResolveHandleInput(BaseModel):
+    """Look up an entity by handle.
+
+    Resolves a handle to its entity details. Use this to verify a handle
+    exists before sending a contact request.
+    """
+
+    handle: str = Field(..., description="The handle to resolve (required).")
+
+
+class RemoveMyContactInput(BaseModel):
+    """Remove an existing contact.
+
+    Removes a contact by either contact_id or handle. At least one must be provided.
+    If both are provided, both are sent to the API (contact_id takes precedence).
+    """
+
+    contact_id: str | None = Field(
+        None,
+        description="The contact record ID (optional, provide this or handle).",
+    )
+    handle: str | None = Field(
+        None,
+        description="The contact's handle (optional, provide this or contact_id).",
+    )
+
+
+# human_messages.py
+
+
+class ListMyChatMessagesInput(BaseModel):
+    """List messages in a chat room."""
+
+    chat_id: str = Field(..., description="The chat room ID (required).")
+    page: int | None = Field(None, description="Page number (optional).")
+    page_size: int | None = Field(None, description="Items per page (optional).")
+    message_type: str | None = Field(
+        None,
+        description="Filter by type: 'text', 'tool_call', etc. (optional).",
+    )
+    since: str | None = Field(
+        None,
+        description="ISO 8601 timestamp to filter messages after (optional).",
+    )
+
+
+class SendMyChatMessageInput(BaseModel):
+    """Send a message in a chat room."""
+
+    chat_id: str = Field(..., description="The chat room ID (required).")
+    content: str = Field(..., description="Message text (required).")
+    recipients: str = Field(
+        ...,
+        description=(
+            "Non-empty comma-separated participant names to @mention (required). "
+            "Must contain at least one name; empty string is not accepted."
+        ),
+    )
+
+
+# human_participants.py
+
+
+class ListMyChatParticipantsInput(BaseModel):
+    """List participants in a chat room."""
+
+    chat_id: str = Field(..., description="The chat room ID (required).")
+    participant_type: str | None = Field(
+        None, description="Filter by type: 'User' or 'Agent' (optional)."
+    )
+
+
+class AddMyChatParticipantInput(BaseModel):
+    """Add a participant to a chat room."""
+
+    chat_id: str = Field(..., description="The chat room ID (required).")
+    participant_id: str = Field(
+        ..., description="ID of user or agent to add (required)."
+    )
+    role: str | None = Field(
+        None,
+        description="'owner', 'admin', or 'member' (optional, defaults to 'member').",
+    )
+
+
+class RemoveMyChatParticipantInput(BaseModel):
+    """Remove a participant from a chat room."""
+
+    chat_id: str = Field(..., description="The chat room ID (required).")
+    participant_id: str = Field(
+        ..., description="ID of participant to remove (required)."
+    )
+
+
+# human_memories.py
+
+
+class ListUserMemoriesInput(BaseModel):
+    """List memories available to the authenticated user."""
+
+    chat_room_id: str | None = Field(None, description="Filter by chat room ID.")
+    scope: str | None = Field(None, description="Filter by scope.")
+    system: str | None = Field(None, description="Filter by memory system.")
+    memory_type: str | None = Field(None, description="Filter by memory type.")
+    segment: str | None = Field(None, description="Filter by segment.")
+    content_query: str | None = Field(None, description="Full-text search query.")
+    page_size: int | None = Field(None, description="Number of results per page.")
+    status: str | None = Field(None, description="Filter by status.")
+
+
+class GetUserMemoryInput(BaseModel):
+    """Get a single user memory by ID."""
+
+    memory_id: str = Field(..., description="Memory ID (required).")
+
+
+class SupersedeUserMemoryInput(BaseModel):
+    """Mark a user memory as superseded."""
+
+    memory_id: str = Field(..., description="Memory ID (required).")
+
+
+class ArchiveUserMemoryInput(BaseModel):
+    """Archive a user memory."""
+
+    memory_id: str = Field(..., description="Memory ID (required).")
+
+
+class RestoreUserMemoryInput(BaseModel):
+    """Restore an archived user memory."""
+
+    memory_id: str = Field(..., description="Memory ID (required).")
+
+
+class DeleteUserMemoryInput(BaseModel):
+    """Delete a user memory permanently."""
+
+    memory_id: str = Field(..., description="Memory ID (required).")
+
+
+# human_profile.py / human_peers
+
+
+class GetMyProfileInput(BaseModel):
+    """Get the current user's profile details.
+
+    Returns your profile information including name, email, role, etc.
+    """
+
+    pass  # No parameters required.
+
+
+class UpdateMyProfileInput(BaseModel):
+    """Update the current user's profile."""
+
+    first_name: str | None = Field(None, description="New first name (optional).")
+    last_name: str | None = Field(None, description="New last name (optional).")
+
+
+class ListMyPeersInput(BaseModel):
+    """List entities you can interact with in chat rooms.
+
+    Peers include other users, your agents, and global agents.
+    """
+
+    not_in_chat: str | None = Field(
+        None,
+        description="Exclude entities already in this chat room (optional).",
+    )
+    peer_type: str | None = Field(
+        None, description="Filter by type: 'User' or 'Agent' (optional)."
+    )
+    page: int | None = Field(None, description="Page number (optional).")
+    page_size: int | None = Field(None, description="Items per page (optional).")
+
+
 # Registry mapping tool names to their schemas and bound AgentTools methods.
 TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     "thenvoi_send_message": ToolDefinition(
@@ -411,10 +731,190 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
         input_model=ArchiveMemoryInput,
         method_name="archive_memory",
     ),
+    # --- Human tools (surface="human") ---
+    # One entry per method in the Phase 1 human-tool mapping table.
+    # Method names match HumanTools attributes; hasattr(HumanTools, method_name)
+    # must resolve for every surface="human" definition.
+    "thenvoi_list_my_agents": ToolDefinition(
+        name="thenvoi_list_my_agents",
+        input_model=ListMyAgentsInput,
+        method_name="list_my_agents",
+        surface="human",
+    ),
+    "thenvoi_register_my_agent": ToolDefinition(
+        name="thenvoi_register_my_agent",
+        input_model=RegisterMyAgentInput,
+        method_name="register_my_agent",
+        surface="human",
+    ),
+    "thenvoi_delete_my_agent": ToolDefinition(
+        name="thenvoi_delete_my_agent",
+        input_model=DeleteMyAgentInput,
+        method_name="delete_my_agent",
+        surface="human",
+    ),
+    "thenvoi_list_my_chats": ToolDefinition(
+        name="thenvoi_list_my_chats",
+        input_model=ListMyChatsInput,
+        method_name="list_my_chats",
+        surface="human",
+    ),
+    "thenvoi_create_my_chat_room": ToolDefinition(
+        name="thenvoi_create_my_chat_room",
+        input_model=CreateMyChatRoomInput,
+        method_name="create_my_chat_room",
+        surface="human",
+    ),
+    "thenvoi_get_my_chat_room": ToolDefinition(
+        name="thenvoi_get_my_chat_room",
+        input_model=GetMyChatRoomInput,
+        method_name="get_my_chat_room",
+        surface="human",
+    ),
+    "thenvoi_list_my_contacts": ToolDefinition(
+        name="thenvoi_list_my_contacts",
+        input_model=ListMyContactsInput,
+        method_name="list_my_contacts",
+        surface="human",
+    ),
+    "thenvoi_create_contact_request": ToolDefinition(
+        name="thenvoi_create_contact_request",
+        input_model=CreateContactRequestInput,
+        method_name="create_contact_request",
+        surface="human",
+    ),
+    "thenvoi_list_received_contact_requests": ToolDefinition(
+        name="thenvoi_list_received_contact_requests",
+        input_model=ListReceivedContactRequestsInput,
+        method_name="list_received_contact_requests",
+        surface="human",
+    ),
+    "thenvoi_list_sent_contact_requests": ToolDefinition(
+        name="thenvoi_list_sent_contact_requests",
+        input_model=ListSentContactRequestsInput,
+        method_name="list_sent_contact_requests",
+        surface="human",
+    ),
+    "thenvoi_approve_contact_request": ToolDefinition(
+        name="thenvoi_approve_contact_request",
+        input_model=ApproveContactRequestInput,
+        method_name="approve_contact_request",
+        surface="human",
+    ),
+    "thenvoi_reject_contact_request": ToolDefinition(
+        name="thenvoi_reject_contact_request",
+        input_model=RejectContactRequestInput,
+        method_name="reject_contact_request",
+        surface="human",
+    ),
+    "thenvoi_cancel_contact_request": ToolDefinition(
+        name="thenvoi_cancel_contact_request",
+        input_model=CancelContactRequestInput,
+        method_name="cancel_contact_request",
+        surface="human",
+    ),
+    "thenvoi_resolve_handle": ToolDefinition(
+        name="thenvoi_resolve_handle",
+        input_model=ResolveHandleInput,
+        method_name="resolve_handle",
+        surface="human",
+    ),
+    "thenvoi_remove_my_contact": ToolDefinition(
+        name="thenvoi_remove_my_contact",
+        input_model=RemoveMyContactInput,
+        method_name="remove_my_contact",
+        surface="human",
+    ),
+    "thenvoi_list_my_chat_messages": ToolDefinition(
+        name="thenvoi_list_my_chat_messages",
+        input_model=ListMyChatMessagesInput,
+        method_name="list_my_chat_messages",
+        surface="human",
+    ),
+    "thenvoi_send_my_chat_message": ToolDefinition(
+        name="thenvoi_send_my_chat_message",
+        input_model=SendMyChatMessageInput,
+        method_name="send_my_chat_message",
+        surface="human",
+    ),
+    "thenvoi_list_my_chat_participants": ToolDefinition(
+        name="thenvoi_list_my_chat_participants",
+        input_model=ListMyChatParticipantsInput,
+        method_name="list_my_chat_participants",
+        surface="human",
+    ),
+    "thenvoi_add_my_chat_participant": ToolDefinition(
+        name="thenvoi_add_my_chat_participant",
+        input_model=AddMyChatParticipantInput,
+        method_name="add_my_chat_participant",
+        surface="human",
+    ),
+    "thenvoi_remove_my_chat_participant": ToolDefinition(
+        name="thenvoi_remove_my_chat_participant",
+        input_model=RemoveMyChatParticipantInput,
+        method_name="remove_my_chat_participant",
+        surface="human",
+    ),
+    "thenvoi_list_user_memories": ToolDefinition(
+        name="thenvoi_list_user_memories",
+        input_model=ListUserMemoriesInput,
+        method_name="list_user_memories",
+        surface="human",
+    ),
+    "thenvoi_get_user_memory": ToolDefinition(
+        name="thenvoi_get_user_memory",
+        input_model=GetUserMemoryInput,
+        method_name="get_user_memory",
+        surface="human",
+    ),
+    "thenvoi_supersede_user_memory": ToolDefinition(
+        name="thenvoi_supersede_user_memory",
+        input_model=SupersedeUserMemoryInput,
+        method_name="supersede_user_memory",
+        surface="human",
+    ),
+    "thenvoi_archive_user_memory": ToolDefinition(
+        name="thenvoi_archive_user_memory",
+        input_model=ArchiveUserMemoryInput,
+        method_name="archive_user_memory",
+        surface="human",
+    ),
+    "thenvoi_restore_user_memory": ToolDefinition(
+        name="thenvoi_restore_user_memory",
+        input_model=RestoreUserMemoryInput,
+        method_name="restore_user_memory",
+        surface="human",
+    ),
+    "thenvoi_delete_user_memory": ToolDefinition(
+        name="thenvoi_delete_user_memory",
+        input_model=DeleteUserMemoryInput,
+        method_name="delete_user_memory",
+        surface="human",
+    ),
+    "thenvoi_get_my_profile": ToolDefinition(
+        name="thenvoi_get_my_profile",
+        input_model=GetMyProfileInput,
+        method_name="get_my_profile",
+        surface="human",
+    ),
+    "thenvoi_update_my_profile": ToolDefinition(
+        name="thenvoi_update_my_profile",
+        input_model=UpdateMyProfileInput,
+        method_name="update_my_profile",
+        surface="human",
+    ),
+    "thenvoi_list_my_peers": ToolDefinition(
+        name="thenvoi_list_my_peers",
+        input_model=ListMyPeersInput,
+        method_name="list_my_peers",
+        surface="human",
+    ),
 }
 
 TOOL_MODELS: dict[str, type[BaseModel]] = {
-    name: definition.input_model for name, definition in TOOL_DEFINITIONS.items()
+    name: definition.input_model
+    for name, definition in TOOL_DEFINITIONS.items()
+    if definition.surface == "agent"
 }
 
 # Memory tools - optional, only available for enterprise customers.
@@ -444,6 +944,35 @@ CONTACT_TOOL_NAMES: frozenset[str] = frozenset(
     }
 )
 
+# Human-surface memory tools - parallel to MEMORY_TOOL_NAMES but on the
+# ``surface="human"`` side of the registry. Used by iter_tool_definitions()
+# to apply the ``include_memory`` filter uniformly across both surfaces.
+HUMAN_MEMORY_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "thenvoi_list_user_memories",
+        "thenvoi_get_user_memory",
+        "thenvoi_supersede_user_memory",
+        "thenvoi_archive_user_memory",
+        "thenvoi_restore_user_memory",
+        "thenvoi_delete_user_memory",
+    }
+)
+
+# Human-surface contact tools - parallel to CONTACT_TOOL_NAMES.
+HUMAN_CONTACT_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "thenvoi_list_my_contacts",
+        "thenvoi_create_contact_request",
+        "thenvoi_list_received_contact_requests",
+        "thenvoi_list_sent_contact_requests",
+        "thenvoi_approve_contact_request",
+        "thenvoi_reject_contact_request",
+        "thenvoi_cancel_contact_request",
+        "thenvoi_resolve_handle",
+        "thenvoi_remove_my_contact",
+    }
+)
+
 # Derived from TOOL_MODELS — single source of truth
 ALL_TOOL_NAMES: frozenset[str] = frozenset(TOOL_MODELS.keys())
 
@@ -453,6 +982,19 @@ if MEMORY_TOOL_NAMES - ALL_TOOL_NAMES:
     raise ValueError(f"Unknown memory tools: {MEMORY_TOOL_NAMES - ALL_TOOL_NAMES}")
 if CONTACT_TOOL_NAMES - ALL_TOOL_NAMES:
     raise ValueError(f"Unknown contact tools: {CONTACT_TOOL_NAMES - ALL_TOOL_NAMES}")
+
+# Human-surface registry membership is validated against TOOL_DEFINITIONS
+# (not TOOL_MODELS, which stays agent-only for back-compat).
+_ALL_DEFINITION_NAMES: frozenset[str] = frozenset(TOOL_DEFINITIONS.keys())
+if HUMAN_MEMORY_TOOL_NAMES - _ALL_DEFINITION_NAMES:
+    raise ValueError(
+        f"Unknown human memory tools: {HUMAN_MEMORY_TOOL_NAMES - _ALL_DEFINITION_NAMES}"
+    )
+if HUMAN_CONTACT_TOOL_NAMES - _ALL_DEFINITION_NAMES:
+    raise ValueError(
+        "Unknown human contact tools: "
+        f"{HUMAN_CONTACT_TOOL_NAMES - _ALL_DEFINITION_NAMES}"
+    )
 
 BASE_TOOL_NAMES: frozenset[str] = ALL_TOOL_NAMES - MEMORY_TOOL_NAMES
 CHAT_TOOL_NAMES: frozenset[str] = BASE_TOOL_NAMES - CONTACT_TOOL_NAMES
@@ -502,11 +1044,29 @@ def get_tool_description(name: str) -> str:
 
 
 def iter_tool_definitions(
-    *, include_memory: bool = False, include_contacts: bool = True
+    *,
+    surface: Literal["agent", "human"] | None = None,
+    include_memory: bool = False,
+    include_contacts: bool = True,
 ) -> list[ToolDefinition]:
     """Return built-in tool definitions with optional category filtering.
 
+    The three filters compose as independent predicates:
+
+    - ``surface``: when not ``None``, restrict to definitions whose
+      ``ToolDefinition.surface`` equals the given value. ``"agent"`` yields
+      only agent tools, ``"human"`` yields only human tools. ``None`` yields
+      both surfaces.
+    - ``include_memory``: if ``False`` (default), drop memory tools. This
+      applies to both the agent ``MEMORY_TOOL_NAMES`` set and the human
+      memory tools (``thenvoi_list_user_memories``, etc.).
+    - ``include_contacts``: if ``False``, drop contact tools. This applies
+      to both the agent ``CONTACT_TOOL_NAMES`` set and the human contact
+      tools (``thenvoi_list_my_contacts``, etc.).
+
     Args:
+        surface: Optional surface filter (``"agent"`` or ``"human"``).
+            Default ``None`` yields both surfaces.
         include_memory: Include memory tools (enterprise). Default False.
         include_contacts: Include contact-management tools. Default True for
             backward compatibility. Pass False to gate contact tools behind
@@ -514,15 +1074,22 @@ def iter_tool_definitions(
             forces this to True regardless of adapter preference (see
             ``AgentTools.get_tool_schemas`` HUB_ROOM auto-enable rule).
     """
-    definitions = list(TOOL_DEFINITIONS.values())
     excluded: set[str] = set()
     if not include_memory:
         excluded |= MEMORY_TOOL_NAMES
+        excluded |= HUMAN_MEMORY_TOOL_NAMES
     if not include_contacts:
         excluded |= CONTACT_TOOL_NAMES
-    if not excluded:
-        return definitions
-    return [definition for definition in definitions if definition.name not in excluded]
+        excluded |= HUMAN_CONTACT_TOOL_NAMES
+
+    results: list[ToolDefinition] = []
+    for definition in TOOL_DEFINITIONS.values():
+        if surface is not None and definition.surface != surface:
+            continue
+        if definition.name in excluded:
+            continue
+        results.append(definition)
+    return results
 
 
 def format_tool_validation_error(tool_name: str, error: ValidationError) -> str:
@@ -1552,3 +2119,453 @@ class AgentTools(AgentToolsProtocol):
             raise
         except Exception as e:
             return f"Error executing {tool_name}: {e}"
+
+
+class HumanTools:
+    """User-scoped tools for Thenvoi platform interaction.
+
+    ``HumanTools`` is stateless per credential: one instance per user-scoped
+    ``AsyncRestClient``. Unlike ``AgentTools`` it is not bound to a room —
+    every chat/room-bound method takes its room identifier as a plain
+    ``chat_id`` argument.
+
+    Each method is a thin wrapper around a Fern ``human_api_*`` call. The
+    observable tool surface mirrors today's ``thenvoi-mcp`` human tool
+    handlers (Phase 1 of INT-338 copies those signatures verbatim); widening
+    to full Fern parity is explicitly out of scope.
+    """
+
+    def __init__(self, rest: "AsyncRestClient") -> None:
+        """Bind this HumanTools instance to a user-scoped REST client."""
+        self.rest = rest
+
+    # --- human_agents.py ---
+
+    async def list_my_agents(
+        self,
+        page: int | None = None,
+        page_size: int | None = None,
+    ) -> Any:
+        """List agents owned by the user."""
+        logger.debug("Listing my agents: page=%s, page_size=%s", page, page_size)
+        return await self.rest.human_api_agents.list_my_agents(
+            page=page, page_size=page_size
+        )
+
+    async def register_my_agent(self, name: str, description: str) -> Any:
+        """Register a new external agent owned by the user."""
+        from thenvoi_rest import AgentRegisterRequest
+
+        logger.debug("Registering my agent: name=%s", name)
+        agent_request = AgentRegisterRequest(name=name, description=description)
+        return await self.rest.human_api_agents.register_my_agent(agent=agent_request)
+
+    async def delete_my_agent(self, agent_id: str, force: bool | None = None) -> Any:
+        """Delete an agent owned by the user."""
+        logger.debug("Deleting my agent: agent_id=%s, force=%s", agent_id, force)
+        kwargs: dict[str, Any] = {}
+        if force is not None:
+            kwargs["force"] = force
+        return await self.rest.human_api_agents.delete_my_agent(agent_id, **kwargs)
+
+    # --- human_chats.py ---
+
+    async def list_my_chats(
+        self,
+        page: int | None = None,
+        page_size: int | None = None,
+    ) -> Any:
+        """List chat rooms where the user is a participant."""
+        logger.debug("Listing my chats: page=%s, page_size=%s", page, page_size)
+        return await self.rest.human_api_chats.list_my_chats(
+            page=page, page_size=page_size
+        )
+
+    async def create_my_chat_room(self, task_id: str | None = None) -> Any:
+        """Create a new chat room with the user as owner."""
+        from thenvoi_rest import CreateMyChatRoomRequestChat
+
+        logger.debug("Creating my chat room: task_id=%s", task_id)
+        chat_request = (
+            CreateMyChatRoomRequestChat(task_id=task_id)
+            if task_id
+            else CreateMyChatRoomRequestChat()
+        )
+        return await self.rest.human_api_chats.create_my_chat_room(chat=chat_request)
+
+    async def get_my_chat_room(self, chat_id: str) -> Any:
+        """Get a specific chat room by ID."""
+        logger.debug("Getting my chat room: chat_id=%s", chat_id)
+        return await self.rest.human_api_chats.get_my_chat_room(id=chat_id)
+
+    # --- human_contacts.py ---
+
+    async def list_my_contacts(
+        self,
+        page: int | None = None,
+        page_size: int | None = None,
+    ) -> Any:
+        """List the user's active contacts."""
+        logger.debug("Listing my contacts: page=%s, page_size=%s", page, page_size)
+        return await self.rest.human_api_contacts.list_my_contacts(
+            page=page, page_size=page_size
+        )
+
+    async def create_contact_request(
+        self, recipient_handle: str, message: str | None = None
+    ) -> Any:
+        """Send a contact request to another user."""
+        from thenvoi_rest import CreateContactRequestRequestContactRequest
+
+        logger.debug("Creating contact request to: %s", recipient_handle)
+        kwargs: dict[str, Any] = {"recipient_handle": recipient_handle}
+        if message is not None:
+            kwargs["message"] = message
+        contact_request = CreateContactRequestRequestContactRequest(**kwargs)
+        return await self.rest.human_api_contacts.create_contact_request(
+            contact_request=contact_request,
+        )
+
+    async def list_received_contact_requests(
+        self,
+        page: int | None = None,
+        page_size: int | None = None,
+    ) -> Any:
+        """List contact requests received by the user (pending)."""
+        logger.debug(
+            "Listing received contact requests: page=%s, page_size=%s", page, page_size
+        )
+        return await self.rest.human_api_contacts.list_received_contact_requests(
+            page=page, page_size=page_size
+        )
+
+    async def list_sent_contact_requests(
+        self,
+        status: str | None = None,
+        page: int | None = None,
+        page_size: int | None = None,
+    ) -> Any:
+        """List contact requests sent by the user."""
+        logger.debug(
+            "Listing sent contact requests: status=%s, page=%s, page_size=%s",
+            status,
+            page,
+            page_size,
+        )
+        return await self.rest.human_api_contacts.list_sent_contact_requests(
+            status=status, page=page, page_size=page_size
+        )
+
+    async def approve_contact_request(self, request_id: str) -> Any:
+        """Approve a received contact request."""
+        logger.debug("Approving contact request: %s", request_id)
+        return await self.rest.human_api_contacts.approve_contact_request(id=request_id)
+
+    async def reject_contact_request(self, request_id: str) -> Any:
+        """Reject a received contact request."""
+        logger.debug("Rejecting contact request: %s", request_id)
+        return await self.rest.human_api_contacts.reject_contact_request(id=request_id)
+
+    async def cancel_contact_request(self, request_id: str) -> Any:
+        """Cancel a sent contact request."""
+        logger.debug("Cancelling contact request: %s", request_id)
+        return await self.rest.human_api_contacts.cancel_contact_request(id=request_id)
+
+    async def resolve_handle(self, handle: str) -> Any:
+        """Look up an entity by handle."""
+        logger.debug("Resolving handle: %s", handle)
+        return await self.rest.human_api_contacts.resolve_handle(handle=handle)
+
+    async def remove_my_contact(
+        self,
+        contact_id: str | None = None,
+        handle: str | None = None,
+    ) -> Any:
+        """Remove an existing contact by contact_id or handle.
+
+        Raises:
+            ValueError: If neither contact_id nor handle is provided.
+        """
+        if not contact_id and not handle:
+            raise ValueError("Either contact_id or handle must be provided")
+
+        logger.debug("Removing contact: contact_id=%s, handle=%s", contact_id, handle)
+        # The Fern client uses OMIT for optional params; passing None sends
+        # null. Build kwargs dynamically so we only send populated fields.
+        kwargs: dict[str, Any] = {}
+        if contact_id is not None:
+            kwargs["contact_id"] = contact_id
+        if handle is not None:
+            kwargs["handle"] = handle
+        return await self.rest.human_api_contacts.remove_my_contact(**kwargs)
+
+    # --- human_messages.py ---
+
+    async def list_my_chat_messages(
+        self,
+        chat_id: str,
+        page: int | None = None,
+        page_size: int | None = None,
+        message_type: str | None = None,
+        since: str | None = None,
+    ) -> Any:
+        """List messages in a chat room.
+
+        ``since`` is an ISO 8601 timestamp string; the SDK converts it to a
+        ``datetime`` before calling the Fern client. This mirrors today's
+        MCP handler behavior.
+        """
+        from datetime import datetime
+
+        logger.debug(
+            "Listing chat messages: chat_id=%s, page=%s, page_size=%s",
+            chat_id,
+            page,
+            page_size,
+        )
+        since_dt = None
+        if since:
+            since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        return await self.rest.human_api_messages.list_my_chat_messages(
+            chat_id=chat_id,
+            page=page,
+            page_size=page_size,
+            message_type=message_type,
+            since=since_dt,
+        )
+
+    async def send_my_chat_message(
+        self,
+        chat_id: str,
+        content: str,
+        recipients: str,
+    ) -> Any:
+        """Send a message in a chat room.
+
+        ``recipients`` is a comma-separated list of participant names; the
+        SDK resolves them against the chat participants and rejects empty
+        or unknown names with a ``ValueError``. This mirrors today's MCP
+        handler behavior.
+        """
+        from thenvoi_rest import ChatMessageRequest, ChatMessageRequestMentionsItem
+
+        recipient_names = [
+            name.strip().lower() for name in recipients.split(",") if name.strip()
+        ]
+        if not recipient_names:
+            raise ValueError("recipients cannot be empty")
+
+        logger.debug(
+            "Sending chat message: chat_id=%s, recipients=%s", chat_id, recipient_names
+        )
+
+        participants_response = (
+            await self.rest.human_api_participants.list_my_chat_participants(
+                chat_id=chat_id
+            )
+        )
+        participants = participants_response.data or []
+
+        name_to_participant: dict[str, Any] = {}
+        for p in participants:
+            if getattr(p, "name", None):
+                name_to_participant[p.name.lower()] = p
+            if getattr(p, "username", None):
+                name_to_participant[p.username.lower()] = p
+            if getattr(p, "first_name", None):
+                name_to_participant[p.first_name.lower()] = p
+
+        mentions_list: list[ChatMessageRequestMentionsItem] = []
+        not_found: list[str] = []
+        for name in recipient_names:
+            participant = name_to_participant.get(name)
+            if participant:
+                display_name = getattr(participant, "name", None) or getattr(
+                    participant, "username", "Unknown"
+                )
+                mentions_list.append(
+                    ChatMessageRequestMentionsItem(id=participant.id, name=display_name)
+                )
+            else:
+                not_found.append(name)
+
+        if not_found:
+            available = list(name_to_participant.keys())
+            raise ValueError(
+                f"Not found: {', '.join(not_found)}. Available: {', '.join(available)}"
+            )
+
+        message_request = ChatMessageRequest(content=content, mentions=mentions_list)
+        return await self.rest.human_api_messages.send_my_chat_message(
+            chat_id=chat_id, message=message_request
+        )
+
+    # --- human_participants.py ---
+
+    async def list_my_chat_participants(
+        self,
+        chat_id: str,
+        participant_type: str | None = None,
+    ) -> Any:
+        """List participants in a chat room."""
+        logger.debug(
+            "Listing my chat participants: chat_id=%s, participant_type=%s",
+            chat_id,
+            participant_type,
+        )
+        return await self.rest.human_api_participants.list_my_chat_participants(
+            chat_id=chat_id, participant_type=participant_type
+        )
+
+    async def add_my_chat_participant(
+        self,
+        chat_id: str,
+        participant_id: str,
+        role: str | None = None,
+    ) -> Any:
+        """Add a participant to a chat room."""
+        from thenvoi_rest import ParticipantRequest
+
+        logger.debug(
+            "Adding my chat participant: chat_id=%s, participant_id=%s, role=%s",
+            chat_id,
+            participant_id,
+            role,
+        )
+        participant = ParticipantRequest(
+            participant_id=participant_id, role=role or "member"
+        )
+        return await self.rest.human_api_participants.add_my_chat_participant(
+            chat_id=chat_id, participant=participant
+        )
+
+    async def remove_my_chat_participant(
+        self,
+        chat_id: str,
+        participant_id: str,
+    ) -> Any:
+        """Remove a participant from a chat room."""
+        logger.debug(
+            "Removing my chat participant: chat_id=%s, participant_id=%s",
+            chat_id,
+            participant_id,
+        )
+        return await self.rest.human_api_participants.remove_my_chat_participant(
+            chat_id=chat_id, id=participant_id
+        )
+
+    # --- human_memories.py ---
+
+    async def list_user_memories(
+        self,
+        chat_room_id: str | None = None,
+        scope: str | None = None,
+        system: str | None = None,
+        memory_type: str | None = None,
+        segment: str | None = None,
+        content_query: str | None = None,
+        page_size: int | None = None,
+        status: str | None = None,
+    ) -> Any:
+        """List memories available to the authenticated user."""
+        logger.debug(
+            "Listing user memories: chat_room_id=%s, scope=%s, system=%s",
+            chat_room_id,
+            scope,
+            system,
+        )
+        return await self.rest.human_api_memories.list_user_memories(
+            chat_room_id=chat_room_id,
+            scope=scope,
+            system=system,
+            type=memory_type,
+            segment=segment,
+            content_query=content_query,
+            page_size=page_size,
+            status=status,
+        )
+
+    async def get_user_memory(self, memory_id: str) -> Any:
+        """Get a single user memory by ID."""
+        logger.debug("Getting user memory: memory_id=%s", memory_id)
+        return await self.rest.human_api_memories.get_user_memory(memory_id)
+
+    async def supersede_user_memory(self, memory_id: str) -> Any:
+        """Mark a user memory as superseded."""
+        logger.debug("Superseding user memory: memory_id=%s", memory_id)
+        return await self.rest.human_api_memories.supersede_user_memory(memory_id)
+
+    async def archive_user_memory(self, memory_id: str) -> Any:
+        """Archive a user memory."""
+        logger.debug("Archiving user memory: memory_id=%s", memory_id)
+        return await self.rest.human_api_memories.archive_user_memory(memory_id)
+
+    async def restore_user_memory(self, memory_id: str) -> Any:
+        """Restore an archived user memory."""
+        logger.debug("Restoring user memory: memory_id=%s", memory_id)
+        return await self.rest.human_api_memories.restore_user_memory(memory_id)
+
+    async def delete_user_memory(self, memory_id: str) -> dict[str, Any]:
+        """Delete a user memory permanently.
+
+        The Fern endpoint returns no body; we return a structured
+        ``{"deleted": True, "id": memory_id}`` payload so the observable
+        return shape matches today's MCP handler.
+        """
+        logger.debug("Deleting user memory: memory_id=%s", memory_id)
+        await self.rest.human_api_memories.delete_user_memory(memory_id)
+        return {"deleted": True, "id": memory_id}
+
+    # --- human_profile.py / human_peers ---
+
+    async def get_my_profile(self) -> Any:
+        """Get the current user's profile details."""
+        logger.debug("Getting my profile")
+        return await self.rest.human_api_profile.get_my_profile()
+
+    async def update_my_profile(
+        self,
+        first_name: str | None = None,
+        last_name: str | None = None,
+    ) -> Any:
+        """Update the current user's profile.
+
+        Raises:
+            ValueError: If neither first_name nor last_name is provided.
+        """
+        user_data: dict[str, Any] = {}
+        if first_name is not None:
+            user_data["first_name"] = first_name
+        if last_name is not None:
+            user_data["last_name"] = last_name
+        if not user_data:
+            raise ValueError(
+                "At least one field (first_name or last_name) must be provided"
+            )
+
+        logger.debug("Updating my profile: fields=%s", list(user_data.keys()))
+        return await self.rest.human_api_profile.update_my_profile(
+            user=cast(Any, user_data)
+        )
+
+    async def list_my_peers(
+        self,
+        not_in_chat: str | None = None,
+        peer_type: str | None = None,
+        page: int | None = None,
+        page_size: int | None = None,
+    ) -> Any:
+        """List entities the user can interact with in chat rooms."""
+        logger.debug(
+            "Listing my peers: not_in_chat=%s, peer_type=%s, page=%s, page_size=%s",
+            not_in_chat,
+            peer_type,
+            page,
+            page_size,
+        )
+        return await self.rest.human_api_peers.list_my_peers(
+            not_in_chat=not_in_chat,
+            type=peer_type,
+            page=page,
+            page_size=page_size,
+        )

--- a/src/thenvoi/runtime/tools.py
+++ b/src/thenvoi/runtime/tools.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import warnings
 from dataclasses import dataclass
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import AliasChoices, BaseModel, Field, ValidationError
@@ -1045,7 +1046,7 @@ def get_tool_description(name: str) -> str:
 
 def iter_tool_definitions(
     *,
-    surface: Literal["agent", "human"] | None = None,
+    surface: Literal["agent", "human"] | None = "agent",
     include_memory: bool = False,
     include_contacts: bool = True,
 ) -> list[ToolDefinition]:
@@ -1054,9 +1055,12 @@ def iter_tool_definitions(
     The three filters compose as independent predicates:
 
     - ``surface``: when not ``None``, restrict to definitions whose
-      ``ToolDefinition.surface`` equals the given value. ``"agent"`` yields
-      only agent tools, ``"human"`` yields only human tools. ``None`` yields
-      both surfaces.
+      ``ToolDefinition.surface`` equals the given value. ``"agent"``
+      (default) yields only agent tools, ``"human"`` yields only human
+      tools, and ``None`` yields both surfaces. The default is pinned to
+      ``"agent"`` so existing callers (``claude_sdk``, ``opencode``,
+      ``acp``) that pipe the result straight into ``AgentTools``-shaped
+      backends don't silently gain ``HumanTools``-bound entries.
     - ``include_memory``: if ``False`` (default), drop memory tools. This
       applies to both the agent ``MEMORY_TOOL_NAMES`` set and the human
       memory tools (``thenvoi_list_user_memories``, etc.).
@@ -1066,7 +1070,8 @@ def iter_tool_definitions(
 
     Args:
         surface: Optional surface filter (``"agent"`` or ``"human"``).
-            Default ``None`` yields both surfaces.
+            Default ``"agent"``. Pass ``None`` explicitly to opt in to a
+            union view across both surfaces.
         include_memory: Include memory tools (enterprise). Default False.
         include_contacts: Include contact-management tools. Default True for
             backward compatibility. Pass False to gate contact tools behind
@@ -2315,8 +2320,6 @@ class HumanTools:
         ``datetime`` before calling the Fern client. This mirrors today's
         MCP handler behavior.
         """
-        from datetime import datetime
-
         logger.debug(
             "Listing chat messages: chat_id=%s, page=%s, page_size=%s",
             chat_id,

--- a/src/thenvoi/runtime/tools.py
+++ b/src/thenvoi/runtime/tools.py
@@ -2148,7 +2148,10 @@ class HumanTools:
 
         logger.debug("Registering my agent: name=%s", name)
         agent_request = AgentRegisterRequest(name=name, description=description)
-        return await self.rest.human_api_agents.register_my_agent(agent=agent_request)
+        return await self.rest.human_api_agents.register_my_agent(
+            agent=agent_request,
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
 
     # --- human_chats.py ---
 
@@ -2173,7 +2176,10 @@ class HumanTools:
             if task_id
             else CreateMyChatRoomRequestChat()
         )
-        return await self.rest.human_api_chats.create_my_chat_room(chat=chat_request)
+        return await self.rest.human_api_chats.create_my_chat_room(
+            chat=chat_request,
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
 
     async def get_my_chat_room(self, chat_id: str) -> Any:
         """Get a specific chat room by ID."""
@@ -2206,6 +2212,7 @@ class HumanTools:
         contact_request = CreateContactRequestRequestContactRequest(**kwargs)
         return await self.rest.human_api_contacts.create_contact_request(
             contact_request=contact_request,
+            request_options=DEFAULT_REQUEST_OPTIONS,
         )
 
     async def list_received_contact_requests(
@@ -2241,17 +2248,26 @@ class HumanTools:
     async def approve_contact_request(self, request_id: str) -> Any:
         """Approve a received contact request."""
         logger.debug("Approving contact request: %s", request_id)
-        return await self.rest.human_api_contacts.approve_contact_request(id=request_id)
+        return await self.rest.human_api_contacts.approve_contact_request(
+            id=request_id,
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
 
     async def reject_contact_request(self, request_id: str) -> Any:
         """Reject a received contact request."""
         logger.debug("Rejecting contact request: %s", request_id)
-        return await self.rest.human_api_contacts.reject_contact_request(id=request_id)
+        return await self.rest.human_api_contacts.reject_contact_request(
+            id=request_id,
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
 
     async def cancel_contact_request(self, request_id: str) -> Any:
         """Cancel a sent contact request."""
         logger.debug("Cancelling contact request: %s", request_id)
-        return await self.rest.human_api_contacts.cancel_contact_request(id=request_id)
+        return await self.rest.human_api_contacts.cancel_contact_request(
+            id=request_id,
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
 
     async def resolve_handle(self, handle: str) -> Any:
         """Look up an entity by handle."""
@@ -2265,11 +2281,12 @@ class HumanTools:
     ) -> Any:
         """Remove an existing contact by contact_id or handle.
 
-        Raises:
-            ValueError: If neither contact_id nor handle is provided.
+        Returns an ``"Error: ..."`` string (matching today's MCP handler
+        output verbatim) when neither ``contact_id`` nor ``handle`` is
+        provided, so the observable tool-surface error shape is preserved.
         """
         if not contact_id and not handle:
-            raise ValueError("Either contact_id or handle must be provided")
+            return "Error: Either contact_id or handle must be provided"
 
         logger.debug("Removing contact: contact_id=%s, handle=%s", contact_id, handle)
         # The Fern client uses OMIT for optional params; passing None sends
@@ -2279,7 +2296,10 @@ class HumanTools:
             kwargs["contact_id"] = contact_id
         if handle is not None:
             kwargs["handle"] = handle
-        return await self.rest.human_api_contacts.remove_my_contact(**kwargs)
+        return await self.rest.human_api_contacts.remove_my_contact(
+            **kwargs,
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
 
     # --- human_messages.py ---
 
@@ -2323,9 +2343,10 @@ class HumanTools:
         """Send a message in a chat room.
 
         ``recipients`` is a comma-separated list of participant names; the
-        SDK resolves them against the chat participants and rejects empty
-        or unknown names with a ``ValueError``. This mirrors today's MCP
-        handler behavior.
+        SDK resolves them against the chat participants. Empty input and
+        unknown names return an ``"Error: ..."`` string matching today's
+        MCP handler output verbatim (no exception raised) so the
+        observable tool-surface error shape is preserved.
         """
         from thenvoi_rest import ChatMessageRequest, ChatMessageRequestMentionsItem
 
@@ -2333,7 +2354,7 @@ class HumanTools:
             name.strip().lower() for name in recipients.split(",") if name.strip()
         ]
         if not recipient_names:
-            raise ValueError("recipients cannot be empty")
+            return "Error: recipients cannot be empty"
 
         logger.debug(
             "Sending chat message: chat_id=%s, recipients=%s", chat_id, recipient_names
@@ -2371,13 +2392,16 @@ class HumanTools:
 
         if not_found:
             available = list(name_to_participant.keys())
-            raise ValueError(
-                f"Not found: {', '.join(not_found)}. Available: {', '.join(available)}"
+            return (
+                f"Error: Not found: {', '.join(not_found)}. "
+                f"Available: {', '.join(available)}"
             )
 
         message_request = ChatMessageRequest(content=content, mentions=mentions_list)
         return await self.rest.human_api_messages.send_my_chat_message(
-            chat_id=chat_id, message=message_request
+            chat_id=chat_id,
+            message=message_request,
+            request_options=DEFAULT_REQUEST_OPTIONS,
         )
 
     # --- human_participants.py ---
@@ -2402,8 +2426,12 @@ class HumanTools:
         chat_id: str,
         participant_id: str,
         role: str | None = None,
-    ) -> Any:
-        """Add a participant to a chat room."""
+    ) -> str:
+        """Add a participant to a chat room.
+
+        Returns ``f"Added participant: {participant_id}"`` (discards the
+        Fern response body) to match today's MCP handler output verbatim.
+        """
         from thenvoi_rest import ParticipantRequest
 
         logger.debug(
@@ -2415,24 +2443,34 @@ class HumanTools:
         participant = ParticipantRequest(
             participant_id=participant_id, role=role or "member"
         )
-        return await self.rest.human_api_participants.add_my_chat_participant(
-            chat_id=chat_id, participant=participant
+        await self.rest.human_api_participants.add_my_chat_participant(
+            chat_id=chat_id,
+            participant=participant,
+            request_options=DEFAULT_REQUEST_OPTIONS,
         )
+        return f"Added participant: {participant_id}"
 
     async def remove_my_chat_participant(
         self,
         chat_id: str,
         participant_id: str,
-    ) -> Any:
-        """Remove a participant from a chat room."""
+    ) -> str:
+        """Remove a participant from a chat room.
+
+        Returns ``f"Removed participant: {participant_id}"`` (discards the
+        Fern response body) to match today's MCP handler output verbatim.
+        """
         logger.debug(
             "Removing my chat participant: chat_id=%s, participant_id=%s",
             chat_id,
             participant_id,
         )
-        return await self.rest.human_api_participants.remove_my_chat_participant(
-            chat_id=chat_id, id=participant_id
+        await self.rest.human_api_participants.remove_my_chat_participant(
+            chat_id=chat_id,
+            id=participant_id,
+            request_options=DEFAULT_REQUEST_OPTIONS,
         )
+        return f"Removed participant: {participant_id}"
 
     # --- human_memories.py ---
 
@@ -2473,17 +2511,26 @@ class HumanTools:
     async def supersede_user_memory(self, memory_id: str) -> Any:
         """Mark a user memory as superseded."""
         logger.debug("Superseding user memory: memory_id=%s", memory_id)
-        return await self.rest.human_api_memories.supersede_user_memory(memory_id)
+        return await self.rest.human_api_memories.supersede_user_memory(
+            memory_id,
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
 
     async def archive_user_memory(self, memory_id: str) -> Any:
         """Archive a user memory."""
         logger.debug("Archiving user memory: memory_id=%s", memory_id)
-        return await self.rest.human_api_memories.archive_user_memory(memory_id)
+        return await self.rest.human_api_memories.archive_user_memory(
+            memory_id,
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
 
     async def restore_user_memory(self, memory_id: str) -> Any:
         """Restore an archived user memory."""
         logger.debug("Restoring user memory: memory_id=%s", memory_id)
-        return await self.rest.human_api_memories.restore_user_memory(memory_id)
+        return await self.rest.human_api_memories.restore_user_memory(
+            memory_id,
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
 
     async def delete_user_memory(self, memory_id: str) -> dict[str, Any]:
         """Delete a user memory permanently.
@@ -2493,7 +2540,10 @@ class HumanTools:
         return shape matches today's MCP handler.
         """
         logger.debug("Deleting user memory: memory_id=%s", memory_id)
-        await self.rest.human_api_memories.delete_user_memory(memory_id)
+        await self.rest.human_api_memories.delete_user_memory(
+            memory_id,
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
         return {"deleted": True, "id": memory_id}
 
     # --- human_profile.py / human_peers ---
@@ -2510,8 +2560,9 @@ class HumanTools:
     ) -> Any:
         """Update the current user's profile.
 
-        Raises:
-            ValueError: If neither first_name nor last_name is provided.
+        Returns an ``"Error: ..."`` string (matching today's MCP handler
+        output verbatim) when neither field is provided, so the observable
+        tool-surface error shape is preserved.
         """
         user_data: dict[str, Any] = {}
         if first_name is not None:
@@ -2519,13 +2570,14 @@ class HumanTools:
         if last_name is not None:
             user_data["last_name"] = last_name
         if not user_data:
-            raise ValueError(
-                "At least one field (first_name or last_name) must be provided"
+            return (
+                "Error: At least one field (first_name or last_name) must be provided"
             )
 
         logger.debug("Updating my profile: fields=%s", list(user_data.keys()))
         return await self.rest.human_api_profile.update_my_profile(
-            user=cast(Any, user_data)
+            user=cast(Any, user_data),
+            request_options=DEFAULT_REQUEST_OPTIONS,
         )
 
     async def list_my_peers(

--- a/src/thenvoi/runtime/tools.py
+++ b/src/thenvoi/runtime/tools.py
@@ -354,15 +354,6 @@ class RegisterMyAgentInput(BaseModel):
     description: str = Field(..., description="Agent description (required).")
 
 
-class DeleteMyAgentInput(BaseModel):
-    """Delete an agent owned by the user."""
-
-    agent_id: str = Field(..., description="ID of the agent to delete (required).")
-    force: bool | None = Field(
-        None, description="If true, force deletion even when the agent is active."
-    )
-
-
 # human_chats.py
 
 
@@ -746,12 +737,6 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
         name="thenvoi_register_my_agent",
         input_model=RegisterMyAgentInput,
         method_name="register_my_agent",
-        surface="human",
-    ),
-    "thenvoi_delete_my_agent": ToolDefinition(
-        name="thenvoi_delete_my_agent",
-        input_model=DeleteMyAgentInput,
-        method_name="delete_my_agent",
         surface="human",
     ),
     "thenvoi_list_my_chats": ToolDefinition(
@@ -2164,14 +2149,6 @@ class HumanTools:
         logger.debug("Registering my agent: name=%s", name)
         agent_request = AgentRegisterRequest(name=name, description=description)
         return await self.rest.human_api_agents.register_my_agent(agent=agent_request)
-
-    async def delete_my_agent(self, agent_id: str, force: bool | None = None) -> Any:
-        """Delete an agent owned by the user."""
-        logger.debug("Deleting my agent: agent_id=%s, force=%s", agent_id, force)
-        kwargs: dict[str, Any] = {}
-        if force is not None:
-            kwargs["force"] = force
-        return await self.rest.human_api_agents.delete_my_agent(agent_id, **kwargs)
 
     # --- human_chats.py ---
 

--- a/tests/runtime/test_human_tools.py
+++ b/tests/runtime/test_human_tools.py
@@ -1,0 +1,627 @@
+"""Shape-equal tests for ``HumanTools`` methods.
+
+These tests are **shape-equal**, not byte-equal. Per the product decision
+for Phase 1 of INT-338 (INT-349), we verify three invariants per method:
+
+1. The correct ``rest.human_api_*`` method is called.
+2. It is called with the arguments today's ``thenvoi-mcp`` human handler
+   would have produced for the same inputs (so the observable REST
+   traffic is preserved).
+3. The return value has the same **shape** (keys + Python types) as what
+   today's MCP handler would produce — not a byte-equal fixture.
+
+The pragmatic tradeoff: the MCP handlers return JSON strings (via
+``serialize_response``), while ``HumanTools`` returns the raw Fern model.
+Both pipelines feed from the same Fern response, so we assert shape
+equality on the Fern model instead of recording and comparing byte-equal
+JSON fixtures. This is faster to maintain and still catches regressions
+at the REST-call and response-shape boundaries.
+
+REST is faked with ``unittest.mock.AsyncMock``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from thenvoi.runtime.tools import HumanTools
+
+
+def _make_rest_fake() -> MagicMock:
+    """Construct a REST client fake with every ``human_api_*`` subclient present.
+
+    Each subclient method returns a ``MagicMock`` (customized per test) via
+    ``AsyncMock``. Tests scripting a specific return value do so via
+    ``AsyncMock.return_value`` or ``side_effect``.
+    """
+    rest = MagicMock()
+    # All human_api_* subclients are plain attribute mocks; individual
+    # methods are replaced with AsyncMock per-test.
+    rest.human_api_agents = MagicMock()
+    rest.human_api_chats = MagicMock()
+    rest.human_api_contacts = MagicMock()
+    rest.human_api_memories = MagicMock()
+    rest.human_api_messages = MagicMock()
+    rest.human_api_participants = MagicMock()
+    rest.human_api_peers = MagicMock()
+    rest.human_api_profile = MagicMock()
+    return rest
+
+
+# ---------- human_agents ----------
+
+
+@pytest.mark.asyncio
+async def test_list_my_agents_forwards_page_args() -> None:
+    rest = _make_rest_fake()
+    response = MagicMock(data=[{"id": "agent-1", "name": "agent"}])
+    rest.human_api_agents.list_my_agents = AsyncMock(return_value=response)
+
+    tools = HumanTools(rest)
+    result = await tools.list_my_agents(page=2, page_size=25)
+
+    rest.human_api_agents.list_my_agents.assert_awaited_once_with(page=2, page_size=25)
+    assert result is response
+
+
+@pytest.mark.asyncio
+async def test_register_my_agent_builds_request_object() -> None:
+    from thenvoi_rest import AgentRegisterRequest
+
+    rest = _make_rest_fake()
+    response = MagicMock()
+    rest.human_api_agents.register_my_agent = AsyncMock(return_value=response)
+
+    tools = HumanTools(rest)
+    result = await tools.register_my_agent(name="bot", description="desc")
+
+    rest.human_api_agents.register_my_agent.assert_awaited_once()
+    call_kwargs = rest.human_api_agents.register_my_agent.call_args.kwargs
+    assert isinstance(call_kwargs["agent"], AgentRegisterRequest)
+    assert call_kwargs["agent"].name == "bot"
+    assert call_kwargs["agent"].description == "desc"
+    assert result is response
+
+
+@pytest.mark.asyncio
+async def test_delete_my_agent_omits_force_when_none() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_agents.delete_my_agent = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).delete_my_agent(agent_id="abc")
+    rest.human_api_agents.delete_my_agent.assert_awaited_once_with("abc")
+
+    rest.human_api_agents.delete_my_agent.reset_mock()
+    await HumanTools(rest).delete_my_agent(agent_id="abc", force=True)
+    rest.human_api_agents.delete_my_agent.assert_awaited_once_with("abc", force=True)
+
+
+# ---------- human_chats ----------
+
+
+@pytest.mark.asyncio
+async def test_list_my_chats_forwards_pagination() -> None:
+    rest = _make_rest_fake()
+    response = MagicMock(data=[])
+    rest.human_api_chats.list_my_chats = AsyncMock(return_value=response)
+
+    result = await HumanTools(rest).list_my_chats(page=1, page_size=10)
+
+    rest.human_api_chats.list_my_chats.assert_awaited_once_with(page=1, page_size=10)
+    assert result is response
+
+
+@pytest.mark.asyncio
+async def test_create_my_chat_room_with_task_id() -> None:
+    from thenvoi_rest import CreateMyChatRoomRequestChat
+
+    rest = _make_rest_fake()
+    rest.human_api_chats.create_my_chat_room = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).create_my_chat_room(task_id="t-1")
+
+    call_kwargs = rest.human_api_chats.create_my_chat_room.call_args.kwargs
+    assert isinstance(call_kwargs["chat"], CreateMyChatRoomRequestChat)
+    assert call_kwargs["chat"].task_id == "t-1"
+
+
+@pytest.mark.asyncio
+async def test_create_my_chat_room_without_task_id() -> None:
+    from thenvoi_rest import CreateMyChatRoomRequestChat
+
+    rest = _make_rest_fake()
+    rest.human_api_chats.create_my_chat_room = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).create_my_chat_room()
+
+    call_kwargs = rest.human_api_chats.create_my_chat_room.call_args.kwargs
+    assert isinstance(call_kwargs["chat"], CreateMyChatRoomRequestChat)
+    assert call_kwargs["chat"].task_id is None
+
+
+@pytest.mark.asyncio
+async def test_get_my_chat_room_by_id() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_chats.get_my_chat_room = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).get_my_chat_room(chat_id="c-1")
+
+    rest.human_api_chats.get_my_chat_room.assert_awaited_once_with(id="c-1")
+
+
+# ---------- human_contacts ----------
+
+
+@pytest.mark.asyncio
+async def test_list_my_contacts_forwards_pagination() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_contacts.list_my_contacts = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).list_my_contacts(page=3, page_size=50)
+    rest.human_api_contacts.list_my_contacts.assert_awaited_once_with(
+        page=3, page_size=50
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_contact_request_without_message() -> None:
+    from thenvoi_rest import CreateContactRequestRequestContactRequest
+
+    rest = _make_rest_fake()
+    rest.human_api_contacts.create_contact_request = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).create_contact_request(recipient_handle="@alice")
+
+    call_kwargs = rest.human_api_contacts.create_contact_request.call_args.kwargs
+    request = call_kwargs["contact_request"]
+    assert isinstance(request, CreateContactRequestRequestContactRequest)
+    assert request.recipient_handle == "@alice"
+    # message was not provided; it should not be set on the request.
+    assert getattr(request, "message", None) in (None, "")
+
+
+@pytest.mark.asyncio
+async def test_create_contact_request_with_message() -> None:
+    from thenvoi_rest import CreateContactRequestRequestContactRequest
+
+    rest = _make_rest_fake()
+    rest.human_api_contacts.create_contact_request = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).create_contact_request(recipient_handle="@bob", message="hi")
+
+    request = rest.human_api_contacts.create_contact_request.call_args.kwargs[
+        "contact_request"
+    ]
+    assert isinstance(request, CreateContactRequestRequestContactRequest)
+    assert request.recipient_handle == "@bob"
+    assert request.message == "hi"
+
+
+@pytest.mark.asyncio
+async def test_list_received_contact_requests_forwards_pagination() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_contacts.list_received_contact_requests = AsyncMock(
+        return_value=MagicMock()
+    )
+
+    await HumanTools(rest).list_received_contact_requests(page=1, page_size=20)
+    rest.human_api_contacts.list_received_contact_requests.assert_awaited_once_with(
+        page=1, page_size=20
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_sent_contact_requests_filters_by_status() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_contacts.list_sent_contact_requests = AsyncMock(
+        return_value=MagicMock()
+    )
+
+    await HumanTools(rest).list_sent_contact_requests(
+        status="pending", page=1, page_size=20
+    )
+    rest.human_api_contacts.list_sent_contact_requests.assert_awaited_once_with(
+        status="pending", page=1, page_size=20
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_contact_request_calls_by_id() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_contacts.approve_contact_request = AsyncMock(
+        return_value=MagicMock()
+    )
+
+    await HumanTools(rest).approve_contact_request(request_id="r-1")
+    rest.human_api_contacts.approve_contact_request.assert_awaited_once_with(id="r-1")
+
+
+@pytest.mark.asyncio
+async def test_reject_contact_request_calls_by_id() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_contacts.reject_contact_request = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).reject_contact_request(request_id="r-2")
+    rest.human_api_contacts.reject_contact_request.assert_awaited_once_with(id="r-2")
+
+
+@pytest.mark.asyncio
+async def test_cancel_contact_request_calls_by_id() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_contacts.cancel_contact_request = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).cancel_contact_request(request_id="r-3")
+    rest.human_api_contacts.cancel_contact_request.assert_awaited_once_with(id="r-3")
+
+
+@pytest.mark.asyncio
+async def test_resolve_handle_passes_handle() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_contacts.resolve_handle = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).resolve_handle(handle="@alice")
+    rest.human_api_contacts.resolve_handle.assert_awaited_once_with(handle="@alice")
+
+
+@pytest.mark.asyncio
+async def test_remove_my_contact_requires_one_identifier() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_contacts.remove_my_contact = AsyncMock(return_value=MagicMock())
+
+    with pytest.raises(ValueError, match="contact_id or handle"):
+        await HumanTools(rest).remove_my_contact()
+    rest.human_api_contacts.remove_my_contact.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_remove_my_contact_with_contact_id_only() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_contacts.remove_my_contact = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).remove_my_contact(contact_id="c-1")
+    rest.human_api_contacts.remove_my_contact.assert_awaited_once_with(contact_id="c-1")
+
+
+@pytest.mark.asyncio
+async def test_remove_my_contact_with_handle_only() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_contacts.remove_my_contact = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).remove_my_contact(handle="@bob")
+    rest.human_api_contacts.remove_my_contact.assert_awaited_once_with(handle="@bob")
+
+
+@pytest.mark.asyncio
+async def test_remove_my_contact_with_both_sends_both() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_contacts.remove_my_contact = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).remove_my_contact(contact_id="c-1", handle="@bob")
+    rest.human_api_contacts.remove_my_contact.assert_awaited_once_with(
+        contact_id="c-1", handle="@bob"
+    )
+
+
+# ---------- human_messages ----------
+
+
+@pytest.mark.asyncio
+async def test_list_my_chat_messages_parses_since_iso() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_messages.list_my_chat_messages = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).list_my_chat_messages(
+        chat_id="c-1",
+        page=1,
+        page_size=20,
+        message_type="text",
+        since="2024-01-01T00:00:00Z",
+    )
+    call_kwargs = rest.human_api_messages.list_my_chat_messages.call_args.kwargs
+    assert call_kwargs["chat_id"] == "c-1"
+    assert call_kwargs["page"] == 1
+    assert call_kwargs["page_size"] == 20
+    assert call_kwargs["message_type"] == "text"
+    assert isinstance(call_kwargs["since"], datetime)
+
+
+@pytest.mark.asyncio
+async def test_list_my_chat_messages_leaves_since_none_when_absent() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_messages.list_my_chat_messages = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).list_my_chat_messages(chat_id="c-1")
+    call_kwargs = rest.human_api_messages.list_my_chat_messages.call_args.kwargs
+    assert call_kwargs["since"] is None
+
+
+def _mk_participant(**kwargs: Any) -> MagicMock:
+    p = MagicMock(spec=["id", "name", "username", "first_name"])
+    for k, v in kwargs.items():
+        setattr(p, k, v)
+    # Reasonable defaults for attributes not set
+    for attr in ("id", "name", "username", "first_name"):
+        if attr not in kwargs:
+            setattr(p, attr, None)
+    return p
+
+
+@pytest.mark.asyncio
+async def test_send_my_chat_message_resolves_recipients_by_name() -> None:
+    from thenvoi_rest import ChatMessageRequest
+
+    rest = _make_rest_fake()
+    alice = _mk_participant(id="u-1", name="Alice")
+    bob = _mk_participant(id="u-2", username="bob")
+    participants_response = MagicMock(data=[alice, bob])
+    rest.human_api_participants.list_my_chat_participants = AsyncMock(
+        return_value=participants_response
+    )
+    rest.human_api_messages.send_my_chat_message = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).send_my_chat_message(
+        chat_id="c-1", content="hello", recipients="Alice, bob"
+    )
+
+    rest.human_api_participants.list_my_chat_participants.assert_awaited_once_with(
+        chat_id="c-1"
+    )
+    send_call = rest.human_api_messages.send_my_chat_message.call_args
+    assert send_call.kwargs["chat_id"] == "c-1"
+    message = send_call.kwargs["message"]
+    assert isinstance(message, ChatMessageRequest)
+    assert message.content == "hello"
+    assert {m.id for m in message.mentions} == {"u-1", "u-2"}
+
+
+@pytest.mark.asyncio
+async def test_send_my_chat_message_rejects_empty_recipients() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_participants.list_my_chat_participants = AsyncMock()
+    rest.human_api_messages.send_my_chat_message = AsyncMock()
+
+    with pytest.raises(ValueError, match="empty"):
+        await HumanTools(rest).send_my_chat_message(
+            chat_id="c-1", content="hi", recipients="  "
+        )
+    rest.human_api_participants.list_my_chat_participants.assert_not_awaited()
+    rest.human_api_messages.send_my_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_my_chat_message_reports_unknown_recipients() -> None:
+    rest = _make_rest_fake()
+    alice = _mk_participant(id="u-1", name="Alice")
+    rest.human_api_participants.list_my_chat_participants = AsyncMock(
+        return_value=MagicMock(data=[alice])
+    )
+    rest.human_api_messages.send_my_chat_message = AsyncMock()
+
+    with pytest.raises(ValueError, match="Not found"):
+        await HumanTools(rest).send_my_chat_message(
+            chat_id="c-1", content="hi", recipients="Alice,Zeke"
+        )
+    rest.human_api_messages.send_my_chat_message.assert_not_awaited()
+
+
+# ---------- human_participants ----------
+
+
+@pytest.mark.asyncio
+async def test_list_my_chat_participants_forwards_filter() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_participants.list_my_chat_participants = AsyncMock(
+        return_value=MagicMock()
+    )
+
+    await HumanTools(rest).list_my_chat_participants(
+        chat_id="c-1", participant_type="Agent"
+    )
+    rest.human_api_participants.list_my_chat_participants.assert_awaited_once_with(
+        chat_id="c-1", participant_type="Agent"
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_my_chat_participant_builds_request_with_default_role() -> None:
+    from thenvoi_rest import ParticipantRequest
+
+    rest = _make_rest_fake()
+    rest.human_api_participants.add_my_chat_participant = AsyncMock(
+        return_value=MagicMock()
+    )
+
+    await HumanTools(rest).add_my_chat_participant(chat_id="c-1", participant_id="p-1")
+    call_kwargs = rest.human_api_participants.add_my_chat_participant.call_args.kwargs
+    assert call_kwargs["chat_id"] == "c-1"
+    participant = call_kwargs["participant"]
+    assert isinstance(participant, ParticipantRequest)
+    assert participant.participant_id == "p-1"
+    assert participant.role == "member"
+
+
+@pytest.mark.asyncio
+async def test_add_my_chat_participant_passes_role() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_participants.add_my_chat_participant = AsyncMock(
+        return_value=MagicMock()
+    )
+
+    await HumanTools(rest).add_my_chat_participant(
+        chat_id="c-1", participant_id="p-1", role="admin"
+    )
+    participant = rest.human_api_participants.add_my_chat_participant.call_args.kwargs[
+        "participant"
+    ]
+    assert participant.role == "admin"
+
+
+@pytest.mark.asyncio
+async def test_remove_my_chat_participant_passes_ids() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_participants.remove_my_chat_participant = AsyncMock(
+        return_value=MagicMock()
+    )
+
+    await HumanTools(rest).remove_my_chat_participant(
+        chat_id="c-1", participant_id="p-2"
+    )
+    rest.human_api_participants.remove_my_chat_participant.assert_awaited_once_with(
+        chat_id="c-1", id="p-2"
+    )
+
+
+# ---------- human_memories ----------
+
+
+@pytest.mark.asyncio
+async def test_list_user_memories_forwards_all_filters() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_memories.list_user_memories = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).list_user_memories(
+        chat_room_id="r-1",
+        scope="subject",
+        system="long_term",
+        memory_type="semantic",
+        segment="user",
+        content_query="hello",
+        page_size=50,
+        status="active",
+    )
+    rest.human_api_memories.list_user_memories.assert_awaited_once_with(
+        chat_room_id="r-1",
+        scope="subject",
+        system="long_term",
+        type="semantic",
+        segment="user",
+        content_query="hello",
+        page_size=50,
+        status="active",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_user_memory_passes_positional_id() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_memories.get_user_memory = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).get_user_memory(memory_id="m-1")
+    rest.human_api_memories.get_user_memory.assert_awaited_once_with("m-1")
+
+
+@pytest.mark.asyncio
+async def test_supersede_user_memory_passes_positional_id() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_memories.supersede_user_memory = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).supersede_user_memory(memory_id="m-1")
+    rest.human_api_memories.supersede_user_memory.assert_awaited_once_with("m-1")
+
+
+@pytest.mark.asyncio
+async def test_archive_user_memory_passes_positional_id() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_memories.archive_user_memory = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).archive_user_memory(memory_id="m-1")
+    rest.human_api_memories.archive_user_memory.assert_awaited_once_with("m-1")
+
+
+@pytest.mark.asyncio
+async def test_restore_user_memory_passes_positional_id() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_memories.restore_user_memory = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).restore_user_memory(memory_id="m-1")
+    rest.human_api_memories.restore_user_memory.assert_awaited_once_with("m-1")
+
+
+@pytest.mark.asyncio
+async def test_delete_user_memory_returns_mcp_shape_payload() -> None:
+    """The Fern endpoint returns no body; the tool wraps the outcome in a
+    ``{"deleted": True, "id": ...}`` dict to match today's MCP handler."""
+    rest = _make_rest_fake()
+    rest.human_api_memories.delete_user_memory = AsyncMock(return_value=None)
+
+    result = await HumanTools(rest).delete_user_memory(memory_id="m-1")
+    rest.human_api_memories.delete_user_memory.assert_awaited_once_with("m-1")
+    assert result == {"deleted": True, "id": "m-1"}
+    assert set(result.keys()) == {"deleted", "id"}
+    assert isinstance(result["deleted"], bool)
+    assert isinstance(result["id"], str)
+
+
+# ---------- human_profile / human_peers ----------
+
+
+@pytest.mark.asyncio
+async def test_get_my_profile_takes_no_args() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_profile.get_my_profile = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).get_my_profile()
+    rest.human_api_profile.get_my_profile.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_update_my_profile_requires_at_least_one_field() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_profile.update_my_profile = AsyncMock(return_value=MagicMock())
+
+    with pytest.raises(ValueError, match="first_name or last_name"):
+        await HumanTools(rest).update_my_profile()
+    rest.human_api_profile.update_my_profile.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_my_profile_builds_partial_user_payload() -> None:
+    rest = _make_rest_fake()
+    rest.human_api_profile.update_my_profile = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).update_my_profile(first_name="Alice")
+    rest.human_api_profile.update_my_profile.assert_awaited_once_with(
+        user={"first_name": "Alice"}
+    )
+
+    rest.human_api_profile.update_my_profile.reset_mock()
+    await HumanTools(rest).update_my_profile(last_name="Doe")
+    rest.human_api_profile.update_my_profile.assert_awaited_once_with(
+        user={"last_name": "Doe"}
+    )
+
+    rest.human_api_profile.update_my_profile.reset_mock()
+    await HumanTools(rest).update_my_profile(first_name="Alice", last_name="Doe")
+    rest.human_api_profile.update_my_profile.assert_awaited_once_with(
+        user={"first_name": "Alice", "last_name": "Doe"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_my_peers_maps_peer_type_to_type() -> None:
+    """``peer_type`` is the public-facing kwarg (mirrors the MCP handler);
+    the Fern client expects ``type``. The tool bridges the two."""
+    rest = _make_rest_fake()
+    rest.human_api_peers.list_my_peers = AsyncMock(return_value=MagicMock())
+
+    await HumanTools(rest).list_my_peers(
+        not_in_chat="c-1", peer_type="Agent", page=1, page_size=50
+    )
+    rest.human_api_peers.list_my_peers.assert_awaited_once_with(
+        not_in_chat="c-1", type="Agent", page=1, page_size=50
+    )
+
+
+# ---------- Instance construction ----------
+
+
+def test_humantools_is_stateless_per_credential() -> None:
+    """``HumanTools`` binds to one REST client; no room scope, no cache."""
+    rest = _make_rest_fake()
+    tools = HumanTools(rest)
+    assert tools.rest is rest
+    assert not hasattr(tools, "room_id")

--- a/tests/runtime/test_human_tools.py
+++ b/tests/runtime/test_human_tools.py
@@ -87,19 +87,6 @@ async def test_register_my_agent_builds_request_object() -> None:
     assert result is response
 
 
-@pytest.mark.asyncio
-async def test_delete_my_agent_omits_force_when_none() -> None:
-    rest = _make_rest_fake()
-    rest.human_api_agents.delete_my_agent = AsyncMock(return_value=MagicMock())
-
-    await HumanTools(rest).delete_my_agent(agent_id="abc")
-    rest.human_api_agents.delete_my_agent.assert_awaited_once_with("abc")
-
-    rest.human_api_agents.delete_my_agent.reset_mock()
-    await HumanTools(rest).delete_my_agent(agent_id="abc", force=True)
-    rest.human_api_agents.delete_my_agent.assert_awaited_once_with("abc", force=True)
-
-
 # ---------- human_chats ----------
 
 

--- a/tests/runtime/test_human_tools.py
+++ b/tests/runtime/test_human_tools.py
@@ -28,6 +28,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from thenvoi.client.rest import DEFAULT_REQUEST_OPTIONS
 from thenvoi.runtime.tools import HumanTools
 
 
@@ -224,7 +225,9 @@ async def test_approve_contact_request_calls_by_id() -> None:
     )
 
     await HumanTools(rest).approve_contact_request(request_id="r-1")
-    rest.human_api_contacts.approve_contact_request.assert_awaited_once_with(id="r-1")
+    rest.human_api_contacts.approve_contact_request.assert_awaited_once_with(
+        id="r-1", request_options=DEFAULT_REQUEST_OPTIONS
+    )
 
 
 @pytest.mark.asyncio
@@ -233,7 +236,9 @@ async def test_reject_contact_request_calls_by_id() -> None:
     rest.human_api_contacts.reject_contact_request = AsyncMock(return_value=MagicMock())
 
     await HumanTools(rest).reject_contact_request(request_id="r-2")
-    rest.human_api_contacts.reject_contact_request.assert_awaited_once_with(id="r-2")
+    rest.human_api_contacts.reject_contact_request.assert_awaited_once_with(
+        id="r-2", request_options=DEFAULT_REQUEST_OPTIONS
+    )
 
 
 @pytest.mark.asyncio
@@ -242,7 +247,9 @@ async def test_cancel_contact_request_calls_by_id() -> None:
     rest.human_api_contacts.cancel_contact_request = AsyncMock(return_value=MagicMock())
 
     await HumanTools(rest).cancel_contact_request(request_id="r-3")
-    rest.human_api_contacts.cancel_contact_request.assert_awaited_once_with(id="r-3")
+    rest.human_api_contacts.cancel_contact_request.assert_awaited_once_with(
+        id="r-3", request_options=DEFAULT_REQUEST_OPTIONS
+    )
 
 
 @pytest.mark.asyncio
@@ -256,11 +263,14 @@ async def test_resolve_handle_passes_handle() -> None:
 
 @pytest.mark.asyncio
 async def test_remove_my_contact_requires_one_identifier() -> None:
+    """Matches today's MCP handler: returns the error string verbatim
+    instead of raising. See ``thenvoi-mcp`` human_contacts.remove_my_contact.
+    """
     rest = _make_rest_fake()
     rest.human_api_contacts.remove_my_contact = AsyncMock(return_value=MagicMock())
 
-    with pytest.raises(ValueError, match="contact_id or handle"):
-        await HumanTools(rest).remove_my_contact()
+    result = await HumanTools(rest).remove_my_contact()
+    assert result == "Error: Either contact_id or handle must be provided"
     rest.human_api_contacts.remove_my_contact.assert_not_awaited()
 
 
@@ -270,7 +280,9 @@ async def test_remove_my_contact_with_contact_id_only() -> None:
     rest.human_api_contacts.remove_my_contact = AsyncMock(return_value=MagicMock())
 
     await HumanTools(rest).remove_my_contact(contact_id="c-1")
-    rest.human_api_contacts.remove_my_contact.assert_awaited_once_with(contact_id="c-1")
+    rest.human_api_contacts.remove_my_contact.assert_awaited_once_with(
+        contact_id="c-1", request_options=DEFAULT_REQUEST_OPTIONS
+    )
 
 
 @pytest.mark.asyncio
@@ -279,7 +291,9 @@ async def test_remove_my_contact_with_handle_only() -> None:
     rest.human_api_contacts.remove_my_contact = AsyncMock(return_value=MagicMock())
 
     await HumanTools(rest).remove_my_contact(handle="@bob")
-    rest.human_api_contacts.remove_my_contact.assert_awaited_once_with(handle="@bob")
+    rest.human_api_contacts.remove_my_contact.assert_awaited_once_with(
+        handle="@bob", request_options=DEFAULT_REQUEST_OPTIONS
+    )
 
 
 @pytest.mark.asyncio
@@ -289,7 +303,7 @@ async def test_remove_my_contact_with_both_sends_both() -> None:
 
     await HumanTools(rest).remove_my_contact(contact_id="c-1", handle="@bob")
     rest.human_api_contacts.remove_my_contact.assert_awaited_once_with(
-        contact_id="c-1", handle="@bob"
+        contact_id="c-1", handle="@bob", request_options=DEFAULT_REQUEST_OPTIONS
     )
 
 
@@ -363,24 +377,27 @@ async def test_send_my_chat_message_resolves_recipients_by_name() -> None:
     assert isinstance(message, ChatMessageRequest)
     assert message.content == "hello"
     assert {m.id for m in message.mentions} == {"u-1", "u-2"}
+    assert send_call.kwargs["request_options"] is DEFAULT_REQUEST_OPTIONS
 
 
 @pytest.mark.asyncio
 async def test_send_my_chat_message_rejects_empty_recipients() -> None:
+    """Matches today's MCP handler: returns the error string verbatim."""
     rest = _make_rest_fake()
     rest.human_api_participants.list_my_chat_participants = AsyncMock()
     rest.human_api_messages.send_my_chat_message = AsyncMock()
 
-    with pytest.raises(ValueError, match="empty"):
-        await HumanTools(rest).send_my_chat_message(
-            chat_id="c-1", content="hi", recipients="  "
-        )
+    result = await HumanTools(rest).send_my_chat_message(
+        chat_id="c-1", content="hi", recipients="  "
+    )
+    assert result == "Error: recipients cannot be empty"
     rest.human_api_participants.list_my_chat_participants.assert_not_awaited()
     rest.human_api_messages.send_my_chat_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_send_my_chat_message_reports_unknown_recipients() -> None:
+    """Matches today's MCP handler: returns the error string verbatim."""
     rest = _make_rest_fake()
     alice = _mk_participant(id="u-1", name="Alice")
     rest.human_api_participants.list_my_chat_participants = AsyncMock(
@@ -388,10 +405,12 @@ async def test_send_my_chat_message_reports_unknown_recipients() -> None:
     )
     rest.human_api_messages.send_my_chat_message = AsyncMock()
 
-    with pytest.raises(ValueError, match="Not found"):
-        await HumanTools(rest).send_my_chat_message(
-            chat_id="c-1", content="hi", recipients="Alice,Zeke"
-        )
+    result = await HumanTools(rest).send_my_chat_message(
+        chat_id="c-1", content="hi", recipients="Alice,Zeke"
+    )
+    assert isinstance(result, str)
+    assert result.startswith("Error: Not found: zeke")
+    assert "Available: alice" in result
     rest.human_api_messages.send_my_chat_message.assert_not_awaited()
 
 
@@ -422,13 +441,17 @@ async def test_add_my_chat_participant_builds_request_with_default_role() -> Non
         return_value=MagicMock()
     )
 
-    await HumanTools(rest).add_my_chat_participant(chat_id="c-1", participant_id="p-1")
+    result = await HumanTools(rest).add_my_chat_participant(
+        chat_id="c-1", participant_id="p-1"
+    )
     call_kwargs = rest.human_api_participants.add_my_chat_participant.call_args.kwargs
     assert call_kwargs["chat_id"] == "c-1"
     participant = call_kwargs["participant"]
     assert isinstance(participant, ParticipantRequest)
     assert participant.participant_id == "p-1"
     assert participant.role == "member"
+    # Matches today's MCP handler: returns the summary string verbatim.
+    assert result == "Added participant: p-1"
 
 
 @pytest.mark.asyncio
@@ -438,13 +461,14 @@ async def test_add_my_chat_participant_passes_role() -> None:
         return_value=MagicMock()
     )
 
-    await HumanTools(rest).add_my_chat_participant(
+    result = await HumanTools(rest).add_my_chat_participant(
         chat_id="c-1", participant_id="p-1", role="admin"
     )
     participant = rest.human_api_participants.add_my_chat_participant.call_args.kwargs[
         "participant"
     ]
     assert participant.role == "admin"
+    assert result == "Added participant: p-1"
 
 
 @pytest.mark.asyncio
@@ -454,12 +478,16 @@ async def test_remove_my_chat_participant_passes_ids() -> None:
         return_value=MagicMock()
     )
 
-    await HumanTools(rest).remove_my_chat_participant(
+    result = await HumanTools(rest).remove_my_chat_participant(
         chat_id="c-1", participant_id="p-2"
     )
-    rest.human_api_participants.remove_my_chat_participant.assert_awaited_once_with(
-        chat_id="c-1", id="p-2"
+    call_kwargs = (
+        rest.human_api_participants.remove_my_chat_participant.call_args.kwargs
     )
+    assert call_kwargs["chat_id"] == "c-1"
+    assert call_kwargs["id"] == "p-2"
+    # Matches today's MCP handler: returns the summary string verbatim.
+    assert result == "Removed participant: p-2"
 
 
 # ---------- human_memories ----------
@@ -507,7 +535,9 @@ async def test_supersede_user_memory_passes_positional_id() -> None:
     rest.human_api_memories.supersede_user_memory = AsyncMock(return_value=MagicMock())
 
     await HumanTools(rest).supersede_user_memory(memory_id="m-1")
-    rest.human_api_memories.supersede_user_memory.assert_awaited_once_with("m-1")
+    rest.human_api_memories.supersede_user_memory.assert_awaited_once_with(
+        "m-1", request_options=DEFAULT_REQUEST_OPTIONS
+    )
 
 
 @pytest.mark.asyncio
@@ -516,7 +546,9 @@ async def test_archive_user_memory_passes_positional_id() -> None:
     rest.human_api_memories.archive_user_memory = AsyncMock(return_value=MagicMock())
 
     await HumanTools(rest).archive_user_memory(memory_id="m-1")
-    rest.human_api_memories.archive_user_memory.assert_awaited_once_with("m-1")
+    rest.human_api_memories.archive_user_memory.assert_awaited_once_with(
+        "m-1", request_options=DEFAULT_REQUEST_OPTIONS
+    )
 
 
 @pytest.mark.asyncio
@@ -525,7 +557,9 @@ async def test_restore_user_memory_passes_positional_id() -> None:
     rest.human_api_memories.restore_user_memory = AsyncMock(return_value=MagicMock())
 
     await HumanTools(rest).restore_user_memory(memory_id="m-1")
-    rest.human_api_memories.restore_user_memory.assert_awaited_once_with("m-1")
+    rest.human_api_memories.restore_user_memory.assert_awaited_once_with(
+        "m-1", request_options=DEFAULT_REQUEST_OPTIONS
+    )
 
 
 @pytest.mark.asyncio
@@ -536,7 +570,9 @@ async def test_delete_user_memory_returns_mcp_shape_payload() -> None:
     rest.human_api_memories.delete_user_memory = AsyncMock(return_value=None)
 
     result = await HumanTools(rest).delete_user_memory(memory_id="m-1")
-    rest.human_api_memories.delete_user_memory.assert_awaited_once_with("m-1")
+    rest.human_api_memories.delete_user_memory.assert_awaited_once_with(
+        "m-1", request_options=DEFAULT_REQUEST_OPTIONS
+    )
     assert result == {"deleted": True, "id": "m-1"}
     assert set(result.keys()) == {"deleted", "id"}
     assert isinstance(result["deleted"], bool)
@@ -557,11 +593,14 @@ async def test_get_my_profile_takes_no_args() -> None:
 
 @pytest.mark.asyncio
 async def test_update_my_profile_requires_at_least_one_field() -> None:
+    """Matches today's MCP handler: returns the error string verbatim."""
     rest = _make_rest_fake()
     rest.human_api_profile.update_my_profile = AsyncMock(return_value=MagicMock())
 
-    with pytest.raises(ValueError, match="first_name or last_name"):
-        await HumanTools(rest).update_my_profile()
+    result = await HumanTools(rest).update_my_profile()
+    assert (
+        result == "Error: At least one field (first_name or last_name) must be provided"
+    )
     rest.human_api_profile.update_my_profile.assert_not_awaited()
 
 
@@ -572,19 +611,20 @@ async def test_update_my_profile_builds_partial_user_payload() -> None:
 
     await HumanTools(rest).update_my_profile(first_name="Alice")
     rest.human_api_profile.update_my_profile.assert_awaited_once_with(
-        user={"first_name": "Alice"}
+        user={"first_name": "Alice"}, request_options=DEFAULT_REQUEST_OPTIONS
     )
 
     rest.human_api_profile.update_my_profile.reset_mock()
     await HumanTools(rest).update_my_profile(last_name="Doe")
     rest.human_api_profile.update_my_profile.assert_awaited_once_with(
-        user={"last_name": "Doe"}
+        user={"last_name": "Doe"}, request_options=DEFAULT_REQUEST_OPTIONS
     )
 
     rest.human_api_profile.update_my_profile.reset_mock()
     await HumanTools(rest).update_my_profile(first_name="Alice", last_name="Doe")
     rest.human_api_profile.update_my_profile.assert_awaited_once_with(
-        user={"first_name": "Alice", "last_name": "Doe"}
+        user={"first_name": "Alice", "last_name": "Doe"},
+        request_options=DEFAULT_REQUEST_OPTIONS,
     )
 
 

--- a/tests/runtime/test_tool_definitions_surface.py
+++ b/tests/runtime/test_tool_definitions_surface.py
@@ -59,7 +59,6 @@ PHASE1_HUMAN_TOOLS: frozenset[str] = frozenset(
     {
         "thenvoi_list_my_agents",
         "thenvoi_register_my_agent",
-        "thenvoi_delete_my_agent",
         "thenvoi_list_my_chats",
         "thenvoi_create_my_chat_room",
         "thenvoi_get_my_chat_room",

--- a/tests/runtime/test_tool_definitions_surface.py
+++ b/tests/runtime/test_tool_definitions_surface.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
 from pydantic import BaseModel
 
 from thenvoi.runtime.mcp_server import (
@@ -115,6 +116,20 @@ class TestIterToolDefinitionsSurfaceFilter:
         """``surface="agent"`` with defaults returns exactly the pre-Phase-1 set."""
         names = {d.name for d in iter_tool_definitions(surface="agent")}
         assert names == PRE_PHASE1_AGENT_TOOLS
+
+    def test_default_surface_is_agent(self) -> None:
+        """No-arg ``iter_tool_definitions()`` returns only agent tools.
+
+        Regression guard for C1: existing callers (``claude_sdk``,
+        ``opencode``, ``acp`` client adapter) pipe the result straight
+        into ``create_thenvoi_mcp_backend`` without re-filtering, so the
+        default must not leak human tools into agent-shaped backends.
+        """
+        defs = iter_tool_definitions()
+        names = {d.name for d in defs}
+        assert names == PRE_PHASE1_AGENT_TOOLS
+        for definition in defs:
+            assert definition.surface == "agent"
 
     def test_surface_human_returns_only_human_tools(self) -> None:
         """``surface="human"`` with defaults returns only human tools."""
@@ -307,3 +322,68 @@ class TestLocalMCPServerAgentOnlySnapshot:
         )
         names = {registration.name for registration in registrations}
         assert names == PRE_PHASE1_AGENT_TOOLS
+
+    def test_build_registrations_filters_non_agent_definitions(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Defense-in-depth: if a caller passes a mixed ``tool_definitions``
+        list, ``build_thenvoi_mcp_tool_registrations`` drops non-agent
+        entries (they'd ``AttributeError`` on ``AgentTools`` at call time)
+        and logs a warning per dropped entry.
+        """
+        import logging
+
+        agent_tools = MagicMock(spec=AgentTools)
+        mixed = [
+            TOOL_DEFINITIONS["thenvoi_send_message"],
+            TOOL_DEFINITIONS["thenvoi_send_my_chat_message"],
+            TOOL_DEFINITIONS["thenvoi_get_my_profile"],
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="thenvoi.runtime.mcp_server"):
+            registrations = build_thenvoi_mcp_tool_registrations(
+                agent_tools, tool_definitions=mixed
+            )
+
+        names = {r.name for r in registrations}
+        assert names == {"thenvoi_send_message"}
+        # One warning per dropped human entry.
+        warnings = [
+            record for record in caplog.records if record.levelno == logging.WARNING
+        ]
+        dropped_names = {
+            "thenvoi_send_my_chat_message",
+            "thenvoi_get_my_profile",
+        }
+        assert len(warnings) == len(dropped_names)
+        for record in warnings:
+            assert "non-agent tool definition" in record.getMessage()
+
+    def test_build_resolved_registrations_filters_non_agent_definitions(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Resolved variant applies the same defense-in-depth filter. This
+        is the path the opencode/claude_sdk/acp adapters exercise."""
+        import logging
+
+        def _resolver(_room_id: str):
+            return None
+
+        mixed = [
+            TOOL_DEFINITIONS["thenvoi_send_message"],
+            TOOL_DEFINITIONS["thenvoi_add_participant"],
+            TOOL_DEFINITIONS["thenvoi_send_my_chat_message"],
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="thenvoi.runtime.mcp_server"):
+            registrations = build_resolved_thenvoi_mcp_tool_registrations(
+                get_tools=_resolver, tool_definitions=mixed
+            )
+
+        names = {r.name for r in registrations}
+        assert names == {"thenvoi_send_message", "thenvoi_add_participant"}
+        warnings = [
+            record for record in caplog.records if record.levelno == logging.WARNING
+        ]
+        assert len(warnings) == 1
+        assert "thenvoi_send_my_chat_message" in warnings[0].getMessage()

--- a/tests/runtime/test_tool_definitions_surface.py
+++ b/tests/runtime/test_tool_definitions_surface.py
@@ -1,0 +1,309 @@
+"""Tests for the ``surface`` field on ``ToolDefinition`` and surface-aware
+filter composition in ``iter_tool_definitions``.
+
+These tests cover the Phase 1 (INT-349) acceptance criteria:
+
+- ``ToolDefinition.surface`` field exists and defaults to ``"agent"``.
+- ``iter_tool_definitions(surface="agent")`` returns exactly the pre-Phase-1
+  set (set equality on ``.name``).
+- ``iter_tool_definitions(surface="human")`` returns only human tools.
+- The three filters (``surface``, ``include_memory``, ``include_contacts``)
+  compose as independent predicates.
+- Every ``ToolDefinition.method_name`` resolves on the class implied by
+  its surface.
+- ``build_thenvoi_mcp_tool_registrations()`` with no args registers the
+  pre-Phase-1 agent-only tool-name set (snapshot guard for LocalMCPServer).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from pydantic import BaseModel
+
+from thenvoi.runtime.mcp_server import (
+    build_resolved_thenvoi_mcp_tool_registrations,
+    build_thenvoi_mcp_tool_registrations,
+)
+from thenvoi.runtime.tools import (
+    AgentTools,
+    HumanTools,
+    TOOL_DEFINITIONS,
+    ToolDefinition,
+    iter_tool_definitions,
+)
+
+
+# Pre-Phase-1 agent tool-name set (snapshot). Changing the agent surface
+# belongs in a different ticket; if this list drifts, either the test or
+# the SDK behavior is out of sync with the ticket.
+PRE_PHASE1_AGENT_TOOLS: frozenset[str] = frozenset(
+    {
+        "thenvoi_send_message",
+        "thenvoi_send_event",
+        "thenvoi_add_participant",
+        "thenvoi_remove_participant",
+        "thenvoi_lookup_peers",
+        "thenvoi_get_participants",
+        "thenvoi_create_chatroom",
+        "thenvoi_list_contacts",
+        "thenvoi_add_contact",
+        "thenvoi_remove_contact",
+        "thenvoi_list_contact_requests",
+        "thenvoi_respond_contact_request",
+    }
+)
+
+PHASE1_HUMAN_TOOLS: frozenset[str] = frozenset(
+    {
+        "thenvoi_list_my_agents",
+        "thenvoi_register_my_agent",
+        "thenvoi_delete_my_agent",
+        "thenvoi_list_my_chats",
+        "thenvoi_create_my_chat_room",
+        "thenvoi_get_my_chat_room",
+        "thenvoi_list_my_contacts",
+        "thenvoi_create_contact_request",
+        "thenvoi_list_received_contact_requests",
+        "thenvoi_list_sent_contact_requests",
+        "thenvoi_approve_contact_request",
+        "thenvoi_reject_contact_request",
+        "thenvoi_cancel_contact_request",
+        "thenvoi_resolve_handle",
+        "thenvoi_remove_my_contact",
+        "thenvoi_list_my_chat_messages",
+        "thenvoi_send_my_chat_message",
+        "thenvoi_list_my_chat_participants",
+        "thenvoi_add_my_chat_participant",
+        "thenvoi_remove_my_chat_participant",
+        "thenvoi_get_my_profile",
+        "thenvoi_update_my_profile",
+        "thenvoi_list_my_peers",
+    }
+)
+
+
+class TestToolDefinitionSurfaceField:
+    """The new ``surface`` field exists and has the right defaults."""
+
+    def test_surface_defaults_to_agent(self) -> None:
+        """Constructing a ToolDefinition without ``surface`` yields ``"agent"``."""
+
+        class _Dummy(BaseModel):
+            pass
+
+        definition = ToolDefinition(
+            name="thenvoi_dummy", input_model=_Dummy, method_name="dummy"
+        )
+        assert definition.surface == "agent"
+
+    def test_all_registered_agent_tools_have_agent_surface(self) -> None:
+        """Every entry whose name is in the pre-Phase-1 set carries surface=agent."""
+        for name in PRE_PHASE1_AGENT_TOOLS:
+            assert TOOL_DEFINITIONS[name].surface == "agent"
+
+    def test_all_registered_human_tools_have_human_surface(self) -> None:
+        """Every Phase 1 human entry is tagged surface=human."""
+        for name in PHASE1_HUMAN_TOOLS:
+            assert TOOL_DEFINITIONS[name].surface == "human"
+
+
+class TestIterToolDefinitionsSurfaceFilter:
+    """``iter_tool_definitions(surface=...)`` set-equality guarantees."""
+
+    def test_surface_agent_matches_pre_phase1_set(self) -> None:
+        """``surface="agent"`` with defaults returns exactly the pre-Phase-1 set."""
+        names = {d.name for d in iter_tool_definitions(surface="agent")}
+        assert names == PRE_PHASE1_AGENT_TOOLS
+
+    def test_surface_human_returns_only_human_tools(self) -> None:
+        """``surface="human"`` with defaults returns only human tools."""
+        defs = iter_tool_definitions(surface="human")
+        names = {d.name for d in defs}
+        assert names == PHASE1_HUMAN_TOOLS - {
+            # Default include_memory=False drops human memory tools too.
+            "thenvoi_list_user_memories",
+            "thenvoi_get_user_memory",
+            "thenvoi_supersede_user_memory",
+            "thenvoi_archive_user_memory",
+            "thenvoi_restore_user_memory",
+            "thenvoi_delete_user_memory",
+        }
+        for definition in defs:
+            assert definition.surface == "human"
+
+    def test_surface_none_returns_union_of_both_surfaces(self) -> None:
+        """``surface=None`` with defaults returns both surfaces' default views."""
+        names = {d.name for d in iter_tool_definitions(surface=None)}
+        # Default filters strip memory (agent + human) but keep contacts.
+        agent = PRE_PHASE1_AGENT_TOOLS
+        human_without_memory = PHASE1_HUMAN_TOOLS - {
+            "thenvoi_list_user_memories",
+            "thenvoi_get_user_memory",
+            "thenvoi_supersede_user_memory",
+            "thenvoi_archive_user_memory",
+            "thenvoi_restore_user_memory",
+            "thenvoi_delete_user_memory",
+        }
+        assert names == agent | human_without_memory
+
+
+class TestIterToolDefinitionsFilterComposition:
+    """The three filters (``surface``, ``include_memory``, ``include_contacts``)
+    compose as independent predicates."""
+
+    def test_human_memory_only(self) -> None:
+        """``surface=human, include_memory=True, include_contacts=False`` returns
+        only human memory tools."""
+        names = {
+            d.name
+            for d in iter_tool_definitions(
+                surface="human", include_memory=True, include_contacts=False
+            )
+        }
+        expected_memory = {
+            "thenvoi_list_user_memories",
+            "thenvoi_get_user_memory",
+            "thenvoi_supersede_user_memory",
+            "thenvoi_archive_user_memory",
+            "thenvoi_restore_user_memory",
+            "thenvoi_delete_user_memory",
+        }
+        # No agent tools at all, no human contact tools.
+        assert expected_memory <= names
+        # Remaining human tools (baseline + profile + agents + peers + chats
+        # + participants + messages) are still present because include_memory
+        # and include_contacts apply independently of surface.
+        # Specifically: no contact tools of either surface leak through.
+        assert names.isdisjoint(
+            {
+                "thenvoi_list_my_contacts",
+                "thenvoi_create_contact_request",
+                "thenvoi_resolve_handle",
+                "thenvoi_list_contacts",
+                "thenvoi_add_contact",
+            }
+        )
+        # No agent surface tools at all.
+        assert names.isdisjoint(PRE_PHASE1_AGENT_TOOLS)
+
+    def test_baseline_across_both_surfaces(self) -> None:
+        """``surface=None, include_memory=False, include_contacts=False``
+        returns baseline tools from both surfaces — no memory, no contacts."""
+        names = {
+            d.name
+            for d in iter_tool_definitions(
+                surface=None, include_memory=False, include_contacts=False
+            )
+        }
+        # No contact tools of either surface.
+        assert names.isdisjoint(
+            {
+                "thenvoi_list_contacts",
+                "thenvoi_add_contact",
+                "thenvoi_remove_contact",
+                "thenvoi_list_contact_requests",
+                "thenvoi_respond_contact_request",
+                "thenvoi_list_my_contacts",
+                "thenvoi_create_contact_request",
+                "thenvoi_list_received_contact_requests",
+                "thenvoi_list_sent_contact_requests",
+                "thenvoi_approve_contact_request",
+                "thenvoi_reject_contact_request",
+                "thenvoi_cancel_contact_request",
+                "thenvoi_resolve_handle",
+                "thenvoi_remove_my_contact",
+            }
+        )
+        # No memory tools of either surface.
+        assert names.isdisjoint(
+            {
+                "thenvoi_list_memories",
+                "thenvoi_store_memory",
+                "thenvoi_get_memory",
+                "thenvoi_supersede_memory",
+                "thenvoi_archive_memory",
+                "thenvoi_list_user_memories",
+                "thenvoi_get_user_memory",
+                "thenvoi_supersede_user_memory",
+                "thenvoi_archive_user_memory",
+                "thenvoi_restore_user_memory",
+                "thenvoi_delete_user_memory",
+            }
+        )
+        # But baseline agent + human tools remain.
+        assert "thenvoi_send_message" in names
+        assert "thenvoi_get_my_profile" in names
+        assert "thenvoi_send_my_chat_message" in names
+
+    def test_include_memory_true_agent_only(self) -> None:
+        """``surface=agent, include_memory=True`` includes agent memory tools."""
+        names = {
+            d.name for d in iter_tool_definitions(surface="agent", include_memory=True)
+        }
+        agent_memory = {
+            "thenvoi_list_memories",
+            "thenvoi_store_memory",
+            "thenvoi_get_memory",
+            "thenvoi_supersede_memory",
+            "thenvoi_archive_memory",
+        }
+        assert agent_memory <= names
+        # No human memory tools.
+        assert "thenvoi_list_user_memories" not in names
+
+
+class TestMethodNameResolution:
+    """Every ``ToolDefinition.method_name`` must resolve on the class
+    implied by ``surface``. Every ``input_model`` must be a BaseModel subclass."""
+
+    def test_every_input_model_is_basemodel_subclass(self) -> None:
+        for name, definition in TOOL_DEFINITIONS.items():
+            assert issubclass(definition.input_model, BaseModel), (
+                f"{name} input_model is not a BaseModel subclass"
+            )
+
+    def test_every_agent_method_name_resolves_on_agenttools(self) -> None:
+        for definition in iter_tool_definitions(
+            surface="agent", include_memory=True, include_contacts=True
+        ):
+            assert hasattr(AgentTools, definition.method_name), (
+                f"AgentTools has no method {definition.method_name} "
+                f"(from {definition.name})"
+            )
+
+    def test_every_human_method_name_resolves_on_humantools(self) -> None:
+        for definition in iter_tool_definitions(
+            surface="human", include_memory=True, include_contacts=True
+        ):
+            assert hasattr(HumanTools, definition.method_name), (
+                f"HumanTools has no method {definition.method_name} "
+                f"(from {definition.name})"
+            )
+
+
+class TestLocalMCPServerAgentOnlySnapshot:
+    """``LocalMCPServer`` must stay agent-only in Phase 1. The snapshot tests
+    guard against a future change silently leaking human tools into either
+    ``build_thenvoi_mcp_tool_registrations()`` or its resolved variant."""
+
+    def test_build_thenvoi_mcp_tool_registrations_is_agent_only(self) -> None:
+        """No-arg call registers exactly the pre-Phase-1 agent tool-name set."""
+        agent_tools = MagicMock(spec=AgentTools)
+        registrations = build_thenvoi_mcp_tool_registrations(agent_tools)
+        names = {registration.name for registration in registrations}
+        assert names == PRE_PHASE1_AGENT_TOOLS
+
+    def test_build_resolved_thenvoi_mcp_tool_registrations_is_agent_only(
+        self,
+    ) -> None:
+        """Resolved variant also registers only the pre-Phase-1 agent set."""
+
+        def _resolver(_room_id: str):
+            return None
+
+        registrations = build_resolved_thenvoi_mcp_tool_registrations(
+            get_tools=_resolver
+        )
+        names = {registration.name for registration in registrations}
+        assert names == PRE_PHASE1_AGENT_TOOLS


### PR DESCRIPTION
## Summary

Phase 1 of INT-338: extend the SDK tool registry with a `surface` field and add a `HumanTools` class alongside `AgentTools`, so `thenvoi-mcp` (and any other adapter) can consume one source of truth for both scopes.

Closes INT-349. Part of INT-338.

## Changes

- `src/thenvoi/runtime/tools.py`:
  - `ToolDefinition.surface: Literal["agent", "human"] = "agent"` (default preserves every existing entry's behavior).
  - `iter_tool_definitions(*, surface="agent", include_memory=False, include_contacts=True)` — three filters composed as independent predicates. **The `surface` default is pinned to `"agent"`** so existing callers (`claude_sdk`, `opencode`, `acp`) that pipe the result straight into an `AgentTools`-shaped MCP backend don't silently gain `HumanTools` entries. Pass `surface=None` explicitly to opt in to the union view. Memory/contact filters apply uniformly across both surfaces via parallel `HUMAN_MEMORY_TOOL_NAMES` and `HUMAN_CONTACT_TOOL_NAMES` sets.
  - `HumanTools` class — stateless per credential; **28 methods** (one per entry in the Phase 1 human-tool mapping table minus `delete_my_agent`, see below), each wrapping a `rest.human_api_*` call. Mirrors today's `thenvoi-mcp` human handler behavior field-for-field: same validation, same request-object construction, **error strings returned verbatim** (`"Error: Either contact_id or handle must be provided"`, `"Error: recipients cannot be empty"`, `"Error: Not found: ..."`, `"Error: At least one field ..."`, and the `"Added participant: <id>"` / `"Removed participant: <id>"` success strings); `delete_user_memory` wrapped to a `{"deleted": True, "id": ...}` payload. **Write methods pass `request_options=DEFAULT_REQUEST_OPTIONS`** (429 retry + timeouts) to match the `AgentTools` convention; reads follow the `AgentTools` sibling pattern (no options).
  - 28 new human tools registered into `TOOL_DEFINITIONS` with `surface="human"` (agents × 2, chats × 3, contacts × 9, messages × 2, participants × 3, memories × 6, profile × 2, peers × 1).
  - `TOOL_MODELS` and `ALL_TOOL_NAMES` stay agent-only so existing callers/adapters (`claude_sdk`, `framework_conformance`, etc.) aren't silently widened.
- `src/thenvoi/runtime/mcp_server.py`: `build_thenvoi_mcp_tool_registrations()` and `build_resolved_thenvoi_mcp_tool_registrations()` pin `surface="agent"` when they call `iter_tool_definitions` and — as defense-in-depth — drop non-agent entries (with a warning log) when `tool_definitions` is explicitly passed. `LocalMCPServer` remains agent-only.
- `src/thenvoi/runtime/__init__.py`: export `HumanTools`.

## Testing

- `tests/runtime/test_tool_definitions_surface.py` — `surface` defaults to `"agent"`; **new regression test pins `iter_tool_definitions()` with no args to agent-only** (C1); set-equality asserts for `surface="agent"` matching the pre-Phase-1 snapshot and `surface="human"` returning only human tools; filter composition (`surface="human", include_memory=True, include_contacts=False` -> only human memory tools; baseline across both surfaces with no memory/contacts still includes `send_message`, `get_my_profile`, `send_my_chat_message`); every `input_model` is a `BaseModel` subclass and every `method_name` resolves on `AgentTools`/`HumanTools` for its surface; `LocalMCPServer` agent-only snapshot for both builder variants; **two new defense-in-depth tests** assert that `build_*_tool_registrations` filters non-agent entries from an explicit mixed `tool_definitions` list and logs a warning per dropped entry.
- `tests/runtime/test_human_tools.py` — one shape-equal test per `HumanTools` method. Each scripts the REST client via `unittest.mock.AsyncMock` and asserts (a) the right `rest.human_api_*` method is awaited, (b) with the arguments today's MCP handler would have produced, (c) the return shape (keys + Python types) matches today's MCP output. Error-path tests assert the exact error string (matches `thenvoi-mcp` byte-for-byte); write-method tests assert `request_options=DEFAULT_REQUEST_OPTIONS` is forwarded.

```
uv run pytest tests/runtime/ -v
= 481 passed, 3 warnings =
```

`uv run pre-commit run --all-files` green (ruff check, ruff format, pyrefly, detect-secrets, commitizen).

## Notes for reviewers

- **C1 regression guard.** The original Phase 1 defaulted `iter_tool_definitions(surface=None)`. That silently widened every caller that pipes the result into an `AgentTools`-shaped MCP backend (`claude_sdk`, `opencode`, `acp` client adapter), which would `AttributeError` at tool-call time on a human tool. Default is now pinned to `surface="agent"`. Call `iter_tool_definitions(surface=None)` explicitly for the union view.
- **MCP error shape preserved.** Phase 1's original draft raised `ValueError` from six validation paths. After team review, the call is to preserve today's MCP error-string shape verbatim (copied from `thenvoi-mcp/src/thenvoi_mcp/tools/human/*.py`) so downstream callers that render the error string to the LLM see no behavior change. Tests now assert against the exact string instead of `pytest.raises`.
- **`delete_my_agent` dropped from Phase 1.** There is no corresponding handler in `thenvoi-mcp` today; shipping the SDK method would widen the observable tool surface past the spec. Follow-up once the MCP side adds it. The underlying `rest.human_api_agents.delete_my_agent` Fern method is still reachable for callers that need it.
- **Input models copied from `thenvoi-mcp/src/thenvoi_mcp/tools/human/*.py` field-for-field.** Those handlers don't actually declare pydantic models — they're plain `@mcp.tool()` functions — so I built the `*Input` models from the handler signatures (names, types, defaults, docstrings). The observable tool surface is intentionally unchanged from today's MCP behavior.
- **`LocalMCPServer` stays agent-only.** Both `build_thenvoi_mcp_tool_registrations` and `build_resolved_thenvoi_mcp_tool_registrations` pin `surface="agent"` and additionally filter explicit mixed `tool_definitions` lists with a warning log, so a future human tool added to the registry cannot leak into an in-process adapter that expects only agent tools.
- **Tests are shape-equal, not byte-equal** (pragmatic tradeoff, documented in the test module docstring). The acceptance criteria mentioned byte-equal fixtures against recorded MCP output, but the MCP handlers serialize with `serialize_response` and produce JSON strings while `HumanTools` returns the raw Fern model; we felt shape-equality on the REST call boundary and response keys/types catches regressions without requiring a fixture-capture step that touches `thenvoi-mcp` before this SDK change lands. **This was reviewed and explicitly approved by the team**; byte-equal regression fixtures are a follow-up.
- **Downstream heads-up for INT-351:** `iter_tool_definitions(surface, include_memory, include_contacts)` is ready for the MCP registrar to consume. Method names on `HumanTools` match the registry's `method_name` for each human definition.