### PR TITLE
fix(websocket): keep room deletion handler optional

### DIFF
--- a/src/thenvoi/client/streaming/client.py
+++ b/src/thenvoi/client/streaming/client.py
@@ -99,6 +99,10 @@ class RoomDeletedPayload(BaseModel):
     id: str
 
 
+async def _noop_room_deleted(_: RoomDeletedPayload) -> None:
+    return None
+
+
 class ParticipantAddedPayload(BaseModel):
     """Payload for participant_added events."""
 
@@ -332,7 +336,9 @@ class WebSocketClient:
         chat_room_id: str,
         on_participant_added: Callable[[ParticipantAddedPayload], Awaitable[None]],
         on_participant_removed: Callable[[ParticipantRemovedPayload], Awaitable[None]],
-        on_room_deleted: Callable[[RoomDeletedPayload], Awaitable[None]],
+        on_room_deleted: Callable[
+            [RoomDeletedPayload], Awaitable[None]
+        ] = _noop_room_deleted,
     ):
         """Subscribe to room participants topic with async callbacks"""
         topic = f"room_participants:{chat_room_id}"

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -355,6 +356,67 @@ async def test_accepts_valid_participant_removed_payload():
     await client._handle_events(MockMessage(), {"participant_removed": test_callback})
     assert isinstance(received_payload, ParticipantRemovedPayload)
     assert received_payload.id == "p-123"
+
+
+async def test_join_room_participants_channel_allows_omitted_room_deleted_handler():
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+    client.client = AsyncMock()
+
+    async def on_participant_added(payload):
+        pass
+
+    async def on_participant_removed(payload):
+        pass
+
+    await client.join_room_participants_channel(
+        "room-123",
+        on_participant_added=on_participant_added,
+        on_participant_removed=on_participant_removed,
+    )
+
+    client.client.subscribe_to_topic.assert_awaited_once()
+    topic, message_handler = client.client.subscribe_to_topic.await_args.args
+    assert topic == "room_participants:room-123"
+
+    class MockMessage:
+        event = "room_deleted"
+        payload = {"id": "room-123"}
+
+    await message_handler(MockMessage())
+
+
+async def test_join_room_participants_channel_routes_room_deleted_handler():
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+    client.client = AsyncMock()
+    received_payload = None
+
+    async def on_participant_added(payload):
+        pass
+
+    async def on_participant_removed(payload):
+        pass
+
+    async def on_room_deleted(payload):
+        nonlocal received_payload
+        received_payload = payload
+
+    await client.join_room_participants_channel(
+        "room-123",
+        on_participant_added=on_participant_added,
+        on_participant_removed=on_participant_removed,
+        on_room_deleted=on_room_deleted,
+    )
+
+    _, message_handler = client.client.subscribe_to_topic.await_args.args
+
+    class MockMessage:
+        event = "room_deleted"
+        payload = {"id": "room-123"}
+
+    await message_handler(MockMessage())
+
+    assert isinstance(received_payload, RoomDeletedPayload)
+    assert received_payload.id == "room-123"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Make `WebSocketClient.join_room_participants_channel` backward-compatible by defaulting `on_room_deleted` to an async no-op.
- Add regression coverage for callers that omit the room deletion handler.
- Keep explicit `room_deleted` handlers routed and typed as before.

## Test plan
- `uv run pytest tests/websocket/test_client.py -v`
- `uv run ruff check . && uv run ruff format --check . && uv run pyrefly check`
- `uv run pytest tests/*.py tests/adapters tests/bridge tests/cli tests/client tests/compat tests/converters tests/core tests/docker tests/docs tests/example_agents tests/examples tests/framework_configs tests/framework_conformance tests/github_actions tests/integrations tests/platform tests/preprocessing tests/prompt_policies tests/prompts tests/runtime tests/testing tests/websocket -q`

Fixes INT-450.