### PR TITLE
feat(integrations): expose custom tools to CrewAI flows

### DIFF
--- a/examples/crewai/08_flow_router.py
+++ b/examples/crewai/08_flow_router.py
@@ -140,7 +140,7 @@ async def main() -> None:
     if not rest_url:
         raise ValueError("THENVOI_REST_URL environment variable is required")
 
-    agent_config = load_agent_config("crewai_flow_router")
+    agent_id, api_key = load_agent_config("crewai_flow_router")
 
     adapter = CrewAIFlowAdapter(
         flow_factory=flow_factory,
@@ -150,8 +150,8 @@ async def main() -> None:
 
     agent = Agent.create(
         adapter=adapter,
-        agent_id=agent_config["agent_id"],
-        api_key=agent_config["api_key"],
+        agent_id=agent_id,
+        api_key=api_key,
         ws_url=ws_url,
         rest_url=rest_url,
     )

--- a/examples/crewai/09_flow_custom_tools.py
+++ b/examples/crewai/09_flow_custom_tools.py
@@ -1,0 +1,123 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["thenvoi-sdk[crewai]"]
+#
+# [tool.uv.sources]
+# thenvoi-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# ///
+"""CrewAI Flow custom tools example.
+
+Demonstrates registering an adapter-level custom tool and calling it from
+inside a Flow via ``get_current_flow_runtime()``.
+
+Run with:
+    uv run examples/crewai/09_flow_custom_tools.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from typing import Any
+
+from dotenv import load_dotenv
+from pydantic import BaseModel
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from setup_logging import setup_logging  # noqa: E402
+
+from thenvoi import Agent  # noqa: E402
+from thenvoi.adapters import CrewAIFlowAdapter  # noqa: E402
+from thenvoi.adapters.crewai_flow import get_current_flow_runtime  # noqa: E402
+from thenvoi.config import load_agent_config  # noqa: E402
+from thenvoi.core.types import AdapterFeatures, Emit  # noqa: E402
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+USER_INBOX_TEXT = """Recent emails:
+- Finance asked for a Q2 budget summary by Friday.
+- Sales sent updated Genpact renewal notes.
+- Priya shared the draft onboarding deck.
+"""
+
+
+class EmailsInput(BaseModel):
+    """Return the user's recent emails."""
+
+
+def emails() -> str:
+    return USER_INBOX_TEXT
+
+
+class InboxAwareFlow:
+    async def kickoff_async(
+        self, inputs: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        inputs = inputs or {}
+        message = inputs.get("message") or {}
+        content = str(message.get("content") or "").lower()
+        if "email" not in content and "inbox" not in content:
+            return {
+                "decision": "direct_response",
+                "content": "I do not need inbox context for this request.",
+                "mentions": [],
+            }
+
+        runtime = get_current_flow_runtime()
+        if runtime is None:
+            return {
+                "decision": "failed",
+                "error": {
+                    "code": "runtime_unavailable",
+                    "message": "Flow runtime is unavailable.",
+                    "retryable": False,
+                },
+            }
+
+        inbox = await runtime.tools.emails()
+        return {
+            "decision": "direct_response",
+            "content": f"I found this inbox context:\n{inbox}",
+            "mentions": [],
+        }
+
+
+def flow_factory() -> InboxAwareFlow:
+    return InboxAwareFlow()
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("THENVOI_WS_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
+    if not ws_url:
+        raise ValueError("THENVOI_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("THENVOI_REST_URL environment variable is required")
+
+    agent_config = load_agent_config("crewai_flow_custom_tools")
+
+    adapter = CrewAIFlowAdapter(
+        flow_factory=flow_factory,
+        additional_tools=[(EmailsInput, emails)],
+        features=AdapterFeatures(emit=frozenset({Emit.EXECUTION})),
+    )
+
+    agent = Agent.create(
+        adapter=adapter,
+        agent_id=agent_config["agent_id"],
+        api_key=agent_config["api_key"],
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+    logger.info("CrewAI Flow custom tools agent starting")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/crewai/09_flow_custom_tools.py
+++ b/examples/crewai/09_flow_custom_tools.py
@@ -100,7 +100,7 @@ async def main() -> None:
     if not rest_url:
         raise ValueError("THENVOI_REST_URL environment variable is required")
 
-    agent_config = load_agent_config("crewai_flow_custom_tools")
+    agent_id, api_key = load_agent_config("crewai_flow_custom_tools")
 
     adapter = CrewAIFlowAdapter(
         flow_factory=flow_factory,
@@ -110,8 +110,8 @@ async def main() -> None:
 
     agent = Agent.create(
         adapter=adapter,
-        agent_id=agent_config["agent_id"],
-        api_key=agent_config["api_key"],
+        agent_id=agent_id,
+        api_key=api_key,
         ws_url=ws_url,
         rest_url=rest_url,
     )

--- a/src/thenvoi/adapters/crewai_flow.py
+++ b/src/thenvoi/adapters/crewai_flow.py
@@ -18,7 +18,7 @@ import asyncio
 import inspect
 import logging
 from collections import OrderedDict
-from collections.abc import Mapping
+from collections.abc import Awaitable, Mapping
 from contextvars import ContextVar
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Literal, Protocol, Union, runtime_checkable
@@ -50,6 +50,12 @@ from thenvoi.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+)
+from thenvoi.runtime.custom_tools import (
+    CustomToolDef,
+    custom_tools_to_schemas,
+    execute_custom_tool,
+    get_custom_tool_name,
 )
 
 try:  # pragma: no cover - optional dependency guard
@@ -521,6 +527,84 @@ class _RoomLockEntry:
         self.cleanup_requested = False
 
 
+class CrewAIFlowCustomTools:
+    """Runtime access to adapter-registered custom tools."""
+
+    def __init__(
+        self,
+        *,
+        custom_tools: Mapping[str, CustomToolDef],
+        tools: AgentToolsProtocol,
+        features: AdapterFeatures,
+    ) -> None:
+        from thenvoi.integrations.crewai import EmitExecutionReporter
+
+        self._custom_tools = custom_tools
+        self._tools = tools
+        self._reporter = EmitExecutionReporter(features)
+
+    def __dir__(self) -> list[str]:
+        return sorted({*super().__dir__(), *self._custom_tools})
+
+    def __getattr__(self, name: str) -> Callable[..., Awaitable[Any]]:
+        if name not in self._custom_tools:
+            raise AttributeError(name)
+
+        async def _call(**arguments: Any) -> Any:
+            return await self.call_tool(name, arguments)
+
+        return _call
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        return tuple(sorted(self._custom_tools))
+
+    @property
+    def anthropic_schemas(self) -> list[dict[str, Any]]:
+        return custom_tools_to_schemas(
+            [tool for _, tool in sorted(self._custom_tools.items())],
+            "anthropic",
+        )
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        if arguments is not None and kwargs:
+            raise ValueError("pass either arguments or keyword arguments, not both")
+        tool = self._custom_tools.get(name)
+        if tool is None:
+            raise ValueError(f"Unknown custom tool: {name}")
+        input_data = dict(arguments or kwargs)
+        await self._report_call(name, input_data)
+        try:
+            result = await execute_custom_tool(tool, input_data)
+        except Exception as exc:
+            await self._report_result(name, str(exc), is_error=True)
+            raise
+        await self._report_result(name, result)
+        return result
+
+    async def _report_call(self, tool_name: str, input_data: dict[str, Any]) -> None:
+        await self._reporter.report_call(self._tools, tool_name, input_data)
+
+    async def _report_result(
+        self,
+        tool_name: str,
+        result: Any,
+        *,
+        is_error: bool = False,
+    ) -> None:
+        await self._reporter.report_result(
+            self._tools,
+            tool_name,
+            result,
+            is_error=is_error,
+        )
+
+
 class CrewAIFlowRuntimeTools:
     """Read-only Flow runtime surface.
 
@@ -544,6 +628,7 @@ class CrewAIFlowRuntimeTools:
         run_id: str,
         state: CrewAIFlowSessionState,
         features: AdapterFeatures,
+        custom_tools: Mapping[str, CustomToolDef],
         fallback_loop: asyncio.AbstractEventLoop | None,
     ) -> None:
         self._room_id = room_id
@@ -555,6 +640,12 @@ class CrewAIFlowRuntimeTools:
         self._run_id = run_id
         self._state = state
         self._features = features
+        self._custom_tool_defs = dict(custom_tools)
+        self._custom_tools = CrewAIFlowCustomTools(
+            custom_tools=self._custom_tool_defs,
+            tools=tools,
+            features=features,
+        )
         self._fallback_loop = fallback_loop
 
     @property
@@ -576,6 +667,18 @@ class CrewAIFlowRuntimeTools:
     @property
     def run_id(self) -> str:
         return self._run_id
+
+    @property
+    def tools(self) -> CrewAIFlowCustomTools:
+        return self._custom_tools
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        return await self._custom_tools.call_tool(name, arguments, **kwargs)
 
     async def lookup_peers(self, page: int = 1, page_size: int = 50) -> Any:
         return await self._tools.lookup_peers(page=page, page_size=page_size)
@@ -681,11 +784,16 @@ class CrewAIFlowRuntimeTools:
         def _get_context() -> CrewAIToolContext:
             return ctx
 
+        effective_custom_tools = (
+            custom_tools
+            if custom_tools is not None
+            else list(self._custom_tool_defs.values())
+        )
         return build_thenvoi_crewai_tools(
             get_context=_get_context,
             reporter=reporter,
             features=features,
-            custom_tools=custom_tools,
+            custom_tools=effective_custom_tools,
             fallback_loop=self._fallback_loop,
         )
 
@@ -1422,6 +1530,7 @@ class CrewAIFlowAdapter(SimpleAdapter[CrewAIFlowSessionState]):
         sequential_chains: Mapping[str, str] | None = None,
         accept_agent_initiated: bool = False,
         history_converter: CrewAIFlowStateConverter | None = None,
+        additional_tools: list[CustomToolDef] | None = None,
         features: AdapterFeatures | None = None,
     ) -> None:
         # ---- flow_factory -------------------------------------------------
@@ -1513,6 +1622,27 @@ class CrewAIFlowAdapter(SimpleAdapter[CrewAIFlowSessionState]):
         if not isinstance(accept_agent_initiated, bool):
             raise ThenvoiConfigError("accept_agent_initiated must be a bool")
 
+        # ---- additional_tools ----------------------------------------------
+        custom_tools_by_name: dict[str, CustomToolDef] = {}
+        for tool in additional_tools or []:
+            if not isinstance(tool, tuple) or len(tool) != 2:
+                raise ThenvoiConfigError(
+                    "additional_tools must be a list of (InputModel, callable) tuples"
+                )
+            input_model, handler = tool
+            if not isinstance(input_model, type) or not issubclass(
+                input_model, BaseModel
+            ):
+                raise ThenvoiConfigError(
+                    "additional_tools InputModel values must be Pydantic BaseModel subclasses"
+                )
+            if not callable(handler):
+                raise ThenvoiConfigError("additional_tools handlers must be callable")
+            tool_name = get_custom_tool_name(input_model)
+            if tool_name in custom_tools_by_name:
+                raise ThenvoiConfigError(f"Duplicate custom tool name: {tool_name}")
+            custom_tools_by_name[tool_name] = tool
+
         # ---- history_converter --------------------------------------------
         # Default converter picks up max_run_age and the namespace once
         # on_started resolves the namespace.
@@ -1535,6 +1665,7 @@ class CrewAIFlowAdapter(SimpleAdapter[CrewAIFlowSessionState]):
         self._tagged_peer_policy = tagged_peer_policy
         self._sequential_chains: dict[str, str] = dict(sequential_chains or {})
         self._accept_agent_initiated = accept_agent_initiated
+        self._custom_tools = custom_tools_by_name
 
         self._tool_loop: asyncio.AbstractEventLoop | None = None
 
@@ -1854,6 +1985,7 @@ class CrewAIFlowAdapter(SimpleAdapter[CrewAIFlowSessionState]):
             run_id=run_id,
             state=state,
             features=self.features,
+            custom_tools=self._custom_tools,
             fallback_loop=self._tool_loop,
         )
         token = _current_flow_runtime.set(runtime)

--- a/src/thenvoi/integrations/crewai/tools.py
+++ b/src/thenvoi/integrations/crewai/tools.py
@@ -18,7 +18,6 @@ one platform tool surface.
 from __future__ import annotations
 
 import asyncio
-import inspect
 import json
 import logging
 from dataclasses import dataclass
@@ -48,7 +47,11 @@ from thenvoi.core.protocols import AgentToolsProtocol
 from thenvoi.core.tool_filter import filter_tool_schemas
 from thenvoi.core.types import AdapterFeatures, Capability, Emit
 from thenvoi.integrations.crewai.runtime import run_async
-from thenvoi.runtime.custom_tools import CustomToolDef, get_custom_tool_name
+from thenvoi.runtime.custom_tools import (
+    CustomToolDef,
+    execute_custom_tool,
+    get_custom_tool_name,
+)
 from thenvoi.runtime.tools import get_tool_description
 
 logger = logging.getLogger(__name__)
@@ -959,14 +962,8 @@ def _make_custom_tools(
                 def _run(self, *_args: Any, **kwargs: Any) -> Any:
                     async def execute(_tools: AgentToolsProtocol) -> str:
                         try:
-                            validated = model.model_validate(kwargs)
                             await reporter.report_call(_tools, _tool_name, kwargs)
-
-                            if inspect.iscoroutinefunction(handler):
-                                result = await handler(validated)
-                            else:
-                                result = handler(validated)
-
+                            result = await execute_custom_tool((model, handler), kwargs)
                             await reporter.report_result(_tools, _tool_name, result)
                             if isinstance(result, str):
                                 return json.dumps(

--- a/src/thenvoi/runtime/custom_tools.py
+++ b/src/thenvoi/runtime/custom_tools.py
@@ -8,7 +8,9 @@ and execute custom tools with validation.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
+from functools import lru_cache
 from typing import Any, Callable
 
 from pydantic import BaseModel, ValidationError
@@ -146,6 +148,14 @@ def find_custom_tool(
     return None
 
 
+@lru_cache(maxsize=256)
+def _custom_tool_accepts_input(func: Callable[..., Any]) -> bool:
+    try:
+        return len(inspect.signature(func).parameters) > 0
+    except (TypeError, ValueError):
+        return True
+
+
 async def execute_custom_tool(
     tool: CustomToolDef,
     arguments: dict[str, Any],
@@ -179,6 +189,14 @@ async def execute_custom_tool(
             f"Invalid arguments for {tool_name}: {', '.join(errors)}"
         ) from e
 
+    accepts_input = _custom_tool_accepts_input(func)
+    if not accepts_input and (arguments or model.model_fields):
+        tool_name = get_custom_tool_name(model)
+        raise ValueError(
+            f"Invalid handler for {tool_name}: zero-argument handlers require an empty InputModel and no arguments"
+        )
+    args = (validated,) if accepts_input else ()
+
     if asyncio.iscoroutinefunction(func):
-        return await func(validated)
-    return func(validated)
+        return await func(*args)
+    return func(*args)

--- a/tests/adapters/test_crewai_flow_adapter.py
+++ b/tests/adapters/test_crewai_flow_adapter.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import BaseModel
 
 
 # Mock crewai imports BEFORE importing the adapter module so the optional
@@ -91,6 +92,20 @@ class TestInit:
         )
         assert isinstance(adapter._state_source, HistoryCrewAIFlowStateSource)
 
+    def test_init_accepts_additional_tools(self) -> None:
+        class EmailsInput(BaseModel):
+            pass
+
+        def emails() -> str:
+            return "inbox"
+
+        adapter = CrewAIFlowAdapter(
+            flow_factory=_factory,
+            additional_tools=[(EmailsInput, emails)],
+        )
+
+        assert list(adapter._custom_tools) == ["emails"]
+
 
 # ---------------------------------------------------------------------------
 # Validation
@@ -101,6 +116,26 @@ class TestValidation:
     def test_flow_factory_must_be_callable(self) -> None:
         with pytest.raises(ThenvoiConfigError):
             CrewAIFlowAdapter(flow_factory="not callable")  # type: ignore[arg-type]
+
+    def test_additional_tools_requires_pydantic_model(self) -> None:
+        with pytest.raises(ThenvoiConfigError):
+            CrewAIFlowAdapter(
+                flow_factory=_factory,
+                additional_tools=[(object, lambda: None)],  # type: ignore[list-item]
+            )
+
+    def test_additional_tools_rejects_duplicate_names(self) -> None:
+        class EmailsInput(BaseModel):
+            pass
+
+        with pytest.raises(ThenvoiConfigError, match="Duplicate custom tool name"):
+            CrewAIFlowAdapter(
+                flow_factory=_factory,
+                additional_tools=[
+                    (EmailsInput, lambda: None),
+                    (EmailsInput, lambda: None),
+                ],
+            )
 
     def test_state_source_must_have_load_task_events(self) -> None:
         with pytest.raises(ThenvoiConfigError):

--- a/tests/adapters/test_crewai_flow_phase3.py
+++ b/tests/adapters/test_crewai_flow_phase3.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import BaseModel, Field
 
 
 @pytest.fixture(autouse=True)
@@ -40,7 +42,7 @@ from thenvoi.adapters.crewai_flow import (  # noqa: E402
     get_current_flow_runtime,
 )
 from thenvoi.converters.crewai_flow import CrewAIFlowStateConverter  # noqa: E402
-from thenvoi.core.types import AdapterFeatures, Capability, PlatformMessage  # noqa: E402
+from thenvoi.core.types import AdapterFeatures, Capability, Emit, PlatformMessage  # noqa: E402
 from thenvoi.testing.fake_tools import FakeAgentTools  # noqa: E402
 
 
@@ -496,6 +498,128 @@ class TestRuntimeTools:
         assert "create_crewai_tools" in public_attrs
 
     @pytest.mark.asyncio
+    async def test_runtime_exposes_registered_custom_tool_by_attribute(self) -> None:
+        class EmailsInput(BaseModel):
+            """Return the user's recent emails."""
+
+        def emails() -> str:
+            return "inbox text"
+
+        def factory():
+            class _Flow:
+                async def kickoff_async(self, inputs: dict | None = None) -> Any:
+                    rt = get_current_flow_runtime()
+                    assert rt is not None
+                    result = await rt.tools.emails()
+                    assert result == "inbox text"
+                    assert rt.tools.names == ("emails",)
+                    assert rt.tools.anthropic_schemas[0]["name"] == "emails"
+                    return {
+                        "decision": "direct_response",
+                        "content": result,
+                        "mentions": [],
+                    }
+
+            return _Flow()
+
+        adapter = CrewAIFlowAdapter(
+            flow_factory=factory,
+            state_source=HistoryCrewAIFlowStateSource(acknowledge_test_only=True),
+            additional_tools=[(EmailsInput, emails)],
+        )
+        tools = FakeAgentTools()
+        await _run_one_turn(adapter, tools, _msg())
+
+        assert tools.messages_sent == [
+            {"id": "msg-0", "content": "inbox text", "mentions": ["user-1"]}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_runtime_call_tool_validates_inputs_and_supports_async_handlers(
+        self,
+    ) -> None:
+        class EchoInput(BaseModel):
+            """Echo text."""
+
+            message: str = Field(description="Message to echo")
+
+        async def echo(args: EchoInput) -> str:
+            return f"Echo: {args.message}"
+
+        captured = {}
+
+        def factory():
+            class _Flow:
+                async def kickoff_async(self, inputs: dict | None = None) -> Any:
+                    rt = get_current_flow_runtime()
+                    assert rt is not None
+                    captured["result"] = await rt.call_tool(
+                        "echo", {"message": "hello"}
+                    )
+                    with pytest.raises(ValueError, match="message"):
+                        await rt.call_tool("echo", {})
+                    return {"decision": "waiting", "reason": "done"}
+
+            return _Flow()
+
+        adapter = CrewAIFlowAdapter(
+            flow_factory=factory,
+            state_source=HistoryCrewAIFlowStateSource(acknowledge_test_only=True),
+            additional_tools=[(EchoInput, echo)],
+        )
+        tools = FakeAgentTools()
+        await _run_one_turn(adapter, tools, _msg())
+
+        assert captured["result"] == "Echo: hello"
+
+    @pytest.mark.asyncio
+    async def test_runtime_custom_tool_reports_execution_events(self) -> None:
+        class EchoInput(BaseModel):
+            """Echo text."""
+
+            message: str = Field(description="Message to echo")
+
+        def echo(args: EchoInput) -> str:
+            return f"Echo: {args.message}"
+
+        def factory():
+            class _Flow:
+                async def kickoff_async(self, inputs: dict | None = None) -> Any:
+                    rt = get_current_flow_runtime()
+                    assert rt is not None
+                    await rt.call_tool("echo", message="hello")
+                    return {"decision": "waiting", "reason": "done"}
+
+            return _Flow()
+
+        adapter = CrewAIFlowAdapter(
+            flow_factory=factory,
+            state_source=HistoryCrewAIFlowStateSource(acknowledge_test_only=True),
+            additional_tools=[(EchoInput, echo)],
+            features=AdapterFeatures(emit=frozenset({Emit.EXECUTION})),
+        )
+        tools = FakeAgentTools()
+        await _run_one_turn(adapter, tools, _msg())
+
+        tool_events = [
+            event
+            for event in tools.events_sent
+            if event["message_type"].startswith("tool_")
+        ]
+        assert [event["message_type"] for event in tool_events] == [
+            "tool_call",
+            "tool_result",
+        ]
+        assert json.loads(tool_events[0]["content"]) == {
+            "tool": "echo",
+            "input": {"message": "hello"},
+        }
+        assert json.loads(tool_events[1]["content"]) == {
+            "tool": "echo",
+            "result": "Echo: hello",
+        }
+
+    @pytest.mark.asyncio
     async def test_ensure_participant_refreshes_snapshot_for_same_turn_delegation(
         self,
     ) -> None:
@@ -544,6 +668,49 @@ class TestRuntimeTools:
         assert tools.messages_sent == [
             {"id": "msg-0", "content": "please help", "mentions": [participant_id]}
         ]
+
+    @pytest.mark.asyncio
+    async def test_create_crewai_tools_includes_adapter_registered_custom_tools(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_tools_module = MagicMock()
+        mock_tools_module.BaseTool = type("BaseTool", (), {})
+        monkeypatch.setitem(sys.modules, "crewai.tools", mock_tools_module)
+        for mod in (
+            "thenvoi.integrations.crewai",
+            "thenvoi.integrations.crewai.runtime",
+            "thenvoi.integrations.crewai.tools",
+        ):
+            sys.modules.pop(mod, None)
+
+        class EmailsInput(BaseModel):
+            """Return the user's recent emails."""
+
+        def emails() -> str:
+            return "inbox text"
+
+        captured = {}
+
+        def factory():
+            class _Flow:
+                async def kickoff_async(self, inputs: dict | None = None) -> Any:
+                    rt = get_current_flow_runtime()
+                    assert rt is not None
+                    captured["tool_names"] = {t.name for t in rt.create_crewai_tools()}
+                    return {"decision": "waiting", "reason": "checking tools"}
+
+            return _Flow()
+
+        adapter = CrewAIFlowAdapter(
+            flow_factory=factory,
+            state_source=HistoryCrewAIFlowStateSource(acknowledge_test_only=True),
+            additional_tools=[(EmailsInput, emails)],
+        )
+        tools = FakeAgentTools()
+        await _run_one_turn(adapter, tools, _msg())
+
+        assert "thenvoi_send_message" in captured["tool_names"]
+        assert "emails" in captured["tool_names"]
 
     @pytest.mark.asyncio
     async def test_create_crewai_tools_applies_adapter_feature_filters(

--- a/tests/integrations/test_crewai_flow_real_sdk.py
+++ b/tests/integrations/test_crewai_flow_real_sdk.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from crewai.flow.flow import Flow, start
+from pydantic import BaseModel
+
+from thenvoi.adapters.crewai_flow import (
+    CrewAIFlowAdapter,
+    HistoryCrewAIFlowStateSource,
+    get_current_flow_runtime,
+)
+from thenvoi.core.types import PlatformMessage
+from thenvoi.testing.fake_tools import FakeAgentTools
+
+
+class EmailsInput(BaseModel):
+    """Return the user's recent emails."""
+
+
+@pytest.mark.asyncio
+async def test_real_crewai_flow_can_call_adapter_registered_custom_tool() -> None:
+    calls: list[str] = []
+
+    def emails() -> str:
+        calls.append("emails")
+        return "real crewai flow inbox text"
+
+    class InboxFlow(Flow):
+        @start()
+        async def decide(self) -> dict[str, Any]:
+            runtime = get_current_flow_runtime()
+            assert runtime is not None
+            result = await runtime.tools.emails()
+            via_name = await runtime.call_tool("emails")
+            assert result == via_name == "real crewai flow inbox text"
+            return {"decision": "direct_response", "content": result, "mentions": []}
+
+    msg = PlatformMessage(
+        id="msg-real-flow",
+        room_id="room-real-flow",
+        content="build a deck from my emails",
+        sender_id="user-real",
+        sender_type="User",
+        sender_name="Pat",
+        message_type="text",
+        metadata={},
+        created_at=datetime.now(timezone.utc),
+    )
+    adapter = CrewAIFlowAdapter(
+        flow_factory=InboxFlow,
+        state_source=HistoryCrewAIFlowStateSource(acknowledge_test_only=True),
+        additional_tools=[(EmailsInput, emails)],
+    )
+    tools = FakeAgentTools(room_id="room-real-flow")
+
+    await adapter.on_started("agent-real", "Real Flow validation")
+    await adapter.on_message(
+        msg=msg,
+        tools=tools,
+        history=None,  # type: ignore[arg-type]
+        participants_msg=None,
+        contacts_msg=None,
+        is_session_bootstrap=True,
+        room_id="room-real-flow",
+    )
+
+    assert calls == ["emails", "emails"]
+    assert tools.messages_sent == [
+        {
+            "id": "msg-0",
+            "content": "real crewai flow inbox text",
+            "mentions": ["user-real"],
+        }
+    ]


### PR DESCRIPTION
## Summary
- Add `additional_tools` to `CrewAIFlowAdapter` with the same `(InputModel, callable)` shape as `CrewAIAdapter`.
- Expose registered tools inside CrewAI Flow execution through `runtime.tools.<name>()` and `runtime.call_tool(...)`, with Pydantic validation and sync/async handler support.
- Emit `tool_call` / `tool_result` events when `features=AdapterFeatures(emit={Emit.EXECUTION})` is configured.
- Add a real CrewAI SDK Flow regression test using `Flow` + `@start()` and a custom tool called from inside the Flow.
- Add an example under `examples/crewai/`.

## Test plan
- `uv run pytest tests/integrations/test_crewai_flow_real_sdk.py -q`
- `uv run pytest tests/adapters/test_crewai_flow_adapter.py tests/adapters/test_crewai_flow_phase3.py tests/adapters/test_crewai_adapter.py::TestCustomTools tests/integrations/test_crewai_tools.py -q`
- `uv run ruff check . && uv run ruff format --check . && uv run pyrefly check`

Fixes INT-451.