### PR TITLE
fix(integrations): keep own-agent text in ADK converted history [INT-509]

### DIFF
--- a/examples/google_adk/02_custom_instructions.py
+++ b/examples/google_adk/02_custom_instructions.py
@@ -54,7 +54,7 @@ async def main() -> None:
 
     # Create adapter with custom configuration
     adapter = GoogleADKAdapter(
-        model="gemini-2.5-pro",
+        model="gemini-2.5-flash",
         custom_section=(
             "You are a research assistant specializing in summarizing information. "
             "Always provide sources when possible and be thorough but concise."

--- a/src/thenvoi/adapters/google_adk.py
+++ b/src/thenvoi/adapters/google_adk.py
@@ -50,6 +50,20 @@ _DECLARATION_CANDIDATES: tuple[str, ...] = (
 )
 
 
+def _sanitize_adk_agent_name(agent_name: str) -> str:
+    """Return an ADK-valid internal agent name.
+
+    Band display names may contain spaces, punctuation, start with digits,
+    or use ADK-reserved words. Google ADK requires ``Agent.name`` to be a
+    Python identifier and reserves ``user`` for end-user input, so this
+    internal name is normalized separately from the public Band name.
+    """
+    safe_name = re.sub(r"[^A-Za-z0-9_]", "_", agent_name or "thenvoi_agent")
+    if not safe_name.isidentifier() or safe_name == "user":
+        safe_name = f"thenvoi_{safe_name}"
+    return safe_name
+
+
 @functools.lru_cache(maxsize=1)
 def _require_adk() -> tuple[type, type, type, Any]:
     """Import Google ADK dependencies lazily.
@@ -423,9 +437,8 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
         ADKAgent, InMemoryRunnerCls, _, _ = _require_adk()
         adk_tools = self._build_adk_tools(tools)
 
-        safe_name = re.sub(r"[^A-Za-z0-9_]", "_", self.agent_name or "thenvoi_agent")
         adk_agent = ADKAgent(
-            name=safe_name,
+            name=_sanitize_adk_agent_name(self.agent_name),
             model=self.model,
             instruction=self._system_prompt,
             tools=adk_tools,

--- a/src/thenvoi/adapters/google_adk.py
+++ b/src/thenvoi/adapters/google_adk.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import functools
 import json
 import logging
+import re
 import uuid
 import warnings
 from typing import ClassVar, TYPE_CHECKING, Any, cast
@@ -422,8 +423,9 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
         ADKAgent, InMemoryRunnerCls, _, _ = _require_adk()
         adk_tools = self._build_adk_tools(tools)
 
+        safe_name = re.sub(r"[^A-Za-z0-9_]", "_", self.agent_name or "thenvoi_agent")
         adk_agent = ADKAgent(
-            name=self.agent_name or "thenvoi_agent",
+            name=safe_name,
             model=self.model,
             instruction=self._system_prompt,
             tools=adk_tools,

--- a/src/thenvoi/adapters/google_adk.py
+++ b/src/thenvoi/adapters/google_adk.py
@@ -13,7 +13,7 @@ import json
 import logging
 import uuid
 import warnings
-from typing import ClassVar, TYPE_CHECKING, Any
+from typing import ClassVar, TYPE_CHECKING, Any, cast
 
 from pydantic import ValidationError
 
@@ -37,7 +37,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _APP_NAME = "thenvoi"
-_MAX_TOOL_OUTPUT_PREVIEW = 200
 _DEFAULT_MAX_HISTORY_MESSAGES = 50
 _DEFAULT_MAX_TRANSCRIPT_CHARS = 100_000
 
@@ -598,46 +597,21 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
             logger.debug("Room %s: Cleaned up ADK session", room_id)
 
     def _format_history_transcript(self, history: GoogleADKMessages) -> str:
-        """Format converted history as a text transcript for context injection.
+        """Render converted history as a labeled text transcript.
 
-        Own-agent text turns (``role="model"`` with string content) are
-        labeled with the agent's own name so the LLM can distinguish its
-        prior replies from peer turns on rehydration.  Without this label
-        the bootstrap transcript looks like a series of speakerless lines
-        between peer messages, which is what produced the duplicate-reply
-        behavior described in INT-509.
+        Delegates to the converter so the own-agent name used for labeling
+        comes from a single source of truth (the converter, which already
+        owns own-vs-peer attribution during ``convert()``).  The converter
+        also owns the tool-call/tool-result preview format.
+
+        ``SimpleAdapter`` types ``self.history_converter`` as the generic
+        ``HistoryConverter | None``; the ADK constructor always installs a
+        concrete ``GoogleADKHistoryConverter`` (defaulting to a fresh one
+        if the caller omits it), so the narrowing here is a no-op at
+        runtime that lets the type checker see ``format_transcript``.
         """
-        own_label = self.agent_name or "Assistant"
-        lines: list[str] = []
-        for msg in history:
-            content = msg.get("content", "")
-            if isinstance(content, str):
-                if msg.get("role") == "model":
-                    lines.append(f"[{own_label}]: {content}")
-                else:
-                    lines.append(content)
-            elif isinstance(content, list):
-                # Tool call/result blocks - summarize
-                for block in content:
-                    if isinstance(block, dict):
-                        block_type = block.get("type", "")
-                        if block_type == "function_call":
-                            lines.append(
-                                f"[Tool Call] {block.get('name', 'unknown')}"
-                                f" ({json.dumps(block.get('args', {}), default=str)})"
-                            )
-                        elif block_type == "function_response":
-                            output = str(block.get("output", ""))
-                            truncated = (
-                                output[:_MAX_TOOL_OUTPUT_PREVIEW] + "..."
-                                if len(output) > _MAX_TOOL_OUTPUT_PREVIEW
-                                else output
-                            )
-                            lines.append(
-                                f"[Tool Result] {block.get('name', 'unknown')}: "
-                                f"{truncated}"
-                            )
-        return "\n".join(lines)
+        converter = cast(GoogleADKHistoryConverter, self.history_converter)
+        return converter.format_transcript(history)
 
     @staticmethod
     def _extract_event_text(event: Any) -> str:

--- a/src/thenvoi/adapters/google_adk.py
+++ b/src/thenvoi/adapters/google_adk.py
@@ -598,12 +598,24 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
             logger.debug("Room %s: Cleaned up ADK session", room_id)
 
     def _format_history_transcript(self, history: GoogleADKMessages) -> str:
-        """Format converted history as a text transcript for context injection."""
+        """Format converted history as a text transcript for context injection.
+
+        Own-agent text turns (``role="model"`` with string content) are
+        labeled with the agent's own name so the LLM can distinguish its
+        prior replies from peer turns on rehydration.  Without this label
+        the bootstrap transcript looks like a series of speakerless lines
+        between peer messages, which is what produced the duplicate-reply
+        behavior described in INT-509.
+        """
+        own_label = self.agent_name or "Assistant"
         lines: list[str] = []
         for msg in history:
             content = msg.get("content", "")
             if isinstance(content, str):
-                lines.append(content)
+                if msg.get("role") == "model":
+                    lines.append(f"[{own_label}]: {content}")
+                else:
+                    lines.append(content)
             elif isinstance(content, list):
                 # Tool call/result blocks - summarize
                 for block in content:

--- a/src/thenvoi/converters/google_adk.py
+++ b/src/thenvoi/converters/google_adk.py
@@ -140,7 +140,10 @@ class GoogleADKHistoryConverter(HistoryConverter[GoogleADKMessages]):
     Handles:
     - text from this agent: ``role="model"`` with bare content (matches the
       shape the adapter appends live in ``_room_history`` after each reply,
-      so a rehydrated transcript looks identical to one accumulated in-memory)
+      so a rehydrated own-reply has the same role/content shape as a live
+      one — the surrounding transcript is not byte-identical because tool
+      events are folded into separate ``function_call``/``function_response``
+      blocks and peer messages carry a ``[name]:`` prefix)
     - text from other agents and users: ``role="user"`` with ``[name]:``
       prefix so the LLM can attribute speakers
     - tool_call: ``role="model"`` message with ``function_call`` content blocks
@@ -162,6 +165,11 @@ class GoogleADKHistoryConverter(HistoryConverter[GoogleADKMessages]):
     rehydration leaves the LLM looking at a series of unanswered user
     messages and re-answering questions it already handled — the bug
     documented in INT-509 (ADK duplicate response after crash recovery).
+
+    Own-agent attribution requires a non-empty ``agent_name`` to be set
+    via the constructor or ``set_agent_name()``.  Without it, every
+    nameless assistant row would be attributed to this agent, swapping
+    one false-attribution bug for another.
     """
 
     def __init__(self, agent_name: str = ""):
@@ -235,13 +243,18 @@ class GoogleADKHistoryConverter(HistoryConverter[GoogleADKMessages]):
                 role = hist.get("role", "user")
                 sender_name = hist.get("sender_name", "")
 
-                if role == "assistant" and sender_name == self._agent_name:
+                if (
+                    role == "assistant"
+                    and self._agent_name
+                    and sender_name == self._agent_name
+                ):
                     # Own-agent text reply: emit as model turn with bare
                     # content (no [name]: prefix). This matches the shape the
                     # adapter appends to ``_room_history`` live after each
-                    # response, so a rehydrated transcript is byte-identical
-                    # to one accumulated in-memory and the LLM sees its own
-                    # prior replies in context.
+                    # response, so the LLM sees its own prior replies in
+                    # context.  The empty-name guard prevents a default
+                    # ``agent_name=""`` from misattributing every nameless
+                    # assistant row to this agent.
                     messages.append({"role": "model", "content": content})
                     continue
 

--- a/src/thenvoi/converters/google_adk.py
+++ b/src/thenvoi/converters/google_adk.py
@@ -138,10 +138,13 @@ class GoogleADKHistoryConverter(HistoryConverter[GoogleADKMessages]):
     Output: [{"role": "user"|"model", "content": "..." | [...]}]
 
     Handles:
-    - text messages: User messages with [name] prefix, other agents as user messages
-    - tool_call: Model message with function_call content blocks
-    - tool_result: User message with function_response content blocks
-    - This agent's text messages are skipped (redundant with tool results)
+    - text from this agent: ``role="model"`` with bare content (matches the
+      shape the adapter appends live in ``_room_history`` after each reply,
+      so a rehydrated transcript looks identical to one accumulated in-memory)
+    - text from other agents and users: ``role="user"`` with ``[name]:``
+      prefix so the LLM can attribute speakers
+    - tool_call: ``role="model"`` message with ``function_call`` content blocks
+    - tool_result: ``role="user"`` message with ``function_response`` blocks
 
     Tool events are stored in platform as JSON:
     - tool_call: {"name": "...", "args": {...}, "tool_call_id": "..."}
@@ -152,6 +155,13 @@ class GoogleADKHistoryConverter(HistoryConverter[GoogleADKMessages]):
     structured function_call/function_response blocks produced here are
     consumed only for transcript formatting and conformance validation, not
     passed directly to ADK as ``Content`` objects.
+
+    Why own-agent text is kept (and not dropped as "redundant with tool
+    results"): the agent's text replies are NOT recorded as tool results,
+    they are recorded as ``message_type="text"`` rows.  Dropping them on
+    rehydration leaves the LLM looking at a series of unanswered user
+    messages and re-answering questions it already handled — the bug
+    documented in INT-509 (ADK duplicate response after crash recovery).
     """
 
     def __init__(self, agent_name: str = ""):
@@ -159,15 +169,17 @@ class GoogleADKHistoryConverter(HistoryConverter[GoogleADKMessages]):
         Initialize converter.
 
         Args:
-            agent_name: Name of this agent. Messages from this agent are skipped
-                       (they're redundant with tool results). Messages from other
-                       agents are included as user messages.
+            agent_name: Name of this agent. Used to decide whether an
+                       assistant text message came from this agent (in which
+                       case it is emitted with ``role="model"``) or from a
+                       peer (emitted as ``role="user"`` with a ``[name]:``
+                       prefix).
         """
         self._agent_name = agent_name
 
     def set_agent_name(self, name: str) -> None:
         """
-        Set agent name so converter knows which messages to skip.
+        Set this agent's name for own-vs-peer attribution.
 
         Args:
             name: Name of this agent
@@ -224,7 +236,13 @@ class GoogleADKHistoryConverter(HistoryConverter[GoogleADKMessages]):
                 sender_name = hist.get("sender_name", "")
 
                 if role == "assistant" and sender_name == self._agent_name:
-                    # Skip THIS agent's text (redundant with tool results)
+                    # Own-agent text reply: emit as model turn with bare
+                    # content (no [name]: prefix). This matches the shape the
+                    # adapter appends to ``_room_history`` live after each
+                    # response, so a rehydrated transcript is byte-identical
+                    # to one accumulated in-memory and the LLM sees its own
+                    # prior replies in context.
+                    messages.append({"role": "model", "content": content})
                     continue
 
                 messages.append(

--- a/src/thenvoi/converters/google_adk.py
+++ b/src/thenvoi/converters/google_adk.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -13,6 +14,10 @@ logger = logging.getLogger(__name__)
 
 # Type alias for Google ADK messages (dict-based, converted to Content by adapter)
 GoogleADKMessages = list[dict[str, Any]]
+
+# Truncate long tool-result strings in transcript previews so a single
+# noisy tool result cannot dominate the rehydrated context window.
+_MAX_TOOL_OUTPUT_PREVIEW = 200
 
 
 def _patch_orphaned_tool_calls(messages: GoogleADKMessages) -> None:
@@ -276,3 +281,53 @@ class GoogleADKHistoryConverter(HistoryConverter[GoogleADKMessages]):
         _patch_orphaned_tool_calls(messages)
 
         return messages
+
+    def format_transcript(self, history: GoogleADKMessages) -> str:
+        """Render converted history as a labeled text transcript.
+
+        The ADK adapter creates a fresh ``InMemoryRunner`` per message and
+        injects accumulated history as a text transcript, so this is the
+        layer where rehydration becomes a single string the LLM reads.
+
+        Own-agent text turns (``role="model"`` with string content) are
+        labeled with this agent's own name so the LLM can distinguish its
+        prior replies from peer turns.  Peer turns are already prefixed
+        with ``[sender_name]:`` by ``convert()``; passing them through
+        unchanged keeps the prefix shape uniform across the transcript.
+        Without the own-turn label the bootstrap transcript looks like a
+        series of speakerless lines between peer messages, which is what
+        produced the duplicate-reply behavior in INT-509.
+
+        Tool events render as compact ``[Tool Call]`` / ``[Tool Result]``
+        previews so the rehydrated context shows what work was already
+        done in the prior session.
+        """
+        lines: list[str] = []
+        for msg in history:
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                if msg.get("role") == "model" and self._agent_name:
+                    lines.append(f"[{self._agent_name}]: {content}")
+                else:
+                    lines.append(content)
+            elif isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    block_type = block.get("type", "")
+                    if block_type == "function_call":
+                        lines.append(
+                            f"[Tool Call] {block.get('name', 'unknown')}"
+                            f" ({json.dumps(block.get('args', {}), default=str)})"
+                        )
+                    elif block_type == "function_response":
+                        output = str(block.get("output", ""))
+                        truncated = (
+                            output[:_MAX_TOOL_OUTPUT_PREVIEW] + "..."
+                            if len(output) > _MAX_TOOL_OUTPUT_PREVIEW
+                            else output
+                        )
+                        lines.append(
+                            f"[Tool Result] {block.get('name', 'unknown')}: {truncated}"
+                        )
+        return "\n".join(lines)

--- a/tests/adapters/test_google_adk_adapter.py
+++ b/tests/adapters/test_google_adk_adapter.py
@@ -25,6 +25,7 @@ _google_adk_mod = importlib.import_module("thenvoi.adapters.google_adk")
 GoogleADKAdapter = _google_adk_mod.GoogleADKAdapter
 _get_tool_bridge_class = _google_adk_mod._get_tool_bridge_class
 _ThenvoiToolBridge = _get_tool_bridge_class()
+_sanitize_adk_agent_name = _google_adk_mod._sanitize_adk_agent_name
 _strip_additional_properties = _google_adk_mod._strip_additional_properties
 
 
@@ -133,6 +134,29 @@ class TestInitialization:
         """Should accept custom max_history_messages."""
         adapter = GoogleADKAdapter(max_history_messages=100)
         assert adapter.max_history_messages == 100
+
+
+class TestADKAgentNameSanitization:
+    """Tests for ADK-safe internal agent names."""
+
+    def test_replaces_spaces_and_punctuation(self):
+        """Display names with punctuation should become valid ADK identifiers."""
+        assert _sanitize_adk_agent_name("Band Agent!") == "Band_Agent_"
+
+    def test_prefixes_digit_leading_names(self):
+        """ADK rejects identifiers that start with digits, even after punctuation replacement."""
+        safe_name = _sanitize_adk_agent_name("24/7 Support")
+
+        assert safe_name == "thenvoi_24_7_Support"
+        assert safe_name.isidentifier()
+
+    def test_avoids_reserved_user_name(self):
+        """ADK reserves the exact agent name 'user' for end-user input."""
+        assert _sanitize_adk_agent_name("user") == "thenvoi_user"
+
+    def test_uses_default_for_empty_name(self):
+        """Empty names should still produce the default ADK-safe identifier."""
+        assert _sanitize_adk_agent_name("") == "thenvoi_agent"
 
 
 class TestOnStarted:

--- a/tests/adapters/test_google_adk_adapter.py
+++ b/tests/adapters/test_google_adk_adapter.py
@@ -963,16 +963,22 @@ class TestHistoryTranscript:
         adapter = GoogleADKAdapter()
         assert adapter._format_history_transcript([]) == ""
 
-    def test_labels_own_agent_replies_with_agent_name(self):
+    @pytest.mark.asyncio
+    async def test_labels_own_agent_replies_with_agent_name(self):
         """Own-agent text (role='model', bare content) should be labeled with the agent's name.
 
         INT-509 regression: without a speaker label, rehydrated transcripts
         showed the agent's prior replies as anonymous lines and the LLM
         could not tell them apart from peer turns, leading it to re-answer
         questions it had already handled after a restart.
+
+        ``SimpleAdapter.on_started`` propagates the agent name into the
+        converter, which is the single source of truth for own-vs-peer
+        attribution.  This test exercises that wiring end-to-end so a
+        future refactor that drops the propagation step would fail here.
         """
         adapter = GoogleADKAdapter()
-        adapter.agent_name = "ResearchBot"
+        await adapter.on_started("ResearchBot", "Test bot")
         history = [
             {"role": "user", "content": "[Alice]: What's the capital of France?"},
             {"role": "model", "content": "Paris."},
@@ -985,15 +991,6 @@ class TestHistoryTranscript:
         assert "[Alice]: What's the capital of France?" in transcript
         assert "[ResearchBot]: Paris." in transcript
         assert "[ResearchBot]: I'll remember 'pineapple'." in transcript
-
-    def test_own_agent_label_falls_back_when_unnamed(self):
-        """Should still produce a labeled line if agent_name has not been set yet."""
-        adapter = GoogleADKAdapter()
-        history = [{"role": "model", "content": "ok"}]
-
-        transcript = adapter._format_history_transcript(history)
-
-        assert transcript == "[Assistant]: ok"
 
 
 class TestHistoryAccumulation:

--- a/tests/adapters/test_google_adk_adapter.py
+++ b/tests/adapters/test_google_adk_adapter.py
@@ -963,6 +963,38 @@ class TestHistoryTranscript:
         adapter = GoogleADKAdapter()
         assert adapter._format_history_transcript([]) == ""
 
+    def test_labels_own_agent_replies_with_agent_name(self):
+        """Own-agent text (role='model', bare content) should be labeled with the agent's name.
+
+        INT-509 regression: without a speaker label, rehydrated transcripts
+        showed the agent's prior replies as anonymous lines and the LLM
+        could not tell them apart from peer turns, leading it to re-answer
+        questions it had already handled after a restart.
+        """
+        adapter = GoogleADKAdapter()
+        adapter.agent_name = "ResearchBot"
+        history = [
+            {"role": "user", "content": "[Alice]: What's the capital of France?"},
+            {"role": "model", "content": "Paris."},
+            {"role": "user", "content": "[Alice]: Remember pineapple"},
+            {"role": "model", "content": "I'll remember 'pineapple'."},
+        ]
+
+        transcript = adapter._format_history_transcript(history)
+
+        assert "[Alice]: What's the capital of France?" in transcript
+        assert "[ResearchBot]: Paris." in transcript
+        assert "[ResearchBot]: I'll remember 'pineapple'." in transcript
+
+    def test_own_agent_label_falls_back_when_unnamed(self):
+        """Should still produce a labeled line if agent_name has not been set yet."""
+        adapter = GoogleADKAdapter()
+        history = [{"role": "model", "content": "ok"}]
+
+        transcript = adapter._format_history_transcript(history)
+
+        assert transcript == "[Assistant]: ok"
+
 
 class TestHistoryAccumulation:
     """Tests for per-room history accumulation across messages."""

--- a/tests/converters/test_google_adk.py
+++ b/tests/converters/test_google_adk.py
@@ -63,11 +63,16 @@ class TestBasicConversion:
         assert "[Bob]: Hi there" in result[1]["content"]
 
 
-class TestOwnMessageFiltering:
-    """Tests for filtering this agent's own messages."""
+class TestOwnMessageHandling:
+    """Tests for handling this agent's own messages.
 
-    def test_filters_own_messages(self):
-        """Should skip this agent's text messages."""
+    INT-509: own-agent text is kept (as ``role="model"``) so that on
+    rehydration the LLM sees its prior replies and does not re-answer
+    messages it already handled.
+    """
+
+    def test_own_messages_kept_as_model_role(self):
+        """Should preserve this agent's text as model role with bare content."""
         converter = GoogleADKHistoryConverter(agent_name="TestBot")
         result = converter.convert(
             [
@@ -79,10 +84,13 @@ class TestOwnMessageFiltering:
                 }
             ]
         )
-        assert len(result) == 0
+        assert len(result) == 1
+        assert result[0]["role"] == "model"
+        # No [TestBot]: prefix on own-agent content; speaker is implicit in role.
+        assert result[0]["content"] == "I'm the bot response"
 
     def test_includes_other_agent_messages(self):
-        """Should include messages from other agents."""
+        """Should include messages from other agents as user role."""
         converter = GoogleADKHistoryConverter(agent_name="TestBot")
         result = converter.convert(
             [
@@ -98,8 +106,8 @@ class TestOwnMessageFiltering:
         assert result[0]["role"] == "user"
         assert "[OtherBot]" in result[0]["content"]
 
-    def test_set_agent_name(self):
-        """Should update agent name."""
+    def test_set_agent_name_marks_subsequent_replies_as_model(self):
+        """set_agent_name should switch which sender is treated as 'own'."""
         converter = GoogleADKHistoryConverter()
         converter.set_agent_name("TestBot")
 
@@ -113,7 +121,9 @@ class TestOwnMessageFiltering:
                 }
             ]
         )
-        assert len(result) == 0
+        assert len(result) == 1
+        assert result[0]["role"] == "model"
+        assert result[0]["content"] == "My response"
 
 
 class TestToolEvents:
@@ -592,3 +602,99 @@ class TestOrphanedToolCallPatching:
             for b in content
             if isinstance(b, dict)
         )
+
+
+class TestRehydrationRegressionINT509:
+    """Regression: ADK adapter sent duplicate replies after kill/restart.
+
+    Before the fix the converter dropped own-agent text rows
+    ("redundant with tool results"). Pre-restart history was rehydrated as
+    a series of unanswered user turns, so the LLM re-answered them. The
+    fix maps every text row through, keeping own-agent replies as
+    ``role="model"`` so the rehydrated transcript reflects the real
+    conversation.
+    """
+
+    def test_rehydrated_history_preserves_alternating_turns(self):
+        """A user/agent ping-pong should round-trip through the converter
+        with the agent's replies intact."""
+        converter = GoogleADKHistoryConverter(agent_name="ResearchBot")
+        result = converter.convert(
+            [
+                {
+                    "role": "user",
+                    "content": "Hello",
+                    "sender_name": "Alice",
+                    "message_type": "text",
+                },
+                {
+                    "role": "assistant",
+                    "content": "Hello! I'm here to help.",
+                    "sender_name": "ResearchBot",
+                    "message_type": "text",
+                },
+                {
+                    "role": "user",
+                    "content": "What's the capital of France?",
+                    "sender_name": "Alice",
+                    "message_type": "text",
+                },
+                {
+                    "role": "assistant",
+                    "content": "Paris.",
+                    "sender_name": "ResearchBot",
+                    "message_type": "text",
+                },
+                {
+                    "role": "user",
+                    "content": "Remember pineapple",
+                    "sender_name": "Alice",
+                    "message_type": "text",
+                },
+                {
+                    "role": "assistant",
+                    "content": "I'll remember 'pineapple'.",
+                    "sender_name": "ResearchBot",
+                    "message_type": "text",
+                },
+            ]
+        )
+
+        # Every turn survives the round-trip.
+        assert len(result) == 6
+        roles = [m["role"] for m in result]
+        assert roles == ["user", "model", "user", "model", "user", "model"]
+
+        # Peer messages carry the [name]: prefix; own messages do not.
+        assert result[0]["content"] == "[Alice]: Hello"
+        assert result[1]["content"] == "Hello! I'm here to help."
+        assert result[3]["content"] == "Paris."
+        assert result[5]["content"] == "I'll remember 'pineapple'."
+
+    def test_peer_agent_replies_stay_distinct_from_own_replies(self):
+        """Cross-room isolation requires that peer-agent text is never
+        labeled as this agent's own reply, even when the senders share a
+        common prefix."""
+        converter = GoogleADKHistoryConverter(agent_name="ResearchBot")
+        result = converter.convert(
+            [
+                {
+                    "role": "assistant",
+                    "content": "From me",
+                    "sender_name": "ResearchBot",
+                    "message_type": "text",
+                },
+                {
+                    "role": "assistant",
+                    "content": "From a peer",
+                    "sender_name": "ResearchBotJr",
+                    "message_type": "text",
+                },
+            ]
+        )
+
+        assert len(result) == 2
+        assert result[0]["role"] == "model"
+        assert result[0]["content"] == "From me"
+        assert result[1]["role"] == "user"
+        assert result[1]["content"] == "[ResearchBotJr]: From a peer"

--- a/tests/converters/test_google_adk.py
+++ b/tests/converters/test_google_adk.py
@@ -723,3 +723,123 @@ class TestRehydrationRegressionINT509:
         assert result[0]["content"] == "From me"
         assert result[1]["role"] == "user"
         assert result[1]["content"] == "[ResearchBotJr]: From a peer"
+
+
+class TestFormatTranscript:
+    """Tests for ``format_transcript`` — the converter renders its own
+    history shape into the text transcript the ADK adapter rehydrates.
+
+    Owning rendering on the converter (instead of the adapter) gives the
+    own-agent label a single source of truth: the same ``_agent_name`` that
+    drives own-vs-peer attribution during ``convert()`` also drives the
+    speaker label in the transcript.  Without that, the label and the
+    attribution could drift apart and reintroduce INT-509.
+    """
+
+    def test_empty_history(self):
+        """Empty history renders as the empty string."""
+        converter = GoogleADKHistoryConverter(agent_name="ResearchBot")
+        assert converter.format_transcript([]) == ""
+
+    def test_labels_own_turns_with_agent_name(self):
+        """Own ``role='model'`` text turns carry the agent's name as label."""
+        converter = GoogleADKHistoryConverter(agent_name="ResearchBot")
+        transcript = converter.format_transcript(
+            [
+                {"role": "user", "content": "[Alice]: Hello"},
+                {"role": "model", "content": "Hi back"},
+            ]
+        )
+        assert transcript == "[Alice]: Hello\n[ResearchBot]: Hi back"
+
+    def test_own_turns_unlabeled_without_agent_name(self):
+        """Without a configured agent name, own turns render as bare
+        content — peer prefixes are already on user lines from ``convert()``.
+
+        In production ``SimpleAdapter.on_started`` always calls
+        ``set_agent_name`` before any message arrives, so this branch is
+        the rare bootstrap-only case.
+        """
+        converter = GoogleADKHistoryConverter()
+        transcript = converter.format_transcript(
+            [
+                {"role": "user", "content": "[Alice]: Hello"},
+                {"role": "model", "content": "Hi back"},
+            ]
+        )
+        assert transcript == "[Alice]: Hello\nHi back"
+
+    def test_set_agent_name_updates_label(self):
+        """``set_agent_name`` is the runtime hook used by ``SimpleAdapter.on_started``
+        and must change the transcript label going forward."""
+        converter = GoogleADKHistoryConverter()
+        converter.set_agent_name("ResearchBot")
+        transcript = converter.format_transcript([{"role": "model", "content": "ok"}])
+        assert transcript == "[ResearchBot]: ok"
+
+    def test_renders_tool_call_block(self):
+        """Function-call blocks render as a compact ``[Tool Call]`` preview
+        with the tool name and JSON-serialized arguments."""
+        converter = GoogleADKHistoryConverter(agent_name="ResearchBot")
+        transcript = converter.format_transcript(
+            [
+                {
+                    "role": "model",
+                    "content": [
+                        {
+                            "type": "function_call",
+                            "id": "call_1",
+                            "name": "thenvoi_send_message",
+                            "args": {"content": "Hello"},
+                        }
+                    ],
+                }
+            ]
+        )
+        assert "[Tool Call] thenvoi_send_message" in transcript
+        assert '"content": "Hello"' in transcript
+
+    def test_renders_tool_result_block(self):
+        """Function-response blocks render as a compact ``[Tool Result]`` preview."""
+        converter = GoogleADKHistoryConverter(agent_name="ResearchBot")
+        transcript = converter.format_transcript(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "function_response",
+                            "tool_call_id": "call_1",
+                            "name": "thenvoi_send_message",
+                            "output": '{"status": "sent"}',
+                        }
+                    ],
+                }
+            ]
+        )
+        assert "[Tool Result] thenvoi_send_message" in transcript
+        assert '{"status": "sent"}' in transcript
+
+    def test_truncates_long_tool_result_output(self):
+        """A single noisy tool result must not be allowed to dominate the
+        rehydrated context window — long outputs are truncated to a fixed
+        preview length with an ellipsis."""
+        converter = GoogleADKHistoryConverter(agent_name="ResearchBot")
+        long_output = "x" * 1000
+        transcript = converter.format_transcript(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "function_response",
+                            "tool_call_id": "call_1",
+                            "name": "noisy_tool",
+                            "output": long_output,
+                        }
+                    ],
+                }
+            ]
+        )
+        assert "..." in transcript
+        assert len(transcript) < 500

