### PR TITLE
fix(sdk): remove redundant unsubscribe on shutdown [INT-505]

### DIFF
--- a/src/thenvoi/runtime/platform_runtime.py
+++ b/src/thenvoi/runtime/platform_runtime.py
@@ -188,13 +188,8 @@ class PlatformRuntime:
         if self._runtime:
             graceful = await self._runtime.stop(timeout=timeout)
 
-        # Unsubscribe from contacts channel before disconnecting
-        if self._link and self._contacts_subscribed:
-            await self._link.unsubscribe_agent_contacts()
-            self._contacts_subscribed = False
-            logger.debug("Unsubscribed from contacts channel")
-
         if self._link:
+            self._contacts_subscribed = False
             await self._link.disconnect()
         logger.info("Platform runtime stopped")
         return graceful

--- a/tests/test_agent_contacts.py
+++ b/tests/test_agent_contacts.py
@@ -329,8 +329,13 @@ class TestPlatformRuntimeContactSetup:
         assert runtime.is_contacts_subscribed is True
 
     @pytest.mark.asyncio
-    async def test_stop_unsubscribes_when_subscribed(self):
-        """PlatformRuntime.stop() should unsubscribe from contacts."""
+    async def test_stop_clears_contacts_subscribed_flag(self):
+        """PlatformRuntime.stop() should clear contacts flag without explicit unsubscribe.
+
+        The PHX client's shutdown already unsubscribes all topics before
+        stop() runs, so an explicit unsubscribe races with that cleanup
+        and produces a spurious warning. Socket close handles the rest.
+        """
         runtime = PlatformRuntime(
             agent_id="test-agent-id",
             api_key="test-api-key",
@@ -348,30 +353,9 @@ class TestPlatformRuntimeContactSetup:
 
         await runtime.stop()
 
-        mock_link.unsubscribe_agent_contacts.assert_called_once()
-        assert runtime.is_contacts_subscribed is False
-
-    @pytest.mark.asyncio
-    async def test_stop_skips_unsubscribe_when_not_subscribed(self):
-        """PlatformRuntime.stop() should not unsubscribe if not subscribed."""
-        runtime = PlatformRuntime(
-            agent_id="test-agent-id",
-            api_key="test-api-key",
-        )
-
-        mock_link = MagicMock()
-        mock_link.unsubscribe_agent_contacts = AsyncMock()
-        mock_link.disconnect = AsyncMock()
-        runtime._link = mock_link
-        runtime._contacts_subscribed = False
-
-        mock_internal = MagicMock()
-        mock_internal.stop = AsyncMock(return_value=True)
-        runtime._runtime = mock_internal
-
-        await runtime.stop()
-
         mock_link.unsubscribe_agent_contacts.assert_not_called()
+        mock_link.disconnect.assert_called_once()
+        assert runtime.is_contacts_subscribed is False
 
 
 class TestStartupOrder:


### PR DESCRIPTION
## Summary
- Removed the explicit `unsubscribe_agent_contacts()` call from `platform_runtime.stop()`
- During signal-triggered shutdown, the PHX client's `shutdown()` already unsubscribes all topics before `stop()` runs — the explicit call races with that and logs a spurious `WARNING: Error unsubscribing from agent_contacts: Topic agent_contacts:... not subscribed`
- Socket close via `disconnect()` handles any remaining server-side cleanup, matching how room channels already work via `presence.stop()`

## Test plan
- [x] Updated `test_stop_clears_contacts_subscribed_flag` to verify flag is cleared and `disconnect()` is called without explicit unsubscribe
- [x] All 72 contact/agent tests pass
- [ ] Manual: start agent with contact handling → Ctrl-C → confirm no spurious warning in logs