### PR TITLE
chore(ci): add dev-parlant CI job for parlant adapter coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,10 @@ jobs:
       run: uv sync --extra dev-parlant
 
     - name: Run parlant tests
+      env:
+        # dev-parlant venv lacks langgraph/anthropic/crewai/etc.; tolerate
+        # missing framework adapter/converter configs instead of failing fast.
+        THENVOI_ALLOW_MISSING_FRAMEWORKS: "1"
       run: |
         uv run pytest \
           tests/adapters/test_parlant_adapter.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,50 @@ jobs:
       run: uv run pytest
 
 
+  test-parlant:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12']
+      fail-fast: false
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Configure git to use HTTPS for GitHub
+      run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: "**/pyproject.toml"
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install parlant dependencies
+      run: uv sync --extra dev-parlant
+
+    - name: Run parlant tests
+      run: |
+        uv run pytest \
+          tests/adapters/test_parlant_adapter.py \
+          tests/converters/test_parlant.py \
+          tests/integrations/parlant/ \
+          tests/framework_conformance/ -k parlant
+
+    - name: Pyrefly check (parlant sources)
+      run: |
+        uv run pyrefly check \
+          src/thenvoi/adapters/parlant.py \
+          src/thenvoi/converters/parlant.py \
+          src/thenvoi/integrations/parlant/
+
+
   packaging:
     runs-on: ubuntu-latest
     steps:

--- a/tests/framework_configs/_sentinel.py
+++ b/tests/framework_configs/_sentinel.py
@@ -17,3 +17,9 @@ class _MissingSentinel:
 MISSING = _MissingSentinel()
 
 IN_CI = bool(environ.get("CI") or environ.get("GITHUB_ACTIONS"))
+
+# Strict CI mode: framework config builders raise on import failure instead of
+# warning. Opt out via THENVOI_ALLOW_MISSING_FRAMEWORKS=1 for partial-deps CI
+# environments (e.g. the dev-parlant matrix job, which only has parlant
+# installed and cannot import langgraph/anthropic/crewai/etc.).
+STRICT_CI = IN_CI and not environ.get("THENVOI_ALLOW_MISSING_FRAMEWORKS")

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable
 from unittest.mock import MagicMock
 
-from tests.framework_configs._sentinel import IN_CI, MISSING, _MissingSentinel
+from tests.framework_configs._sentinel import MISSING, STRICT_CI, _MissingSentinel
 from thenvoi.adapters.claude_sdk import _CLAUDE_SDK_AVAILABLE as _HAS_CLAUDE_SDK
 
 __all__ = ["AdapterConfig", "ADAPTER_CONFIGS", "ADAPTER_EXCLUDED_MODULES"]
@@ -755,7 +755,7 @@ def _build_adapter_configs() -> list[AdapterConfig]:
             if result is not None:
                 configs.append(result)
         except Exception as exc:
-            if IN_CI:
+            if STRICT_CI:
                 raise RuntimeError(
                     f"Adapter config builder {builder.__name__} failed in CI: {exc}"
                 ) from exc

--- a/tests/framework_configs/converters.py
+++ b/tests/framework_configs/converters.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, Callable
 if TYPE_CHECKING:
     from tests.framework_configs.output_adapters import OutputAdapter
 
-from tests.framework_configs._sentinel import IN_CI
+from tests.framework_configs._sentinel import STRICT_CI
 
 __all__ = [
     "ConverterConfig",
@@ -313,7 +313,7 @@ def _build_converter_configs() -> list[ConverterConfig]:
         try:
             configs.append(builder())
         except Exception as exc:
-            if IN_CI:
+            if STRICT_CI:
                 raise RuntimeError(
                     f"Converter config builder {builder.__name__} failed in CI: {exc}"
                 ) from exc


### PR DESCRIPTION
## Summary
- Add `test-parlant` matrix job (3.11, 3.12) installing `--extra dev-parlant`
- Run parlant-targeted tests: adapter, converter, integration, conformance `-k parlant`
- Run pyrefly scoped to parlant sources (full-tree check fails in dev-parlant venv due to missing langgraph/anthropic/etc.)

Closes [INT-344](https://linear.app/thenvoi/issue/INT-344/choreci-add-dev-parlant-ci-job-for-parlant-adapter-test-coverage).

## Test plan
- [x] Local `uv sync --extra dev-parlant` + targeted pytest: 90 passed, 4 skipped
- [x] Local scoped pyrefly: 0 errors
- [ ] CI `test-parlant (3.11)` green
- [ ] CI `test-parlant (3.12)` green
- [ ] Existing `lint`, `test`, `packaging` jobs still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)