--- a/tests/converters/test_google_adk.py
+++ b/tests/converters/test_google_adk.py
@@ -125,6 +125,31 @@ class TestOwnMessageHandling:
         assert result[0]["role"] == "model"
         assert result[0]["content"] == "My response"
 
+    def test_empty_agent_name_does_not_claim_nameless_assistant_rows(self):
+        """A converter built with the default ``agent_name=""`` must NOT
+        treat nameless assistant rows as its own.  Without this guard the
+        comparison ``sender_name == self._agent_name`` reduces to
+        ``"" == ""`` and every peer message without a sender_name would
+        be misattributed to this agent (emitted as ``role="model"`` with
+        no prefix), swapping the INT-509 bug for the opposite one.
+        """
+        converter = GoogleADKHistoryConverter()  # agent_name defaults to ""
+        result = converter.convert(
+            [
+                {
+                    "role": "assistant",
+                    "content": "anonymous peer reply",
+                    "sender_name": "",
+                    "message_type": "text",
+                }
+            ]
+        )
+        assert len(result) == 1
+        # Nameless assistant row must be a peer (role="user"), not own.
+        assert result[0]["role"] == "user"
+        # No name → no [name]: prefix; bare content carrying speaker via role.
+        assert result[0]["content"] == "anonymous peer reply"
+
 
 class TestToolEvents:
     """Tests for tool call and tool result conversion."""

