### PR TITLE
fix(examples): resolve 7 startup/doc issues [INT-467,468,469,471,472,473,482]

### DIFF
--- a/agent_config.yaml.example
+++ b/agent_config.yaml.example
@@ -148,6 +148,11 @@ crewai_flow_router:
   agent_id: ""
   api_key: ""
 
+# 09_flow_custom_tools.py
+crewai_flow_custom_tools:
+  agent_id: ""
+  api_key: ""
+
 # =============================================================================
 # Gemini Examples
 # =============================================================================
@@ -208,6 +213,11 @@ acp_client_agent:
 
 # 06_cursor_client.py
 cursor_agent:
+  agent_id: ""
+  api_key: ""
+
+# 07_jetbrains_server.py
+jetbrains_acp_agent:
   agent_id: ""
   api_key: ""
 

--- a/examples/20-questions-arena/guesser_agent.py
+++ b/examples/20-questions-arena/guesser_agent.py
@@ -22,7 +22,6 @@ Run with (from repo root):
     # Multi-guesser: each terminal runs a different config + model
     uv run examples/20-questions-arena/guesser_agent.py --config arena_guesser_2 --model gpt-5.2
     uv run examples/20-questions-arena/guesser_agent.py -c arena_guesser_3 -m claude-opus-4-6
-    uv run examples/20-questions-arena/guesser_agent.py -c arena_guesser_4 -m claude-sonnet-4-6
 """
 
 from __future__ import annotations

--- a/examples/crewai/README.md
+++ b/examples/crewai/README.md
@@ -20,7 +20,7 @@ In this repo, the CrewAI adapter lets those agents use Thenvoi rooms and Thenvoi
 | `01_basic_agent.py` | **Minimal setup** - Smallest working CrewAI + Thenvoi example. |
 | `02_role_based_agent.py` | **Role definition** - Shows how role, goal, and backstory shape behavior. |
 | `03_coordinator_agent.py` | **Coordinator** - Uses Thenvoi tools to discover peers and manage participation in a room. |
-| `04_research_crew.py` | **Research crew** - Three agents collaborate in the same room. |
+| `04_research_crew.py` | **Research crew** - Three agents collaborate in the same room. Requires a `<role>` argument: `researcher`, `writer`, or `editor`. |
 | `05_tom_agent.py` | **Character agent** - Tom the cat with a custom character prompt. |
 | `06_jerry_agent.py` | **Character agent** - Jerry the mouse with a custom character prompt. |
 | `07_contact_and_memory_agent.py` | **Contacts + memory** - Shows CrewAI contact tools, memory tools, and broadcast contact updates. |

--- a/examples/gemini/01_basic_agent.py
+++ b/examples/gemini/01_basic_agent.py
@@ -26,6 +26,8 @@ import logging
 import os
 import sys
 
+from dotenv import load_dotenv
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from setup_logging import setup_logging
@@ -39,6 +41,16 @@ logger = logging.getLogger(__name__)
 
 
 async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("THENVOI_WS_URL")
+    rest_url = os.getenv("THENVOI_REST_URL")
+
+    if not ws_url:
+        raise ValueError("THENVOI_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("THENVOI_REST_URL environment variable is required")
+
     # Load agent credentials from agent_config.yaml
     agent_id, api_key = load_agent_config("gemini_agent")
 
@@ -54,6 +66,8 @@ async def main() -> None:
         adapter=adapter,
         agent_id=agent_id,
         api_key=api_key,
+        ws_url=ws_url,
+        rest_url=rest_url,
     )
 
     logger.info("Starting Gemini agent...")

--- a/examples/parlant/03_support_agent.py
+++ b/examples/parlant/03_support_agent.py
@@ -113,7 +113,7 @@ async def main() -> None:
     agent_id, api_key = load_agent_config("support_agent")
 
     # Start Parlant server
-    async with p.Server() as server:
+    async with p.Server(nlp_service=p.NLPServices.openai) as server:
         # Create support agent with guidelines
         parlant_agent = await setup_support_agent(server)
         logger.info("Support agent created: %s", parlant_agent.id)

--- a/examples/pydantic_ai/02_custom_instructions.py
+++ b/examples/pydantic_ai/02_custom_instructions.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["thenvoi-sdk[pydantic-ai]"]
+# dependencies = ["thenvoi-sdk[pydantic-ai,anthropic]"]
 #
 # [tool.uv.sources]
 # thenvoi-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }


### PR DESCRIPTION
## Summary

Fixes 7 example/documentation bugs from the **M1: Zero Startup Errors** milestone:

- **INT-471**: Add `load_dotenv`, URL validation, and `ws_url`/`rest_url` to gemini example
- **INT-469**: Add `jetbrains_acp_agent` config key to template
- **INT-468**: Add `crewai_flow_custom_tools` config key to template
- **INT-472**: Add `nlp_service=p.NLPServices.openai` to parlant 03 `Server()` call
- **INT-467**: Add `anthropic` to pydantic_ai 02 PEP 723 dependencies
- **INT-473**: Remove stale `arena_guesser_4` reference from 20-questions docstring
- **INT-482**: Document required `<role>` CLI argument for crewai 04 in README table

## Test plan

- [x] `ruff check` passes on all modified Python files
- [x] 938 unit tests pass (1 pre-existing flaky test unrelated to changes)
- [x] `grep` confirms new config keys present and stale reference removed