### PR TITLE
feat(agent): add bootstrap_room_message for self-starting agents

### DIFF
--- a/examples/scenarios/self_start_kickoff.py
+++ b/examples/scenarios/self_start_kickoff.py
@@ -6,22 +6,21 @@
 # thenvoi-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
 # ///
 """
-Self-starting agent example using ``Agent.kickoff()``.
+Self-starting agent example using ``Agent.bootstrap_room_message()``.
 
 Most agents react to messages from the platform. Sometimes you want the
 opposite: the agent should start working on its own, with an initial
 message that did NOT come from a real user — for example, a webhook that
 just received an event, or a cron job that wakes the agent every morning.
 
-``Agent.kickoff(content)`` does exactly that. It optionally creates a
-fresh chat room, then injects a synthetic in-memory message so the
-adapter starts processing as if the user had typed it. The message is
-NOT persisted on the platform and other participants never see it.
+``Agent.bootstrap_room_message(content)`` does exactly that. Pass a
+plain string and it creates a fresh chat room, then injects a synthetic
+in-memory message so the adapter starts processing as if the user had
+typed it. The message is NOT persisted on the platform and other
+participants never see it.
 
-This example shows the kickoff message dropping the agent into a fresh
-room and telling it to use platform tools (peer lookup, contacts, room
-participants) to recruit collaborators rather than answering alone — the
-collaborative behavior is the point of Thenvoi.
+For external systems that need stable ids for retry/replay idempotency,
+pass a ``PlatformMessage`` with your own ``id`` and a ``room_id``.
 
 Run with:
     uv run examples/scenarios/self_start_kickoff.py
@@ -96,8 +95,8 @@ async def main() -> None:
     )
 
     async with agent:
-        room_id = await agent.kickoff(KICKOFF_MESSAGE)
-        logger.info("Kicked off in room %s", room_id)
+        room_id = await agent.bootstrap_room_message(KICKOFF_MESSAGE)
+        logger.info("Bootstrapped agent in room %s", room_id)
         # Stay running so the agent can iterate with the peers it invites.
         await agent.run_forever()
 

--- a/examples/scenarios/self_start_kickoff.py
+++ b/examples/scenarios/self_start_kickoff.py
@@ -1,0 +1,90 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["thenvoi-sdk[anthropic]", "python-dotenv"]
+#
+# [tool.uv.sources]
+# thenvoi-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# ///
+"""
+Self-starting agent example using ``Agent.kickoff()``.
+
+Most agents react to messages from the platform. Sometimes you want the
+opposite: the agent should start working on its own, with an initial
+message that did NOT come from a real user — for example, a webhook that
+just received a deploy event, or a cron job that wakes an agent every
+morning to file a daily report.
+
+``Agent.kickoff(content)`` does exactly that. It optionally creates a
+fresh chat room, then injects a synthetic in-memory message so the
+adapter starts processing as if the user had typed it. The message is
+NOT persisted on the platform and other participants never see it.
+
+Run with:
+    uv run examples/scenarios/self_start_kickoff.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from anthropic.setup_logging import setup_logging  # noqa: E402
+from thenvoi import Agent  # noqa: E402
+from thenvoi.adapters import AnthropicAdapter  # noqa: E402
+from thenvoi.config import load_agent_config  # noqa: E402
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("THENVOI_WS_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
+    if not ws_url:
+        raise ValueError("THENVOI_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("THENVOI_REST_URL environment variable is required")
+
+    agent_id, api_key = load_agent_config("anthropic_agent")
+
+    adapter = AnthropicAdapter(
+        model="claude-sonnet-4-5-20250929",
+        prompt=(
+            "You are a helpful assistant. When kicked off, do the work the "
+            "kickoff message asks for and report your findings concisely."
+        ),
+    )
+
+    agent = Agent.create(
+        adapter=adapter,
+        agent_id=agent_id,
+        api_key=api_key,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    async with agent:
+        # Create a fresh chat room and seed it with the initial task. The
+        # adapter will receive this as a normal message and respond as it
+        # would to any other input.
+        room_id = await agent.kickoff(
+            "Please look up the weather in San Francisco and Paris, then "
+            "summarize which one is more pleasant right now."
+        )
+        logger.info("Kicked off in room %s", room_id)
+
+        # Keep running so the agent can finish the work, observe its own
+        # response, and respond to any human follow-ups in the new room.
+        await agent.run_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/scenarios/self_start_kickoff.py
+++ b/examples/scenarios/self_start_kickoff.py
@@ -11,13 +11,17 @@ Self-starting agent example using ``Agent.kickoff()``.
 Most agents react to messages from the platform. Sometimes you want the
 opposite: the agent should start working on its own, with an initial
 message that did NOT come from a real user — for example, a webhook that
-just received a deploy event, or a cron job that wakes an agent every
-morning to file a daily report.
+just received an event, or a cron job that wakes the agent every morning.
 
 ``Agent.kickoff(content)`` does exactly that. It optionally creates a
 fresh chat room, then injects a synthetic in-memory message so the
 adapter starts processing as if the user had typed it. The message is
 NOT persisted on the platform and other participants never see it.
+
+This example shows the kickoff message dropping the agent into a fresh
+room and telling it to use platform tools (peer lookup, contacts, room
+participants) to recruit collaborators rather than answering alone — the
+collaborative behavior is the point of Thenvoi.
 
 Run with:
     uv run examples/scenarios/self_start_kickoff.py
@@ -43,6 +47,25 @@ setup_logging()
 logger = logging.getLogger(__name__)
 
 
+KICKOFF_MESSAGE = """\
+You are starting in a fresh chat room with no other participants yet.
+Your job: find out the current weather in San Francisco and Paris.
+
+You don't have a weather tool yourself. Use the platform to recruit
+help:
+
+1. Look up peers (agents or users) that can help with weather, web
+   search, or general lookups.
+2. Add the most promising candidate to this room.
+3. Ask them, in this room, for the current weather in both cities.
+4. When you have answers from the collaborator, summarize which city is
+   more pleasant right now and stop.
+
+Prefer asking real collaborators over guessing. If no peer is available,
+say so plainly instead of fabricating numbers.
+"""
+
+
 async def main() -> None:
     load_dotenv()
 
@@ -56,10 +79,11 @@ async def main() -> None:
     agent_id, api_key = load_agent_config("anthropic_agent")
 
     adapter = AnthropicAdapter(
-        model="claude-sonnet-4-5-20250929",
+        model="claude-sonnet-4-6",
         prompt=(
-            "You are a helpful assistant. When kicked off, do the work the "
-            "kickoff message asks for and report your findings concisely."
+            "You are a coordinator agent on the Thenvoi platform. You can "
+            "discover peers, add them to rooms, and message them. Prefer "
+            "delegating specialized work to peers over answering alone."
         ),
     )
 
@@ -72,17 +96,9 @@ async def main() -> None:
     )
 
     async with agent:
-        # Create a fresh chat room and seed it with the initial task. The
-        # adapter will receive this as a normal message and respond as it
-        # would to any other input.
-        room_id = await agent.kickoff(
-            "Please look up the weather in San Francisco and Paris, then "
-            "summarize which one is more pleasant right now."
-        )
+        room_id = await agent.kickoff(KICKOFF_MESSAGE)
         logger.info("Kicked off in room %s", room_id)
-
-        # Keep running so the agent can finish the work, observe its own
-        # response, and respond to any human follow-ups in the new room.
+        # Stay running so the agent can iterate with the peers it invites.
         await agent.run_forever()
 
 

--- a/src/thenvoi/agent.py
+++ b/src/thenvoi/agent.py
@@ -380,6 +380,10 @@ class Agent:
         adapter as a synthetic ``MessageEvent`` — no platform persistence,
         no mark_processing/mark_processed lifecycle.
 
+        Safe to call repeatedly: each call with ``room_id=None`` creates a
+        new room. The returned room id is ready to use immediately with the
+        rest of the Agent / AgentTools API.
+
         Args:
             content: The initial message content for the agent.
             room_id: Existing room to inject into. If None, a new room is

--- a/src/thenvoi/agent.py
+++ b/src/thenvoi/agent.py
@@ -336,35 +336,8 @@ class Agent:
         await self._runtime.run_forever()
 
     async def bootstrap_room_message(
-        self, room_id: str, message: PlatformMessage
-    ) -> None:
-        """
-        Kick the agent off in ``room_id`` with an initial message that did NOT
-        come from the platform.
-
-        Low-level primitive behind :meth:`kickoff`. Use this when you want
-        full control over the synthetic ``PlatformMessage`` — in particular
-        its ``id``. External systems often pass stable ids (e.g.
-        ``"daily-standup:2026-05-06"`` or ``"webhook:{event_id}"``) so they
-        can dedupe retries and replays.
-
-        The message is delivered to the adapter exactly like a real chat
-        message but is NOT persisted on the platform: nothing is written to
-        the database, no mark_processing / mark_processed lifecycle, and
-        other participants never see it.
-
-        Returns as soon as the message is enqueued. The adapter processes it
-        asynchronously on the execution context's loop.
-
-        Requires :meth:`start` to have been called.
-        """
-        if not self._started:
-            raise RuntimeError("Agent not started")
-        await self._runtime.bootstrap_room_message(room_id, message)
-
-    async def kickoff(
         self,
-        content: str,
+        content: str | PlatformMessage,
         *,
         room_id: str | None = None,
         task_id: str | None = None,
@@ -376,43 +349,64 @@ class Agent:
         Start the agent on its own with an initial message that did NOT come
         through the platform.
 
-        If ``room_id`` is omitted, a fresh chat room is created (optionally
-        linked to ``task_id``). The message is delivered to the agent's
-        adapter as a synthetic ``MessageEvent`` — no platform persistence,
-        no mark_processing/mark_processed lifecycle.
-
-        Safe to call repeatedly: each call with ``room_id=None`` creates a
-        new room. The returned room id is ready to use immediately with the
-        rest of the Agent / AgentTools API.
+        If ``room_id`` is omitted, a fresh chat room is created (linked to
+        ``task_id`` when provided). The message is delivered to the adapter
+        exactly like a real chat message but is NOT persisted on the
+        platform: nothing is written to the database, no
+        mark_processing / mark_processed lifecycle, and other participants
+        never see it.
 
         Returns as soon as the message is enqueued. The adapter processes it
         asynchronously on the execution context's loop.
 
+        Two calling shapes:
+
+        - ``bootstrap_room_message("do the thing")`` — pass a plain string.
+          The message id, sender identity, and timestamp are filled in.
+        - ``bootstrap_room_message(PlatformMessage(...), room_id=...)`` —
+          pass a fully-constructed ``PlatformMessage`` when you need
+          control over the message ``id`` (external systems often want
+          stable ids like ``"daily-standup:2026-05-06"`` or
+          ``"webhook:{event_id}"`` for retry / replay idempotency). The
+          ``room_id`` arg is required in this shape.
+
         Args:
-            content: The initial message content for the agent.
-            room_id: Existing room to inject into. If None, a new room is
-                created via REST.
+            content: The initial message — either a plain string or a
+                fully-constructed ``PlatformMessage``.
+            room_id: Existing room to inject into. Required when ``content``
+                is a ``PlatformMessage``. When omitted with a string, a new
+                room is created via REST.
             task_id: Optional task association when creating a new room.
+                Ignored when ``content`` is a ``PlatformMessage`` or
+                ``room_id`` is given.
             message_type: Platform message type. Defaults to ``"message"``.
+                Ignored when ``content`` is a ``PlatformMessage``.
             metadata: Optional metadata dict (mentions/status are filled in
-                if missing).
+                if missing). Ignored when ``content`` is a
+                ``PlatformMessage``.
             message_id: Stable id for the synthetic message. Defaults to a
-                generated ``"kickoff:{uuid4}"``. Provide your own when an
-                external system needs to dedupe by id.
+                generated ``"kickoff:{uuid4}"``. Ignored when ``content`` is
+                a ``PlatformMessage`` (use ``message.id`` instead).
 
         Returns:
-            The room id the kickoff was injected into (newly created when
+            The room id the message was injected into (newly created when
             ``room_id`` was None; otherwise the same id that was passed in).
         """
         if not self._started:
             raise RuntimeError("Agent not started")
 
-        link = self._runtime.link
+        if isinstance(content, PlatformMessage):
+            if room_id is None:
+                raise ValueError(
+                    "room_id is required when content is a PlatformMessage"
+                )
+            await self._runtime.bootstrap_room_message(room_id, content)
+            return room_id
 
         if room_id is None:
             from thenvoi.client.rest import ChatRoomRequest, DEFAULT_REQUEST_OPTIONS
 
-            response = await link.rest.agent_api_chats.create_agent_chat(
+            response = await self._runtime.link.rest.agent_api_chats.create_agent_chat(
                 chat=ChatRoomRequest(task_id=task_id),
                 request_options=DEFAULT_REQUEST_OPTIONS,
             )
@@ -421,7 +415,7 @@ class Agent:
                     f"create_agent_chat returned no data for task_id={task_id!r}"
                 )
             room_id = response.data.id
-            logger.info("Kickoff created new room: %s", room_id)
+            logger.info("Bootstrap created new room: %s", room_id)
 
         # Sender identity is intentionally fixed to the synthetic constants —
         # ExecutionContext relies on (sender_type=System, sender_id=kickoff)
@@ -438,7 +432,7 @@ class Agent:
             metadata=metadata or {},
             created_at=datetime.now(timezone.utc),
         )
-        await self.bootstrap_room_message(room_id, message)
+        await self._runtime.bootstrap_room_message(room_id, message)
         return room_id
 
     async def _on_execute(

--- a/src/thenvoi/agent.py
+++ b/src/thenvoi/agent.py
@@ -353,6 +353,9 @@ class Agent:
         the database, no mark_processing / mark_processed lifecycle, and
         other participants never see it.
 
+        Returns as soon as the message is enqueued. The adapter processes it
+        asynchronously on the execution context's loop.
+
         Requires :meth:`start` to have been called.
         """
         if not self._started:
@@ -365,8 +368,6 @@ class Agent:
         *,
         room_id: str | None = None,
         task_id: str | None = None,
-        sender_id: str | None = None,
-        sender_name: str | None = None,
         message_type: str = "message",
         metadata: dict[str, Any] | None = None,
         message_id: str | None = None,
@@ -384,14 +385,14 @@ class Agent:
         new room. The returned room id is ready to use immediately with the
         rest of the Agent / AgentTools API.
 
+        Returns as soon as the message is enqueued. The adapter processes it
+        asynchronously on the execution context's loop.
+
         Args:
             content: The initial message content for the agent.
             room_id: Existing room to inject into. If None, a new room is
                 created via REST.
             task_id: Optional task association when creating a new room.
-            sender_id: Override the synthetic sender id (defaults to
-                ``"kickoff"``). Most callers should leave this as the default.
-            sender_name: Display name for the synthetic sender.
             message_type: Platform message type. Defaults to ``"message"``.
             metadata: Optional metadata dict (mentions/status are filled in
                 if missing).
@@ -401,7 +402,7 @@ class Agent:
 
         Returns:
             The room id the kickoff was injected into (newly created when
-            ``room_id`` was None).
+            ``room_id`` was None; otherwise the same id that was passed in).
         """
         if not self._started:
             raise RuntimeError("Agent not started")
@@ -416,17 +417,23 @@ class Agent:
                 request_options=DEFAULT_REQUEST_OPTIONS,
             )
             if not response.data:
-                raise RuntimeError("Failed to create chat room for kickoff")
+                raise RuntimeError(
+                    f"create_agent_chat returned no data for task_id={task_id!r}"
+                )
             room_id = response.data.id
             logger.info("Kickoff created new room: %s", room_id)
 
+        # Sender identity is intentionally fixed to the synthetic constants —
+        # ExecutionContext relies on (sender_type=System, sender_id=kickoff)
+        # to skip platform persistence. ExecutionContext.bootstrap_message
+        # forces these regardless of what is set here.
         message = PlatformMessage(
             id=message_id or f"kickoff:{uuid.uuid4()}",
             room_id=room_id,
             content=content,
-            sender_id=sender_id or SYNTHETIC_KICKOFF_SENDER_ID,
+            sender_id=SYNTHETIC_KICKOFF_SENDER_ID,
             sender_type=SYNTHETIC_SENDER_TYPE,
-            sender_name=sender_name or SYNTHETIC_KICKOFF_SENDER_NAME,
+            sender_name=SYNTHETIC_KICKOFF_SENDER_NAME,
             message_type=message_type,
             metadata=metadata or {},
             created_at=datetime.now(timezone.utc),

--- a/src/thenvoi/agent.py
+++ b/src/thenvoi/agent.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import uuid
+from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _get_version
 from pathlib import Path
@@ -17,7 +19,11 @@ from thenvoi.runtime.types import (
     ContactEventConfig,
     ParticipantAddedCallback,
     ParticipantRemovedCallback,
+    PlatformMessage,
     SessionConfig,
+    SYNTHETIC_KICKOFF_SENDER_ID,
+    SYNTHETIC_KICKOFF_SENDER_NAME,
+    SYNTHETIC_SENDER_TYPE,
 )
 from thenvoi.preprocessing.default import DefaultPreprocessor
 
@@ -328,6 +334,101 @@ class Agent:
                 await agent.stop()
         """
         await self._runtime.run_forever()
+
+    async def bootstrap_room_message(
+        self, room_id: str, message: PlatformMessage
+    ) -> None:
+        """
+        Kick the agent off in ``room_id`` with an initial message that did NOT
+        come from the platform.
+
+        Low-level primitive behind :meth:`kickoff`. Use this when you want
+        full control over the synthetic ``PlatformMessage`` — in particular
+        its ``id``. External systems often pass stable ids (e.g.
+        ``"daily-standup:2026-05-06"`` or ``"webhook:{event_id}"``) so they
+        can dedupe retries and replays.
+
+        The message is delivered to the adapter exactly like a real chat
+        message but is NOT persisted on the platform: nothing is written to
+        the database, no mark_processing / mark_processed lifecycle, and
+        other participants never see it.
+
+        Requires :meth:`start` to have been called.
+        """
+        if not self._started:
+            raise RuntimeError("Agent not started")
+        await self._runtime.bootstrap_room_message(room_id, message)
+
+    async def kickoff(
+        self,
+        content: str,
+        *,
+        room_id: str | None = None,
+        task_id: str | None = None,
+        sender_id: str | None = None,
+        sender_name: str | None = None,
+        message_type: str = "message",
+        metadata: dict[str, Any] | None = None,
+        message_id: str | None = None,
+    ) -> str:
+        """
+        Start the agent on its own with an initial message that did NOT come
+        through the platform.
+
+        If ``room_id`` is omitted, a fresh chat room is created (optionally
+        linked to ``task_id``). The message is delivered to the agent's
+        adapter as a synthetic ``MessageEvent`` — no platform persistence,
+        no mark_processing/mark_processed lifecycle.
+
+        Args:
+            content: The initial message content for the agent.
+            room_id: Existing room to inject into. If None, a new room is
+                created via REST.
+            task_id: Optional task association when creating a new room.
+            sender_id: Override the synthetic sender id (defaults to
+                ``"kickoff"``). Most callers should leave this as the default.
+            sender_name: Display name for the synthetic sender.
+            message_type: Platform message type. Defaults to ``"message"``.
+            metadata: Optional metadata dict (mentions/status are filled in
+                if missing).
+            message_id: Stable id for the synthetic message. Defaults to a
+                generated ``"kickoff:{uuid4}"``. Provide your own when an
+                external system needs to dedupe by id.
+
+        Returns:
+            The room id the kickoff was injected into (newly created when
+            ``room_id`` was None).
+        """
+        if not self._started:
+            raise RuntimeError("Agent not started")
+
+        link = self._runtime.link
+
+        if room_id is None:
+            from thenvoi.client.rest import ChatRoomRequest, DEFAULT_REQUEST_OPTIONS
+
+            response = await link.rest.agent_api_chats.create_agent_chat(
+                chat=ChatRoomRequest(task_id=task_id),
+                request_options=DEFAULT_REQUEST_OPTIONS,
+            )
+            if not response.data:
+                raise RuntimeError("Failed to create chat room for kickoff")
+            room_id = response.data.id
+            logger.info("Kickoff created new room: %s", room_id)
+
+        message = PlatformMessage(
+            id=message_id or f"kickoff:{uuid.uuid4()}",
+            room_id=room_id,
+            content=content,
+            sender_id=sender_id or SYNTHETIC_KICKOFF_SENDER_ID,
+            sender_type=SYNTHETIC_SENDER_TYPE,
+            sender_name=sender_name or SYNTHETIC_KICKOFF_SENDER_NAME,
+            message_type=message_type,
+            metadata=metadata or {},
+            created_at=datetime.now(timezone.utc),
+        )
+        await self.bootstrap_room_message(room_id, message)
+        return room_id
 
     async def _on_execute(
         self,

--- a/src/thenvoi/runtime/execution.py
+++ b/src/thenvoi/runtime/execution.py
@@ -132,6 +132,23 @@ class Execution(Protocol):
         """Handle a platform event for this room."""
         ...
 
+    async def bootstrap_message(self, message: PlatformMessage) -> None:
+        """Inject a synthetic kickoff message into this execution.
+
+        .. versionchanged:: 0.3.0
+            Custom ``Execution`` implementations should add ``bootstrap_message()``.
+            ``AgentRuntime`` falls back safely for legacy implementations that do
+            not provide it (raises ``RuntimeError`` at the bootstrap call site),
+            but typed protocol conformance now includes this method.
+
+        Called by ``Agent.kickoff`` and ``Agent.bootstrap_room_message`` to start
+        the agent on its own with an initial message that did not come through
+        the platform. The supplied ``PlatformMessage`` is wrapped as a synthetic
+        ``MessageEvent`` and delivered to the adapter without platform
+        persistence, retry tracking, or other-participant visibility.
+        """
+        ...
+
     async def request_resync(self) -> None:
         """Signal the process loop to re-poll /next immediately.
 

--- a/src/thenvoi/runtime/execution.py
+++ b/src/thenvoi/runtime/execution.py
@@ -1236,7 +1236,10 @@ class ExecutionContext:
                 and payload.sender_id in SYNTHETIC_SENDER_IDS
             )
             if is_synthetic:
-                logger.debug("Processing synthetic contact event message")
+                logger.debug(
+                    "Processing synthetic message (sender_id=%s)",
+                    payload.sender_id,
+                )
                 msg_id = None  # Clear to skip message marking later
                 # Skip all tracking for synthetic messages - go directly to processing
             else:

--- a/src/thenvoi/runtime/execution.py
+++ b/src/thenvoi/runtime/execution.py
@@ -44,7 +44,9 @@ from .types import (
     ParticipantRemovedCallback,
     SessionConfig,
     SYNTHETIC_SENDER_TYPE,
-    SYNTHETIC_CONTACT_EVENTS_SENDER_ID,
+    SYNTHETIC_KICKOFF_SENDER_ID,
+    SYNTHETIC_KICKOFF_SENDER_NAME,
+    SYNTHETIC_SENDER_IDS,
 )
 from .retry_tracker import MessageRetryTracker
 from ._context_serialization import context_item_to_dict
@@ -394,10 +396,19 @@ class ExecutionContext:
             logger.debug("Event %s enqueued for room %s", event.type, self.room_id)
             return
 
-        # Track first WebSocket message ID for sync point
+        # Track first WebSocket message ID for sync point. Skip synthetic
+        # messages (kickoff, contact-event injections) — they aren't in the DB,
+        # so using their id as the sync marker would prevent
+        # _synchronize_with_next from ever finding a matching /next row.
         if isinstance(event, MessageEvent) and self._first_ws_msg_id is None:
             msg_id = event.payload.id if event.payload else None
-            if msg_id:
+            payload = event.payload
+            is_synthetic = (
+                payload is not None
+                and payload.sender_type == SYNTHETIC_SENDER_TYPE
+                and payload.sender_id in SYNTHETIC_SENDER_IDS
+            )
+            if msg_id and not is_synthetic:
                 self._first_ws_msg_id = msg_id
                 logger.debug("Sync point marker set: %s", msg_id)
 
@@ -467,6 +478,60 @@ class ExecutionContext:
     def mark_participants_sent(self) -> None:
         """Mark current participants as sent to LLM."""
         self._last_participants_sent = self._participants.copy()
+
+    async def bootstrap_message(self, message: PlatformMessage) -> None:
+        """
+        Inject a synthetic kickoff message into this execution context.
+
+        The supplied PlatformMessage is wrapped in a MessageEvent and enqueued
+        through the same path real messages take, but with a synthetic sender
+        identity (sender_type="System", sender_id="kickoff"). _process_event
+        recognizes this combination and skips all platform persistence
+        (mark_processing / mark_processed / mark_failed) and retry tracking —
+        the message exists only in memory.
+
+        The caller-supplied message.id is preserved as-is so external systems
+        can use stable ids (e.g. ``"daily-standup:2026-05-06"`` or
+        ``"webhook:{event_id}"``) to dedupe retries and replays.
+
+        Args:
+            message: PlatformMessage to inject. id, content, sender_name,
+                message_type, metadata, and created_at are passed through.
+                sender_type and sender_id are forced to the synthetic identity.
+        """
+        from thenvoi.client.streaming import MessageCreatedPayload, MessageMetadata
+
+        metadata: dict[str, Any] = dict(message.metadata) if message.metadata else {}
+        metadata.setdefault("mentions", [])
+        metadata.setdefault("status", "sent")
+
+        created_at_str = (
+            message.created_at.isoformat()
+            if message.created_at
+            else datetime.now(timezone.utc).isoformat()
+        )
+
+        event = MessageEvent(
+            room_id=self.room_id,
+            payload=MessageCreatedPayload(
+                id=message.id,
+                content=message.content,
+                sender_id=SYNTHETIC_KICKOFF_SENDER_ID,
+                sender_type=SYNTHETIC_SENDER_TYPE,
+                sender_name=message.sender_name or SYNTHETIC_KICKOFF_SENDER_NAME,
+                message_type=message.message_type,
+                metadata=MessageMetadata(**metadata),
+                chat_room_id=self.room_id,
+                inserted_at=created_at_str,
+                updated_at=created_at_str,
+            ),
+        )
+        await self.on_event(event)
+        logger.info(
+            "Bootstrap (kickoff) message %s enqueued for room %s",
+            message.id,
+            self.room_id,
+        )
 
     def inject_system_message(self, message: str) -> None:
         """
@@ -1161,11 +1226,14 @@ class ExecutionContext:
                 logger.debug("Skipping self-message %s", msg_id)
                 return
 
-            # Detect synthetic messages (e.g., contact events injected into hub room)
-            # These don't exist in the database, so skip all tracking and marking
+            # Detect synthetic messages (e.g., contact events injected into hub
+            # room, or kickoff/bootstrap injections). These don't exist in the
+            # database, so skip all tracking and marking. Both sender_type AND
+            # sender_id must match — never broaden to type alone, since real
+            # platform "System" messages must keep full mark_* lifecycle.
             is_synthetic = (
                 payload.sender_type == SYNTHETIC_SENDER_TYPE
-                and payload.sender_id == SYNTHETIC_CONTACT_EVENTS_SENDER_ID
+                and payload.sender_id in SYNTHETIC_SENDER_IDS
             )
             if is_synthetic:
                 logger.debug("Processing synthetic contact event message")

--- a/src/thenvoi/runtime/platform_runtime.py
+++ b/src/thenvoi/runtime/platform_runtime.py
@@ -18,6 +18,7 @@ from thenvoi.runtime.types import (
     ContactEventStrategy,
     ParticipantAddedCallback,
     ParticipantRemovedCallback,
+    PlatformMessage,
     SessionConfig,
 )
 from thenvoi_rest.core.api_error import ApiError
@@ -203,6 +204,18 @@ class PlatformRuntime:
         """Run until interrupted."""
         if self._link:
             await self._link.run_forever()
+
+    async def bootstrap_room_message(
+        self, room_id: str, message: PlatformMessage
+    ) -> None:
+        """Inject a synthetic kickoff message into ``room_id``.
+
+        Forwards to ``AgentRuntime.bootstrap_room_message``. Requires the
+        runtime to be started; raises ``RuntimeError`` otherwise.
+        """
+        if self._runtime is None:
+            raise RuntimeError("Runtime not started")
+        await self._runtime.bootstrap_room_message(room_id, message)
 
     async def _fetch_agent_metadata(self) -> None:
         """Fetch agent metadata from platform."""

--- a/src/thenvoi/runtime/presence.py
+++ b/src/thenvoi/runtime/presence.py
@@ -197,6 +197,15 @@ class RoomPresence:
             logger.warning("room_added event without room_id or payload")
             return
 
+        # Skip if already tracked. Happens when bootstrap_room_message
+        # (kickoff) claimed the room and subscribed before the platform's
+        # room_added event arrived. Re-running subscribe_room would issue a
+        # duplicate Phoenix join. The filter and on_room_joined work was
+        # already done by the bootstrap path or the original add.
+        if room_id in self.rooms:
+            logger.debug("room_added for already-tracked room %s, skipping", room_id)
+            return
+
         payload = event.payload.model_dump(exclude_none=True)
 
         # Apply filter if configured

--- a/src/thenvoi/runtime/runtime.py
+++ b/src/thenvoi/runtime/runtime.py
@@ -271,8 +271,14 @@ class AgentRuntime:
         flow through the normal presence pipeline afterwards.
         """
         if room_id not in self.presence.rooms:
-            await self.link.subscribe_room(room_id)
+            # Claim the slot before awaiting subscribe_room so concurrent
+            # bootstrap calls for the same room don't double-subscribe.
             self.presence.rooms.add(room_id)
+            try:
+                await self.link.subscribe_room(room_id)
+            except Exception:
+                self.presence.rooms.discard(room_id)
+                raise
             logger.debug(
                 "Bootstrap subscribed to room %s outside presence flow", room_id
             )

--- a/src/thenvoi/runtime/runtime.py
+++ b/src/thenvoi/runtime/runtime.py
@@ -17,6 +17,7 @@ from .presence import RoomPresence
 from .types import (
     ParticipantAddedCallback,
     ParticipantRemovedCallback,
+    PlatformMessage,
     SessionConfig,
 )
 
@@ -244,6 +245,48 @@ class AgentRuntime:
                 logger.warning("Failed to request resync for room %s: %s", room_id, e)
 
     # --- Execution management ---
+
+    async def bootstrap_room_message(
+        self, room_id: str, message: PlatformMessage
+    ) -> None:
+        """
+        Kick the agent off in ``room_id`` with an initial message that did NOT
+        come from the platform.
+
+        Use this to start an agent on its own. Common examples: a webhook
+        handler that creates a fresh chat room and wants the agent to begin
+        work immediately with full context, a scheduled cron job that wakes
+        an agent at 9am to file a daily report, or a self-starting demo
+        agent. The message is delivered to the adapter exactly like a real
+        chat message, but lives only in memory: nothing is written to the
+        platform, no mark_processing / mark_processed lifecycle, no retry
+        tracking, no other participants ever see it.
+
+        The caller's ``message.id`` is preserved so external systems can use
+        stable ids (e.g. ``"daily-standup:2026-05-06"`` or
+        ``"webhook:{event_id}"``) for idempotency across retries.
+
+        If the agent has not yet joined ``room_id``, this also subscribes to
+        the room and creates its execution context, so future real messages
+        flow through the normal presence pipeline afterwards.
+        """
+        if room_id not in self.presence.rooms:
+            await self.link.subscribe_room(room_id)
+            self.presence.rooms.add(room_id)
+            logger.debug(
+                "Bootstrap subscribed to room %s outside presence flow", room_id
+            )
+
+        execution = self.executions.get(room_id)
+        if execution is None:
+            execution = await self._create_execution(room_id)
+
+        bootstrap = getattr(execution, "bootstrap_message", None)
+        if bootstrap is None:
+            raise RuntimeError(
+                f"Execution for room {room_id} does not support bootstrap_message"
+            )
+        await bootstrap(message)
 
     async def _create_execution(self, room_id: str) -> Execution:
         """Create and start execution context for a room."""

--- a/src/thenvoi/runtime/runtime.py
+++ b/src/thenvoi/runtime/runtime.py
@@ -270,29 +270,46 @@ class AgentRuntime:
         the room and creates its execution context, so future real messages
         flow through the normal presence pipeline afterwards.
         """
-        if room_id not in self.presence.rooms:
-            # Claim the slot before awaiting subscribe_room so concurrent
-            # bootstrap calls for the same room don't double-subscribe.
-            self.presence.rooms.add(room_id)
-            try:
-                await self.link.subscribe_room(room_id)
-            except Exception:
+        claimed_room = False
+        created_execution = False
+        try:
+            if room_id not in self.presence.rooms:
+                # Claim the slot before awaiting subscribe_room so concurrent
+                # bootstrap calls for the same room don't double-subscribe.
+                self.presence.rooms.add(room_id)
+                claimed_room = True
+                try:
+                    await self.link.subscribe_room(room_id)
+                except Exception:
+                    self.presence.rooms.discard(room_id)
+                    raise
+                logger.debug(
+                    "Bootstrap subscribed to room %s outside presence flow", room_id
+                )
+
+            execution = self.executions.get(room_id)
+            if execution is None:
+                execution = await self._create_execution(room_id)
+                created_execution = True
+
+            bootstrap = getattr(execution, "bootstrap_message", None)
+            if bootstrap is None:
+                raise RuntimeError(
+                    f"Execution for room {room_id} does not support bootstrap_message"
+                )
+            await bootstrap(message)
+        except Exception:
+            if created_execution:
+                await self._destroy_execution(room_id)
+            if claimed_room:
                 self.presence.rooms.discard(room_id)
-                raise
-            logger.debug(
-                "Bootstrap subscribed to room %s outside presence flow", room_id
-            )
-
-        execution = self.executions.get(room_id)
-        if execution is None:
-            execution = await self._create_execution(room_id)
-
-        bootstrap = getattr(execution, "bootstrap_message", None)
-        if bootstrap is None:
-            raise RuntimeError(
-                f"Execution for room {room_id} does not support bootstrap_message"
-            )
-        await bootstrap(message)
+                try:
+                    await self.link.unsubscribe_room(room_id)
+                except Exception:
+                    logger.exception(
+                        "Failed to unsubscribe room %s after bootstrap failure", room_id
+                    )
+            raise
 
     async def _create_execution(self, room_id: str) -> Execution:
         """Create and start execution context for a room."""
@@ -325,7 +342,11 @@ class AgentRuntime:
             )
 
         self.executions[room_id] = execution
-        await execution.start()
+        try:
+            await execution.start()
+        except Exception:
+            self.executions.pop(room_id, None)
+            raise
 
         logger.debug("Created execution for room %s", room_id)
         return execution

--- a/src/thenvoi/runtime/types.py
+++ b/src/thenvoi/runtime/types.py
@@ -37,6 +37,24 @@ SYNTHETIC_CONTACT_EVENTS_SENDER_ID = "contact-events"
 # messages. Used in MessageEvent.payload.sender_name.
 SYNTHETIC_CONTACT_EVENTS_SENDER_NAME = "Contact Events"
 
+# Sender ID for synthetic kickoff messages — bootstrap_room_message / kickoff()
+# inject these to start an agent in a room with an initial message that did not
+# come from the platform. Treated like contact-event synthetics: ExecutionContext
+# skips mark_processing/mark_processed/retry tracking for them.
+SYNTHETIC_KICKOFF_SENDER_ID = "kickoff"
+SYNTHETIC_KICKOFF_SENDER_NAME = "Kickoff"
+
+# Closed set of recognized synthetic sender ids. ExecutionContext requires BOTH
+# sender_type == SYNTHETIC_SENDER_TYPE AND sender_id in this set before
+# treating a message as synthetic — never broaden to type alone, since real
+# platform "System" messages must keep full mark_* lifecycle.
+SYNTHETIC_SENDER_IDS: frozenset[str] = frozenset(
+    {
+        SYNTHETIC_CONTACT_EVENTS_SENDER_ID,
+        SYNTHETIC_KICKOFF_SENDER_ID,
+    }
+)
+
 
 def normalize_handle(handle: str | None) -> str | None:
     """

--- a/tests/runtime/test_kickoff.py
+++ b/tests/runtime/test_kickoff.py
@@ -41,6 +41,7 @@ def mock_link():
     link.get_next_message = AsyncMock(return_value=None)
     link.get_stale_processing_messages = AsyncMock(return_value=[])
     link.subscribe_room = AsyncMock()
+    link.unsubscribe_room = AsyncMock()
     return link
 
 
@@ -214,6 +215,60 @@ class TestAgentRuntimeBootstrap:
 
         for room_id in list(runtime.executions.keys()):
             await runtime.executions[room_id].stop()
+
+    @pytest.mark.asyncio
+    async def test_rolls_back_claimed_room_when_execution_lacks_bootstrap(
+        self, mock_link
+    ):
+        from thenvoi.runtime.runtime import AgentRuntime
+
+        class NoBootstrapExecution:
+            async def start(self):
+                return None
+
+            async def stop(self, timeout=None):
+                return True
+
+        runtime = AgentRuntime(
+            mock_link,
+            "agent-123",
+            on_execute=AsyncMock(),
+            execution_factory=lambda *_args, **_kwargs: NoBootstrapExecution(),
+        )
+
+        with pytest.raises(RuntimeError, match="does not support bootstrap_message"):
+            await runtime.bootstrap_room_message("new-room", _platform_message())
+
+        assert "new-room" not in runtime.presence.rooms
+        assert "new-room" not in runtime.executions
+        mock_link.subscribe_room.assert_awaited_once_with("new-room")
+        mock_link.unsubscribe_room.assert_awaited_once_with("new-room")
+
+    @pytest.mark.asyncio
+    async def test_rolls_back_execution_slot_when_start_fails(self, mock_link):
+        from thenvoi.runtime.runtime import AgentRuntime
+
+        class FailingStartExecution:
+            async def start(self):
+                raise RuntimeError("start failed")
+
+            async def stop(self, timeout=None):
+                return True
+
+        runtime = AgentRuntime(
+            mock_link,
+            "agent-123",
+            on_execute=AsyncMock(),
+            execution_factory=lambda *_args, **_kwargs: FailingStartExecution(),
+        )
+
+        with pytest.raises(RuntimeError, match="start failed"):
+            await runtime.bootstrap_room_message("new-room", _platform_message())
+
+        assert "new-room" not in runtime.presence.rooms
+        assert "new-room" not in runtime.executions
+        mock_link.subscribe_room.assert_awaited_once_with("new-room")
+        mock_link.unsubscribe_room.assert_awaited_once_with("new-room")
 
 
 class TestAgentBootstrap:

--- a/tests/runtime/test_kickoff.py
+++ b/tests/runtime/test_kickoff.py
@@ -1,0 +1,268 @@
+"""Tests for the kickoff / bootstrap_room_message feature.
+
+These tests cover the synthetic-injection path that lets an agent start work
+in a room from an initial message that did not come through the platform.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from thenvoi.client.streaming import MessageCreatedPayload, MessageMetadata
+from thenvoi.platform.event import MessageEvent
+from thenvoi.runtime.execution import ExecutionContext
+from thenvoi.runtime.types import (
+    PlatformMessage,
+    SYNTHETIC_KICKOFF_SENDER_ID,
+    SYNTHETIC_SENDER_TYPE,
+)
+
+
+@pytest.fixture
+def mock_link():
+    link = MagicMock()
+    link.agent_id = "agent-123"
+    link.rest = MagicMock()
+    link.rest.agent_api_participants = MagicMock()
+    link.rest.agent_api_participants.list_agent_chat_participants = AsyncMock(
+        return_value=MagicMock(data=[])
+    )
+    link.rest.agent_api_context = MagicMock()
+    link.rest.agent_api_context.get_agent_chat_context = AsyncMock(
+        return_value=MagicMock(data=[])
+    )
+    link.mark_processing = AsyncMock()
+    link.mark_processed = AsyncMock()
+    link.mark_failed = AsyncMock()
+    link.get_next_message = AsyncMock(return_value=None)
+    link.get_stale_processing_messages = AsyncMock(return_value=[])
+    link.subscribe_room = AsyncMock()
+    return link
+
+
+def _platform_message(
+    *,
+    msg_id: str = "kickoff:test-1",
+    content: str = "begin work on the ticket",
+    metadata: dict | None = None,
+) -> PlatformMessage:
+    return PlatformMessage(
+        id=msg_id,
+        room_id="room-1",
+        content=content,
+        sender_id=SYNTHETIC_KICKOFF_SENDER_ID,
+        sender_type=SYNTHETIC_SENDER_TYPE,
+        sender_name="Kickoff",
+        message_type="message",
+        metadata=metadata or {},
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+class TestExecutionBootstrapMessage:
+    """Direct tests on ExecutionContext.bootstrap_message."""
+
+    @pytest.mark.asyncio
+    async def test_delivers_synthetic_event_to_handler(self, mock_link):
+        handler = AsyncMock()
+        ctx = ExecutionContext("room-1", mock_link, handler, agent_id="agent-123")
+        await ctx.start()
+        try:
+            await ctx.bootstrap_message(_platform_message(content="hello"))
+            await asyncio.wait_for(_wait_for_handler(handler), timeout=2.0)
+        finally:
+            await ctx.stop()
+
+        # Handler called with a MessageEvent carrying synthetic identity
+        assert handler.await_count == 1
+        delivered_event = handler.await_args.args[1]
+        assert isinstance(delivered_event, MessageEvent)
+        assert delivered_event.payload is not None
+        assert delivered_event.payload.content == "hello"
+        assert delivered_event.payload.sender_id == SYNTHETIC_KICKOFF_SENDER_ID
+        assert delivered_event.payload.sender_type == SYNTHETIC_SENDER_TYPE
+
+    @pytest.mark.asyncio
+    async def test_no_platform_persistence_calls(self, mock_link):
+        """Synthetic kickoff messages must skip mark_processing/mark_processed."""
+        handler = AsyncMock()
+        ctx = ExecutionContext("room-1", mock_link, handler, agent_id="agent-123")
+        await ctx.start()
+        try:
+            await ctx.bootstrap_message(_platform_message())
+            await asyncio.wait_for(_wait_for_handler(handler), timeout=2.0)
+        finally:
+            await ctx.stop()
+
+        mock_link.mark_processing.assert_not_called()
+        mock_link.mark_processed.assert_not_called()
+        mock_link.mark_failed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_preserves_caller_message_id(self, mock_link):
+        """External systems depend on stable ids for retry/replay idempotency."""
+        handler = AsyncMock()
+        ctx = ExecutionContext("room-1", mock_link, handler, agent_id="agent-123")
+        await ctx.start()
+        try:
+            await ctx.bootstrap_message(_platform_message(msg_id="webhook:event-abc"))
+            await asyncio.wait_for(_wait_for_handler(handler), timeout=2.0)
+        finally:
+            await ctx.stop()
+
+        delivered_event = handler.await_args.args[1]
+        assert delivered_event.payload.id == "webhook:event-abc"
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_does_not_poison_sync_marker(self, mock_link):
+        """A kickoff arriving before any real WS message must not become the sync point."""
+        handler = AsyncMock()
+        ctx = ExecutionContext("room-1", mock_link, handler, agent_id="agent-123")
+
+        # Inject a kickoff first
+        await ctx.bootstrap_message(_platform_message(msg_id="kickoff:should-not-mark"))
+        assert ctx._first_ws_msg_id is None
+
+        # Then a real WS message
+        real_event = MessageEvent(
+            room_id="room-1",
+            payload=MessageCreatedPayload(
+                id="real-msg-42",
+                content="hi",
+                sender_id="user-1",
+                sender_type="User",
+                sender_name="Alice",
+                message_type="message",
+                metadata=MessageMetadata(mentions=[], status="sent"),
+                chat_room_id="room-1",
+                inserted_at="2024-01-01T00:00:00Z",
+                updated_at="2024-01-01T00:00:00Z",
+            ),
+        )
+        await ctx.on_event(real_event)
+        assert ctx._first_ws_msg_id == "real-msg-42"
+
+
+class TestRealSystemMessageStillTracked:
+    """Regression: real platform 'System' messages must keep mark_* lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_real_system_message_calls_mark_processed(self, mock_link):
+        handler = AsyncMock()
+        ctx = ExecutionContext("room-1", mock_link, handler, agent_id="agent-123")
+        await ctx.start()
+        try:
+            real_system_event = MessageEvent(
+                room_id="room-1",
+                payload=MessageCreatedPayload(
+                    id="real-sys-1",
+                    content="moderator note",
+                    sender_id="some-real-system-sender",  # NOT a synthetic id
+                    sender_type=SYNTHETIC_SENDER_TYPE,
+                    sender_name="System",
+                    message_type="message",
+                    metadata=MessageMetadata(mentions=[], status="sent"),
+                    chat_room_id="room-1",
+                    inserted_at="2024-01-01T00:00:00Z",
+                    updated_at="2024-01-01T00:00:00Z",
+                ),
+            )
+            await ctx.on_event(real_system_event)
+            await asyncio.wait_for(_wait_for_handler(handler), timeout=2.0)
+        finally:
+            await ctx.stop()
+
+        mock_link.mark_processing.assert_called_once_with("room-1", "real-sys-1")
+        mock_link.mark_processed.assert_called_once_with("room-1", "real-sys-1")
+
+
+class TestAgentRuntimeBootstrap:
+    """AgentRuntime.bootstrap_room_message subscribes + ensures execution."""
+
+    @pytest.mark.asyncio
+    async def test_subscribes_when_room_unknown(self, mock_link):
+        from thenvoi.runtime.runtime import AgentRuntime
+
+        handler = AsyncMock()
+        runtime = AgentRuntime(mock_link, "agent-123", on_execute=handler)
+
+        await runtime.bootstrap_room_message("new-room", _platform_message())
+
+        mock_link.subscribe_room.assert_awaited_once_with("new-room")
+        assert "new-room" in runtime.presence.rooms
+        assert "new-room" in runtime.executions
+
+        # Cleanup
+        for room_id in list(runtime.executions.keys()):
+            await runtime.executions[room_id].stop()
+
+    @pytest.mark.asyncio
+    async def test_skips_subscribe_when_room_known(self, mock_link):
+        from thenvoi.runtime.runtime import AgentRuntime
+
+        handler = AsyncMock()
+        runtime = AgentRuntime(mock_link, "agent-123", on_execute=handler)
+        runtime.presence.rooms.add("known-room")
+
+        await runtime.bootstrap_room_message("known-room", _platform_message())
+
+        mock_link.subscribe_room.assert_not_called()
+
+        for room_id in list(runtime.executions.keys()):
+            await runtime.executions[room_id].stop()
+
+
+class TestAgentKickoff:
+    """Agent.kickoff helper end-to-end with mocked runtime."""
+
+    @pytest.mark.asyncio
+    async def test_kickoff_creates_room_when_not_provided(self, mock_link):
+        from thenvoi.agent import Agent
+        from thenvoi.runtime.runtime import AgentRuntime
+
+        # Wire a real AgentRuntime around the mock link so bootstrap goes
+        # through the real subscription/execution path.
+        handler = AsyncMock()
+        runtime = AgentRuntime(mock_link, "agent-123", on_execute=handler)
+
+        # Mock the chat-creation REST call
+        created = MagicMock()
+        created.id = "fresh-room-9"
+        mock_link.rest.agent_api_chats = MagicMock()
+        mock_link.rest.agent_api_chats.create_agent_chat = AsyncMock(
+            return_value=MagicMock(data=created)
+        )
+
+        # Build an Agent with the runtime stubbed in
+        agent = Agent.__new__(Agent)
+        agent._adapter = MagicMock()
+        agent._preprocessor = MagicMock()
+        agent._started = True
+        agent._runtime = MagicMock()
+        agent._runtime.link = mock_link
+
+        async def _forward(room_id: str, message) -> None:
+            await runtime.bootstrap_room_message(room_id, message)
+
+        agent._runtime.bootstrap_room_message = AsyncMock(side_effect=_forward)
+
+        room_id = await agent.kickoff("go!", task_id="task-7")
+        assert room_id == "fresh-room-9"
+        mock_link.rest.agent_api_chats.create_agent_chat.assert_awaited_once()
+        agent._runtime.bootstrap_room_message.assert_awaited_once()
+
+        # Cleanup any executions started by the runtime
+        for r in list(runtime.executions.keys()):
+            await runtime.executions[r].stop()
+
+
+# --- helpers ---
+
+
+async def _wait_for_handler(handler: AsyncMock) -> None:
+    while handler.await_count == 0:
+        await asyncio.sleep(0.01)

--- a/tests/runtime/test_kickoff.py
+++ b/tests/runtime/test_kickoff.py
@@ -216,8 +216,8 @@ class TestAgentRuntimeBootstrap:
             await runtime.executions[room_id].stop()
 
 
-class TestAgentKickoff:
-    """Agent.kickoff and Agent.bootstrap_room_message public-entry tests."""
+class TestAgentBootstrap:
+    """Agent.bootstrap_room_message public-entry tests (string + PlatformMessage)."""
 
     @pytest.fixture
     def started_agent(self, mock_link):
@@ -233,8 +233,6 @@ class TestAgentKickoff:
         handler = AsyncMock()
         agent_runtime = AgentRuntime(mock_link, "agent-123", on_execute=handler)
 
-        # Build a PlatformRuntime stand-in that delegates bootstrap to the
-        # real AgentRuntime so the full call chain is exercised.
         platform_runtime = MagicMock()
         platform_runtime.link = mock_link
         platform_runtime.bootstrap_room_message = AsyncMock(
@@ -247,12 +245,12 @@ class TestAgentKickoff:
         adapter.on_cleanup = AsyncMock()
 
         agent = Agent(runtime=platform_runtime, adapter=adapter)
-        agent._started = True  # simulate post-start state without WS connect
+        agent._started = True
 
         return agent, agent_runtime, handler
 
     @pytest.mark.asyncio
-    async def test_kickoff_creates_room_when_not_provided(
+    async def test_string_creates_room_and_delivers_to_adapter(
         self, started_agent, mock_link
     ):
         agent, agent_runtime, handler = started_agent
@@ -264,15 +262,12 @@ class TestAgentKickoff:
             return_value=MagicMock(data=created)
         )
 
-        room_id = await agent.kickoff("go!", task_id="task-7")
+        room_id = await agent.bootstrap_room_message("go!", task_id="task-7")
 
         assert room_id == "fresh-room-9"
         mock_link.rest.agent_api_chats.create_agent_chat.assert_awaited_once()
-        agent.runtime.bootstrap_room_message.assert_awaited_once()
         assert "fresh-room-9" in agent_runtime.executions
 
-        # Confirm the synthetic message reached the adapter, not just that
-        # the room was created and execution started.
         await asyncio.wait_for(_wait_for_handler(handler), timeout=2.0)
         delivered = handler.await_args.args[1]
         assert delivered.payload.content == "go!"
@@ -282,27 +277,26 @@ class TestAgentKickoff:
             await agent_runtime.executions[r].stop()
 
     @pytest.mark.asyncio
-    async def test_kickoff_raises_specific_error_when_create_chat_returns_no_data(
+    async def test_string_raises_when_create_chat_returns_no_data(
         self, started_agent, mock_link
     ):
-        agent, agent_runtime, _handler = started_agent
+        agent, _agent_runtime, _handler = started_agent
         mock_link.rest.agent_api_chats = MagicMock()
         mock_link.rest.agent_api_chats.create_agent_chat = AsyncMock(
             return_value=MagicMock(data=None)
         )
         with pytest.raises(RuntimeError, match="task_id='task-9'"):
-            await agent.kickoff("go!", task_id="task-9")
+            await agent.bootstrap_room_message("go!", task_id="task-9")
 
     @pytest.mark.asyncio
-    async def test_bootstrap_room_message_preserves_caller_id_end_to_end(
+    async def test_platform_message_preserves_caller_id_end_to_end(
         self, started_agent, mock_link
     ):
-        """Public-entry test through Agent.bootstrap_room_message: a caller-
-        supplied PlatformMessage id must reach the adapter unchanged."""
+        """Caller-supplied PlatformMessage id must reach the adapter unchanged."""
         agent, agent_runtime, handler = started_agent
 
         message = _platform_message(msg_id="webhook:event-xyz", content="run report")
-        await agent.bootstrap_room_message("room-42", message)
+        await agent.bootstrap_room_message(message, room_id="room-42")
 
         await asyncio.wait_for(_wait_for_handler(handler), timeout=2.0)
         delivered = handler.await_args.args[1]
@@ -313,7 +307,13 @@ class TestAgentKickoff:
             await agent_runtime.executions[r].stop()
 
     @pytest.mark.asyncio
-    async def test_kickoff_raises_when_agent_not_started(self, mock_link):
+    async def test_platform_message_requires_room_id(self, started_agent):
+        agent, _agent_runtime, _handler = started_agent
+        with pytest.raises(ValueError, match="room_id is required"):
+            await agent.bootstrap_room_message(_platform_message())
+
+    @pytest.mark.asyncio
+    async def test_raises_when_agent_not_started(self):
         from thenvoi.agent import Agent
 
         adapter = MagicMock()
@@ -322,20 +322,10 @@ class TestAgentKickoff:
         # _started defaults to False
 
         with pytest.raises(RuntimeError, match="Agent not started"):
-            await agent.kickoff("nope")
-
-    @pytest.mark.asyncio
-    async def test_bootstrap_room_message_raises_when_agent_not_started(
-        self, mock_link
-    ):
-        from thenvoi.agent import Agent
-
-        adapter = MagicMock()
-        platform_runtime = MagicMock()
-        agent = Agent(runtime=platform_runtime, adapter=adapter)
+            await agent.bootstrap_room_message("nope")
 
         with pytest.raises(RuntimeError, match="Agent not started"):
-            await agent.bootstrap_room_message("room-1", _platform_message())
+            await agent.bootstrap_room_message(_platform_message(), room_id="room-1")
 
 
 class TestRoomAddedDedupe:

--- a/tests/runtime/test_kickoff.py
+++ b/tests/runtime/test_kickoff.py
@@ -255,7 +255,7 @@ class TestAgentKickoff:
     async def test_kickoff_creates_room_when_not_provided(
         self, started_agent, mock_link
     ):
-        agent, agent_runtime, _handler = started_agent
+        agent, agent_runtime, handler = started_agent
 
         created = MagicMock()
         created.id = "fresh-room-9"
@@ -271,8 +271,27 @@ class TestAgentKickoff:
         agent.runtime.bootstrap_room_message.assert_awaited_once()
         assert "fresh-room-9" in agent_runtime.executions
 
+        # Confirm the synthetic message reached the adapter, not just that
+        # the room was created and execution started.
+        await asyncio.wait_for(_wait_for_handler(handler), timeout=2.0)
+        delivered = handler.await_args.args[1]
+        assert delivered.payload.content == "go!"
+        assert delivered.payload.sender_id == SYNTHETIC_KICKOFF_SENDER_ID
+
         for r in list(agent_runtime.executions.keys()):
             await agent_runtime.executions[r].stop()
+
+    @pytest.mark.asyncio
+    async def test_kickoff_raises_specific_error_when_create_chat_returns_no_data(
+        self, started_agent, mock_link
+    ):
+        agent, agent_runtime, _handler = started_agent
+        mock_link.rest.agent_api_chats = MagicMock()
+        mock_link.rest.agent_api_chats.create_agent_chat = AsyncMock(
+            return_value=MagicMock(data=None)
+        )
+        with pytest.raises(RuntimeError, match="task_id='task-9'"):
+            await agent.kickoff("go!", task_id="task-9")
 
     @pytest.mark.asyncio
     async def test_bootstrap_room_message_preserves_caller_id_end_to_end(
@@ -304,6 +323,53 @@ class TestAgentKickoff:
 
         with pytest.raises(RuntimeError, match="Agent not started"):
             await agent.kickoff("nope")
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_room_message_raises_when_agent_not_started(
+        self, mock_link
+    ):
+        from thenvoi.agent import Agent
+
+        adapter = MagicMock()
+        platform_runtime = MagicMock()
+        agent = Agent(runtime=platform_runtime, adapter=adapter)
+
+        with pytest.raises(RuntimeError, match="Agent not started"):
+            await agent.bootstrap_room_message("room-1", _platform_message())
+
+
+class TestRoomAddedDedupe:
+    """Regression: WS room_added for a kickoff-claimed room must not double-subscribe."""
+
+    @pytest.mark.asyncio
+    async def test_room_added_skips_subscribe_when_room_already_tracked(
+        self, mock_link
+    ):
+        from thenvoi.client.streaming import RoomAddedPayload
+        from thenvoi.platform.event import RoomAddedEvent
+        from thenvoi.runtime.presence import RoomPresence
+
+        presence = RoomPresence(mock_link)
+        # Simulate kickoff having already claimed and subscribed to the room.
+        presence.rooms.add("claimed-room")
+        on_joined = AsyncMock()
+        presence.on_room_joined = on_joined
+
+        event = RoomAddedEvent(
+            room_id="claimed-room",
+            payload=RoomAddedPayload(
+                id="claimed-room",
+                inserted_at="2024-01-01T00:00:00Z",
+                updated_at="2024-01-01T00:00:00Z",
+            ),
+        )
+        await presence._handle_room_added(event)
+
+        # subscribe_room must not be called a second time, and on_room_joined
+        # should not re-fire (execution would already exist anyway, but the
+        # callback contract is "once per join").
+        mock_link.subscribe_room.assert_not_called()
+        on_joined.assert_not_called()
 
 
 # --- helpers ---

--- a/tests/runtime/test_kickoff.py
+++ b/tests/runtime/test_kickoff.py
@@ -217,19 +217,46 @@ class TestAgentRuntimeBootstrap:
 
 
 class TestAgentKickoff:
-    """Agent.kickoff helper end-to-end with mocked runtime."""
+    """Agent.kickoff and Agent.bootstrap_room_message public-entry tests."""
 
-    @pytest.mark.asyncio
-    async def test_kickoff_creates_room_when_not_provided(self, mock_link):
+    @pytest.fixture
+    def started_agent(self, mock_link):
+        """Build a started Agent backed by a real AgentRuntime + mock link.
+
+        Avoids reaching into private attributes — uses the public Agent
+        constructor with a stubbed PlatformRuntime, then flips the started
+        flag the same way Agent.start() would.
+        """
         from thenvoi.agent import Agent
         from thenvoi.runtime.runtime import AgentRuntime
 
-        # Wire a real AgentRuntime around the mock link so bootstrap goes
-        # through the real subscription/execution path.
         handler = AsyncMock()
-        runtime = AgentRuntime(mock_link, "agent-123", on_execute=handler)
+        agent_runtime = AgentRuntime(mock_link, "agent-123", on_execute=handler)
 
-        # Mock the chat-creation REST call
+        # Build a PlatformRuntime stand-in that delegates bootstrap to the
+        # real AgentRuntime so the full call chain is exercised.
+        platform_runtime = MagicMock()
+        platform_runtime.link = mock_link
+        platform_runtime.bootstrap_room_message = AsyncMock(
+            side_effect=agent_runtime.bootstrap_room_message
+        )
+
+        adapter = MagicMock()
+        adapter.on_started = AsyncMock()
+        adapter.on_event = AsyncMock()
+        adapter.on_cleanup = AsyncMock()
+
+        agent = Agent(runtime=platform_runtime, adapter=adapter)
+        agent._started = True  # simulate post-start state without WS connect
+
+        return agent, agent_runtime, handler
+
+    @pytest.mark.asyncio
+    async def test_kickoff_creates_room_when_not_provided(
+        self, started_agent, mock_link
+    ):
+        agent, agent_runtime, _handler = started_agent
+
         created = MagicMock()
         created.id = "fresh-room-9"
         mock_link.rest.agent_api_chats = MagicMock()
@@ -237,27 +264,46 @@ class TestAgentKickoff:
             return_value=MagicMock(data=created)
         )
 
-        # Build an Agent with the runtime stubbed in
-        agent = Agent.__new__(Agent)
-        agent._adapter = MagicMock()
-        agent._preprocessor = MagicMock()
-        agent._started = True
-        agent._runtime = MagicMock()
-        agent._runtime.link = mock_link
-
-        async def _forward(room_id: str, message) -> None:
-            await runtime.bootstrap_room_message(room_id, message)
-
-        agent._runtime.bootstrap_room_message = AsyncMock(side_effect=_forward)
-
         room_id = await agent.kickoff("go!", task_id="task-7")
+
         assert room_id == "fresh-room-9"
         mock_link.rest.agent_api_chats.create_agent_chat.assert_awaited_once()
-        agent._runtime.bootstrap_room_message.assert_awaited_once()
+        agent.runtime.bootstrap_room_message.assert_awaited_once()
+        assert "fresh-room-9" in agent_runtime.executions
 
-        # Cleanup any executions started by the runtime
-        for r in list(runtime.executions.keys()):
-            await runtime.executions[r].stop()
+        for r in list(agent_runtime.executions.keys()):
+            await agent_runtime.executions[r].stop()
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_room_message_preserves_caller_id_end_to_end(
+        self, started_agent, mock_link
+    ):
+        """Public-entry test through Agent.bootstrap_room_message: a caller-
+        supplied PlatformMessage id must reach the adapter unchanged."""
+        agent, agent_runtime, handler = started_agent
+
+        message = _platform_message(msg_id="webhook:event-xyz", content="run report")
+        await agent.bootstrap_room_message("room-42", message)
+
+        await asyncio.wait_for(_wait_for_handler(handler), timeout=2.0)
+        delivered = handler.await_args.args[1]
+        assert delivered.payload.id == "webhook:event-xyz"
+        assert delivered.payload.content == "run report"
+
+        for r in list(agent_runtime.executions.keys()):
+            await agent_runtime.executions[r].stop()
+
+    @pytest.mark.asyncio
+    async def test_kickoff_raises_when_agent_not_started(self, mock_link):
+        from thenvoi.agent import Agent
+
+        adapter = MagicMock()
+        platform_runtime = MagicMock()
+        agent = Agent(runtime=platform_runtime, adapter=adapter)
+        # _started defaults to False
+
+        with pytest.raises(RuntimeError, match="Agent not started"):
+            await agent.kickoff("nope")
 
 
 # --- helpers ---

--- a/uv.lock
+++ b/uv.lock
@@ -8152,7 +8152,7 @@ wheels = [
 
 [[package]]
 name = "thenvoi-sdk"
-version = "0.2.8"
+version = "0.2.10"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Adds a single new public Agent API for self-starting agents — work that begins without a real platform message arriving:

```python
async with agent:
    room_id = await agent.bootstrap_room_message(
        "Find out the current weather in SF and Paris, then tell me which is more pleasant."
    )
    await agent.run_forever()
```

`Agent.bootstrap_room_message` accepts either shape:

- **Plain string** (the common case): the method creates a fresh chat room (optionally task-linked via `task_id=`), wraps the string in a synthetic `PlatformMessage`, and injects it. Returns the new room id.
- **A fully-constructed `PlatformMessage` + `room_id`**: the escape hatch for callers that need stable message ids for retry/replay idempotency (webhooks, cron jobs, external bridges that need to dedupe). Returns the same room id back.

The injected message is delivered to the adapter exactly like a real chat message but is **not** persisted: no DB write, no `mark_processing` / `mark_processed` lifecycle, no retry tracking, other participants never see it.

## How it works

1. `Agent.bootstrap_room_message` (string shape) calls REST `create_agent_chat` to mint a room, builds a synthetic `PlatformMessage`, and forwards to the runtime.
2. `PlatformRuntime.bootstrap_room_message` requires the runtime to be started and forwards to `AgentRuntime`.
3. `AgentRuntime.bootstrap_room_message` ensures the room is subscribed (claim-the-slot-then-subscribe with rollback on failure) and an `ExecutionContext` exists, then delegates to `ExecutionContext.bootstrap_message`.
4. `ExecutionContext.bootstrap_message` wraps the `PlatformMessage` in a synthetic `MessageEvent` (`sender_type="System"`, `sender_id="kickoff"`) and enqueues it via `on_event`. The existing synthetic-message branch in `_process_event` skips DB persistence and retry tracking.

The synthetic identity is forced inside `ExecutionContext.bootstrap_message` — callers cannot override it, because that combination is what triggers the persistence-skip.

Two safety guards:

- `on_event` skips the `_first_ws_msg_id` sync-point marker for synthetic messages so a bootstrap arriving before any real WS message can't poison the `/next` resync.
- `_handle_room_added` early-returns when the room is already tracked, avoiding a duplicate Phoenix join when bootstrap has already claimed and subscribed before the platform's `room_added` event arrives.

## Synthetic-sender check, broadened safely

The `_process_event` synthetic shortcut used to match a single `sender_id == SYNTHETIC_CONTACT_EVENTS_SENDER_ID`. It now matches `sender_id in SYNTHETIC_SENDER_IDS` (a closed `frozenset` of known synthetic ids). The check still requires `sender_type == "System"` AND a recognized id, so real platform "System" messages keep their full `mark_*` lifecycle. A regression test pins this.

## Files

| File | Change |
|---|---|
| `src/thenvoi/agent.py` | `bootstrap_room_message(str \| PlatformMessage, *, room_id=None, ...)` — single public method |
| `src/thenvoi/runtime/types.py` | `SYNTHETIC_KICKOFF_SENDER_ID`, `SYNTHETIC_KICKOFF_SENDER_NAME`, `SYNTHETIC_SENDER_IDS` |
| `src/thenvoi/runtime/execution.py` | `bootstrap_message` impl + Protocol declaration; on_event sync-marker guard; broadened synthetic check |
| `src/thenvoi/runtime/runtime.py` | `AgentRuntime.bootstrap_room_message` (subscribe + ensure execution + bootstrap, with rollback) |
| `src/thenvoi/runtime/platform_runtime.py` | thin forwarder |
| `src/thenvoi/runtime/presence.py` | early-return in `_handle_room_added` for already-tracked rooms |
| `tests/runtime/test_kickoff.py` | 13 tests: synthetic event delivery, no platform persistence, caller-id preservation, sync-marker safety, real-System-message regression, runtime subscribe/dedupe, public-entry string + PlatformMessage shapes, missing-room_id guard, not-started guard, room_added dedupe regression |
| `examples/scenarios/self_start_kickoff.py` | runnable demo using the existing `anthropic_agent` config stanza |

## Live smoke test

Ran `python examples/scenarios/self_start_kickoff.py` against `app.thenvoi.com` (real REST + WS). The example calls `agent.bootstrap_room_message("Find out the current weather in San Francisco and Paris...")` with no `room_id` and no custom prompt.

Observed log sequence:

```
thenvoi.adapters.anthropic: Anthropic adapter started for agent: Claude Code
thenvoi.runtime.presence:   RoomPresence started for agent 81c89ef9-…
thenvoi.runtime.platform_runtime: Platform runtime started for agent: Claude Code
thenvoi.agent:              Agent started: Claude Code (thenvoi-sdk 0.2.8)
thenvoi.agent:              Bootstrap created new room: 0cff218f-9b74-4951-b55e-f5b522dcc73b
thenvoi.runtime.execution:  Bootstrap (kickoff) message kickoff:82071a56-… enqueued for room 0cff218f-…
thenvoi.preprocessing.default: Room 0cff218f-…: Got 0 messages
thenvoi.adapters.anthropic: Room 0cff218f-…: Calling Anthropic with 2 messages (first_msg=True)
```

What this proves end-to-end:

- The string shape made the REST `create_agent_chat` call and got a fresh room back. The room id propagated all the way to the adapter.
- `bootstrap_message` enqueued a synthetic `MessageEvent` with the auto-generated id `kickoff:82071a56-…`.
- The synthetic message was NOT loaded from the platform (`Got 0 messages`) — it was injected in-memory only, exactly as designed.
- The Anthropic adapter received it with `first_msg=True` and dispatched the model call.
- No `mark_processing` / `mark_processed` calls fired against the platform for the synthetic id (verified in unit tests; the live run hit the same code path).

The agent then made an Anthropic API call against the bootstrap message. We did not wait for the model response in this run; the goal was to prove the new code path delivers the message to the adapter, which it does.

## Test plan

- [x] Unit: `uv run pytest tests/runtime/test_kickoff.py -v` — 13/13 passing
- [x] Unit suite: `uv run pytest tests/runtime/ tests/adapters/ tests/converters/ tests/preprocessing/ --no-cov -q` — 1461 passing
- [x] Lint: `uv run ruff check . && uv run ruff format .` — clean
- [x] Types: `uv run pyrefly check` — 0 errors
- [x] Live smoke (string shape): `python examples/scenarios/self_start_kickoff.py` against `app.thenvoi.com` — confirmed bootstrap → room creation → synthetic enqueue → adapter delivery → model call
- [ ] Reviewer-side live run before un-drafting