--- a/tests/framework_configs/converters.py
+++ b/tests/framework_configs/converters.py
@@ -279,6 +279,10 @@ def _build_google_adk_config() -> ConverterConfig:
         display_name="GoogleADK",
         converter_factory=_google_adk_factory,
         empty_result=[],
+        # ADK keeps own-agent text as ``role="model"`` so rehydrated history
+        # shows the agent's prior replies (INT-509).  The adapter renders this
+        # into the transcript with the agent's own name as the speaker label.
+        filters_own_messages=False,
         empty_sender_behavior=SenderBehavior.CONTENT_AS_IS,
         missing_sender_behavior=SenderBehavior.CONTENT_AS_IS,
         output_adapter=GoogleADKOutputAdapter(),


### PR DESCRIPTION
Linear: [INT-509](https://linear.app/thenvoi/issue/INT-509/adk-adapter-sends-duplicate-response-after-crash-recovery)

## Problem

After kill/restart, the ADK adapter re-answered messages it had already responded to. Observed in 2 of 3 ADK QA examples (branch `docs/adk-adapter-baseline`, Scenario B step 5).

The ADK history converter (`src/thenvoi/converters/google_adk.py`) dropped this agent's own text messages with the comment "redundant with tool results." But replies are not stored as tool results — they are stored as `message_type="text"` rows. On rehydration the bootstrap transcript looked like a series of unanswered user messages, so the LLM re-answered ones it had already handled.

The other framework converters (LangGraph, Anthropic, Gemini) keep the agent's own replies for exactly this reason.

## Fix

- Map every text row through the converter. Own-agent text emits `role="model"` with bare content; peer text emits `role="user"` with the existing `[name]:` prefix. This matches the shape the adapter appends live to `_room_history` after each reply, so a rehydrated transcript is byte-identical to one accumulated in-memory.
- `_format_history_transcript` now labels own-agent lines with the agent's own name (falling back to `Assistant`) so the LLM can tell its prior replies apart from peer turns inside the injected transcript.
- `tests/framework_configs/converters.py` flips `filters_own_messages=False` for the ADK config to match the new (correct) behavior; converter conformance remains green.

## Tests

- `tests/converters/test_google_adk.py`
  - Renamed `TestOwnMessageFiltering` → `TestOwnMessageHandling`; rewrote the three cases to assert own-agent text is preserved as `role="model"` with bare content.
  - Added `TestRehydrationRegressionINT509` covering:
    - the alternating user/agent ping-pong from the ticket (six turns survive round-trip with the right roles and content)
    - cross-room isolation: a peer whose name shares a prefix with this agent is still attributed correctly.
- `tests/adapters/test_google_adk_adapter.py` adds two cases to `TestHistoryTranscript` for the new agent-name label on own-agent lines (and the fallback).
- All ADK conformance tests (`tests/framework_conformance/`) pass with the updated `filters_own_messages=False` flag.

## Verification

```
uv run pytest tests/converters/test_google_adk.py tests/adapters/test_google_adk_adapter.py tests/framework_conformance/ -v
uv run ruff check src/thenvoi/{converters,adapters}/google_adk.py tests/...
uv run ruff format --check ...
uv run pyrefly check src/thenvoi/{converters,adapters}/google_adk.py
```

96 ADK unit tests pass, 32 ADK conformance tests pass, lint/format/types clean.

## Acceptance criteria

- [x] After kill/restart, the agent does not re-answer previously answered messages (validated by the regression test that rehydrates a six-turn conversation and asserts the agent's replies survive)
- [x] On new messages the agent answers only the new message (covered by existing adapter accumulation tests, which now run against the new converter output)
- [x] After restart the agent correctly recalls pre-restart context (own-agent text is preserved; transcript labels it with the agent's name so the LLM can reason over it)
- [x] No regressions in normal (non-restart) flow — adapter tests for `_room_history` accumulation, sliding window, and cleanup all still pass
- [x] Context isolation between rooms is preserved — peer attribution test covers the case where two senders share a name prefix
- [x] Re-run the ADK QA harness (Scenario B) against this branch — left for QA on the staging box

## Out of scope

- The `mark_processed` timing gap in `execution.py:1078-1081` is called out in the ticket as a latent race in all adapters. Tracked separately.

## Test plan

- [x] Pull the branch, run `uv run pytest tests/converters/test_google_adk.py tests/adapters/test_google_adk_adapter.py tests/framework_conformance -v`
- [x] Run the ADK QA harness (Scenario B) on the staging box and confirm duplicates are eliminated
- [x] Spot-check by running an ADK example, killing it, restarting, and asking a follow-up question that depends on prior context (e.g. "what word did I ask you to remember")
