### PR TITLE
feat: make Claude SDK model and fallback_model optional (Codex parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,10 @@ from thenvoi import Agent
 from thenvoi.adapters import ClaudeSDKAdapter
 
 adapter = ClaudeSDKAdapter(
-    model="claude-sonnet-4-5-20250929",
+    # Omit `model` to use the npm `claude` binary's default, or pass a
+    # family alias (`"sonnet"` / `"opus"` / `"haiku"`) for latest-of-family.
+    model="opus",
+    fallback_model="sonnet",
     max_thinking_tokens=10000,  # Enable extended thinking
     enable_execution_reporting=True,
 )

--- a/docker/claude_sdk/runner.py
+++ b/docker/claude_sdk/runner.py
@@ -176,7 +176,8 @@ async def main() -> None:
 
     agent_id = config["agent_id"]
     api_key = config["api_key"]
-    model = config.get("model", "claude-sonnet-4-5-20250929")
+    model = config.get("model")
+    fallback_model = config.get("fallback_model")
     custom_prompt = config.get("prompt", "")
     thinking_tokens = config.get("thinking_tokens")
     tool_names = config.get("tools", [])
@@ -222,6 +223,7 @@ async def main() -> None:
 
     adapter = ClaudeSDKAdapter(
         model=model,
+        fallback_model=fallback_model,
         custom_section=final_prompt,
         max_thinking_tokens=thinking_tokens,
         enable_execution_reporting=True,
@@ -238,7 +240,9 @@ async def main() -> None:
     )
 
     logger.info("Starting agent: %s", agent_id)
-    logger.info("Model: %s", model)
+    logger.info("Model: %s", model or "auto")
+    if fallback_model:
+        logger.info("Fallback model: %s", fallback_model)
     if role:
         logger.info("Role: %s", role)
     if workspace:

--- a/examples/claude_sdk/01_basic_agent.py
+++ b/examples/claude_sdk/01_basic_agent.py
@@ -62,9 +62,9 @@ async def main() -> None:
     # Load credentials from agent_config.yaml
     agent_id, api_key = load_agent_config("claude_sdk_agent")
 
-    # Create adapter with Claude SDK settings
+    # Create adapter with Claude SDK settings.  Omitting `model` lets the
+    # npm `claude` binary pick its own default (latest installed model).
     adapter = ClaudeSDKAdapter(
-        model="claude-sonnet-4-5-20250929",
         custom_section="You are a helpful assistant. Be concise and friendly.",
         features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
     )

--- a/examples/claude_sdk/02_extended_thinking.py
+++ b/examples/claude_sdk/02_extended_thinking.py
@@ -68,9 +68,12 @@ async def main() -> None:
     # Load credentials from agent_config.yaml
     agent_id, api_key = load_agent_config("claude_sdk_agent")
 
-    # Create adapter with extended thinking enabled
+    # Create adapter with extended thinking enabled.  `model="opus"` is a
+    # family alias resolved by the npm `claude` binary at runtime — always
+    # the latest Opus on the installed CLI, no version pinning.
     adapter = ClaudeSDKAdapter(
-        model="claude-sonnet-4-5-20250929",
+        model="opus",
+        fallback_model="sonnet",
         custom_section="""You are a thoughtful AI assistant that excels at
 complex problem-solving. When faced with challenging questions:
 1. Break down the problem into smaller parts

--- a/examples/claude_sdk/03_tom_agent.py
+++ b/examples/claude_sdk/03_tom_agent.py
@@ -63,7 +63,6 @@ async def main() -> None:
 
     # Create adapter with Tom's character prompt
     adapter = ClaudeSDKAdapter(
-        model="claude-sonnet-4-5-20250929",
         custom_section=generate_tom_prompt("Tom"),
         features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
     )

--- a/examples/claude_sdk/04_jerry_agent.py
+++ b/examples/claude_sdk/04_jerry_agent.py
@@ -63,7 +63,6 @@ async def main() -> None:
 
     # Create adapter with Jerry's character prompt
     adapter = ClaudeSDKAdapter(
-        model="claude-sonnet-4-5-20250929",
         custom_section=generate_jerry_prompt("Jerry"),
         features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
     )

--- a/examples/claude_sdk/README.md
+++ b/examples/claude_sdk/README.md
@@ -77,7 +77,7 @@ python examples/claude_sdk/01_basic_agent.py
 ```
 
 Features:
-- Standard Claude Sonnet model
+- npm `claude` binary's default model (no override)
 - Platform tool integration
 - Execution reporting
 

--- a/examples/claude_sdk/README.md
+++ b/examples/claude_sdk/README.md
@@ -51,7 +51,8 @@ from thenvoi import Agent
 from thenvoi.adapters import ClaudeSDKAdapter
 
 adapter = ClaudeSDKAdapter(
-    model="claude-sonnet-4-5-20250929",
+    # Omit `model` to use the npm `claude` binary's default, or pass a
+    # family alias (`"sonnet"` / `"opus"` / `"haiku"`).
     custom_section="You are a helpful assistant.",
 )
 
@@ -101,7 +102,8 @@ Enable extended thinking for complex reasoning tasks:
 
 ```python
 adapter = ClaudeSDKAdapter(
-    model="claude-sonnet-4-5-20250929",
+    model="opus",
+    fallback_model="sonnet",
     max_thinking_tokens=10000,  # Enable extended thinking
     enable_execution_reporting=True,
 )

--- a/examples/claude_sdk_docker/README.md
+++ b/examples/claude_sdk_docker/README.md
@@ -102,8 +102,12 @@ docker compose up
 agent_id: "agt_abc123xyz"
 api_key: "sk_live_..."
 
-# Optional: customize your agent
-model: claude-sonnet-4-5-20250929
+# Optional: customize your agent.  Omit `model` to use the npm `claude`
+# binary's default; aliases like `opus` / `sonnet` / `haiku` resolve to the
+# latest of that family.  `fallback_model` is used by the binary when the
+# primary model is unavailable.
+# model: opus
+# fallback_model: sonnet
 prompt: |
   You are a helpful assistant that specializes in customer support.
   Be friendly, concise, and always offer to help further.
@@ -111,11 +115,11 @@ tools:
   - calculator
   - get_time
 
-# Optional: extended thinking (requires claude-sonnet-4-5-20250929 or newer)
+# Optional: extended thinking (requires Sonnet 4.5+ or any Opus)
 # thinking_tokens: 10000
 ```
 
-> **Note:** The `thinking_tokens` option enables extended thinking and requires Claude Sonnet 4.5 or newer models (e.g., `claude-sonnet-4-5-20250929`).
+> **Note:** The `thinking_tokens` option enables extended thinking and requires Sonnet 4.5 or newer (any Opus also works). Use `model: sonnet` or `model: opus` to always pick the latest available.
 
 ## Multiple Agents
 

--- a/examples/claude_sdk_docker/create_agents.py
+++ b/examples/claude_sdk_docker/create_agents.py
@@ -58,11 +58,13 @@ async def main() -> None:
 
         logger.info("  Created: %s (ID: %s)", agent.name, agent.id)
 
+        # Omit `model` so the runner falls back to None and the npm `claude`
+        # binary picks its own default.  Override per agent by adding
+        # `"model": "opus"` (or any alias / pinned ID) below.
         config = {
             "agent_id": agent.id,
             "api_key": credentials.api_key,
             "role": agent_def["role"],
-            "model": "claude-sonnet-4-5-20250929",
         }
 
         config_path = os.path.join(script_dir, agent_def["file"])

--- a/examples/claude_sdk_docker/example_agent.yaml
+++ b/examples/claude_sdk_docker/example_agent.yaml
@@ -7,7 +7,11 @@
 agent_id: "your-agent-id"
 api_key: "your-api-key"
 
-model: claude-sonnet-4-5-20250929
+# Optional model override.  Omit to let the npm `claude` binary pick its own
+# default.  Aliases (`sonnet` / `opus` / `haiku`) resolve to the latest of
+# that family on the installed binary, so they don't go stale.
+# model: opus
+# fallback_model: sonnet
 
 # Optional: use a predefined role profile
 # Available roles: planner, reviewer

--- a/examples/claude_sdk_docker/runner.py
+++ b/examples/claude_sdk_docker/runner.py
@@ -191,7 +191,8 @@ async def main() -> None:
     # Extract config values
     agent_id = config["agent_id"]
     api_key = config["api_key"]
-    model = config.get("model", "claude-sonnet-4-5-20250929")
+    model = config.get("model")
+    fallback_model = config.get("fallback_model")
     custom_prompt = config.get("prompt", "")
     thinking_tokens = config.get("thinking_tokens")
     tool_names = config.get("tools", [])
@@ -238,6 +239,7 @@ async def main() -> None:
     # Create adapter
     adapter = ClaudeSDKAdapter(
         model=model,
+        fallback_model=fallback_model,
         custom_section=final_prompt,
         max_thinking_tokens=thinking_tokens,
         features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
@@ -255,7 +257,9 @@ async def main() -> None:
     )
 
     logger.info("Starting agent: %s", agent_id)
-    logger.info("Model: %s", model)
+    logger.info("Model: %s", model or "auto")
+    if fallback_model:
+        logger.info("Fallback model: %s", fallback_model)
     if role:
         logger.info("Role: %s", role)
     if workspace:

--- a/examples/coding_agents/create_agents.py
+++ b/examples/coding_agents/create_agents.py
@@ -58,11 +58,13 @@ async def main() -> None:
 
         logger.info("  Created: %s (ID: %s)", agent.name, agent.id)
 
+        # Omit `model` so the runner falls back to None and the npm `claude`
+        # binary picks its own default.  Override per agent by adding
+        # `"model": "opus"` (or any alias / pinned ID) below.
         config = {
             "agent_id": agent.id,
             "api_key": credentials.api_key,
             "role": agent_def["role"],
-            "model": "claude-sonnet-4-5-20250929",
         }
 
         config_path = os.path.join(script_dir, agent_def["file"])

--- a/examples/run_agent.py
+++ b/examples/run_agent.py
@@ -164,18 +164,20 @@ CREWAI_DEFAULTS = {
     "complex topics into understandable insights.",
 }
 
-# When --model is left at the default "openai:gpt-4o", these examples override
-# it to a framework-appropriate model. The user can always pass --model
-# explicitly to bypass this.
+# When --model is omitted, these per-example defaults kick in.  Examples not
+# listed here (e.g. langgraph, claude_sdk) flow through with model=None so the
+# adapter / underlying CLI picks its own default.  The user can always pass
+# --model to override.
 _DEFAULT_MODELS: dict[str, str] = {
+    "pydantic_ai": "openai:gpt-4o",  # preserve previous global-default behavior
     "pydantic_ai_contacts": "anthropic:claude-sonnet-4-5",
     "contacts_auto": "anthropic:claude-sonnet-4-5",
     "contacts_hub": "anthropic:claude-sonnet-4-5",
     "contacts_broadcast": "anthropic:claude-sonnet-4-5",
     "anthropic": "claude-sonnet-4-5-20250929",
-    "claude_sdk": "claude-sonnet-4-5-20250929",
     "parlant": "gpt-4o",
     "crewai": "gpt-4o-mini",
+    # claude_sdk: deliberately omitted — the npm `claude` binary picks its own default.
 }
 
 CONTACTS_INSTRUCTIONS = """
@@ -355,7 +357,8 @@ async def run_claude_sdk_agent(
     api_key: str,
     rest_url: str,
     ws_url: str,
-    model: str,
+    model: str | None,
+    fallback_model: str | None,
     custom_section: str,
     enable_thinking: bool,
     enable_streaming: bool,
@@ -367,6 +370,7 @@ async def run_claude_sdk_agent(
 
     adapter = ClaudeSDKAdapter(
         model=model,
+        fallback_model=fallback_model,
         custom_section=custom_section,
         max_thinking_tokens=10000 if enable_thinking else None,
         features=AdapterFeatures(emit={Emit.EXECUTION}) if enable_streaming else None,
@@ -388,8 +392,12 @@ async def run_claude_sdk_agent(
         options.append("execution reporting")
     if contact_config:
         options.append(f"contacts={contact_config.strategy.value}")
+    if fallback_model:
+        options.append(f"fallback_model={fallback_model}")
     options_str = f" with {', '.join(options)}" if options else ""
-    logger.info("Starting Claude SDK agent with model: %s%s", model, options_str)
+    logger.info(
+        "Starting Claude SDK agent with model: %s%s", model or "auto", options_str
+    )
     await agent.run()
 
 
@@ -874,8 +882,20 @@ Examples:
     parser.add_argument(
         "--model",
         "-m",
-        default="openai:gpt-4o",
-        help="Model for Pydantic AI/Anthropic examples (default: openai:gpt-4o)",
+        default=None,
+        help=(
+            "Model override; defaults vary by example (see _DEFAULT_MODELS). "
+            "Omit for claude_sdk to let the npm claude binary pick its own default."
+        ),
+    )
+    parser.add_argument(
+        "--fallback-model",
+        default=None,
+        help=(
+            "Fallback model passed to ClaudeAgentOptions.fallback_model "
+            "(claude_sdk example only; ignored elsewhere). "
+            "The npm claude binary uses it when the primary model is unavailable."
+        ),
     )
     parser.add_argument(
         "--custom-section",
@@ -1042,11 +1062,12 @@ Examples:
             contact_config.broadcast_changes,
         )
 
-    # Resolve model: override the CLI default when the user hasn't
-    # explicitly chosen a model and the example needs a different one.
+    # Resolve model: when the user didn't pass --model, use the per-example
+    # default if listed.  May stay None (e.g. for claude_sdk and langgraph),
+    # in which case the adapter / underlying CLI picks its own default.
     model = args.model
-    if model == "openai:gpt-4o" and args.example in _DEFAULT_MODELS:
-        model = _DEFAULT_MODELS[args.example]
+    if model is None:
+        model = _DEFAULT_MODELS.get(args.example)
 
     try:
         if args.example == "langgraph":
@@ -1125,6 +1146,7 @@ Examples:
                 rest_url=rest_url,
                 ws_url=ws_url,
                 model=model,
+                fallback_model=args.fallback_model,
                 custom_section=args.custom_section,
                 enable_thinking=args.thinking,
                 enable_streaming=args.streaming,

--- a/src/thenvoi/adapters/claude_sdk.py
+++ b/src/thenvoi/adapters/claude_sdk.py
@@ -154,9 +154,10 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
 
     Example:
         adapter = ClaudeSDKAdapter(
-            model="claude-sonnet-4-5-20250929",
             custom_section="You are a helpful assistant.",
         )
+        # Or pin a model / family alias:
+        # adapter = ClaudeSDKAdapter(model="opus", fallback_model="sonnet")
         agent = Agent.create(adapter=adapter, agent_id="...", api_key="...")
         await agent.run()
     """
@@ -172,7 +173,8 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
 
     def __init__(
         self,
-        model: str = "claude-sonnet-4-5-20250929",
+        model: str | None = None,
+        fallback_model: str | None = None,
         custom_section: str | None = None,
         max_thinking_tokens: int | None = None,
         permission_mode: PermissionMode = "acceptEdits",
@@ -194,7 +196,15 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         Initialize the Claude SDK adapter.
 
         Args:
-            model: Claude model to use
+            model: Claude model to use. Pass a full ID (e.g.
+                ``"claude-opus-4-7-20251224"``) or a family alias
+                (``"sonnet"`` / ``"opus"`` / ``"haiku"`` / ``"inherit"``).
+                When ``None`` (default), the npm ``claude`` binary picks
+                its own default — no ``--model`` flag is sent.
+            fallback_model: Optional fallback model passed to
+                ``ClaudeAgentOptions.fallback_model``. The npm ``claude``
+                binary uses it when the primary model is unavailable.
+                Aliases are accepted here too.
             custom_section: Custom instructions added to system prompt
             max_thinking_tokens: Max tokens for extended thinking (optional)
             permission_mode: SDK permission mode
@@ -281,6 +291,7 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         )
 
         self.model = model
+        self.fallback_model = fallback_model
         self.custom_section = custom_section
         self.max_thinking_tokens = max_thinking_tokens
         self.permission_mode: ClaudeSDKAdapter.PermissionMode = permission_mode
@@ -337,9 +348,12 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
             features=self.features,
         )
 
-        # Build SDK options
+        # Build SDK options. Both model and fallback_model upstream default
+        # to None — passing None is equivalent to omitting them, which lets
+        # the npm `claude` binary pick its own default.
         sdk_options = ClaudeAgentOptions(
             model=self.model,
+            fallback_model=self.fallback_model,
             system_prompt=system_prompt,
             mcp_servers={"thenvoi": self._mcp_server},
             allowed_tools=self._mcp_backend.allowed_tools,
@@ -376,9 +390,10 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         )
 
         logger.info(
-            "Claude SDK adapter started for agent: %s (model=%s, thinking=%s, approval=%s)",
+            "Claude SDK adapter started for agent: %s (model=%s, fallback_model=%s, thinking=%s, approval=%s)",
             agent_name,
-            self.model,
+            self.model or "auto",
+            self.fallback_model or "none",
             self.max_thinking_tokens,
             self.approval_mode,
         )
@@ -985,7 +1000,8 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
 
         lines = [
             "**Claude SDK Status**",
-            f"- model: `{self.model}`",
+            f"- model: `{self.model or 'auto'}`",
+            f"- fallback_model: `{self.fallback_model or 'none'}`",
             f"- permission_mode: `{self.permission_mode}`",
             f"- approval_mode: `{self.approval_mode or 'disabled'}`",
             f"- pending_approvals: {pending_count}",

--- a/src/thenvoi/integrations/claude_sdk/__init__.py
+++ b/src/thenvoi/integrations/claude_sdk/__init__.py
@@ -7,7 +7,8 @@ Use the new composition-based pattern instead:
     from thenvoi import Agent
     from thenvoi.adapters import ClaudeSDKAdapter
 
-    adapter = ClaudeSDKAdapter(model="claude-sonnet-4-5-20250929")
+    adapter = ClaudeSDKAdapter()  # uses npm `claude` binary's default model
+    # Or: ClaudeSDKAdapter(model="opus", fallback_model="sonnet")
     agent = Agent.create(adapter=adapter, agent_id="...", api_key="...")
     await agent.run()
 

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -108,6 +108,64 @@ class TestOnStarted:
             assert adapter._session_manager is not None
             assert adapter._mcp_server is not None
 
+    @pytest.mark.asyncio
+    async def test_default_options_have_no_model(self):
+        """Default ClaudeSDKAdapter() should pass model=None and fallback_model=None."""
+        adapter = ClaudeSDKAdapter()
+
+        with patch(
+            "thenvoi.adapters.claude_sdk.ClaudeSessionManager"
+        ) as mock_manager_class:
+            mock_manager_class.return_value = MagicMock()
+
+            await adapter.on_started(
+                agent_name="TestBot", agent_description="A test bot"
+            )
+
+            sdk_options = mock_manager_class.call_args[0][0]
+            assert sdk_options.model is None
+            assert sdk_options.fallback_model is None
+
+    @pytest.mark.asyncio
+    async def test_explicit_model_is_forwarded(self):
+        """Explicit model= should land in ClaudeAgentOptions.model."""
+        adapter = ClaudeSDKAdapter(model="opus")
+
+        with patch(
+            "thenvoi.adapters.claude_sdk.ClaudeSessionManager"
+        ) as mock_manager_class:
+            mock_manager_class.return_value = MagicMock()
+
+            await adapter.on_started(
+                agent_name="TestBot", agent_description="A test bot"
+            )
+
+            sdk_options = mock_manager_class.call_args[0][0]
+            assert sdk_options.model == "opus"
+            assert sdk_options.fallback_model is None
+
+    @pytest.mark.asyncio
+    async def test_fallback_model_is_forwarded(self):
+        """Both model and fallback_model must reach ClaudeAgentOptions.
+
+        Regression guard: catches a missed `fallback_model=self.fallback_model`
+        in the ClaudeAgentOptions construction in on_started().
+        """
+        adapter = ClaudeSDKAdapter(model="opus", fallback_model="sonnet")
+
+        with patch(
+            "thenvoi.adapters.claude_sdk.ClaudeSessionManager"
+        ) as mock_manager_class:
+            mock_manager_class.return_value = MagicMock()
+
+            await adapter.on_started(
+                agent_name="TestBot", agent_description="A test bot"
+            )
+
+            sdk_options = mock_manager_class.call_args[0][0]
+            assert sdk_options.model == "opus"
+            assert sdk_options.fallback_model == "sonnet"
+
 
 class TestOnMessage:
     """Tests for on_message() method (bootstrap, history, invoke and response)."""

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -384,6 +384,7 @@ def _build_claude_sdk_config() -> AdapterConfig | None:
         adapter_factory=_claude_sdk_factory,
         expected_initial_values={
             "model": _default_from_init(ClaudeSDKAdapter, "model"),
+            "fallback_model": _default_from_init(ClaudeSDKAdapter, "fallback_model"),
             "custom_section": _default_from_init(ClaudeSDKAdapter, "custom_section"),
             "max_thinking_tokens": _default_from_init(
                 ClaudeSDKAdapter, "max_thinking_tokens"
@@ -392,12 +393,14 @@ def _build_claude_sdk_config() -> AdapterConfig | None:
         },
         custom_kwargs={
             "model": "claude-opus-4-20250514",
+            "fallback_model": "sonnet",
             "custom_section": "Be helpful.",
             "max_thinking_tokens": 10000,
             "permission_mode": "bypassPermissions",
         },
         custom_expected={
             "model": "claude-opus-4-20250514",
+            "fallback_model": "sonnet",
             "custom_section": "Be helpful.",
             "max_thinking_tokens": 10000,
             "permission_mode": "bypassPermissions",


### PR DESCRIPTION
## Summary

Make `ClaudeSDKAdapter.model` optional and add `fallback_model`, mirroring how `CodexAdapter` handles model configuration. Removes a stale hardcoded `claude-sonnet-4-5-20250929` default that was overriding the npm `claude` binary's own default even when callers passed nothing.

- `ClaudeSDKAdapter(model=None, fallback_model=None)` is now the default. Both are forwarded directly to upstream `ClaudeAgentOptions` (which already supports `str | None` for both fields).
- When unset, no `--model` flag is sent to the npm `claude` binary, so it picks its own default. Family aliases (`"sonnet"` / `"opus"` / `"haiku"`) are forwarded as-is.
- `examples/run_agent.py` gets a new `--fallback-model` CLI flag and switches `--model` to default `None`. `_DEFAULT_MODELS` is reorganized so `claude_sdk` flows through with `None` and `pydantic_ai`'s de-facto default is preserved explicitly.
- Both docker runners (`docker/claude_sdk/runner.py`, `examples/claude_sdk_docker/runner.py`) drop the stale fallback string and read `fallback_model` from YAML.
- Stale model pins removed from `examples/claude_sdk/01/03/04*.py` and the docker YAML emitters; `02_extended_thinking.py` is kept as the canonical alias demo (`model="opus"`, `fallback_model="sonnet"`).
- Docs (`README.md`, `examples/claude_sdk/README.md`, `examples/claude_sdk_docker/README.md`) updated to use aliases or omit the model.

### Scope note

Configuration-surface parity with Codex only. Codex does runtime discovery via `model/list` on its daemon and tracks a `_selected_model` separate from configured. The npm `claude` binary has no analog, so this PR does **not** add runtime resolution to the Claude SDK adapter; status output reports configured values only (`model: auto` when unset).

## Test plan

- [x] New behavior tests in `TestOnStarted` lock in options forwarding:
  - `test_default_options_have_no_model` — proves no override is sent when caller passes nothing.
  - `test_explicit_model_is_forwarded` — proves `model="opus"` lands in `ClaudeAgentOptions.model`.
  - `test_fallback_model_is_forwarded` — regression guard against forgetting `fallback_model=` in the options construction.
- [x] `uv run pytest tests/adapters/test_claude_sdk_adapter.py tests/integrations/claude_sdk/test_session_manager.py` — 95 passed.
- [x] `uv run pytest tests/framework_conformance/test_config_drift.py tests/framework_conformance/test_adapter_conformance.py -k "claude_sdk or drift"` — 19 passed (including config-drift detection picking up the new `fallback_model` field).
- [x] `uv run ruff check .` and `uv run ruff format .` — clean.
- [x] `uv run pyrefly check` — clean (default scope).
- [ ] Manual smoke against staging/prod: minimal `agent.yaml` (just `agent_id` + `api_key`) connects, `model=auto` shown in logs, npm `claude` CLI runs with no `--model` flag.
- [ ] Manual: `--model opus --fallback-model sonnet` flows into `ClaudeAgentOptions` end-to-end.