### PR TITLE
fix(sdk): surface websocket disconnect reasons [INT-330]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "thenvoi-client-rest==0.0.7",
-    "phoenix-channels-python-client>=0.1.5",
+    "phoenix-channels-python-client>=0.2.1",
     "python-dotenv>=1.2.2",
     "pyyaml>=6.0",
     "cryptography>=46.0.5",

--- a/src/thenvoi/client/streaming/__init__.py
+++ b/src/thenvoi/client/streaming/__init__.py
@@ -9,7 +9,6 @@ Usage:
 from thenvoi.client.streaming.client import (
     WebSocketClient,
     WebSocketDisconnectReason,
-    WebSocketUpgradeError,
     MessageCreatedPayload,
     RoomAddedPayload,
     RoomRemovedPayload,
@@ -24,6 +23,7 @@ from thenvoi.client.streaming.client import (
     ContactRemovedPayload,
     SupersedePayload,
 )
+from thenvoi.client.streaming.errors import WebSocketUpgradeError
 
 __all__ = [
     "WebSocketClient",

--- a/src/thenvoi/client/streaming/__init__.py
+++ b/src/thenvoi/client/streaming/__init__.py
@@ -8,6 +8,8 @@ Usage:
 
 from thenvoi.client.streaming.client import (
     WebSocketClient,
+    WebSocketDisconnectReason,
+    WebSocketUpgradeError,
     MessageCreatedPayload,
     RoomAddedPayload,
     RoomRemovedPayload,
@@ -20,10 +22,13 @@ from thenvoi.client.streaming.client import (
     ContactRequestUpdatedPayload,
     ContactAddedPayload,
     ContactRemovedPayload,
+    SupersedePayload,
 )
 
 __all__ = [
     "WebSocketClient",
+    "WebSocketDisconnectReason",
+    "WebSocketUpgradeError",
     "MessageCreatedPayload",
     "RoomAddedPayload",
     "RoomRemovedPayload",
@@ -36,4 +41,5 @@ __all__ = [
     "ContactRequestUpdatedPayload",
     "ContactAddedPayload",
     "ContactRemovedPayload",
+    "SupersedePayload",
 ]

--- a/src/thenvoi/client/streaming/client.py
+++ b/src/thenvoi/client/streaming/client.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import json
 import logging
+from typing import Any
 
 from phoenix_channels_python_client.client import (
     PHXChannelsClient,
@@ -12,6 +15,110 @@ from phoenix_channels_python_client.phx_messages import PHXMessage
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WebSocketDisconnectReason:
+    """Terminal WebSocket disconnect reason reported by the platform."""
+
+    reason: str
+    message: str
+    retryable: bool
+    retry_after: int | None = None
+    target_socket_id: str | None = None
+    correlation_id: str | None = None
+
+
+class WebSocketUpgradeError(Exception):
+    """HTTP error returned while upgrading the WebSocket connection."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        code: str | None = None,
+        message: str | None = None,
+        request_id: str | None = None,
+        retry_after: int | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.code = code
+        self.message = message or f"WebSocket upgrade failed with HTTP {status_code}"
+        self.request_id = request_id
+        self.retry_after = retry_after
+        super().__init__(self.message)
+
+    @classmethod
+    def from_exception(cls, exc: Exception) -> "WebSocketUpgradeError | None":
+        """Parse a websockets handshake exception when it exposes the HTTP response."""
+        response = getattr(exc, "response", None)
+        status_code = getattr(response, "status_code", None)
+        if status_code is None:
+            status_code = getattr(exc, "status_code", None)
+        if not isinstance(status_code, int):
+            return None
+
+        headers = getattr(response, "headers", None) or getattr(exc, "headers", None)
+        body = getattr(response, "body", b"") if response is not None else b""
+        payload = _decode_upgrade_error_body(body)
+        error = payload.get("error") if isinstance(payload, dict) else None
+        error = error if isinstance(error, dict) else {}
+
+        retry_after = _parse_retry_after(error.get("retry_after"))
+        if status_code == 429 and retry_after is None and headers is not None:
+            retry_after = _parse_retry_after(_get_header(headers, "Retry-After"))
+
+        if status_code in {400, 409, 429, 503}:
+            return cls(
+                status_code=status_code,
+                code=error.get("code") if isinstance(error.get("code"), str) else None,
+                message=(
+                    error.get("message")
+                    if isinstance(error.get("message"), str)
+                    else None
+                ),
+                request_id=(
+                    error.get("request_id")
+                    if isinstance(error.get("request_id"), str)
+                    else None
+                ),
+                retry_after=retry_after,
+            )
+
+        return None
+
+
+def _decode_upgrade_error_body(body: Any) -> dict[str, Any]:
+    if isinstance(body, (bytes, bytearray)):
+        body = body.decode("utf-8", errors="replace")
+    if not isinstance(body, str) or not body.strip():
+        return {}
+    try:
+        decoded = json.loads(body)
+    except json.JSONDecodeError:
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _parse_retry_after(value: Any) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _get_header(headers: Any, name: str) -> str | None:
+    getter = getattr(headers, "get", None)
+    if callable(getter):
+        value = getter(name)
+        if value is None:
+            value = getter(name.lower())
+        return value if isinstance(value, str) else None
+    return None
 
 
 # WebSocket message payloads (based on actual backend messages)
@@ -168,6 +275,29 @@ class ContactRemovedPayload(BaseModel):
     id: str
 
 
+class SupersedePayload(BaseModel):
+    """Payload for terminal agent_control supersede events."""
+
+    model_config = ConfigDict(extra="allow")
+
+    reason: str
+    message: str
+    retryable: bool
+    retry_after: int | None = None
+    target_socket_id: str | None = None
+    correlation_id: str | None = None
+
+    def to_disconnect_reason(self) -> WebSocketDisconnectReason:
+        return WebSocketDisconnectReason(
+            reason=self.reason,
+            message=self.message,
+            retryable=self.retryable,
+            retry_after=self.retry_after,
+            target_socket_id=self.target_socket_id,
+            correlation_id=self.correlation_id,
+        )
+
+
 _PAYLOAD_MODELS: dict[str, type[BaseModel]] = {
     "message_created": MessageCreatedPayload,
     "room_added": RoomAddedPayload,
@@ -179,6 +309,7 @@ _PAYLOAD_MODELS: dict[str, type[BaseModel]] = {
     "contact_request_updated": ContactRequestUpdatedPayload,
     "contact_added": ContactAddedPayload,
     "contact_removed": ContactRemovedPayload,
+    "supersede": SupersedePayload,
 }
 
 
@@ -194,14 +325,21 @@ class WebSocketClient:
         self.ws_url = ws_url
         self.api_key = api_key
         self.agent_id = agent_id
+        self.client: PHXChannelsClient | None = None
         self._on_reconnect = on_reconnect
         self._on_disconnect = on_disconnect
         self._validation_error_count: int = 0
+        self._last_disconnect_reason: WebSocketDisconnectReason | None = None
 
     @property
     def validation_error_count(self) -> int:
         """Number of events dropped due to payload validation errors."""
         return self._validation_error_count
+
+    @property
+    def last_disconnect_reason(self) -> WebSocketDisconnectReason | None:
+        """Most recent terminal disconnect reason reported by the platform."""
+        return self._last_disconnect_reason
 
     def reset_validation_error_count(self) -> int:
         """Reset the validation error counter and return the previous value.
@@ -211,6 +349,11 @@ class WebSocketClient:
         count = self._validation_error_count
         self._validation_error_count = 0
         return count
+
+    def _require_client(self) -> PHXChannelsClient:
+        if self.client is None:
+            raise RuntimeError("WebSocket client is not connected")
+        return self.client
 
     async def __aenter__(self):
         """Create and enter the PHXChannelsClient context"""
@@ -223,7 +366,13 @@ class WebSocketClient:
         )
         if self.agent_id:
             self.client.channel_socket_url += f"&agent_id={self.agent_id}"
-        await self.client.__aenter__()
+        try:
+            await self.client.__aenter__()
+        except Exception as exc:
+            upgrade_error = WebSocketUpgradeError.from_exception(exc)
+            if upgrade_error is not None:
+                raise upgrade_error from exc
+            raise
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
@@ -282,6 +431,32 @@ class WebSocketClient:
                     "[WebSocket] Callback error for %s event", message.event
                 )
 
+    def record_terminal_disconnect(self, reason: WebSocketDisconnectReason) -> None:
+        """Record a terminal platform disconnect reason and disable reconnect."""
+        self._last_disconnect_reason = reason
+        self.disable_reconnect()
+
+    def disable_reconnect(self) -> None:
+        """Disable PHX auto-reconnect for a terminal platform disconnect."""
+        if self.client:
+            self.client.auto_reconnect = False
+
+    async def join_agent_control_channel(
+        self,
+        agent_id: str,
+        on_supersede: Callable[[SupersedePayload], Awaitable[None]],
+    ):
+        """Subscribe to terminal agent-control events for this agent."""
+        topic = f"agent_control:{agent_id}"
+        logger.info("[WebSocket] Subscribing to topic: %s", topic)
+
+        async def message_handler(message):
+            await self._handle_events(message, {"supersede": on_supersede})
+
+        result = await self._require_client().subscribe_to_topic(topic, message_handler)
+        logger.info("[WebSocket] Subscribed to topic: %s", topic)
+        return result
+
     async def join_agent_rooms_channel(
         self,
         agent_id: str,
@@ -297,7 +472,7 @@ class WebSocketClient:
                 message, {"room_added": on_room_added, "room_removed": on_room_removed}
             )
 
-        result = await self.client.subscribe_to_topic(topic, message_handler)
+        result = await self._require_client().subscribe_to_topic(topic, message_handler)
         logger.info("[WebSocket] Subscribed to topic: %s", topic)
         return result
 
@@ -313,7 +488,7 @@ class WebSocketClient:
         async def message_handler(message):
             await self._handle_events(message, {"message_created": on_message_created})
 
-        return await self.client.subscribe_to_topic(topic, message_handler)
+        return await self._require_client().subscribe_to_topic(topic, message_handler)
 
     async def join_user_rooms_channel(
         self,
@@ -329,7 +504,7 @@ class WebSocketClient:
                 message, {"room_added": on_room_added, "room_removed": on_room_removed}
             )
 
-        return await self.client.subscribe_to_topic(topic, message_handler)
+        return await self._require_client().subscribe_to_topic(topic, message_handler)
 
     async def join_room_participants_channel(
         self,
@@ -354,7 +529,7 @@ class WebSocketClient:
                 },
             )
 
-        return await self.client.subscribe_to_topic(topic, message_handler)
+        return await self._require_client().subscribe_to_topic(topic, message_handler)
 
     async def join_tasks_channel(
         self,
@@ -371,35 +546,41 @@ class WebSocketClient:
                 {"task_created": on_task_created, "task_updated": on_task_updated},
             )
 
-        return await self.client.subscribe_to_topic(topic, message_handler)
+        return await self._require_client().subscribe_to_topic(topic, message_handler)
+
+    async def leave_agent_control_channel(self, agent_id: str):
+        """Unsubscribe from agent control topic"""
+        topic = f"agent_control:{agent_id}"
+        logger.info("[WebSocket] Unsubscribing from topic: %s", topic)
+        return await self._require_client().unsubscribe_from_topic(topic)
 
     async def leave_agent_rooms_channel(self, agent_id: str):
         """Unsubscribe from agent rooms topic"""
         topic = f"agent_rooms:{agent_id}"
         logger.info("[WebSocket] Unsubscribing from topic: %s", topic)
-        return await self.client.unsubscribe_from_topic(topic)
+        return await self._require_client().unsubscribe_from_topic(topic)
 
     async def leave_chat_room_channel(self, chat_room_id: str):
         """Unsubscribe from chat room topic"""
         topic = f"chat_room:{chat_room_id}"
         logger.info("[WebSocket] Unsubscribing from topic: %s", topic)
-        return await self.client.unsubscribe_from_topic(topic)
+        return await self._require_client().unsubscribe_from_topic(topic)
 
     async def leave_user_rooms_channel(self, user_id: str):
         """Unsubscribe from user rooms topic"""
         topic = f"user_rooms:{user_id}"
-        return await self.client.unsubscribe_from_topic(topic)
+        return await self._require_client().unsubscribe_from_topic(topic)
 
     async def leave_room_participants_channel(self, chat_room_id: str):
         """Unsubscribe from room participants topic"""
         topic = f"room_participants:{chat_room_id}"
         logger.info("[WebSocket] Unsubscribing from topic: %s", topic)
-        return await self.client.unsubscribe_from_topic(topic)
+        return await self._require_client().unsubscribe_from_topic(topic)
 
     async def leave_tasks_channel(self, user_id: str):
         """Unsubscribe from tasks topic"""
         topic = f"tasks:{user_id}"
-        return await self.client.unsubscribe_from_topic(topic)
+        return await self._require_client().unsubscribe_from_topic(topic)
 
     async def join_agent_contacts_channel(
         self,
@@ -428,7 +609,7 @@ class WebSocketClient:
                 },
             )
 
-        result = await self.client.subscribe_to_topic(topic, message_handler)
+        result = await self._require_client().subscribe_to_topic(topic, message_handler)
         logger.info("[WebSocket] Subscribed to topic: %s", topic)
         return result
 
@@ -436,7 +617,7 @@ class WebSocketClient:
         """Unsubscribe from agent contacts topic."""
         topic = f"agent_contacts:{agent_id}"
         logger.info("[WebSocket] Unsubscribing from topic: %s", topic)
-        return await self.client.unsubscribe_from_topic(topic)
+        return await self._require_client().unsubscribe_from_topic(topic)
 
     async def run_forever(self):
-        await self.client.run_forever()
+        await self._require_client().run_forever()

--- a/src/thenvoi/client/streaming/client.py
+++ b/src/thenvoi/client/streaming/client.py
@@ -4,11 +4,14 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 import logging
+import random
 
 from phoenix_channels_python_client.client import (
     PHXChannelsClient,
     PhoenixChannelsProtocolVersion,
 )
+from phoenix_channels_python_client.client_types import ReconnectPolicy
+from phoenix_channels_python_client.exceptions import PHXConnectionError
 from phoenix_channels_python_client.phx_messages import PHXMessage
 from pydantic import BaseModel, ConfigDict, ValidationError
 
@@ -221,6 +224,15 @@ _PAYLOAD_MODELS: dict[str, type[BaseModel]] = {
 }
 
 
+def _initial_reconnect_delay(policy: ReconnectPolicy, attempt: int) -> float:
+    delay = min(
+        policy.max_delay_s, policy.base_delay_s * (policy.factor ** max(attempt, 0))
+    )
+    if delay <= 0:
+        return 0.0
+    return (delay / 2) + (random.random() * (delay / 2))
+
+
 class WebSocketClient:
     def __init__(
         self,
@@ -265,27 +277,42 @@ class WebSocketClient:
 
     async def __aenter__(self):
         """Create and enter the PHXChannelsClient context"""
-        self.client = PHXChannelsClient(
-            self.ws_url,
-            self.api_key,
-            protocol_version=PhoenixChannelsProtocolVersion.V2,
-            auto_reconnect=False,
-            on_reconnect=self._on_reconnect,
-            on_disconnect=self._on_disconnect,
-        )
-        if self.agent_id:
-            self.client.channel_socket_url += f"&agent_id={self.agent_id}"
-        try:
-            await self.client.__aenter__()
-        except Exception as exc:
-            upgrade_error = await classify_initial_upgrade_error(
-                exc, self.client.channel_socket_url
+        policy = ReconnectPolicy()
+        for attempt in range(policy.rapid_suppress_disconnect_count + 1):
+            self.client = PHXChannelsClient(
+                self.ws_url,
+                self.api_key,
+                protocol_version=PhoenixChannelsProtocolVersion.V2,
+                auto_reconnect=False,
+                on_reconnect=self._on_reconnect,
+                on_disconnect=self._on_disconnect,
             )
-            if upgrade_error is not None:
-                raise upgrade_error from exc
-            raise
-        self.client.auto_reconnect = True
-        return self
+            if self.agent_id:
+                self.client.channel_socket_url += f"&agent_id={self.agent_id}"
+            try:
+                await self.client.__aenter__()
+            except Exception as exc:
+                upgrade_error = await classify_initial_upgrade_error(
+                    exc, self.client.channel_socket_url
+                )
+                if upgrade_error is not None:
+                    raise upgrade_error from exc
+                if not isinstance(exc, PHXConnectionError):
+                    raise
+                if attempt >= policy.rapid_suppress_disconnect_count:
+                    raise
+                delay = _initial_reconnect_delay(policy, attempt)
+                logger.warning(
+                    "Initial WebSocket connection failed; retrying in %.2fs: %s",
+                    delay,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+            else:
+                self.client.auto_reconnect = True
+                return self
+
+        raise RuntimeError("WebSocket client failed to connect")
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Exit the PHXChannelsClient context"""

--- a/src/thenvoi/client/streaming/client.py
+++ b/src/thenvoi/client/streaming/client.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-import json
 import logging
-from typing import Any
 
 from phoenix_channels_python_client.client import (
     PHXChannelsClient,
@@ -13,6 +11,8 @@ from phoenix_channels_python_client.client import (
 )
 from phoenix_channels_python_client.phx_messages import PHXMessage
 from pydantic import BaseModel, ConfigDict, ValidationError
+
+from thenvoi.client.streaming.errors import classify_initial_upgrade_error
 
 logger = logging.getLogger(__name__)
 
@@ -27,91 +27,6 @@ class WebSocketDisconnectReason:
     retry_after: int | None = None
     target_socket_id: str | None = None
     correlation_id: str | None = None
-
-
-class WebSocketUpgradeError(Exception):
-    """HTTP error returned while upgrading the WebSocket connection."""
-
-    def __init__(
-        self,
-        *,
-        status_code: int,
-        code: str | None = None,
-        message: str | None = None,
-        request_id: str | None = None,
-        retry_after: int | None = None,
-    ) -> None:
-        self.status_code = status_code
-        self.code = code
-        self.message = message or f"WebSocket upgrade failed with HTTP {status_code}"
-        self.request_id = request_id
-        self.retry_after = retry_after
-        super().__init__(self.message)
-
-    @classmethod
-    def from_exception(cls, exc: Exception) -> "WebSocketUpgradeError | None":
-        """Parse a websockets handshake exception when it exposes the HTTP response."""
-        response = getattr(exc, "response", None)
-        status_code = getattr(response, "status_code", None)
-        if status_code is None:
-            status_code = getattr(exc, "status_code", None)
-        if not isinstance(status_code, int) or status_code not in {400, 409, 429, 503}:
-            return None
-
-        headers = getattr(response, "headers", None) or getattr(exc, "headers", None)
-        body = getattr(response, "body", b"") if response is not None else b""
-        payload = _decode_upgrade_error_body(body)
-        error = payload.get("error")
-        if not isinstance(error, dict):
-            error = {}
-
-        code = error.get("code")
-        message = error.get("message")
-        request_id = error.get("request_id")
-        retry_after = _parse_retry_after(error.get("retry_after"))
-        if status_code == 429 and retry_after is None and headers is not None:
-            retry_after = _parse_retry_after(_get_header(headers, "Retry-After"))
-
-        return cls(
-            status_code=status_code,
-            code=code if isinstance(code, str) else None,
-            message=message if isinstance(message, str) else None,
-            request_id=request_id if isinstance(request_id, str) else None,
-            retry_after=retry_after,
-        )
-
-
-def _decode_upgrade_error_body(body: Any) -> dict[str, Any]:
-    if isinstance(body, (bytes, bytearray)):
-        body = body.decode("utf-8", errors="replace")
-    if not isinstance(body, str) or not body.strip():
-        return {}
-    try:
-        decoded = json.loads(body)
-    except json.JSONDecodeError:
-        return {}
-    return decoded if isinstance(decoded, dict) else {}
-
-
-def _parse_retry_after(value: Any) -> int | None:
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str):
-        try:
-            return int(value)
-        except ValueError:
-            return None
-    return None
-
-
-def _get_header(headers: Any, name: str) -> str | None:
-    getter = getattr(headers, "get", None)
-    if callable(getter):
-        value = getter(name)
-        if value is None:
-            value = getter(name.lower())
-        return value if isinstance(value, str) else None
-    return None
 
 
 # WebSocket message payloads (based on actual backend messages)
@@ -354,6 +269,7 @@ class WebSocketClient:
             self.ws_url,
             self.api_key,
             protocol_version=PhoenixChannelsProtocolVersion.V2,
+            auto_reconnect=False,
             on_reconnect=self._on_reconnect,
             on_disconnect=self._on_disconnect,
         )
@@ -362,10 +278,13 @@ class WebSocketClient:
         try:
             await self.client.__aenter__()
         except Exception as exc:
-            upgrade_error = WebSocketUpgradeError.from_exception(exc)
+            upgrade_error = await classify_initial_upgrade_error(
+                exc, self.client.channel_socket_url
+            )
             if upgrade_error is not None:
                 raise upgrade_error from exc
             raise
+        self.client.auto_reconnect = True
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/src/thenvoi/client/streaming/client.py
+++ b/src/thenvoi/client/streaming/client.py
@@ -55,37 +55,30 @@ class WebSocketUpgradeError(Exception):
         status_code = getattr(response, "status_code", None)
         if status_code is None:
             status_code = getattr(exc, "status_code", None)
-        if not isinstance(status_code, int):
+        if not isinstance(status_code, int) or status_code not in {400, 409, 429, 503}:
             return None
 
         headers = getattr(response, "headers", None) or getattr(exc, "headers", None)
         body = getattr(response, "body", b"") if response is not None else b""
         payload = _decode_upgrade_error_body(body)
-        error = payload.get("error") if isinstance(payload, dict) else None
-        error = error if isinstance(error, dict) else {}
+        error = payload.get("error")
+        if not isinstance(error, dict):
+            error = {}
 
+        code = error.get("code")
+        message = error.get("message")
+        request_id = error.get("request_id")
         retry_after = _parse_retry_after(error.get("retry_after"))
         if status_code == 429 and retry_after is None and headers is not None:
             retry_after = _parse_retry_after(_get_header(headers, "Retry-After"))
 
-        if status_code in {400, 409, 429, 503}:
-            return cls(
-                status_code=status_code,
-                code=error.get("code") if isinstance(error.get("code"), str) else None,
-                message=(
-                    error.get("message")
-                    if isinstance(error.get("message"), str)
-                    else None
-                ),
-                request_id=(
-                    error.get("request_id")
-                    if isinstance(error.get("request_id"), str)
-                    else None
-                ),
-                retry_after=retry_after,
-            )
-
-        return None
+        return cls(
+            status_code=status_code,
+            code=code if isinstance(code, str) else None,
+            message=message if isinstance(message, str) else None,
+            request_id=request_id if isinstance(request_id, str) else None,
+            retry_after=retry_after,
+        )
 
 
 def _decode_upgrade_error_body(body: Any) -> dict[str, Any]:

--- a/src/thenvoi/client/streaming/errors.py
+++ b/src/thenvoi/client/streaming/errors.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from phoenix_channels_python_client.exceptions import PHXConnectionError
+from websockets.asyncio.client import connect
+
+
+class WebSocketUpgradeError(Exception):
+    """HTTP error returned while upgrading the WebSocket connection."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        code: str | None = None,
+        message: str | None = None,
+        request_id: str | None = None,
+        retry_after: int | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.code = code
+        self.message = message or f"WebSocket upgrade failed with HTTP {status_code}"
+        self.request_id = request_id
+        self.retry_after = retry_after
+        super().__init__(self.message)
+
+    @classmethod
+    def from_exception(cls, exc: Exception) -> "WebSocketUpgradeError | None":
+        """Parse a websockets handshake exception when it exposes the HTTP response."""
+        response = getattr(exc, "response", None)
+        status_code = getattr(response, "status_code", None)
+        if status_code is None:
+            status_code = getattr(exc, "status_code", None)
+        if not isinstance(status_code, int) or status_code not in {400, 409, 429, 503}:
+            return None
+
+        headers = getattr(response, "headers", None) or getattr(exc, "headers", None)
+        body = getattr(response, "body", b"") if response is not None else b""
+        payload = _decode_upgrade_error_body(body)
+        error = payload.get("error")
+        if not isinstance(error, dict):
+            error = {}
+
+        code = error.get("code")
+        message = error.get("message")
+        request_id = error.get("request_id")
+        retry_after = _parse_retry_after(error.get("retry_after"))
+        if status_code == 429 and retry_after is None and headers is not None:
+            retry_after = _parse_retry_after(_get_header(headers, "Retry-After"))
+
+        return cls(
+            status_code=status_code,
+            code=code if isinstance(code, str) else None,
+            message=message if isinstance(message, str) else None,
+            request_id=request_id if isinstance(request_id, str) else None,
+            retry_after=retry_after,
+        )
+
+
+async def classify_initial_upgrade_error(
+    exc: Exception, websocket_url: str
+) -> WebSocketUpgradeError | None:
+    """Recover platform upgrade errors hidden by the Phoenix client supervisor."""
+    upgrade_error = WebSocketUpgradeError.from_exception(exc)
+    if upgrade_error is not None:
+        return upgrade_error
+    if not isinstance(exc, PHXConnectionError):
+        return None
+
+    try:
+        async with connect(websocket_url, open_timeout=5):
+            return None
+    except Exception as probe_exc:
+        return WebSocketUpgradeError.from_exception(probe_exc)
+
+
+def _decode_upgrade_error_body(body: Any) -> dict[str, Any]:
+    if isinstance(body, (bytes, bytearray)):
+        body = body.decode("utf-8", errors="replace")
+    if not isinstance(body, str) or not body.strip():
+        return {}
+    try:
+        decoded = json.loads(body)
+    except json.JSONDecodeError:
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _parse_retry_after(value: Any) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _get_header(headers: Any, name: str) -> str | None:
+    getter = getattr(headers, "get", None)
+    if callable(getter):
+        value = getter(name)
+        if value is None:
+            value = getter(name.lower())
+        return value if isinstance(value, str) else None
+    return None

--- a/src/thenvoi/platform/event.py
+++ b/src/thenvoi/platform/event.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 # Import payload models from streaming client
 from thenvoi.client.streaming import (
     MessageCreatedPayload,
+    WebSocketDisconnectReason,
     RoomAddedPayload,
     RoomRemovedPayload,
     RoomDeletedPayload,
@@ -126,6 +127,16 @@ class ContactRemovedEvent:
 
 
 @dataclass
+class WebSocketDisconnectedEvent:
+    """Emitted when the platform reports a terminal WebSocket disconnect reason."""
+
+    type: Literal["websocket_disconnected"] = "websocket_disconnected"
+    room_id: str | None = None
+    payload: WebSocketDisconnectReason | None = None
+    raw: dict[str, Any] | None = None
+
+
+@dataclass
 class ReconnectedEvent:
     """Emitted when the WebSocket reconnects after a disconnection.
 
@@ -160,5 +171,6 @@ PlatformEvent = (
     | ContactRequestUpdatedEvent
     | ContactAddedEvent
     | ContactRemovedEvent
+    | WebSocketDisconnectedEvent
     | ReconnectedEvent
 )

--- a/src/thenvoi/platform/link.py
+++ b/src/thenvoi/platform/link.py
@@ -99,8 +99,6 @@ class ThenvoiLink:
         # Event queue for async iteration
         self._event_queue: asyncio.Queue[PlatformEvent] = asyncio.Queue(maxsize=1000)
 
-        self._last_disconnect_reason: WebSocketDisconnectReason | None = None
-
     @property
     def is_connected(self) -> bool:
         return self._is_connected
@@ -108,7 +106,9 @@ class ThenvoiLink:
     @property
     def last_disconnect_reason(self) -> WebSocketDisconnectReason | None:
         """Most recent terminal WebSocket disconnect reason, if reported."""
-        return self._last_disconnect_reason
+        if self._ws is None:
+            return None
+        return self._ws.last_disconnect_reason
 
     # --- Async iterator protocol ---
 
@@ -313,7 +313,6 @@ class ThenvoiLink:
     async def _on_supersede(self, payload: "SupersedePayload") -> None:
         """Handle terminal supersede event before the platform closes the socket."""
         reason = payload.to_disconnect_reason()
-        self._last_disconnect_reason = reason
         self._is_connected = False
         if self._ws:
             self._ws.record_terminal_disconnect(reason)
@@ -327,10 +326,10 @@ class ThenvoiLink:
 
     async def _on_disconnected(self, error: Exception | None) -> None:
         """Handle PHX client disconnection."""
-        if self._last_disconnect_reason:
+        if self.last_disconnect_reason:
             logger.warning(
                 "WebSocket disconnected after terminal platform reason: %s",
-                self._last_disconnect_reason.reason,
+                self.last_disconnect_reason.reason,
             )
             return
         logger.warning("WebSocket disconnected: %s", error)

--- a/src/thenvoi/platform/link.py
+++ b/src/thenvoi/platform/link.py
@@ -99,6 +99,9 @@ class ThenvoiLink:
         # Event queue for async iteration
         self._event_queue: asyncio.Queue[PlatformEvent] = asyncio.Queue(maxsize=1000)
 
+        # Durable terminal disconnect reason for the current connection lifecycle.
+        self._last_disconnect_reason: WebSocketDisconnectReason | None = None
+
     @property
     def is_connected(self) -> bool:
         return self._is_connected
@@ -106,9 +109,7 @@ class ThenvoiLink:
     @property
     def last_disconnect_reason(self) -> WebSocketDisconnectReason | None:
         """Most recent terminal WebSocket disconnect reason, if reported."""
-        if self._ws is None:
-            return None
-        return self._ws.last_disconnect_reason
+        return self._last_disconnect_reason
 
     # --- Async iterator protocol ---
 
@@ -132,6 +133,7 @@ class ThenvoiLink:
             logger.warning("Already connected")
             return
 
+        self._last_disconnect_reason = None
         self._ws = WebSocketClient(
             self.ws_url,
             self.api_key,
@@ -313,6 +315,7 @@ class ThenvoiLink:
     async def _on_supersede(self, payload: "SupersedePayload") -> None:
         """Handle terminal supersede event before the platform closes the socket."""
         reason = payload.to_disconnect_reason()
+        self._last_disconnect_reason = reason
         self._is_connected = False
         if self._ws:
             self._ws.record_terminal_disconnect(reason)

--- a/src/thenvoi/platform/link.py
+++ b/src/thenvoi/platform/link.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from thenvoi.client.rest import AsyncRestClient, DEFAULT_REQUEST_OPTIONS
-from thenvoi.client.streaming import WebSocketClient
+from thenvoi.client.streaming import WebSocketClient, WebSocketDisconnectReason
 from thenvoi.runtime.types import PlatformMessage
 from thenvoi_rest.core.api_error import ApiError
 
@@ -23,6 +23,7 @@ from .event import (
     RoomRemovedEvent,
     RoomDeletedEvent,
     ReconnectedEvent,
+    WebSocketDisconnectedEvent,
     ParticipantAddedEvent,
     ParticipantRemovedEvent,
     ContactRequestReceivedEvent,
@@ -44,6 +45,7 @@ if TYPE_CHECKING:
         ContactRequestUpdatedPayload,
         ContactAddedPayload,
         ContactRemovedPayload,
+        SupersedePayload,
     )
 
 logger = logging.getLogger(__name__)
@@ -97,9 +99,16 @@ class ThenvoiLink:
         # Event queue for async iteration
         self._event_queue: asyncio.Queue[PlatformEvent] = asyncio.Queue(maxsize=1000)
 
+        self._last_disconnect_reason: WebSocketDisconnectReason | None = None
+
     @property
     def is_connected(self) -> bool:
         return self._is_connected
+
+    @property
+    def last_disconnect_reason(self) -> WebSocketDisconnectReason | None:
+        """Most recent terminal WebSocket disconnect reason, if reported."""
+        return self._last_disconnect_reason
 
     # --- Async iterator protocol ---
 
@@ -131,6 +140,15 @@ class ThenvoiLink:
             on_disconnect=self._on_disconnected,
         )
         await self._ws.__aenter__()
+        try:
+            await self._ws.join_agent_control_channel(
+                self.agent_id,
+                on_supersede=self._on_supersede,
+            )
+        except Exception:
+            await self._ws.__aexit__(None, None, None)
+            self._ws = None
+            raise
         self._is_connected = True
         logger.info("Connected to platform")
 
@@ -142,6 +160,11 @@ class ThenvoiLink:
         """
         if not self._is_connected or not self._ws:
             return
+
+        try:
+            await self._ws.leave_agent_control_channel(self.agent_id)
+        except Exception as e:
+            logger.warning("Error unsubscribing from agent_control: %s", e)
 
         await self._ws.__aexit__(None, None, None)
         self._ws = None
@@ -287,8 +310,28 @@ class ThenvoiLink:
         logger.info("WebSocket reconnected — reconciling room state")
         self._queue_event(ReconnectedEvent())
 
+    async def _on_supersede(self, payload: "SupersedePayload") -> None:
+        """Handle terminal supersede event before the platform closes the socket."""
+        reason = payload.to_disconnect_reason()
+        self._last_disconnect_reason = reason
+        if self._ws:
+            self._ws.record_terminal_disconnect(reason)
+        logger.warning(
+            "WebSocket connection superseded: reason=%s retryable=%s correlation_id=%s",
+            reason.reason,
+            reason.retryable,
+            reason.correlation_id,
+        )
+        self._queue_event(WebSocketDisconnectedEvent(payload=reason))
+
     async def _on_disconnected(self, error: Exception | None) -> None:
         """Handle PHX client disconnection."""
+        if self._last_disconnect_reason:
+            logger.warning(
+                "WebSocket disconnected after terminal platform reason: %s",
+                self._last_disconnect_reason.reason,
+            )
+            return
         logger.warning("WebSocket disconnected: %s", error)
 
     def _queue_event(self, event: PlatformEvent) -> None:

--- a/src/thenvoi/platform/link.py
+++ b/src/thenvoi/platform/link.py
@@ -158,7 +158,7 @@ class ThenvoiLink:
 
         Extracted from ThenvoiAgent.stop() lines 193-195.
         """
-        if not self._is_connected or not self._ws:
+        if not self._ws:
             return
 
         try:
@@ -314,6 +314,7 @@ class ThenvoiLink:
         """Handle terminal supersede event before the platform closes the socket."""
         reason = payload.to_disconnect_reason()
         self._last_disconnect_reason = reason
+        self._is_connected = False
         if self._ws:
             self._ws.record_terminal_disconnect(reason)
         logger.warning(

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -252,6 +252,8 @@ class TestThenvoiLinkConnection:
         assert link.is_connected is False
         assert link._ws is None
         assert link._subscribed_rooms == set()
+        assert link.last_disconnect_reason is not None
+        assert link.last_disconnect_reason.reason == "session.already_connected"
 
     async def test_close_without_supersede_leaves_disconnect_reason_empty(self):
         """An empty Phoenix close should not invent a terminal reason."""

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -25,7 +25,12 @@ def mock_ws_client():
     ws.leave_chat_room_channel = AsyncMock()
     ws.join_agent_control_channel = AsyncMock()
     ws.leave_agent_control_channel = AsyncMock()
-    ws.record_terminal_disconnect = MagicMock()
+    ws.last_disconnect_reason = None
+
+    def record_terminal_disconnect(reason):
+        ws.last_disconnect_reason = reason
+
+    ws.record_terminal_disconnect = MagicMock(side_effect=record_terminal_disconnect)
     ws.join_agent_rooms_channel = AsyncMock()
     ws.join_room_participants_channel = AsyncMock()
     ws.leave_room_participants_channel = AsyncMock()

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from thenvoi.client.streaming import SupersedePayload
+from thenvoi.platform.event import WebSocketDisconnectedEvent
 from thenvoi.platform.link import ThenvoiLink
 
 
@@ -21,6 +23,9 @@ def mock_ws_client():
     # Mock channel operations
     ws.join_chat_room_channel = AsyncMock()
     ws.leave_chat_room_channel = AsyncMock()
+    ws.join_agent_control_channel = AsyncMock()
+    ws.leave_agent_control_channel = AsyncMock()
+    ws.record_terminal_disconnect = MagicMock()
     ws.join_agent_rooms_channel = AsyncMock()
     ws.join_room_participants_channel = AsyncMock()
     ws.leave_room_participants_channel = AsyncMock()
@@ -103,6 +108,10 @@ class TestThenvoiLinkConnection:
             on_disconnect=link._on_disconnected,
         )
         mock_ws_client.__aenter__.assert_called_once()
+        mock_ws_client.join_agent_control_channel.assert_called_once_with(
+            link.agent_id,
+            on_supersede=link._on_supersede,
+        )
         assert link.is_connected is True
 
     @patch("thenvoi.platform.link.WebSocketClient")
@@ -185,6 +194,41 @@ class TestThenvoiLinkConnection:
 
         with pytest.raises(RuntimeError, match="Not connected"):
             await link.run_forever()
+
+    async def test_supersede_records_terminal_reason_and_queues_event(
+        self, mock_ws_client
+    ):
+        """supersede records the platform reason and disables reconnect before close."""
+        link = ThenvoiLink(agent_id="agent-123", api_key="test-key")
+        link._ws = mock_ws_client
+        payload = SupersedePayload(
+            reason="session.already_connected",
+            message="This connection has been superseded by a newer session for this agent.",
+            retryable=False,
+            retry_after=15,
+            target_socket_id="agent_socket:agent-123",
+            correlation_id="evict-123",
+        )
+
+        await link._on_supersede(payload)
+
+        mock_ws_client.record_terminal_disconnect.assert_called_once_with(
+            link.last_disconnect_reason
+        )
+        assert link.last_disconnect_reason is not None
+        assert link.last_disconnect_reason.reason == "session.already_connected"
+        event = await link.__anext__()
+        assert isinstance(event, WebSocketDisconnectedEvent)
+        assert event.payload == link.last_disconnect_reason
+
+    async def test_close_without_supersede_leaves_disconnect_reason_empty(self):
+        """An empty Phoenix close should not invent a terminal reason."""
+        link = ThenvoiLink(agent_id="agent-123", api_key="test-key")
+
+        await link._on_disconnected(None)
+
+        assert link.last_disconnect_reason is None
+        assert link._event_queue.empty()
 
 
 class TestThenvoiLinkSubscriptions:

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -201,6 +201,7 @@ class TestThenvoiLinkConnection:
         """supersede records the platform reason and disables reconnect before close."""
         link = ThenvoiLink(agent_id="agent-123", api_key="test-key")
         link._ws = mock_ws_client
+        link._is_connected = True
         payload = SupersedePayload(
             reason="session.already_connected",
             message="This connection has been superseded by a newer session for this agent.",
@@ -215,11 +216,37 @@ class TestThenvoiLinkConnection:
         mock_ws_client.record_terminal_disconnect.assert_called_once_with(
             link.last_disconnect_reason
         )
+        assert link.is_connected is False
         assert link.last_disconnect_reason is not None
         assert link.last_disconnect_reason.reason == "session.already_connected"
         event = await link.__anext__()
         assert isinstance(event, WebSocketDisconnectedEvent)
         assert event.payload == link.last_disconnect_reason
+
+    async def test_disconnect_after_supersede_still_cleans_up_websocket(
+        self, mock_ws_client
+    ):
+        """disconnect() should clean up the websocket even after terminal state flips."""
+        link = ThenvoiLink(agent_id="agent-123", api_key="test-key")
+        link._ws = mock_ws_client
+        link._is_connected = True
+        link._subscribed_rooms.add("room-1")
+        payload = SupersedePayload(
+            reason="session.already_connected",
+            message="This connection has been superseded by a newer session for this agent.",
+            retryable=False,
+            retry_after=15,
+            target_socket_id="agent_socket:agent-123",
+            correlation_id="evict-123",
+        )
+
+        await link._on_supersede(payload)
+        await link.disconnect()
+
+        mock_ws_client.__aexit__.assert_called_once_with(None, None, None)
+        assert link.is_connected is False
+        assert link._ws is None
+        assert link._subscribed_rooms == set()
 
     async def test_close_without_supersede_leaves_disconnect_reason_empty(self):
         """An empty Phoenix close should not invent a terminal reason."""

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -414,6 +414,45 @@ async def test_aenter_restores_reconnect_after_successful_initial_connect(monkey
     assert client.client.auto_reconnect is True
 
 
+async def test_aenter_retries_unclassified_initial_connection_errors(monkeypatch):
+    attempts = 0
+    sleep_delays = []
+
+    class FlakyPHXClient:
+        def __init__(self, *args, **kwargs):
+            self.channel_socket_url = "wss://test/socket"
+            self.auto_reconnect = kwargs["auto_reconnect"]
+
+        async def __aenter__(self):
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise PHXConnectionError("temporary network failure")
+            return self
+
+    async def no_upgrade_error(exc, websocket_url):
+        return None
+
+    async def fake_sleep(delay):
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(
+        "thenvoi.client.streaming.client.PHXChannelsClient", FlakyPHXClient
+    )
+    monkeypatch.setattr(
+        "thenvoi.client.streaming.client.classify_initial_upgrade_error",
+        no_upgrade_error,
+    )
+    monkeypatch.setattr("thenvoi.client.streaming.client.asyncio.sleep", fake_sleep)
+
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+    await client.__aenter__()
+
+    assert attempts == 3
+    assert len(sleep_delays) == 2
+    assert client.client.auto_reconnect is True
+
+
 async def test_aenter_reraises_unrecognized_upgrade_error(monkeypatch):
     original_exc = RuntimeError("socket exploded")
 

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -320,6 +320,53 @@ def test_ignores_generic_auth_upgrade_error_without_json_contract():
     assert err is None
 
 
+async def test_aenter_wraps_upgrade_error(monkeypatch):
+    upgrade_exc = _upgrade_exception(
+        409,
+        b'{"error":{"code":"connection_conflict","message":"already connected","request_id":"req-409"}}',
+    )
+
+    class FailingPHXClient:
+        def __init__(self, *args, **kwargs):
+            self.channel_socket_url = "wss://test/socket"
+
+        async def __aenter__(self):
+            raise upgrade_exc
+
+    monkeypatch.setattr(
+        "thenvoi.client.streaming.client.PHXChannelsClient", FailingPHXClient
+    )
+
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+
+    with pytest.raises(WebSocketUpgradeError) as exc_info:
+        await client.__aenter__()
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.code == "connection_conflict"
+    assert exc_info.value.request_id == "req-409"
+
+
+async def test_aenter_reraises_unrecognized_upgrade_error(monkeypatch):
+    original_exc = RuntimeError("socket exploded")
+
+    class FailingPHXClient:
+        def __init__(self, *args, **kwargs):
+            self.channel_socket_url = "wss://test/socket"
+
+        async def __aenter__(self):
+            raise original_exc
+
+    monkeypatch.setattr(
+        "thenvoi.client.streaming.client.PHXChannelsClient", FailingPHXClient
+    )
+
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+
+    with pytest.raises(RuntimeError, match="socket exploded"):
+        await client.__aenter__()
+
+
 # --- Valid payload tests ---
 
 

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -12,9 +12,15 @@ import logging
 from unittest.mock import AsyncMock
 
 import pytest
+from websockets.datastructures import Headers
+from websockets.exceptions import InvalidStatus
+from websockets.http11 import Response
 
 from thenvoi.client.streaming import (
     MessageCreatedPayload,
+    SupersedePayload,
+    WebSocketDisconnectReason,
+    WebSocketUpgradeError,
     ParticipantAddedPayload,
     ParticipantRemovedPayload,
     RoomAddedPayload,
@@ -39,6 +45,19 @@ VALID_MESSAGE_CREATED_PAYLOAD: dict = {
     "inserted_at": "2025-11-17T11:20:10.284136Z",
     "updated_at": "2025-11-17T11:20:10.284136Z",
 }
+
+
+def _upgrade_exception(
+    status_code: int, body: bytes, headers: dict[str, str] | None = None
+):
+    return InvalidStatus(
+        Response(
+            status_code=status_code,
+            reason_phrase="error",
+            headers=Headers(headers or {}),
+            body=body,
+        )
+    )
 
 
 # --- Invalid payload tests: verify graceful handling (log + skip) ---
@@ -204,6 +223,101 @@ async def test_skips_invalid_participant_removed_payload(caplog):
 
     assert not callback_called, "Callback should not be called for invalid payload"
     assert "Invalid participant_removed payload" in caplog.text
+
+
+async def test_supersede_event_records_terminal_reason_and_disables_reconnect():
+    """agent_control supersede should record the server reason and stop reconnects."""
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+    client.client = type("MockPhoenix", (), {"auto_reconnect": True})()
+    received_payload = None
+
+    async def on_supersede(payload: SupersedePayload):
+        nonlocal received_payload
+        received_payload = payload
+        client.record_terminal_disconnect(payload.to_disconnect_reason())
+
+    class MockMessage:
+        event = "supersede"
+        payload = {
+            "reason": "session.already_connected",
+            "message": "This connection has been superseded by a newer session for this agent.",
+            "retryable": False,
+            "retry_after": 15,
+            "target_socket_id": "agent_socket:agent-123",
+            "correlation_id": "evict-123",
+        }
+
+    await client._handle_events(MockMessage(), {"supersede": on_supersede})
+
+    assert isinstance(received_payload, SupersedePayload)
+    assert client.client.auto_reconnect is False
+    assert client.last_disconnect_reason == WebSocketDisconnectReason(
+        reason="session.already_connected",
+        message="This connection has been superseded by a newer session for this agent.",
+        retryable=False,
+        retry_after=15,
+        target_socket_id="agent_socket:agent-123",
+        correlation_id="evict-123",
+    )
+
+
+def test_parses_distinct_upgrade_errors_from_http_json_response():
+    cases = [
+        (
+            409,
+            b'{"error":{"code":"connection_conflict","message":"already connected","request_id":"req-409"}}',
+            "connection_conflict",
+            None,
+        ),
+        (
+            400,
+            b'{"error":{"code":"invalid_on_conflict","message":"bad on_conflict","request_id":"req-400"}}',
+            "invalid_on_conflict",
+            None,
+        ),
+        (
+            503,
+            b'{"error":{"code":"tracking_failed","message":"tracking unavailable","request_id":"req-503"}}',
+            "tracking_failed",
+            None,
+        ),
+        (
+            429,
+            b'{"error":{"code":"too_many_requests","message":"slow down","request_id":"req-429","retry_after":12}}',
+            "too_many_requests",
+            12,
+        ),
+    ]
+
+    for status_code, body, code, retry_after in cases:
+        err = WebSocketUpgradeError.from_exception(
+            _upgrade_exception(status_code, body, {"Retry-After": "30"})
+        )
+
+        assert err is not None
+        assert err.status_code == status_code
+        assert err.code == code
+        assert err.request_id == f"req-{status_code}"
+        assert err.retry_after == retry_after
+
+
+def test_uses_retry_after_header_for_429_upgrade_error():
+    err = WebSocketUpgradeError.from_exception(
+        _upgrade_exception(
+            429,
+            b'{"error":{"code":"too_many_requests","message":"slow down","request_id":"req-header"}}',
+            {"Retry-After": "30"},
+        )
+    )
+
+    assert err is not None
+    assert err.retry_after == 30
+
+
+def test_ignores_generic_auth_upgrade_error_without_json_contract():
+    err = WebSocketUpgradeError.from_exception(_upgrade_exception(403, b""))
+
+    assert err is None
 
 
 # --- Valid payload tests ---

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -12,6 +12,7 @@ import logging
 from unittest.mock import AsyncMock
 
 import pytest
+from phoenix_channels_python_client.exceptions import PHXConnectionError
 from websockets.datastructures import Headers
 from websockets.exceptions import InvalidStatus
 from websockets.http11 import Response
@@ -345,6 +346,72 @@ async def test_aenter_wraps_upgrade_error(monkeypatch):
     assert exc_info.value.status_code == 409
     assert exc_info.value.code == "connection_conflict"
     assert exc_info.value.request_id == "req-409"
+
+
+async def test_aenter_probes_initial_phx_connection_error(monkeypatch):
+    upgrade_exc = _upgrade_exception(
+        429,
+        b'{"error":{"code":"too_many_requests","message":"slow down","request_id":"req-429"}}',
+        {"Retry-After": "30"},
+    )
+    probed_urls = []
+
+    class FailingPHXClient:
+        def __init__(self, *args, **kwargs):
+            assert kwargs["auto_reconnect"] is False
+            self.channel_socket_url = "wss://test/socket"
+
+        async def __aenter__(self):
+            raise PHXConnectionError("Connection supervisor stopped before connecting")
+
+    class FailingProbe:
+        async def __aenter__(self):
+            raise upgrade_exc
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            return None
+
+    def fake_connect(url, *, open_timeout):
+        probed_urls.append((url, open_timeout))
+        return FailingProbe()
+
+    monkeypatch.setattr(
+        "thenvoi.client.streaming.client.PHXChannelsClient", FailingPHXClient
+    )
+    monkeypatch.setattr("thenvoi.client.streaming.errors.connect", fake_connect)
+
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+
+    with pytest.raises(WebSocketUpgradeError) as exc_info:
+        await client.__aenter__()
+
+    assert probed_urls == [("wss://test/socket&agent_id=agent-123", 5)]
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.code == "too_many_requests"
+    assert exc_info.value.retry_after == 30
+
+
+async def test_aenter_restores_reconnect_after_successful_initial_connect(monkeypatch):
+    init_kwargs = {}
+
+    class SuccessfulPHXClient:
+        def __init__(self, *args, **kwargs):
+            init_kwargs.update(kwargs)
+            self.channel_socket_url = "wss://test/socket"
+            self.auto_reconnect = kwargs["auto_reconnect"]
+
+        async def __aenter__(self):
+            return self
+
+    monkeypatch.setattr(
+        "thenvoi.client.streaming.client.PHXChannelsClient", SuccessfulPHXClient
+    )
+
+    client = WebSocketClient("ws://localhost", "test-key", "agent-123")
+    await client.__aenter__()
+
+    assert init_kwargs["auto_reconnect"] is False
+    assert client.client.auto_reconnect is True
 
 
 async def test_aenter_reraises_unrecognized_upgrade_error(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -8366,7 +8366,7 @@ requires-dist = [
     { name = "openai", marker = "extra == 'pydantic-ai'", specifier = ">=1.0.0" },
     { name = "parlant", marker = "extra == 'dev-parlant'", specifier = ">=3.0.0" },
     { name = "parlant", marker = "extra == 'parlant'", specifier = ">=3.0.0" },
-    { name = "phoenix-channels-python-client", specifier = ">=0.1.5" },
+    { name = "phoenix-channels-python-client", specifier = ">=0.2.1" },
     { name = "pillow", marker = "extra == 'crewai'", specifier = ">=12.1.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pydantic-ai-slim", marker = "extra == 'dev'", specifier = ">=1.56.0" },


### PR DESCRIPTION
## Summary
- Join `agent_control:{agent_id}` on SDK websocket connect and handle terminal `supersede` events.
- Record the platform disconnect reason, surface it through `ThenvoiLink.last_disconnect_reason` / `WebSocketDisconnectedEvent`, and disable Phoenix auto-reconnect before the subsequent empty close.
- Add HTTP websocket upgrade error parsing for the platform JSON contracts for 400, 409, 429, and 503 while leaving empty 403 responses generic.

## Platform contract evidence
- `agent_control:{agent_id}` can push `supersede` before the old socket is closed.
- `supersede` includes `reason`, `message`, `retryable`, `retry_after`, `target_socket_id`, and nullable `correlation_id`; the SDK records this payload and does not infer a reason from the later empty Phoenix disconnect.
- Upgrade failures are HTTP/JSON responses, not channel events: 409 `connection_conflict`, 429 `too_many_requests` with `retry_after` / `Retry-After`, 400 `invalid_on_conflict`, and 503 `tracking_failed`. Empty 403 remains generic/auth.

## Test plan
- `pytest tests/websocket/test_client.py tests/platform/test_link.py` — 72 passed
- `ruff check src/thenvoi/client/streaming/client.py src/thenvoi/client/streaming/__init__.py src/thenvoi/platform/event.py src/thenvoi/platform/link.py tests/websocket/test_client.py tests/platform/test_link.py` — passed
- `ruff format --check src/thenvoi/client/streaming/client.py src/thenvoi/client/streaming/__init__.py src/thenvoi/platform/event.py src/thenvoi/platform/link.py tests/websocket/test_client.py tests/platform/test_link.py` — passed
- `pyrefly check src/thenvoi/client/streaming/client.py src/thenvoi/platform/event.py src/thenvoi/platform/link.py` — passed
- GitHub CI — passed
- Live production smoke with a temporary registered agent: opened two Python SDK `ThenvoiLink` connections for the same agent and verified the first received `WebSocketDisconnectedEvent` with `reason=session.already_connected`, `retryable=false`, `retry_after=30`, `target_socket_id=agent_socket:<agent_id>`, nullable `correlation_id`, `last_disconnect_reason` set, and `is_connected=false`.

## Notes
- A raw websocket `on_conflict=reject` production probe did not deterministically produce a live 409 because production routing can place duplicate reject connects on different platform nodes. The 409/429/400/503 parsing remains covered by behavior tests against the platform JSON contract.