### PR TITLE
fix(examples): use correct config keys in Claude SDK examples [INT-462]

### DIFF
--- a/examples/claude_sdk/01_basic_agent.py
+++ b/examples/claude_sdk/01_basic_agent.py
@@ -60,7 +60,7 @@ async def main() -> None:
         raise ValueError("THENVOI_REST_URL environment variable is required")
 
     # Load credentials from agent_config.yaml
-    agent_id, api_key = load_agent_config("claude_sdk_agent")
+    agent_id, api_key = load_agent_config("claude_sdk_basic")
 
     # Create adapter with Claude SDK settings.  Omitting `model` lets the
     # npm `claude` binary pick its own default (latest installed model).

--- a/examples/claude_sdk/02_extended_thinking.py
+++ b/examples/claude_sdk/02_extended_thinking.py
@@ -66,7 +66,7 @@ async def main() -> None:
         raise ValueError("THENVOI_REST_URL environment variable is required")
 
     # Load credentials from agent_config.yaml
-    agent_id, api_key = load_agent_config("claude_sdk_agent")
+    agent_id, api_key = load_agent_config("claude_sdk_extended_thinking")
 
     # Create adapter with extended thinking enabled.  `model="opus"` is a
     # family alias resolved by the npm `claude` binary at runtime — always


### PR DESCRIPTION
## Summary
- Both Claude SDK examples (`01_basic_agent.py`, `02_extended_thinking.py`) were using the same `"claude_sdk_agent"` config key in `load_agent_config()`
- Fixed to use distinct keys: `"claude_sdk_basic"` and `"claude_sdk_extended_thinking"` matching their entries in `agent_config.yaml`

## Test plan
- [ ] Verify `01_basic_agent.py` loads config from `claude_sdk_basic` key
- [ ] Verify `02_extended_thinking.py` loads config from `claude_sdk_extended_thinking` key
- [ ] Confirm both examples run without `KeyError` when `agent_config.yaml` has the correct entries

Closes INT-462