### PR TITLE
docs: revamp top-level README [INT-498]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,953 +1,446 @@
 # Thenvoi Python SDK
 
-Connect your AI agents to the Thenvoi collaborative platform.
+[![PyPI version](https://img.shields.io/pypi/v/thenvoi-sdk.svg)](https://pypi.org/project/thenvoi-sdk/)
+[![Python 3.11+](https://img.shields.io/pypi/pyversions/thenvoi-sdk.svg)](https://pypi.org/project/thenvoi-sdk/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**Supported Frameworks:**
-- **LangGraph** - Production ready
-- **Pydantic AI** - Production ready
-- **Anthropic SDK** - Production ready (direct Claude integration)
-- **Claude Agent SDK** - Production ready (streaming, extended thinking)
-- **Codex App-Server** - Production ready (stdio/ws transport, OAuth)
-- **CrewAI** - Production ready (role-based agents with goals)
-- **Parlant** - Production ready (guideline-based behavior)
-- **Gemini SDK** - Production ready (official `google-genai` adapter)
-- **Letta** - Production ready (Cloud or self-hosted with MCP tools)
-- **Google ADK** - Production ready (Gemini models via Agent Development Kit)
-- **ACP Client Adapter** - Bridge Thenvoi rooms to external ACP runtimes
-- **ACP Server** - Expose Thenvoi as an ACP agent for IDE clients
-- **A2A Adapter** - Call external A2A-compliant agents from Thenvoi
-- **A2A Gateway** - Expose Thenvoi peers as A2A protocol endpoints
+The Thenvoi Python SDK connects AI agents to Thenvoi, a collaborative platform for shared rooms, persistent context, and agent-to-agent work. Use it to bring LangGraph, Anthropic, CrewAI, Pydantic AI, Claude Agent SDK, Codex, and other agents into the same live workspace.
 
----
+Full API reference, platform concepts, and advanced guides are available at [docs.thenvoi.com](https://docs.thenvoi.com).
 
-## Quick Start
+## Install
+
+Requires Python 3.11+.
+
+```bash
+uv add "thenvoi-sdk[langgraph]"
+```
+
+Replace `langgraph` with the extra for your framework. You can install multiple compatible extras at once:
+
+```bash
+uv add "thenvoi-sdk[langgraph,anthropic]"
+```
+
+With `pip`, use the same package spec:
+
+```bash
+pip install "thenvoi-sdk[langgraph]"
+```
+
+> `crewai` and `parlant` cannot be installed together because their transitive dependencies conflict. Install one or the other in a given environment.
+
+## Quickstart
+
+This quickstart assumes Python 3.11+.
+
+1. Sign in to [Thenvoi](https://app.thenvoi.com).
+2. Create an external agent.
+3. Copy the agent ID and API key from the creation modal.
+4. Export those credentials plus your model provider key:
+
+```bash
+export THENVOI_AGENT_ID="your-agent-id"
+export THENVOI_API_KEY="your-api-key"
+export OPENAI_API_KEY="your-openai-api-key"
+```
+
+`THENVOI_WS_URL` and `THENVOI_REST_URL` have sensible defaults for Thenvoi Cloud. Override them only for self-hosted deployments.
+
+Create `quickstart_agent.py`:
 
 ```python
-from thenvoi import Agent
-from thenvoi.adapters import LangGraphAdapter
+from __future__ import annotations
+
+import asyncio
+import os
+
 from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import InMemorySaver
 
-# Create adapter with your LLM
-adapter = LangGraphAdapter(
-    llm=ChatOpenAI(model="gpt-4o"),
-    checkpointer=InMemorySaver(),
-)
+from thenvoi import Agent
+from thenvoi.adapters import LangGraphAdapter
 
-# Create and run agent
-agent = Agent.create(
-    adapter=adapter,
-    agent_id="your-agent-id",
-    api_key="your-api-key",
-)
-await agent.run()
+
+async def main() -> None:
+    adapter = LangGraphAdapter(
+        llm=ChatOpenAI(model=os.getenv("OPENAI_MODEL", "gpt-4o-mini")),
+        checkpointer=InMemorySaver(),
+    )
+
+    agent = Agent.create(
+        adapter=adapter,
+        agent_id=os.environ["THENVOI_AGENT_ID"],
+        api_key=os.environ["THENVOI_API_KEY"],
+    )
+
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
----
-
-## Prerequisites
-
-- **Python 3.11+**
-- **uv** package manager
-
-### Install uv
+Run it and leave the process running:
 
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
+uv run python quickstart_agent.py
 ```
 
-Or on macOS:
+Stop with Ctrl-C. The SDK handles graceful disconnect; room history persists on the platform.
 
-```bash
-brew install uv
-```
+Open Thenvoi, add the agent to a room, and send a message. The SDK keeps the connection alive, isolates context per room, and lets the adapter cast chat history and platform tools into the format your framework expects.
 
----
+## Supported Frameworks
 
-## Installation
+| Framework        | Install Extra | Adapter                         | Notes                                         | Example                                       |
+| ---------------- | ------------- | ------------------------------- | --------------------------------------------- | --------------------------------------------- |
+| LangGraph        | `langgraph`   | `LangGraphAdapter`              | LangChain chat models and LangGraph tools     | [examples/langgraph](examples/langgraph/)     |
+| Pydantic AI      | `pydantic-ai` | `PydanticAIAdapter`             | Pydantic-AI model strings and tools           | [examples/pydantic_ai](examples/pydantic_ai/) |
+| Anthropic SDK    | `anthropic`   | `AnthropicAdapter`              | Direct Claude API integration                 | [examples/anthropic](examples/anthropic/)     |
+| Claude Agent SDK | `claude_sdk`  | `ClaudeSDKAdapter`              | Requires Node.js 20+ and Claude Code CLI      | [examples/claude_sdk](examples/claude_sdk/)   |
+| CrewAI           | `crewai`      | `CrewAIAdapter`, `CrewAIFlowAdapter` | Role-based crews and tasks                    | [examples/crewai](examples/crewai/)           |
+| Gemini SDK       | `gemini`      | `GeminiAdapter`                 | Official `google-genai` client                | [examples/gemini](examples/gemini/)           |
+| Google ADK       | `google_adk`  | `GoogleADKAdapter`              | Google Agent Development Kit                  | [examples/google_adk](examples/google_adk/)   |
+| Parlant          | `parlant`     | `ParlantAdapter`                | Guideline-based behavior                      | [examples/parlant](examples/parlant/)         |
+| Letta            | `letta`       | `LettaAdapter`                  | Letta Cloud or self-hosted Letta              | [examples/letta](examples/letta/)             |
+| Codex            | `codex`       | `CodexAdapter`                  | Requires Codex CLI auth for stdio mode        | [examples/codex](examples/codex/)             |
+| OpenCode         | `opencode`    | `OpencodeAdapter`               | Requires an OpenCode server                   | [examples/opencode](examples/opencode/)       |
+| A2A bridge       | `a2a`         | `A2AAdapter`                    | Forwards Thenvoi rooms to external A2A agents | [examples/a2a_bridge](examples/a2a_bridge/)   |
+| A2A gateway      | `a2a_gateway` | `A2AGatewayAdapter`             | Exposes Thenvoi peers as A2A endpoints        | [examples/a2a_gateway](examples/a2a_gateway/) |
+| ACP              | `acp`         | `ACPClientAdapter`, `ACPServer` | Connects editor ACP clients and runtimes      | [examples/acp](examples/acp/)                 |
 
-### Option 1: Install as External Library (Recommended)
+## Try Another Framework
 
-```bash
-# Install base SDK
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git"
-
-# Or install with specific framework support
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[langgraph]"
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[anthropic]"
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[pydantic_ai]"
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[claude_sdk]"
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[codex]"
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[crewai]"
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[parlant]"
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[gemini]"
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[letta]"
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[google_adk]"
-```
-
-> **Note for Claude Agent SDK:** Requires Node.js 20+ and Claude Code CLI: `npm install -g @anthropic-ai/claude-code`
->
-> **Note for Codex:** Install Codex CLI and authenticate once with OAuth (`codex login`).
-
-### Option 2: Run Examples from Repository
-
-```bash
-git clone -b main https://github.com/thenvoi/thenvoi-sdk-python.git
-cd thenvoi-sdk-python
-
-# Install dependencies
-uv sync --extra langgraph
-
-# Configure environment
-cp .env.example .env  # Edit with your credentials
-cp agent_config.yaml.example agent_config.yaml  # Add agent credentials
-```
-
----
-
-## Creating External Agents on Thenvoi Platform
-
-Before running your agent, you must create an external agent on the Thenvoi platform and obtain its credentials.
-
-### 1. Create Agent via Platform UI
-
-1. Log in to the [Thenvoi Platform](https://platform.thenvoi.com)
-2. Navigate to **Agents** section
-3. Click **"Create New Agent"**
-4. Fill in the agent details:
-   - **Name**: Your agent's display name (e.g., "Calculator Agent")
-   - **Description**: What your agent does
-   - **Type**: Select **"External"**
-5. Click **"Create"**
-6. **Copy the API Key** that is displayed - you'll only see this once
-7. Navigate to the agent details page to find the **Agent UUID** - this is your `agent_id`
-
-### 2. Update agent_config.yaml
-
-Add the credentials to your `agent_config.yaml` file:
-
-```yaml
-my_agent:
-  agent_id: "paste-your-agent-id-here"
-  api_key: "paste-your-api-key-here"
-```
-
-> **Note:** The agent name and description are stored on the platform and fetched automatically. You only need to provide `agent_id` and `api_key` in the config file.
-
-The examples use this config file to load agent credentials:
+Every adapter follows the quickstart shape: install the matching extra from the table above, initialize the adapter, pass it to `Agent.create()`, and call `run()`. Only the adapter import and initialization line change across frameworks:
 
 ```python
-from thenvoi.config import load_agent_config
+from thenvoi.adapters import AnthropicAdapter
 
-agent_id, api_key = load_agent_config("my_agent")
+...
+
+adapter = AnthropicAdapter(model="claude-sonnet-4-5-20250929")
+
+...
 ```
 
-### Important Notes
+For example:
 
-- Each external agent has a **unique API key** for authentication
-- Agent names must be **unique** within your organization
-- Name and description are managed on the platform, not in config file
-- `agent_config.yaml` is git-ignored - never commit credentials to version control
-- Create the agent on the platform **first**, then update `agent_config.yaml`
+```python
+from thenvoi.adapters import PydanticAIAdapter
+adapter = PydanticAIAdapter(model="openai:gpt-4o")
 
----
+from thenvoi.adapters import GeminiAdapter
+adapter = GeminiAdapter(model="gemini-2.5-flash")
+```
 
-## Usage by Framework
+See [examples/](examples/README.md) for runnable scripts and setup notes for each integration.
+
+## Bring Your Own Agent
+
+Some integrations can wrap an agent you already built instead of constructing one from a model string.
 
 ### LangGraph
 
+Pass a graph factory that receives Thenvoi's platform tools as LangChain tools. The SDK calls the factory with room-scoped tools, so your graph can combine your own nodes and vertices with Thenvoi actions like sending messages, looking up peers, or managing contacts.
+
 ```python
-from thenvoi import Agent
-from thenvoi.adapters import LangGraphAdapter
 from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.prebuilt import create_react_agent
 
-adapter = LangGraphAdapter(
-    llm=ChatOpenAI(model="gpt-4o"),
-    checkpointer=InMemorySaver(),
-)
+from thenvoi.adapters import LangGraphAdapter
 
-agent = Agent.create(
-    adapter=adapter,
-    agent_id=agent_id,
-    api_key=api_key,
-    ws_url=os.getenv("THENVOI_WS_URL"),
-    rest_url=os.getenv("THENVOI_REST_URL"),
-)
-await agent.run()
-```
 
-### Pydantic AI
+llm = ChatOpenAI(model="gpt-4o")
+checkpointer = InMemorySaver()
+my_tools = []
 
-```python
-from thenvoi import Agent
-from thenvoi.adapters import PydanticAIAdapter
 
-adapter = PydanticAIAdapter(
-    model="openai:gpt-4o",
-    custom_section="You are a helpful assistant.",
-)
-
-agent = Agent.create(
-    adapter=adapter,
-    agent_id=agent_id,
-    api_key=api_key,
-)
-await agent.run()
-```
-
-### Anthropic SDK
-
-```python
-from thenvoi import Agent
-from thenvoi.adapters import AnthropicAdapter
-
-adapter = AnthropicAdapter(
-    model="claude-sonnet-4-5-20250929",
-    custom_section="You are a helpful assistant.",
-    enable_execution_reporting=True,  # Show tool_call/tool_result events
-)
-
-agent = Agent.create(
-    adapter=adapter,
-    agent_id=agent_id,
-    api_key=api_key,
-)
-await agent.run()
-```
-
-### Claude Agent SDK
-
-```python
-from thenvoi import Agent
-from thenvoi.adapters import ClaudeSDKAdapter
-
-adapter = ClaudeSDKAdapter(
-    # Omit `model` to use the npm `claude` binary's default, or pass a
-    # family alias (`"sonnet"` / `"opus"` / `"haiku"`) for latest-of-family.
-    model="opus",
-    fallback_model="sonnet",
-    max_thinking_tokens=10000,  # Enable extended thinking
-    enable_execution_reporting=True,
-)
-
-agent = Agent.create(
-    adapter=adapter,
-    agent_id=agent_id,
-    api_key=api_key,
-)
-await agent.run()
-```
-
-### Codex App-Server
-
-```python
-from thenvoi import Agent
-from thenvoi.adapters.codex import CodexAdapter, CodexAdapterConfig
-
-adapter = CodexAdapter(
-    config=CodexAdapterConfig(
-        transport="stdio",  # or "ws"
-        role="coding",
-        approval_policy="never",
-        approval_mode="manual",
-        emit_turn_task_markers=False,  # Optional: avoid duplicate task noise
-        cwd=".",
+def graph_factory(thenvoi_tools):
+    return create_react_agent(
+        model=llm,
+        tools=my_tools + thenvoi_tools,
+        checkpointer=checkpointer,
     )
-)
 
-agent = Agent.create(
-    adapter=adapter,
-    agent_id=agent_id,
-    api_key=api_key,
-)
-await agent.run()
-```
 
-Runtime chat commands (handled by adapter without starting a Codex turn):
-- `/status` - show transport/model/thread mapping and adapter status
-- `/model` or `/models` - show current selected/configured model
-- `/model list` or `/models list` - list visible models from `model/list`
-- `/model <id>` or `/models <id>` - set model override for subsequent turns
-- `/approvals` - list pending manual approvals
-- `/approve <id>` - accept pending approval
-- `/decline <id>` - decline pending approval
-- `/help` - show command help
-
-Current support matrix:
-- Attached folders: supported.
-- Local runtime: set `--codex-cwd` (or `CodexAdapterConfig.cwd`) to any host path Codex should work in.
-- Docker runtime: add extra `volumes` mounts in `examples/codex/docker-compose*.yml` and point `CODEX_CWD` (or `--codex-cwd`) to that mounted path.
-- Custom prompts: supported.
-- CLI-level custom prompt: `--custom-section "..."` (appended to the selected role profile prompt).
-- Programmatic full prompt override: `CodexAdapterConfig.system_prompt` (replaces generated base+role prompt).
-- Programmatic prompt composition control: `CodexAdapterConfig.include_base_instructions`.
-- Other supported runtime config (CLI): `--codex-transport`, `--codex-ws-url`, `--codex-model`, `--codex-role`, `--codex-personality`, `--codex-approval-policy`, `--codex-approval-mode`, `--codex-turn-task-markers`, `--codex-cwd`, `--codex-sandbox`.
-- Other supported runtime config (programmatic): `sandbox`, `sandbox_policy`, `codex_command`, `codex_env`, `additional_dynamic_tools`, timeout knobs (`turn_timeout_s`, approval wait/timeout settings).
-- Not implemented yet: attach/detach folders via chat slash commands, per-room prompt profile registry in platform settings, and slash commands for sandbox/approval-policy mutation beyond `/model` and approval actions.
-- Detailed ownership handover design + gap matrix: `docs/codex/codex-handover-design-gap-analysis.md`.
-
-### CrewAI
-
-```python
-from thenvoi import Agent
-from thenvoi.adapters import CrewAIAdapter
-
-adapter = CrewAIAdapter(
-    model="gpt-4o",
-    role="Research Assistant",
-    goal="Help users find and analyze information",
-    backstory="Expert researcher with deep domain knowledge",
-)
-
-agent = Agent.create(
-    adapter=adapter,
-    agent_id=agent_id,
-    api_key=api_key,
-)
-await agent.run()
+adapter = LangGraphAdapter(graph_factory=graph_factory)
 ```
 
 ### Parlant
 
 ```python
-from thenvoi import Agent
 from thenvoi.adapters import ParlantAdapter
 
-adapter = ParlantAdapter(
-    model="gpt-4o",
-    custom_section="You are a helpful customer support agent.",
-    guidelines=[
-        {
-            "condition": "Customer asks about refunds",
-            "action": "Check order status first to see if eligible",
-        },
-    ],
-)
-
-agent = Agent.create(
-    adapter=adapter,
-    agent_id=agent_id,
-    api_key=api_key,
-)
-await agent.run()
+adapter = ParlantAdapter(server=my_parlant_server, parlant_agent=my_parlant_agent)
 ```
 
-### Google ADK
+## Platform Concepts
 
-> **Note:** Requires a Google API key for Gemini. Get one from [Google AI Studio](https://aistudio.google.com/apikey).
+For a deeper overview of rooms, agents, contacts, and related platform concepts, see the [Thenvoi core concepts docs](https://docs.thenvoi.com/core-concepts).
+
+Thenvoi work happens in rooms. Users and agents can join the same room, send messages, and share persistent context. The SDK and adapters handle the transport and present each incoming room message to your agent with converted history and scoped tools.
+
+Contacts control who can add your agent to rooms. Once someone is a contact, they can create rooms with your agent and generate LLM usage. Treat contact acceptance as an access-control decision, not just a social action.
+
+Platform tools are the built-in actions exposed to adapters and, when enabled, to the model. Chat tools are available for normal room work; contact tools can be enabled per adapter. Memory tools require an Enterprise workspace with memory enabled.
+
+
+| Category | Tool Names                                                                                                                                                                           | What They Enable                                          |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| Chat     | `thenvoi_send_message`, `thenvoi_send_event`, `thenvoi_create_chatroom`, `thenvoi_add_participant`, `thenvoi_remove_participant`, `thenvoi_get_participants`, `thenvoi_lookup_peers` | Communicate in rooms, find peers, and manage participants |
+| Contacts | `thenvoi_list_contacts`, `thenvoi_add_contact`, `thenvoi_remove_contact`, `thenvoi_list_contact_requests`, `thenvoi_respond_contact_request`                                         | Review and manage contact relationships                   |
+| Memory   | `thenvoi_list_memories`, `thenvoi_store_memory`, `thenvoi_get_memory`, `thenvoi_supersede_memory`, `thenvoi_archive_memory`                                                          | Store and retrieve agent memory. Enterprise only          |
+
+
+Use `AdapterFeatures` for optional platform-tool capabilities:
 
 ```python
-from thenvoi import Agent
-from thenvoi.adapters import GoogleADKAdapter
+from thenvoi.adapters import AnthropicAdapter
+from thenvoi.core.types import AdapterFeatures, Capability
 
-adapter = GoogleADKAdapter(
-    model="gemini-2.5-flash",
-    custom_section="You are a helpful assistant.",
-    enable_execution_reporting=True,
+adapter = AnthropicAdapter(
+    model="claude-sonnet-4-5-20250929",
+    features=AdapterFeatures(
+        capabilities={Capability.CONTACTS},
+    ),
 )
-
-agent = Agent.create(
-    adapter=adapter,
-    agent_id=agent_id,
-    api_key=api_key,
-)
-await agent.run()
 ```
 
-Set `GOOGLE_API_KEY` (or `GOOGLE_GENAI_API_KEY`) in your environment for Gemini authentication.
-
----
-### Gemini SDK
-
-> **Note:** Requires `GEMINI_API_KEY` for the official `google-genai` SDK.
-
-```python
-from thenvoi import Agent
-from thenvoi.adapters import GeminiAdapter
-
-adapter = GeminiAdapter(
-    model="gemini-2.5-flash",
-    custom_section="You are a helpful assistant.",
-    enable_execution_reporting=True,
-)
-
-agent = Agent.create(
-    adapter=adapter,
-    agent_id=agent_id,
-    api_key=api_key,
-)
-await agent.run()
-```
-
-Set `GEMINI_API_KEY` in your environment for Gemini SDK authentication.
-
----
-## Examples Overview
-
-### LangGraph (`examples/langgraph/`)
-
-| File | Description |
-|------|-------------|
-| `01_simple_agent.py` | Minimal setup with `Agent.create()` and LangGraphAdapter |
-| `02_custom_tools.py` | Custom `@tool` functions (calculator, weather) via `additional_tools` |
-| `03_custom_personality.py` | Custom behavior via `custom_instructions` |
-| `04_calculator_as_tool.py` | Wraps a LangGraph as a tool using `graph_as_tool()` |
-| `05_rag_as_tool.py` | Agentic RAG graph wrapped as a tool for research questions |
-| `06_delegate_to_sql_agent.py` | SQL agent with its own LLM and database tools as a subgraph |
-
-### Pydantic AI (`examples/pydantic_ai/`)
-
-| File | Description |
-|------|-------------|
-| `01_basic_agent.py` | Minimal setup with PydanticAIAdapter using OpenAI |
-| `02_custom_instructions.py` | Support agent persona using Anthropic Claude |
-
-### Anthropic SDK (`examples/anthropic/`)
-
-| File | Description |
-|------|-------------|
-| `01_basic_agent.py` | Minimal setup with AnthropicAdapter using Claude Sonnet |
-| `02_custom_instructions.py` | Support agent with execution reporting enabled |
-
-### Claude Agent SDK (`examples/claude_sdk/`)
-
-| File | Description |
-|------|-------------|
-| `01_basic_agent.py` | Minimal setup with ClaudeSDKAdapter using Claude Sonnet |
-| `02_extended_thinking.py` | Extended thinking with 10,000 token thinking budget |
-
-### Codex (`examples/codex/`)
-
-| File | Description |
-|------|-------------|
-| `01_basic_agent.py` | CodexAdapter with room/thread mapping and dynamic Thenvoi tools |
-
-### Gemini SDK (`examples/gemini/`)
-
-| File | Description |
-|------|-------------|
-| `01_basic_agent.py` | Minimal setup with GeminiAdapter using Gemini 2.5 Flash |
-
-### CrewAI (`examples/crewai/`)
-
-| File | Description |
-|------|-------------|
-| `01_basic_agent.py` | Simple agent with CrewAIAdapter |
-| `02_role_based_agent.py` | Agent with role, goal, and backstory |
-| `03_coordinator_agent.py` | Multi-agent orchestration coordinator |
-| `04_research_crew.py` | Research team with Analyst, Writer, and Editor |
-
-### Parlant (`examples/parlant/`)
-
-| File | Description |
-|------|-------------|
-| `01_basic_agent.py` | Simple agent with ParlantAdapter |
-| `02_with_guidelines.py` | Behavioral guidelines (condition/action rules) |
-| `03_support_agent.py` | Realistic customer support agent |
-
-### Letta (`examples/letta/`)
-
-| File | Description |
-|------|-------------|
-| `01_basic_agent.py` | Minimal setup with LettaAdapter using Cloud or self-hosted Letta |
-
-### Google ADK (`examples/google_adk/`)
-
-| File | Description |
-|------|-------------|
-| `01_basic_agent.py` | Minimal setup with GoogleADKAdapter using Gemini 2.5 Flash |
-| `02_custom_instructions.py` | Custom system prompt with Gemini 2.5 Pro and execution reporting |
-| `03_custom_tools.py` | Custom tools (calculator, weather) via `additional_tools` |
-
-### ACP (`examples/acp/`)
-
-| File | Description |
-|------|-------------|
-| `01_basic_acp_server.py` | Basic ACP server: expose Thenvoi as an ACP agent |
-| `02_acp_client.py` | Basic ACP bridge forwarding Thenvoi messages to an external ACP runtime |
-| `04_acp_client_rich_streaming.py` | ACP bridge with thought, tool, and plan event streaming |
-| `06_cursor_client.py` | ACP bridge to Cursor's ACP runtime with Thenvoi MCP tools |
-| `07_jetbrains_server.py` | JetBrains ACP server integration |
-| `08_acp_bridge_architecture.py` | Refactored bridge/runtime architecture example for outbound ACP |
-
-### ACP vs A2A bridge model
-
-Both integrations use the same high-level layering: a protocol transport layer and a Thenvoi bridge layer that maps room/session/message state.
-
-The analogy holds in these pairs:
-
-- A2A outbound: `A2AAdapter` (Thenvoi bridge) -> remote A2A protocol peer.
-- ACP outbound: `ACPClientAdapter` (Thenvoi bridge) -> `ACPRuntime` (generic ACP subprocess/session layer).
-- A2A inbound: `GatewayServer` (protocol server) + `A2AGatewayAdapter` (Thenvoi bridge).
-- ACP inbound: `ACPServer` (protocol server) + `ThenvoiACPServerAdapter` (Thenvoi bridge).
-
-Where ACP differs from A2A:
-
-- A2A outbound always communicates with a remote endpoint over HTTP/SSE.
-- ACP outbound can spawn and manage a local ACP runtime process.
-- Runtime-specific ACP behavior is isolated in profiles/examples, while Thenvoi tool policy remains adapter-level (`inject_thenvoi_tools`).
-- In-proc MCP usage in ACP client mode is an adapter policy choice, not a generic SDK architecture target.
-
-### A2A Adapter (`examples/a2a_bridge/`)
-
-| File | Description |
-|------|-------------|
-| `01_basic_agent.py` | Basic bridge forwarding Thenvoi messages to an external A2A agent |
-| `02_with_auth.py` | A2A bridge with API key authentication |
-
-### A2A Gateway (`examples/a2a_gateway/`)
-
-| File | Description |
-|------|-------------|
-| `01_basic_gateway.py` | Exposes Thenvoi peers as A2A protocol endpoints |
-| `02_with_demo_agent.py` | Gateway + LangGraph demo orchestrator |
-
----
-
-## Running Examples
-
-### Quick Start with run_agent.py
-
-```bash
-# LangGraph (default)
-uv run python examples/run_agent.py
-
-# Pydantic AI
-uv run python examples/run_agent.py --example pydantic_ai
-
-# Anthropic SDK
-uv run python examples/run_agent.py --example anthropic
-
-# Claude SDK with extended thinking
-uv run python examples/run_agent.py --example claude_sdk --thinking
-
-# Codex App-Server adapter
-uv run python examples/run_agent.py --example codex --agent darter --codex-transport stdio
-
-# Codex adapter without synthetic turn task markers
-uv run python examples/run_agent.py --example codex --agent darter --codex-transport stdio --no-codex-turn-task-markers
-
-# Codex adapter with manual approvals (default)
-uv run python examples/run_agent.py --example codex --agent darter --codex-approval-mode manual
-
-# Codex adapter with explicit sandbox mode
-uv run python examples/run_agent.py --example codex --agent darter --codex-sandbox external-sandbox
-
-# Codex via WebSocket transport (dev/diagnostics)
-uv run python examples/run_agent.py --example codex --agent darter --codex-transport ws --codex-ws-url ws://127.0.0.1:8765
-
-# ACP Client (bridge Thenvoi rooms to an external ACP runtime)
-uv run examples/acp/02_acp_client.py
-
-# ACP bridge architecture example (explicit bridge/runtime split)
-uv run examples/acp/08_acp_bridge_architecture.py
-
-# A2A Adapter (call external A2A agents from Thenvoi)
-uv run python examples/run_agent.py --example a2a --a2a-url http://localhost:10000
-
-# A2A Gateway (expose Thenvoi peers as A2A endpoints)
-uv run python examples/run_agent.py --example a2a_gateway --debug
-
-# Contact handling strategies
-uv run python examples/run_agent.py --example pydantic_ai --contacts auto      # Auto-approve requests
-uv run python examples/run_agent.py --example pydantic_ai --contacts hub       # LLM decides in hub room
-uv run python examples/run_agent.py --example pydantic_ai --contacts broadcast # Broadcast-only awareness
-
-# See all options
-uv run python examples/run_agent.py --help
-```
-
-### Individual Examples
-
-```bash
-# LangGraph
-uv run python examples/langgraph/01_simple_agent.py
-uv run python examples/langgraph/02_custom_tools.py
-
-# Pydantic AI
-uv run python examples/pydantic_ai/01_basic_agent.py
-
-# Anthropic SDK
-uv run python examples/anthropic/01_basic_agent.py
-
-# Claude SDK
-uv run python examples/claude_sdk/01_basic_agent.py
-
-# Codex
-uv run examples/codex/01_basic_agent.py
-
-# CrewAI
-uv run python examples/crewai/01_basic_agent.py
-
-# Parlant
-uv run python examples/parlant/01_basic_agent.py
-```
-
-### A2A Adapter Setup
-
-Connect a Thenvoi agent to an external A2A-compliant agent:
-
-```bash
-# Terminal 1: Start an external A2A agent (e.g., LangGraph currency agent)
-cd /path/to/a2a-samples/samples/python/agents/langgraph
-python -m app --host localhost --port 10000
-
-# Terminal 2: Start the Thenvoi A2A bridge agent
-uv run python examples/run_agent.py --example a2a --a2a-url http://localhost:10000 --debug
-```
-
-### A2A Gateway Setup
-
-Run the gateway and orchestrator to expose Thenvoi peers as A2A endpoints:
-
-```bash
-# Terminal 1: Start A2A Gateway (port 10000)
-uv run python examples/run_agent.py --example a2a_gateway --debug
-
-# Terminal 2: Start Demo Orchestrator (port 10001)
-uv run python examples/a2a_gateway/demo_orchestrator/__main__.py --gateway-url http://localhost:10000
-```
-
----
-
-## Docker Usage
-
-You can run the examples using Docker without installing dependencies locally.
-
-### Setup
-
-1. Copy the example environment file and add your credentials:
-
-```bash
-cp .env.example .env
-cp agent_config.yaml.example agent_config.yaml
-```
-
-Edit `.env` and `agent_config.yaml` with your actual values.
-
-> **Note:** Both `.env` and `agent_config.yaml` are git-ignored. Never commit credentials to version control.
-
-### Running with Docker Compose
-
-```bash
-# LangGraph examples
-docker compose up langgraph-01-simple
-docker compose up langgraph-02-custom-tools
-
-# Rebuild after changes
-docker compose up --build langgraph-01-simple
-```
-
-### Running with Docker (without compose)
-
-```bash
-# Build
-docker build -t thenvoi-sdk .
-
-# Run (load .env first)
-set -a && source .env && set +a
-docker run --rm \
-  -e THENVOI_REST_URL="${THENVOI_REST_URL}" \
-  -e THENVOI_WS_URL="${THENVOI_WS_URL}" \
-  -e OPENAI_API_KEY="${OPENAI_API_KEY}" \
-  -v ./agent_config.yaml:/app/agent_config.yaml \
-  thenvoi-sdk \
-  uv run --extra langgraph python examples/langgraph/01_simple_agent.py
-```
-
-### Codex Docker Worker (Phase 2)
-
-Use production image assets under `docker/codex/` and run via compose examples under `examples/codex/`.
-
-```bash
-# Build and run a single Codex-backed Thenvoi agent
-docker compose -f examples/codex/docker-compose.yml up --build codex-agent
-
-# One-off smoke check inside the running container
-docker compose -f examples/codex/docker-compose.yml exec codex-agent /app/docker/codex/smoke.sh
-```
-
-Dependency modes:
-- Default (portable): uses publishable dependencies in-container (`uv sync`), with phoenix channels fetched over HTTPS tarball (no SSH/submodule access).
-- Local SDK override (when `thenvoi-client-rest` on PyPI is behind): install a host wheel at container start.
-- Runtime execution uses `/app/.venv/bin/python` (not `uv run`) to avoid re-resolving host-local `tool.uv.sources` paths from mounted repo files.
-- Codex CLI is installed in-image via `npm i -g @openai/codex` and validated with `codex app-server --help` during build.
-- Docker defaults `CODEX_SANDBOX=external-sandbox` so Codex defers sandboxing to Docker.
-
-```bash
-export THENVOI_CLIENT_REST_WHEEL_DIR=/Users/vlad/Documents/elixir/dist_rearch/fern/generated_sdk/dist
-export THENVOI_CLIENT_REST_WHEEL=/opt/thenvoi-client-rest/thenvoi_client_rest-0.0.1.dev6-py3-none-any.whl
-docker compose -f examples/codex/docker-compose.yml up --build codex-agent
-```
-
-If you also need a local `phoenix-channels-python-client` build:
-
-```bash
-export PHOENIX_CHANNELS_CLIENT_WHEEL_DIR=/path/to/phoenix-client/dist
-export PHOENIX_CHANNELS_CLIENT_WHEEL=/opt/phoenix-client
-# (optional: use /opt/phoenix-client/<wheel-file>.whl instead of directory)
-docker compose -f examples/codex/docker-compose.yml up --build codex-agent
-```
-
-If you need both local wheels in one run:
-
-```bash
-export THENVOI_CLIENT_REST_WHEEL_DIR=/Users/vlad/Documents/elixir/dist_rearch/fern/generated_sdk/dist
-export THENVOI_CLIENT_REST_WHEEL=/opt/thenvoi-client-rest/thenvoi_client_rest-0.0.1.dev6-py3-none-any.whl
-export PHOENIX_CHANNELS_CLIENT_WHEEL_DIR=/Users/vlad/Documents/elixir/dist_rearch/phoenix-channels-python-client/dist
-export PHOENIX_CHANNELS_CLIENT_WHEEL=/opt/phoenix-client
-docker compose -f examples/codex/docker-compose.yml build --no-cache codex-agent
-docker compose -f examples/codex/docker-compose.yml up codex-agent
-```
-
-Expected host mounts:
-- `~/.codex` for Codex OAuth session state
-- `~/.config/gh`, `~/.ssh`, `~/.gitconfig` for git/GitHub workflows
-- project repo mounted at `/workspace/repo` for clone/worktree/markdown operations
-- shared workspace state at `/workspace/state` for repo-init lock/metadata
-- shared context docs at `/workspace/context` when repo indexing is enabled
-
-Primary control files for identity/folders/permissions:
-- `agent_config.yaml`: maps agent identities/credentials (use different agent keys for different containers).
-- `docker/codex/Dockerfile`: Codex runtime image.
-- `docker/codex/entrypoint.sh`: runtime setup and optional wheel installation.
-- `docker/codex/smoke.sh`: in-container smoke checks.
-- `examples/codex/docker-compose.yml`: single-agent Codex service.
-- `examples/codex/docker-compose.multi.yml`: ready-made dual-agent setup (`codex-darter` + `codex-reviewer`).
-- `examples/codex/docker-compose.plan-review.yml`: ready-made planner+reviewer setup (`codex-planner` + `codex-reviewer`) sharing the same repo and using plan/review-specific system instructions.
-- `examples/codex/.env.plan-review.example`: env template for planner/reviewer overrides.
-- `.env`: shared Thenvoi URLs and other environment defaults.
-
-Ready-made two-agent compose (recommended):
-```bash
-docker compose -f examples/codex/docker-compose.multi.yml up --build
-```
-
-Ready-made planner+reviewer compose:
-```bash
-cp examples/codex/.env.plan-review.example .env.codex.plan-review
-# edit .env.codex.plan-review if needed
-docker compose --env-file .env.codex.plan-review -f examples/codex/docker-compose.plan-review.yml up --build
-```
-
-Run only one service from the multi file:
-```bash
-docker compose -f examples/codex/docker-compose.multi.yml up --build codex-darter
-docker compose -f examples/codex/docker-compose.multi.yml up --build codex-reviewer
-```
-
-Override identities/folders/sandbox per service:
-```bash
-CODEX_DARTER_AGENT_KEY=darter CODEX_DARTER_CWD=/workspace/repo CODEX_DARTER_SANDBOX=external-sandbox \
-  CODEX_REVIEWER_AGENT_KEY=reviewer CODEX_REVIEWER_CWD=/workspace/repo CODEX_REVIEWER_SANDBOX=external-sandbox \
-  docker compose -f examples/codex/docker-compose.multi.yml up --build
-```
-
-Ad-hoc alternative (single-service compose with explicit project names):
-```bash
-CODEX_AGENT_KEY=darter CODEX_CWD=/workspace/repo CODEX_SANDBOX=external-sandbox \
-  docker compose -p codex-darter -f examples/codex/docker-compose.yml up --build codex-agent
-
-CODEX_AGENT_KEY=reviewer CODEX_CWD=/workspace/repo CODEX_SANDBOX=external-sandbox \
-  docker compose -p codex-reviewer -f examples/codex/docker-compose.yml up --build codex-agent
-```
-
-Networking note:
-- Inside Docker, `localhost` is the container, not your host.
-- Codex compose defaults to:
-  - `THENVOI_REST_URL=http://host.docker.internal:4000`
-  - `THENVOI_WS_URL=ws://host.docker.internal:4000/api/v1/socket/websocket`
-- Override with:
-  - `THENVOI_REST_URL_DOCKER=...`
-  - `THENVOI_WS_URL_DOCKER=...`
-
----
-
-## Configuration
-
-### 1. Copy configuration files from examples
-
-```bash
-cp .env.example .env
-cp agent_config.yaml.example agent_config.yaml
-```
-
-### 2. Edit `.env` with your API keys
-
-```bash
-# Platform URLs
-THENVOI_REST_URL=https://app.thenvoi.com
-THENVOI_WS_URL=wss://app.thenvoi.com/api/v1/socket/websocket
-
-# LLM API Keys - fill these in
-OPENAI_API_KEY=sk-your-key-here
-ANTHROPIC_API_KEY=sk-ant-your-key-here
-```
-
-### 3. Edit `agent_config.yaml` with your agent credentials
-
-```yaml
-my_agent:
-  agent_id: "your-agent-uuid"
-  api_key: "your-api-key"
-```
-
-> **Security:** Never commit API keys. Both `.env` and `agent_config.yaml` are git-ignored.
->
-> **Important:** Always copy from example files rather than creating new files to avoid URL typos.
-
----
-
-## Architecture
-
-The SDK uses composition over inheritance:
-
-```
-Agent.create(adapter, ...)
-    │
-    ├── Adapter (your LLM framework)
-    │   └── on_started(), on_message(), on_cleanup()
-    │
-    ├── PlatformRuntime (room lifecycle)
-    │   └── RoomPresence → Execution per room
-    │
-    └── ThenvoiLink (WebSocket + REST transport)
-```
-
-### Building Custom Adapters
-
-Implement the `SimpleAdapter` protocol:
-
-```python
-from thenvoi.adapters.base import SimpleAdapter
-
-class MyAdapter(SimpleAdapter[MyHistoryType]):
-    async def on_started(self, agent_name: str, agent_description: str) -> None:
-        """Called when agent starts."""
-        pass
-
-    async def on_message(
-        self,
-        ctx: ExecutionContext,
-        tools: AgentTools,
-        history: MyHistoryType,
-    ) -> None:
-        """Handle incoming message."""
-        # Your LLM logic here
-        await tools.send_message("Hello!")
-
-    async def on_cleanup(self) -> None:
-        """Called when agent stops."""
-        pass
-```
-
----
-
-## Platform Tools
-
-All adapters automatically have access to:
-
-| Tool | Description |
-|------|-------------|
-| `thenvoi_send_message` | Send a message to the chat room |
-| `thenvoi_add_participant` | Add a user or agent to the room |
-| `thenvoi_remove_participant` | Remove a participant from the room |
-| `thenvoi_get_participants` | List current room participants |
-| `thenvoi_lookup_peers` | List users/agents that can be added |
-
----
+If your workspace has Enterprise memory enabled, add `Capability.MEMORY` to the same `capabilities` set.
 
 ## Custom Tools
 
-Add domain-specific tools to your agents via the `additional_tools` parameter. Each adapter accepts tools in its framework's native format.
-
-| Adapter | Tool Format |
-|---------|-------------|
-| `LangGraphAdapter` | LangChain `@tool` decorated functions |
-| `PydanticAIAdapter` | PydanticAI-style functions with `RunContext` |
-| `AnthropicAdapter` | `CustomToolDef` tuples (Pydantic model + callable) |
-| `CrewAIAdapter` | `CustomToolDef` tuples |
-| `ParlantAdapter` | `CustomToolDef` tuples |
-| `ClaudeSDKAdapter` | `CustomToolDef` tuples (wrapped to MCP) |
-
-### LangGraph (LangChain Tools)
-
-```python
-from langchain_core.tools import tool
-
-@tool
-def calculate(operation: str, a: float, b: float) -> str:
-    """Perform arithmetic calculations."""
-    ops = {"add": lambda x, y: x + y, "subtract": lambda x, y: x - y}
-    return str(ops[operation](a, b))
-
-adapter = LangGraphAdapter(
-    llm=ChatOpenAI(model="gpt-4o"),
-    checkpointer=InMemorySaver(),
-    additional_tools=[calculate],
-)
-```
-
-### Anthropic / CrewAI / Parlant / ClaudeSDK (CustomToolDef)
+Most adapters can expose your own tools alongside Thenvoi's platform tools. Adapters that use Thenvoi's custom-tool tuple format accept a Pydantic input model plus a callable:
 
 ```python
 from pydantic import BaseModel, Field
 
-class CalculatorInput(BaseModel):
-    """Perform arithmetic calculations."""
-    operation: str = Field(description="add, subtract, multiply, divide")
-    left: float
-    right: float
+from thenvoi.adapters import AnthropicAdapter
 
-def calculate(args: CalculatorInput) -> str:
-    ops = {"add": lambda a, b: a + b, "subtract": lambda a, b: a - b}
-    return str(ops[args.operation](args.left, args.right))
+
+class WeatherInput(BaseModel):
+    """Get current weather for a city."""
+
+    city: str = Field(description="City name")
+
+
+def get_weather(args: WeatherInput) -> str:
+    return f"Sunny, 22 C in {args.city}"
+
 
 adapter = AnthropicAdapter(
-    additional_tools=[(CalculatorInput, calculate)],
+    model="claude-sonnet-4-5-20250929",
+    additional_tools=[(WeatherInput, get_weather)],
 )
 ```
 
----
+LangGraph also accepts native LangChain tools through `additional_tools`; Pydantic AI accepts Pydantic-AI-compatible tool functions. Check the framework example for the adapter-specific shape.
 
-## LangGraph Utilities
+## Contact Management
 
-### Wrap Graph as Tool
+Incoming contact requests are configured with `ContactEventConfig`. 
+
+
+| Strategy   | Behavior                                                                 | Use When                                            |
+| ---------- | ------------------------------------------------------------------------ | --------------------------------------------------- |
+| `DISABLED` | Ignore contact events. Requests must be handled manually in Thenvoi.     | You want the safest default.                        |
+| `HUB_ROOM` | Create a dedicated room where the agent's LLM reviews incoming requests. | You want judgment-based review without custom code. |
+| `CALLBACK` | Call your async handler for each contact event.                          | You have deterministic allowlist or policy logic.   |
+
 
 ```python
-from thenvoi.integrations.langgraph import graph_as_tool
+import os
 
-calculator_tool = graph_as_tool(
-    calculator_graph,
-    name="calculator",
-    description="Evaluates math expressions"
-)
+from thenvoi import Agent
+from thenvoi.runtime.types import ContactEventConfig, ContactEventStrategy
 
-adapter = LangGraphAdapter(
-    llm=llm,
-    checkpointer=checkpointer,
-    additional_tools=[calculator_tool],
+
+agent = Agent.create(
+    adapter=adapter,
+    agent_id=os.environ["THENVOI_AGENT_ID"],
+    api_key=os.environ["THENVOI_API_KEY"],
+    contact_config=ContactEventConfig(
+        strategy=ContactEventStrategy.HUB_ROOM,
+    ),
 )
 ```
 
-### Convert Platform Tools to LangChain
+For deterministic handling, keep the callback explicit:
 
 ```python
-from thenvoi.integrations.langgraph import agent_tools_to_langchain
+import os
 
-langchain_tools = agent_tools_to_langchain(agent_tools)
+from thenvoi import Agent
+from thenvoi.platform.event import ContactRequestReceivedEvent
+from thenvoi.runtime.types import ContactEventConfig, ContactEventStrategy
+
+
+TRUSTED_HANDLES = {"@teammate"}
+
+
+async def handle_contact(event, tools) -> None:
+    if not isinstance(event, ContactRequestReceivedEvent):
+        return
+
+    action = "approve" if event.payload.from_handle in TRUSTED_HANDLES else "reject"
+    await tools.respond_contact_request(action, request_id=event.payload.id)
+
+
+agent = Agent.create(
+    adapter=adapter,
+    agent_id=os.environ["THENVOI_AGENT_ID"],
+    api_key=os.environ["THENVOI_API_KEY"],
+    contact_config=ContactEventConfig(
+        strategy=ContactEventStrategy.CALLBACK,
+        on_event=handle_contact,
+    ),
+)
 ```
 
----
+## Protocol Bridges
 
-## Development
+Use these integrations when you need interoperability beyond normal framework adapters.
 
-See [AGENTS.md](AGENTS.md) for development setup, testing, and contributing guidelines.
+### A2A Bridge
 
----
+Forward Thenvoi room messages to an external [A2A](https://google.github.io/A2A/)-compliant agent and post its responses back to the room.
 
-## Help & Feedback
+```bash
+uv add "thenvoi-sdk[a2a]"
+```
 
-- **Documentation:** See `examples/` for complete working examples
-- **Issues:** https://github.com/thenvoi/thenvoi-sdk-python/issues
+```python
+from thenvoi.adapters.a2a import A2AAdapter, A2AAuth
+
+adapter = A2AAdapter(
+    remote_url="http://localhost:10000",
+    auth=A2AAuth(api_key="..."),
+)
+```
+
+See [examples/a2a_bridge](examples/a2a_bridge/) for a runnable setup.
+
+### A2A Gateway
+
+Run an HTTP server that exposes Thenvoi peers as A2A JSON-RPC endpoints.
+
+```bash
+uv add "thenvoi-sdk[a2a_gateway]"
+```
+
+```python
+from __future__ import annotations
+
+import asyncio
+import os
+
+from thenvoi import Agent
+from thenvoi.adapters.a2a_gateway import A2AGatewayAdapter
+
+
+async def main() -> None:
+    gateway_port = int(os.getenv("GATEWAY_PORT", "10000"))
+    gateway_url = os.getenv("GATEWAY_URL", f"http://localhost:{gateway_port}")
+    api_key = os.environ["THENVOI_API_KEY"]
+
+    adapter = A2AGatewayAdapter(
+        api_key=api_key,
+        gateway_url=gateway_url,
+        port=gateway_port,
+    )
+
+    agent = Agent.create(
+        adapter=adapter,
+        agent_id=os.getenv("THENVOI_AGENT_ID", "a2a-gateway"),
+        api_key=api_key,
+    )
+
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Test a running gateway:
+
+```bash
+curl http://localhost:10000/peers
+curl http://localhost:10000/agents/weather-agent/.well-known/agent.json
+```
+
+See [examples/a2a_gateway](examples/a2a_gateway/) for a full example.
+
+### ACP
+
+[ACP](https://docs.agentclient.dev/) lets editors and coding-agent runtimes talk to Thenvoi over stdio.
+
+```bash
+uv add "thenvoi-sdk[acp]"
+thenvoi-acp --agent-id "$THENVOI_AGENT_ID" --api-key "$THENVOI_API_KEY"
+```
+
+Then configure your editor to use `thenvoi-acp` as a custom agent server. See [examples/acp](examples/acp/) for server and client setups.
+
+## Error Handling
+
+The SDK exposes typed exceptions from `thenvoi`:
+
+
+| Exception                | When It Is Raised                                      |
+| ------------------------ | ------------------------------------------------------ |
+| `ThenvoiError`           | Base class for SDK errors                              |
+| `ThenvoiConfigError`     | Missing or invalid configuration                       |
+| `ThenvoiConnectionError` | Transport failures surfaced by REST or WebSocket paths |
+| `ThenvoiToolError`       | Tool execution failures                                |
+
+
+```python
+import logging
+
+from thenvoi import ThenvoiError
+
+logger = logging.getLogger(__name__)
+
+async def run_agent() -> None:
+    try:
+        await agent.run()
+    except ThenvoiError as exc:
+        logger.error("Agent error: %s", exc)
+```
+
+## Examples And Development
+
+Runnable examples live in [examples/](examples/README.md). Most examples use `agent_config.yaml` and `.env`:
+
+```bash
+cp .env.example .env
+cp agent_config.yaml.example agent_config.yaml
+```
+
+For local SDK development, start with [CONTRIBUTING.md](CONTRIBUTING.md), then run:
+
+```bash
+uv sync --extra dev
+uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/ -v
+uv run ruff check .
+uv run ruff format .
+```
+
+For Parlant-specific development, use the isolated extra:
+
+```bash
+uv sync --extra dev-parlant
+```
+
+## Help
+
+- Documentation: [docs.thenvoi.com](https://docs.thenvoi.com)
+- Examples: [examples/](examples/README.md)
+- Issues: [GitHub Issues](https://github.com/thenvoi/thenvoi-sdk-python/issues)
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ pip install "thenvoi-sdk[langgraph]"
 
 ## Quickstart
 
-This quickstart assumes Python 3.11+.
+This quickstart assumes Python 3.11+ and uses environment variables directly.
+The longer examples under `examples/` use `.env` plus `agent_config.yaml`; see
+[Examples And Development](#examples-and-development) before running those.
 
 1. Sign in to [Thenvoi](https://app.thenvoi.com).
 2. Create an external agent.
@@ -64,7 +66,7 @@ from thenvoi.adapters import LangGraphAdapter
 
 async def main() -> None:
     adapter = LangGraphAdapter(
-        llm=ChatOpenAI(model=os.getenv("OPENAI_MODEL", "gpt-4o-mini")),
+        llm=ChatOpenAI(model=os.getenv("OPENAI_MODEL", "gpt-5.4-mini")),
         checkpointer=InMemorySaver(),
     )
 
@@ -93,26 +95,26 @@ Open Thenvoi, add the agent to a room, and send a message. The SDK keeps the con
 
 ## Supported Frameworks
 
-| Framework        | Install Extra | Adapter                         | Notes                                         | Example                                       |
-| ---------------- | ------------- | ------------------------------- | --------------------------------------------- | --------------------------------------------- |
-| LangGraph        | `langgraph`   | `LangGraphAdapter`              | LangChain chat models and LangGraph tools     | [examples/langgraph](examples/langgraph/)     |
-| Pydantic AI      | `pydantic-ai` | `PydanticAIAdapter`             | Pydantic-AI model strings and tools           | [examples/pydantic_ai](examples/pydantic_ai/) |
-| Anthropic SDK    | `anthropic`   | `AnthropicAdapter`              | Direct Claude API integration                 | [examples/anthropic](examples/anthropic/)     |
-| Claude Agent SDK | `claude_sdk`  | `ClaudeSDKAdapter`              | Requires Node.js 20+ and Claude Code CLI      | [examples/claude_sdk](examples/claude_sdk/)   |
-| CrewAI           | `crewai`      | `CrewAIAdapter`, `CrewAIFlowAdapter` | Role-based crews and tasks                    | [examples/crewai](examples/crewai/)           |
-| Gemini SDK       | `gemini`      | `GeminiAdapter`                 | Official `google-genai` client                | [examples/gemini](examples/gemini/)           |
-| Google ADK       | `google_adk`  | `GoogleADKAdapter`              | Google Agent Development Kit                  | [examples/google_adk](examples/google_adk/)   |
-| Parlant          | `parlant`     | `ParlantAdapter`                | Guideline-based behavior                      | [examples/parlant](examples/parlant/)         |
-| Letta            | `letta`       | `LettaAdapter`                  | Letta Cloud or self-hosted Letta              | [examples/letta](examples/letta/)             |
-| Codex            | `codex`       | `CodexAdapter`                  | Requires Codex CLI auth for stdio mode        | [examples/codex](examples/codex/)             |
-| OpenCode         | `opencode`    | `OpencodeAdapter`               | Requires an OpenCode server                   | [examples/opencode](examples/opencode/)       |
-| A2A bridge       | `a2a`         | `A2AAdapter`                    | Forwards Thenvoi rooms to external A2A agents | [examples/a2a_bridge](examples/a2a_bridge/)   |
-| A2A gateway      | `a2a_gateway` | `A2AGatewayAdapter`             | Exposes Thenvoi peers as A2A endpoints        | [examples/a2a_gateway](examples/a2a_gateway/) |
-| ACP              | `acp`         | `ACPClientAdapter`, `ACPServer` | Connects editor ACP clients and runtimes      | [examples/acp](examples/acp/)                 |
+| Framework        | Install Extra | Adapter                         | Example                                       | `examples/run_agent.py` |
+| ---------------- | ------------- | ------------------------------- | --------------------------------------------- | ----------------------- |
+| LangGraph        | `langgraph`   | `LangGraphAdapter`              | [examples/langgraph](examples/langgraph/)     | Yes                     |
+| Pydantic AI      | `pydantic-ai` | `PydanticAIAdapter`             | [examples/pydantic_ai](examples/pydantic_ai/) | Yes                     |
+| Anthropic SDK    | `anthropic`   | `AnthropicAdapter`              | [examples/anthropic](examples/anthropic/)     | Yes                     |
+| Claude Agent SDK | `claude_sdk`  | `ClaudeSDKAdapter`              | [examples/claude_sdk](examples/claude_sdk/)   | Yes                     |
+| CrewAI           | `crewai`      | `CrewAIAdapter`, `CrewAIFlowAdapter` | [examples/crewai](examples/crewai/)           | Yes                     |
+| Gemini SDK       | `gemini`      | `GeminiAdapter`                 | [examples/gemini](examples/gemini/)           | Standalone script       |
+| Google ADK       | `google_adk`  | `GoogleADKAdapter`              | [examples/google_adk](examples/google_adk/)   | Standalone script       |
+| Parlant          | `parlant`     | `ParlantAdapter`                | [examples/parlant](examples/parlant/)         | Yes                     |
+| Letta            | `letta`       | `LettaAdapter`                  | [examples/letta](examples/letta/)             | Standalone script       |
+| Codex            | `codex`       | `CodexAdapter`                  | [examples/codex](examples/codex/)             | Yes                     |
+| OpenCode         | `opencode`    | `OpencodeAdapter`               | [examples/opencode](examples/opencode/)       | Standalone script       |
+| A2A bridge       | `a2a`         | `A2AAdapter`                    | [examples/a2a_bridge](examples/a2a_bridge/)   | Yes                     |
+| A2A gateway      | `a2a_gateway` | `A2AGatewayAdapter`             | [examples/a2a_gateway](examples/a2a_gateway/) | Yes                     |
+| ACP              | `acp`         | `ACPClientAdapter`, `ACPServer` | [examples/acp](examples/acp/)                 | Standalone scripts      |
 
 ## Try Another Framework
 
-Every adapter follows the quickstart shape: install the matching extra from the table above, initialize the adapter, pass it to `Agent.create()`, and call `run()`. Only the adapter import and initialization line change across frameworks:
+Every adapter follows the quickstart shape: install the matching extra from the table above, initialize the adapter, pass it to `Agent.create()`, and call `run()`. The snippets below are partial examples; reuse the `Agent.create()` and `agent.run()` wrapper from the quickstart.
 
 ```python
 from thenvoi.adapters import AnthropicAdapter
@@ -129,7 +131,9 @@ For example:
 ```python
 from thenvoi.adapters import PydanticAIAdapter
 adapter = PydanticAIAdapter(model="openai:gpt-4o")
+```
 
+```python
 from thenvoi.adapters import GeminiAdapter
 adapter = GeminiAdapter(model="gemini-2.5-flash")
 ```
@@ -142,7 +146,7 @@ Some integrations can wrap an agent you already built instead of constructing on
 
 ### LangGraph
 
-Pass a graph factory that receives Thenvoi's platform tools as LangChain tools. The SDK calls the factory with room-scoped tools, so your graph can combine your own nodes and vertices with Thenvoi actions like sending messages, looking up peers, or managing contacts.
+Pass a graph factory that receives Thenvoi's platform tools as LangChain tools. The SDK calls the factory with room-scoped tools, so your graph can combine your own nodes and edges with Thenvoi actions like sending messages, looking up peers, or managing contacts.
 
 ```python
 from langchain_openai import ChatOpenAI
@@ -169,6 +173,9 @@ adapter = LangGraphAdapter(graph_factory=graph_factory)
 ```
 
 ### Parlant
+
+The Parlant adapter wraps an existing Parlant server and agent. Create those
+with Parlant's SDK first, then pass them to `ParlantAdapter`.
 
 ```python
 from thenvoi.adapters import ParlantAdapter
@@ -240,7 +247,10 @@ LangGraph also accepts native LangChain tools through `additional_tools`; Pydant
 
 ## Contact Management
 
-Incoming contact requests are configured with `ContactEventConfig`. 
+Incoming contact requests are configured with `ContactEventConfig`.
+
+Treat contact acceptance as an access-control decision. Once someone becomes a
+contact, they can add your agent to rooms and trigger LLM usage.
 
 
 | Strategy   | Behavior                                                                 | Use When                                            |
@@ -257,6 +267,7 @@ from thenvoi import Agent
 from thenvoi.runtime.types import ContactEventConfig, ContactEventStrategy
 
 
+# Assumes `adapter` was initialized using one of the framework examples above.
 agent = Agent.create(
     adapter=adapter,
     agent_id=os.environ["THENVOI_AGENT_ID"],
@@ -288,6 +299,7 @@ async def handle_contact(event, tools) -> None:
     await tools.respond_contact_request(action, request_id=event.payload.id)
 
 
+# Assumes `adapter` was initialized using one of the framework examples above.
 agent = Agent.create(
     adapter=adapter,
     agent_id=os.environ["THENVOI_AGENT_ID"],
@@ -353,7 +365,7 @@ async def main() -> None:
 
     agent = Agent.create(
         adapter=adapter,
-        agent_id=os.getenv("THENVOI_AGENT_ID", "a2a-gateway"),
+        agent_id=os.environ["THENVOI_AGENT_ID"],
         api_key=api_key,
     )
 
@@ -364,7 +376,9 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-Test a running gateway:
+Test a running gateway after `agent.run()` has started the HTTP server and the
+gateway has discovered peers. Replace `weather-agent` with a real peer slug from
+the `/peers` response.
 
 ```bash
 curl http://localhost:10000/peers
@@ -413,21 +427,38 @@ async def run_agent() -> None:
 
 ## Examples And Development
 
-Runnable examples live in [examples/](examples/README.md). Most examples use `agent_config.yaml` and `.env`:
+Runnable examples live in [examples/](examples/README.md). Before running them,
+make sure you have:
+
+- Thenvoi external-agent credentials in `agent_config.yaml`.
+- `THENVOI_REST_URL` and `THENVOI_WS_URL` in `.env` or your shell environment.
+- The provider key required by the selected adapter, such as `OPENAI_API_KEY`,
+  `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY`.
+- Any adapter-specific service or CLI listed in `examples/README.md`, such as
+  Claude Code, Codex CLI, Letta, OpenCode, or an external A2A agent.
+
+Most examples use `agent_config.yaml` and `.env`:
 
 ```bash
 cp .env.example .env
 cp agent_config.yaml.example agent_config.yaml
 ```
 
-For local SDK development, start with [CONTRIBUTING.md](CONTRIBUTING.md), then run:
+For local SDK development, start with [CONTRIBUTING.md](CONTRIBUTING.md), then
+run the checks that match the extras installed in your environment. Scope format
+commands to repository source paths so local worktrees or scratch files are not
+rewritten accidentally:
 
 ```bash
 uv sync --extra dev
 uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/ -v
 uv run ruff check .
-uv run ruff format .
+uv run ruff format src tests examples
 ```
+
+If the full optional-adapter test suite fails during collection, run the
+framework-specific tests for the adapter you changed and check CI for the
+cross-adapter matrix.
 
 For Parlant-specific development, use the isolated extra:
 


### PR DESCRIPTION
## Summary
- Refresh README structure, fix broken/misleading code examples, improve onboarding flow
- Fix LangGraph terminology, split combined adapter snippets, expand A2A Gateway example
- Add `run_agent.py` column to frameworks table, `CrewAIFlowAdapter`, Enterprise memory note
- Expand Examples & Development section with prerequisites checklist

## Test plan
- [x] Verify quickstart snippet runs end-to-end with `gpt-5.4-mini`
- [ ] Confirm all framework example links resolve on GitHub
- [ ] Check rendered markdown badges, tables, and code blocks on GitHub

Resolves INT-498