### PR TITLE
fix: switch Dependabot Python ecosystem from pip to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
-  # Python dependencies
-  - package-ecosystem: "pip"
+  # Python dependencies (uv)
+  - package-ecosystem: "uv"
     directory: "/"
     target-branch: "dev"
     schedule:


### PR DESCRIPTION
## Summary

Dependabot was opening Python dependency PRs against `main` instead of `dev` — e.g. [#267](https://github.com/thenvoi/thenvoi-sdk-python/pull/267).

Root cause: `.github/dependabot.yml` configures `target-branch: dev` only for `package-ecosystem: pip`, but the project uses `uv` (see `uv.lock` + `pyproject.toml`). Dependabot detects the project as a uv ecosystem and opens branches prefixed `dependabot/uv/*`. With no matching config entry, it falls back to the repo's default branch (`main`).

This PR changes the Python block from `pip` to `uv` so future Python dependency PRs correctly target `dev`.

## Follow-up

- **Config only takes effect from the default branch.** Dependabot reads `.github/dependabot.yml` from `main`, so this change only helps future PRs once `dev` is merged into `main`.
- **Existing PR #267**: rebase onto `dev` manually (`gh pr edit 267 --base dev`) or close + comment `@dependabot recreate` after this lands on `main`.

## Test plan

- [ ] Merge to `dev`, then merge `dev` → `main`
- [ ] Retarget PR #267 to `dev`
- [ ] Confirm next weekly Dependabot run (Monday 09:00) opens PRs against `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)