### PR TITLE
fix(integrations): dedupe Claude SDK send_message MCP retries

### DIFF
--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -502,10 +502,10 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                 await existing.update_inner(tools)
                 tools = cast(AgentToolsProtocol, existing)
             else:
-                wrapped: Any = DedupingAgentTools(
+                wrapper = DedupingAgentTools(
                     tools, ttl_seconds=self.send_message_dedup_ttl_seconds
                 )
-                tools = wrapped
+                tools = cast(AgentToolsProtocol, wrapper)
                 self._room_tools[room_id] = tools
         else:
             self._room_tools[room_id] = tools

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -61,6 +61,10 @@ from band.integrations.mcp.backends import (
 )
 from band.integrations.claude_sdk.session_manager import ClaudeSessionManager
 from band.integrations.claude_sdk.prompts import generate_claude_sdk_agent_prompt
+from band.integrations.claude_sdk.dedup_tools import (
+    DEFAULT_DEDUP_TTL_SECONDS,
+    DedupingAgentTools,
+)
 from band.runtime.custom_tools import CustomToolDef
 from band.runtime.tools import (
     ALL_TOOL_NAMES,
@@ -199,6 +203,7 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         max_pending_approvals_per_room: int = 50,
         approval_authorized_senders: set[str] | None = None,
         features: AdapterFeatures | None = None,
+        send_message_dedup_ttl_seconds: float = DEFAULT_DEDUP_TTL_SECONDS,
     ):
         """
         Initialize the Claude SDK adapter.
@@ -249,6 +254,12 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
             features: Unified adapter feature settings. When provided alongside
                 deprecated ``enable_execution_reporting`` or ``enable_memory_tools``,
                 raises ``BandConfigError``.
+            send_message_dedup_ttl_seconds: Window (seconds) inside which two
+                ``band_send_message`` MCP tool calls with identical
+                ``(content, mentions)`` are collapsed into one platform POST.
+                Mitigates duplicate-message events caused by Claude CLI / MCP
+                transport retries when the event loop is stalled.
+                Defaults to 30 s; set to ``0`` to disable dedup entirely.
         """
         if not _CLAUDE_SDK_AVAILABLE:
             raise ImportError(
@@ -315,6 +326,11 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         self.approval_timeout_decision: ApprovalDecision = approval_timeout_decision
         self.max_pending_approvals_per_room = max_pending_approvals_per_room
         self.approval_authorized_senders: set[str] | None = approval_authorized_senders
+
+        # send_message dedup window.  0 disables the wrapper.
+        if send_message_dedup_ttl_seconds < 0:
+            raise ValueError("send_message_dedup_ttl_seconds must be >= 0")
+        self.send_message_dedup_ttl_seconds = send_message_dedup_ttl_seconds
 
         # Session manager and MCP server (created after start)
         self._session_manager: ClaudeSessionManager | None = None
@@ -461,7 +477,22 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                 "ClaudeSDKAdapter session manager not initialized — was on_started() called?"
             )
 
-        # Store tools for MCP server access
+        # Store tools for MCP server access.  Wrap with the send_message
+        # dedup shim so MCP-driven retries (event-loop saturation
+        # under Claude CLI load causes the same band_send_message tool
+        # call to fire more than once for a single LLM-intended send) do
+        # not turn into duplicate chat messages.  Bypass the wrapper when
+        # the operator has explicitly opted out via ttl=0.
+        #
+        # DedupingAgentTools is structurally a superset of AgentToolsProtocol
+        # (the dedup shim only intercepts send_message and __getattr__-forwards
+        # everything else), but pyrefly cannot reason about __getattr__ for
+        # protocol conformance, so we cast through Any.
+        if self.send_message_dedup_ttl_seconds > 0:
+            wrapped: Any = DedupingAgentTools(
+                tools, ttl_seconds=self.send_message_dedup_ttl_seconds
+            )
+            tools = wrapped
         self._room_tools[room_id] = tools
 
         # Approval flow: track notify target and intercept local commands

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -484,13 +484,11 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         # not turn into duplicate chat messages.  Bypass the wrapper when
         # the operator has explicitly opted out via ttl=0.
         #
-        # The wrapper MUST persist across on_message calls for the same
-        # room: the dominant INT-502 pattern is a duplicate tool call
-        # arriving after the original turn's Complete event, which means
-        # the duplicate lands on a *subsequent* on_message (or on a
-        # lingering MCP handler that resolves via self._room_tools.get).
-        # Rebuilding the wrapper per call would throw away the cache and
-        # let that duplicate through.  Swap the inner reference instead.
+        # The wrapper MUST persist for the room so a lingering MCP retry can
+        # still see the cache through self._room_tools.get.  The active
+        # dedup scope is updated from the inbound platform message id so two
+        # legitimate turns with identical text do not suppress each other.
+        # Swap the inner reference instead of rebuilding the wrapper.
         #
         # DedupingAgentTools is structurally a superset of AgentToolsProtocol
         # (the dedup shim only intercepts send_message and __getattr__-forwards
@@ -505,7 +503,9 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                 # the wrapper lock for the rare case where the runtime
                 # hands us the same instance twice.
                 if existing._inner is not tools:
-                    await existing.update_inner(tools)
+                    await existing.update_inner(tools, dedup_scope=msg.id)
+                else:
+                    await existing.update_inner(existing._inner, dedup_scope=msg.id)
                 tools = cast(AgentToolsProtocol, existing)
             else:
                 wrapper = DedupingAgentTools(
@@ -513,6 +513,7 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                     ttl_seconds=self.send_message_dedup_ttl_seconds,
                     label=room_id,
                 )
+                await wrapper.update_inner(tools, dedup_scope=msg.id)
                 tools = cast(AgentToolsProtocol, wrapper)
                 self._room_tools[room_id] = tools
         else:

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -485,10 +485,11 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         # the operator has explicitly opted out via ttl=0.
         #
         # The wrapper MUST persist for the room so a lingering MCP retry can
-        # still see the cache through self._room_tools.get.  The active
-        # dedup scope is updated from the inbound platform message id so two
-        # legitimate turns with identical text do not suppress each other.
-        # Swap the inner reference instead of rebuilding the wrapper.
+        # still see the cache through self._room_tools.get. MCP tool calls
+        # only resolve by room id, not by the original inbound message id, so
+        # the cache is intentionally keyed by the outgoing payload within the
+        # per-room wrapper. Swap the inner reference instead of rebuilding the
+        # wrapper.
         #
         # DedupingAgentTools is structurally a superset of AgentToolsProtocol
         # (the dedup shim only intercepts send_message and __getattr__-forwards
@@ -497,15 +498,8 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         if self.send_message_dedup_ttl_seconds > 0:
             existing = self._room_tools.get(room_id)
             if isinstance(existing, DedupingAgentTools):
-                # ``AgentTools.from_context`` returns a fresh instance per
-                # inbound message, so the identity check is normally false
-                # — but skipping a no-op swap avoids briefly contending on
-                # the wrapper lock for the rare case where the runtime
-                # hands us the same instance twice.
                 if existing._inner is not tools:
-                    await existing.update_inner(tools, dedup_scope=msg.id)
-                else:
-                    await existing.update_inner(existing._inner, dedup_scope=msg.id)
+                    await existing.update_inner(tools)
                 tools = cast(AgentToolsProtocol, existing)
             else:
                 wrapper = DedupingAgentTools(
@@ -513,7 +507,6 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                     ttl_seconds=self.send_message_dedup_ttl_seconds,
                     label=room_id,
                 )
-                await wrapper.update_inner(tools, dedup_scope=msg.id)
                 tools = cast(AgentToolsProtocol, wrapper)
                 self._room_tools[room_id] = tools
         else:

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -499,11 +499,19 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         if self.send_message_dedup_ttl_seconds > 0:
             existing = self._room_tools.get(room_id)
             if isinstance(existing, DedupingAgentTools):
-                await existing.update_inner(tools)
+                # ``AgentTools.from_context`` returns a fresh instance per
+                # inbound message, so the identity check is normally false
+                # — but skipping a no-op swap avoids briefly contending on
+                # the wrapper lock for the rare case where the runtime
+                # hands us the same instance twice.
+                if existing._inner is not tools:
+                    await existing.update_inner(tools)
                 tools = cast(AgentToolsProtocol, existing)
             else:
                 wrapper = DedupingAgentTools(
-                    tools, ttl_seconds=self.send_message_dedup_ttl_seconds
+                    tools,
+                    ttl_seconds=self.send_message_dedup_ttl_seconds,
+                    label=room_id,
                 )
                 tools = cast(AgentToolsProtocol, wrapper)
                 self._room_tools[room_id] = tools

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -18,7 +18,7 @@ import warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, cast
 
 try:
     from claude_agent_sdk import (  # type: ignore[import-not-found]
@@ -484,16 +484,31 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
         # not turn into duplicate chat messages.  Bypass the wrapper when
         # the operator has explicitly opted out via ttl=0.
         #
+        # The wrapper MUST persist across on_message calls for the same
+        # room: the dominant INT-502 pattern is a duplicate tool call
+        # arriving after the original turn's Complete event, which means
+        # the duplicate lands on a *subsequent* on_message (or on a
+        # lingering MCP handler that resolves via self._room_tools.get).
+        # Rebuilding the wrapper per call would throw away the cache and
+        # let that duplicate through.  Swap the inner reference instead.
+        #
         # DedupingAgentTools is structurally a superset of AgentToolsProtocol
         # (the dedup shim only intercepts send_message and __getattr__-forwards
         # everything else), but pyrefly cannot reason about __getattr__ for
         # protocol conformance, so we cast through Any.
         if self.send_message_dedup_ttl_seconds > 0:
-            wrapped: Any = DedupingAgentTools(
-                tools, ttl_seconds=self.send_message_dedup_ttl_seconds
-            )
-            tools = wrapped
-        self._room_tools[room_id] = tools
+            existing = self._room_tools.get(room_id)
+            if isinstance(existing, DedupingAgentTools):
+                await existing.update_inner(tools)
+                tools = cast(AgentToolsProtocol, existing)
+            else:
+                wrapped: Any = DedupingAgentTools(
+                    tools, ttl_seconds=self.send_message_dedup_ttl_seconds
+                )
+                tools = wrapped
+                self._room_tools[room_id] = tools
+        else:
+            self._room_tools[room_id] = tools
 
         # Approval flow: track notify target and intercept local commands
         if self.approval_mode is not None:

--- a/src/band/integrations/claude_sdk/dedup_tools.py
+++ b/src/band/integrations/claude_sdk/dedup_tools.py
@@ -96,6 +96,7 @@ class DedupingAgentTools:
         *,
         ttl_seconds: float = DEFAULT_DEDUP_TTL_SECONDS,
         max_entries: int = DEFAULT_DEDUP_MAX_ENTRIES,
+        label: str | None = None,
     ) -> None:
         if ttl_seconds <= 0:
             raise ValueError("ttl_seconds must be positive")
@@ -104,6 +105,11 @@ class DedupingAgentTools:
         self._inner = inner
         self._ttl_seconds = ttl_seconds
         self._max_entries = max_entries
+        # Optional caller-supplied identifier (room id, agent id, etc.) used
+        # only in dedup-hit warning logs.  Without it, the operator sees
+        # ``suppressing duplicate`` lines that cannot be attributed to a
+        # specific room across a multi-room tenant.
+        self._label = label
         # Ordered for LRU eviction; values are (timestamp, cached_result).
         self._recent_sends: OrderedDict[
             tuple[str, frozenset[str]], tuple[float, Any]
@@ -157,7 +163,8 @@ class DedupingAgentTools:
                 # genuinely-new identical message can go through.
                 logger.warning(
                     "ClaudeSDK send_message dedup: suppressing duplicate "
-                    "send to room (content_len=%d, mentions=%d)",
+                    "send%s (content_len=%d, mentions=%d)",
+                    f" [{self._label}]" if self._label else "",
                     len(content),
                     len(key[1]),
                 )

--- a/src/band/integrations/claude_sdk/dedup_tools.py
+++ b/src/band/integrations/claude_sdk/dedup_tools.py
@@ -19,13 +19,14 @@ tool calls produced by Claude.
 
 This wrapper sits in front of the per-room ``AgentToolsProtocol`` that the
 ``ClaudeSDKAdapter`` registers in ``_room_tools[room_id]``. It dedupes
-``send_message`` invocations by ``(dedup_scope, content, frozenset(mentions))``
-within a short TTL window and returns the cached result for any repeat. The
-scope is set by the adapter from the inbound platform message id so repeated
-identical messages in separate turns do not suppress each other. Every other
-tool call (``send_event``, ``add_participant``, ``lookup_peers``, ...) is
-forwarded unchanged via ``__getattr__`` so the wrapper does not silently
-become a stale interface when ``AgentToolsProtocol`` grows new methods.
+``send_message`` invocations by ``(content, frozenset(mentions))`` within
+a short per-room TTL window and returns the cached result for any repeat. MCP
+retries only identify the room; they do not carry the original inbound message
+id, so a per-message cache key would miss the late cross-turn retry this wrapper
+exists to suppress. Every other tool call (``send_event``, ``add_participant``,
+``lookup_peers``, ...) is forwarded unchanged via ``__getattr__`` so the wrapper
+does not silently become a stale interface when ``AgentToolsProtocol`` grows new
+methods.
 
 The wrapper is intentionally scoped to ``ClaudeSDKAdapter`` because that is
 the only adapter whose framework runs a heavy subprocess that can
@@ -112,41 +113,37 @@ class DedupingAgentTools:
         # ``suppressing duplicate`` lines that cannot be attributed to a
         # specific room across a multi-room tenant.
         self._label = label
-        self._dedup_scope: str | None = None
         # Ordered for LRU eviction; values are (timestamp, cached_result).
         self._recent_sends: OrderedDict[
-            tuple[str | None, str, frozenset[str]], tuple[float, Any]
+            tuple[str, frozenset[str]], tuple[float, Any]
         ] = OrderedDict()
         # Tracks cache misses currently POSTing to the platform. Racing
-        # duplicates await the same task, but distinct sends are not blocked
-        # behind unrelated network I/O.
+        # duplicates within the TTL window await the same task, but distinct
+        # sends are not blocked behind unrelated network I/O.
         self._in_flight: dict[
-            tuple[str | None, str, frozenset[str]], asyncio.Task[Any]
+            tuple[str, frozenset[str]], tuple[float, asyncio.Task[Any]]
         ] = {}
         self._lock = asyncio.Lock()
 
     # --- public API used by callers -----------------------------------
 
-    async def update_inner(
-        self, inner: AgentToolsProtocol, *, dedup_scope: str | None = None
-    ) -> None:
+    async def update_inner(self, inner: AgentToolsProtocol) -> None:
         """Swap the wrapped tools object while preserving the dedup cache.
 
         ``AgentTools.from_context`` is called per inbound message in
         ``preprocessing/default.py`` and produces a fresh ``AgentTools``
         instance each time. If the adapter rebuilt the wrapper on every
         call the cache would be discarded after every turn and the
-        dominant INT-502 failure mode (a duplicate tool call landing
+        dominant failure mode (a duplicate tool call landing
         *after* the original turn's ``Complete`` event) would still slip
         through.
 
-        ``dedup_scope`` should identify the inbound platform message or
-        execution turn. The adapter passes ``msg.id`` so identical content
-        sent in separate user turns is not treated as a duplicate retry.
+        MCP tool invocations resolve by room id and do not include the
+        inbound platform message id, so the cache key intentionally stays
+        scoped to this room wrapper plus the outgoing payload.
         """
         async with self._lock:
             self._inner = inner
-            self._dedup_scope = dedup_scope
 
     async def send_message(
         self,
@@ -154,13 +151,12 @@ class DedupingAgentTools:
         mentions: list[str] | list[dict[str, str]] | None = None,
     ) -> Any:
         now = time.monotonic()
-        key: tuple[str | None, str, frozenset[str]]
+        key: tuple[str, frozenset[str]]
         task: asyncio.Task[Any]
-        owns_task = False
 
         async with self._lock:
             self._evict_expired_locked(now)
-            key = (self._dedup_scope, content, _normalize_mentions(mentions))
+            key = (content, _normalize_mentions(mentions))
 
             cached = self._recent_sends.get(key)
             if cached is not None:
@@ -171,41 +167,34 @@ class DedupingAgentTools:
                 # genuinely-new identical message can go through.
                 logger.warning(
                     "ClaudeSDK send_message dedup: suppressing duplicate "
-                    "send%s (scope=%s, content_len=%d, mentions=%d)",
+                    "send%s (content_len=%d, mentions=%d)",
                     f" [{self._label}]" if self._label else "",
-                    key[0],
                     len(content),
-                    len(key[2]),
+                    len(key[1]),
                 )
                 return cached_result
 
-            existing_task = self._in_flight.get(key)
-            if existing_task is None:
+            existing = self._in_flight.get(key)
+            if existing is None:
                 inner = self._inner
                 task = asyncio.create_task(inner.send_message(content, mentions))
-                self._in_flight[key] = task
-                owns_task = True
+                self._in_flight[key] = (now, task)
+                task.add_done_callback(
+                    lambda completed_task: asyncio.create_task(
+                        self._finalize_in_flight_send(key, completed_task, now)
+                    )
+                )
             else:
-                task = existing_task
+                _started_at, task = existing
 
         try:
-            result = await task
-        except Exception:
-            if owns_task:
-                async with self._lock:
-                    if self._in_flight.get(key) is task:
-                        self._in_flight.pop(key, None)
+            result = await asyncio.shield(task)
+        except BaseException:
+            if task.done():
+                await self._finalize_in_flight_send(key, task, now)
             raise
 
-        if owns_task:
-            async with self._lock:
-                if self._in_flight.get(key) is task:
-                    self._in_flight.pop(key, None)
-                    # Insertion order equals timestamp order because we never
-                    # mutate cache entries after insert.
-                    self._recent_sends[key] = (now, result)
-                    while len(self._recent_sends) > self._max_entries:
-                        self._recent_sends.popitem(last=False)
+        await self._finalize_in_flight_send(key, task, now)
         return result
 
     # --- transparent passthrough --------------------------------------
@@ -219,16 +208,47 @@ class DedupingAgentTools:
 
     # --- internals ----------------------------------------------------
 
+    async def _finalize_in_flight_send(
+        self,
+        key: tuple[str, frozenset[str]],
+        task: asyncio.Task[Any],
+        timestamp: float,
+    ) -> None:
+        try:
+            result = task.result()
+        except BaseException:
+            should_cache = False
+            result = None
+        else:
+            should_cache = True
+
+        async with self._lock:
+            existing = self._in_flight.get(key)
+            if existing is None or existing[1] is not task:
+                return
+            self._in_flight.pop(key, None)
+            if not should_cache:
+                return
+            # Insertion order equals timestamp order because we never mutate
+            # cache entries after insert.
+            self._recent_sends[key] = (timestamp, result)
+            while len(self._recent_sends) > self._max_entries:
+                self._recent_sends.popitem(last=False)
+
     def _evict_expired_locked(self, now: float) -> None:
         """Drop entries older than the TTL window. Caller holds ``_lock``.
 
         Cache entries are append-only after insert (see ``send_message`` —
         we never refresh timestamps on hit), so insertion order equals
         timestamp order and we can stop scanning at the first fresh entry.
-        In-flight sends are not evicted here; they remove themselves on
-        success or failure.
+        In-flight sends older than the same TTL are also evicted so a stalled
+        platform POST cannot extend the dedup window indefinitely.
         """
         cutoff = now - self._ttl_seconds
+        for key, (ts, _task) in list(self._in_flight.items()):
+            if ts < cutoff:
+                self._in_flight.pop(key, None)
+
         while self._recent_sends:
             key, (ts, _result) = next(iter(self._recent_sends.items()))
             if ts >= cutoff:

--- a/src/band/integrations/claude_sdk/dedup_tools.py
+++ b/src/band/integrations/claude_sdk/dedup_tools.py
@@ -19,8 +19,10 @@ tool calls produced by Claude.
 
 This wrapper sits in front of the per-room ``AgentToolsProtocol`` that the
 ``ClaudeSDKAdapter`` registers in ``_room_tools[room_id]``. It dedupes
-``send_message`` invocations by ``(content, frozenset(mentions))`` within a
-short TTL window and returns the cached result for any repeat. Every other
+``send_message`` invocations by ``(dedup_scope, content, frozenset(mentions))``
+within a short TTL window and returns the cached result for any repeat. The
+scope is set by the adapter from the inbound platform message id so repeated
+identical messages in separate turns do not suppress each other. Every other
 tool call (``send_event``, ``add_participant``, ``lookup_peers``, ...) is
 forwarded unchanged via ``__getattr__`` so the wrapper does not silently
 become a stale interface when ``AgentToolsProtocol`` grows new methods.
@@ -110,19 +112,24 @@ class DedupingAgentTools:
         # ``suppressing duplicate`` lines that cannot be attributed to a
         # specific room across a multi-room tenant.
         self._label = label
+        self._dedup_scope: str | None = None
         # Ordered for LRU eviction; values are (timestamp, cached_result).
         self._recent_sends: OrderedDict[
-            tuple[str, frozenset[str]], tuple[float, Any]
+            tuple[str | None, str, frozenset[str]], tuple[float, Any]
         ] = OrderedDict()
-        # Serialize concurrent send_message calls so two racing duplicates
-        # cannot both miss the cache and both POST. We never await
-        # arbitrary I/O while holding this lock — only the in-memory cache
-        # check and the inner send_message call.
+        # Tracks cache misses currently POSTing to the platform. Racing
+        # duplicates await the same task, but distinct sends are not blocked
+        # behind unrelated network I/O.
+        self._in_flight: dict[
+            tuple[str | None, str, frozenset[str]], asyncio.Task[Any]
+        ] = {}
         self._lock = asyncio.Lock()
 
     # --- public API used by callers -----------------------------------
 
-    async def update_inner(self, inner: AgentToolsProtocol) -> None:
+    async def update_inner(
+        self, inner: AgentToolsProtocol, *, dedup_scope: str | None = None
+    ) -> None:
         """Swap the wrapped tools object while preserving the dedup cache.
 
         ``AgentTools.from_context`` is called per inbound message in
@@ -133,26 +140,27 @@ class DedupingAgentTools:
         *after* the original turn's ``Complete`` event) would still slip
         through.
 
-        Holding the lock during the swap prevents a concurrent in-flight
-        ``send_message`` from observing a torn reference: the in-flight
-        call started against the previous ``_inner`` and is holding the
-        lock, so this method waits until that call returns before
-        installing the new tools object. Subsequent calls see the new
-        ``_inner`` immediately.
+        ``dedup_scope`` should identify the inbound platform message or
+        execution turn. The adapter passes ``msg.id`` so identical content
+        sent in separate user turns is not treated as a duplicate retry.
         """
         async with self._lock:
             self._inner = inner
+            self._dedup_scope = dedup_scope
 
     async def send_message(
         self,
         content: str,
         mentions: list[str] | list[dict[str, str]] | None = None,
     ) -> Any:
-        key = (content, _normalize_mentions(mentions))
         now = time.monotonic()
+        key: tuple[str | None, str, frozenset[str]]
+        task: asyncio.Task[Any]
+        owns_task = False
 
         async with self._lock:
             self._evict_expired_locked(now)
+            key = (self._dedup_scope, content, _normalize_mentions(mentions))
 
             cached = self._recent_sends.get(key)
             if cached is not None:
@@ -163,21 +171,42 @@ class DedupingAgentTools:
                 # genuinely-new identical message can go through.
                 logger.warning(
                     "ClaudeSDK send_message dedup: suppressing duplicate "
-                    "send%s (content_len=%d, mentions=%d)",
+                    "send%s (scope=%s, content_len=%d, mentions=%d)",
                     f" [{self._label}]" if self._label else "",
+                    key[0],
                     len(content),
-                    len(key[1]),
+                    len(key[2]),
                 )
                 return cached_result
 
-            result = await self._inner.send_message(content, mentions)
+            existing_task = self._in_flight.get(key)
+            if existing_task is None:
+                inner = self._inner
+                task = asyncio.create_task(inner.send_message(content, mentions))
+                self._in_flight[key] = task
+                owns_task = True
+            else:
+                task = existing_task
 
-            # Insertion order equals timestamp order because we never
-            # mutate cache entries after insert.
-            self._recent_sends[key] = (now, result)
-            while len(self._recent_sends) > self._max_entries:
-                self._recent_sends.popitem(last=False)
-            return result
+        try:
+            result = await task
+        except Exception:
+            if owns_task:
+                async with self._lock:
+                    if self._in_flight.get(key) is task:
+                        self._in_flight.pop(key, None)
+            raise
+
+        if owns_task:
+            async with self._lock:
+                if self._in_flight.get(key) is task:
+                    self._in_flight.pop(key, None)
+                    # Insertion order equals timestamp order because we never
+                    # mutate cache entries after insert.
+                    self._recent_sends[key] = (now, result)
+                    while len(self._recent_sends) > self._max_entries:
+                        self._recent_sends.popitem(last=False)
+        return result
 
     # --- transparent passthrough --------------------------------------
 
@@ -196,6 +225,8 @@ class DedupingAgentTools:
         Cache entries are append-only after insert (see ``send_message`` —
         we never refresh timestamps on hit), so insertion order equals
         timestamp order and we can stop scanning at the first fresh entry.
+        In-flight sends are not evicted here; they remove themselves on
+        success or failure.
         """
         cutoff = now - self._ttl_seconds
         while self._recent_sends:

--- a/src/band/integrations/claude_sdk/dedup_tools.py
+++ b/src/band/integrations/claude_sdk/dedup_tools.py
@@ -1,0 +1,177 @@
+"""
+Send-message dedup wrapper for Claude SDK MCP tool invocations.
+
+When the Claude CLI subprocess saturates the asyncio event loop (its primary
+failure mode under load), several upstream paths can re-emit the
+same ``band_send_message`` MCP tool call for a single LLM-intended send:
+
+* MCP transport retries after the in-process handler takes too long to ack.
+* Session resume after a Phoenix WS reconnect, when the previous response was
+  still being streamed.
+* A new turn produced by Claude CLI after the original ``Complete`` event has
+  already fired (one ``Sending query``, one ``Complete``, two messages in
+  chat).
+
+The platform happily accepts every POST, so the duplicate becomes a visible
+chat message and a charged LLM call. ``ExecutionContext._processed_ids`` only
+dedupes *inbound* user messages from the platform; it has no view of outbound
+tool calls produced by Claude.
+
+This wrapper sits in front of the per-room ``AgentToolsProtocol`` that the
+``ClaudeSDKAdapter`` registers in ``_room_tools[room_id]``. It dedupes
+``send_message`` invocations by ``(content, frozenset(mentions))`` within a
+short TTL window and returns the cached result for any repeat. Every other
+tool call (``send_event``, ``add_participant``, ``lookup_peers``, ...) is
+forwarded unchanged via ``__getattr__`` so the wrapper does not silently
+become a stale interface when ``AgentToolsProtocol`` grows new methods.
+
+The wrapper is intentionally scoped to ``ClaudeSDKAdapter`` because that is
+the only adapter whose framework runs a heavy subprocess that can
+re-issue MCP calls. Other adapters drive HTTP/LLM calls directly from the
+runtime task and do not exhibit this failure mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import OrderedDict
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from band.core.protocols import AgentToolsProtocol
+
+logger = logging.getLogger(__name__)
+
+# 30 s comfortably covers the longest observed Claude-CLI tool-call retry
+# window seen in reconnect storms while staying short
+# enough that a deliberate retransmission of the same message after
+# minutes (e.g. a user re-asking for a status report) is not suppressed.
+DEFAULT_DEDUP_TTL_SECONDS: float = 30.0
+
+# Bound the cache so an adversarial or runaway agent cannot grow it
+# without limit. Each entry is one observed (content, mentions) tuple
+# per room; 64 is well beyond any realistic single-turn fan-out.
+DEFAULT_DEDUP_MAX_ENTRIES: int = 64
+
+
+def _normalize_mentions(
+    mentions: list[str] | list[dict[str, str]] | None,
+) -> frozenset[str]:
+    """Reduce a mentions argument to a hashable, order-insensitive key.
+
+    ``AgentTools.send_message`` accepts handles as plain strings (current
+    contract) and as ``{"id": ..., "handle": ...}`` dicts (deprecated).
+    Both shapes are reduced to the same key so a transport retry that
+    happens to upgrade the encoding still dedupes.
+    """
+    if not mentions:
+        return frozenset()
+    keys: list[str] = []
+    for item in mentions:
+        if isinstance(item, str):
+            keys.append(item)
+        elif isinstance(item, dict):
+            keys.append(item.get("handle") or item.get("id") or "")
+    return frozenset(k for k in keys if k)
+
+
+class DedupingAgentTools:
+    """Wrap an ``AgentToolsProtocol`` to dedupe identical ``send_message`` calls.
+
+    The wrapper is transparent for every method except ``send_message`` and
+    keeps no state of its own beyond the dedup cache, so the underlying
+    tools object (and its ``participants`` view) remain authoritative.
+
+    Not declared as ``AgentToolsProtocol`` subclass: Protocol classes define
+    real method slots that would shadow ``__getattr__`` and break the
+    pass-through. ``AgentToolsProtocol`` is structural, so any caller that
+    types against the protocol still accepts this wrapper.
+    """
+
+    def __init__(
+        self,
+        inner: AgentToolsProtocol,
+        *,
+        ttl_seconds: float = DEFAULT_DEDUP_TTL_SECONDS,
+        max_entries: int = DEFAULT_DEDUP_MAX_ENTRIES,
+    ) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        if max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+        self._inner = inner
+        self._ttl_seconds = ttl_seconds
+        self._max_entries = max_entries
+        # Ordered for LRU eviction; values are (timestamp, cached_result).
+        self._recent_sends: OrderedDict[
+            tuple[str, frozenset[str]], tuple[float, Any]
+        ] = OrderedDict()
+        # Serialize concurrent send_message calls so two racing duplicates
+        # cannot both miss the cache and both POST. We never await
+        # arbitrary I/O while holding this lock — only the in-memory cache
+        # check and the inner send_message call.
+        self._lock = asyncio.Lock()
+
+    # --- public API used by callers -----------------------------------
+
+    async def send_message(
+        self,
+        content: str,
+        mentions: list[str] | list[dict[str, str]] | None = None,
+    ) -> Any:
+        key = (content, _normalize_mentions(mentions))
+        now = time.monotonic()
+
+        async with self._lock:
+            self._evict_expired_locked(now)
+
+            cached = self._recent_sends.get(key)
+            if cached is not None:
+                _, cached_result = cached
+                # Intentionally do NOT move_to_end / refresh timestamp.
+                # A duplicate arriving 25 s after the original is the
+                # same logical send; at T+ttl it should expire and a
+                # genuinely-new identical message can go through.
+                logger.warning(
+                    "ClaudeSDK send_message dedup: suppressing duplicate "
+                    "send to room (content_len=%d, mentions=%d)",
+                    len(content),
+                    len(key[1]),
+                )
+                return cached_result
+
+            result = await self._inner.send_message(content, mentions)
+
+            # Insertion order equals timestamp order because we never
+            # mutate cache entries after insert.
+            self._recent_sends[key] = (now, result)
+            while len(self._recent_sends) > self._max_entries:
+                self._recent_sends.popitem(last=False)
+            return result
+
+    # --- transparent passthrough --------------------------------------
+
+    def __getattr__(self, name: str) -> Any:
+        # ``__getattr__`` only runs for attributes not found via the
+        # normal MRO. ``send_message`` is defined above, so it never
+        # routes here. Everything else (``send_event``, ``participants``,
+        # ``get_tool_schemas``, ...) is forwarded to the wrapped tools.
+        return getattr(self._inner, name)
+
+    # --- internals ----------------------------------------------------
+
+    def _evict_expired_locked(self, now: float) -> None:
+        """Drop entries older than the TTL window. Caller holds ``_lock``.
+
+        Cache entries are append-only after insert (see ``send_message`` —
+        we never refresh timestamps on hit), so insertion order equals
+        timestamp order and we can stop scanning at the first fresh entry.
+        """
+        cutoff = now - self._ttl_seconds
+        while self._recent_sends:
+            key, (ts, _result) = next(iter(self._recent_sends.items()))
+            if ts >= cutoff:
+                return
+            self._recent_sends.pop(key, None)

--- a/src/band/integrations/claude_sdk/dedup_tools.py
+++ b/src/band/integrations/claude_sdk/dedup_tools.py
@@ -116,6 +116,27 @@ class DedupingAgentTools:
 
     # --- public API used by callers -----------------------------------
 
+    async def update_inner(self, inner: AgentToolsProtocol) -> None:
+        """Swap the wrapped tools object while preserving the dedup cache.
+
+        ``AgentTools.from_context`` is called per inbound message in
+        ``preprocessing/default.py`` and produces a fresh ``AgentTools``
+        instance each time. If the adapter rebuilt the wrapper on every
+        call the cache would be discarded after every turn and the
+        dominant INT-502 failure mode (a duplicate tool call landing
+        *after* the original turn's ``Complete`` event) would still slip
+        through.
+
+        Holding the lock during the swap prevents a concurrent in-flight
+        ``send_message`` from observing a torn reference: the in-flight
+        call started against the previous ``_inner`` and is holding the
+        lock, so this method waits until that call returns before
+        installing the new tools object. Subsequent calls see the new
+        ``_inner`` immediately.
+        """
+        async with self._lock:
+            self._inner = inner
+
     async def send_message(
         self,
         content: str,

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -2033,3 +2033,114 @@ class TestSendMessageDedupWiring:
         await stored.send_message("hello", ["alice"])
 
         assert mock_tools.send_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_wrapper_persists_across_on_message_calls(self, sample_message):
+        """Cross-turn regression: the dominant INT-502 pattern is a duplicate
+        tool call arriving *after* the original turn's Complete event. Since
+        SimpleAdapter constructs a fresh AgentTools per inbound message, a
+        wrapper rebuilt per on_message would drop the cache and let the
+        post-Complete duplicate through.
+
+        Drive two on_message calls with different inner tools (mirroring
+        AgentTools.from_context being called per message), then fire two
+        identical send_message calls against the stored wrapper — one before
+        and one after the second on_message — and assert the duplicate is
+        suppressed across the turn boundary.
+        """
+        from thenvoi.integrations.claude_sdk.dedup_tools import DedupingAgentTools
+
+        adapter = ClaudeSDKAdapter()
+        mock_client = MagicMock()
+        mock_client.query = AsyncMock()
+        mock_manager = AsyncMock()
+        mock_manager.get_or_create_session = AsyncMock(return_value=mock_client)
+
+        tools_turn1 = MagicMock()
+        tools_turn1.send_message = AsyncMock(return_value={"id": "m1"})
+        tools_turn2 = MagicMock()
+        tools_turn2.send_message = AsyncMock(return_value={"id": "m2"})
+
+        with (
+            patch(
+                "thenvoi.adapters.claude_sdk.ClaudeSessionManager",
+                return_value=mock_manager,
+            ),
+            patch.object(adapter, "_process_response", new_callable=AsyncMock),
+        ):
+            await adapter.on_started(
+                agent_name="TestBot", agent_description="A test bot"
+            )
+            await adapter.on_message(
+                msg=sample_message,
+                tools=tools_turn1,
+                history=ClaudeSDKSessionState(text=""),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
+            wrapper_after_turn1 = adapter._room_tools["room-1"]
+            assert isinstance(wrapper_after_turn1, DedupingAgentTools)
+
+            # Original send during turn 1 (via the MCP-resolved wrapper).
+            await wrapper_after_turn1.send_message("hi", ["alice"])
+            assert tools_turn1.send_message.await_count == 1
+
+            # Turn 2 arrives; SimpleAdapter builds a fresh AgentTools.
+            await adapter.on_message(
+                msg=sample_message,
+                tools=tools_turn2,
+                history=ClaudeSDKSessionState(text=""),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=False,
+                room_id="room-1",
+            )
+
+            # SAME wrapper instance must still be stored — only _inner swapped.
+            wrapper_after_turn2 = adapter._room_tools["room-1"]
+            assert wrapper_after_turn2 is wrapper_after_turn1
+            assert wrapper_after_turn2._inner is tools_turn2
+
+            # The lingering duplicate from turn 1 fires now. It must hit
+            # the cache and NOT POST through tools_turn2.
+            await wrapper_after_turn2.send_message("hi", ["alice"])
+            assert tools_turn2.send_message.await_count == 0
+            # And tools_turn1 was not called again either.
+            assert tools_turn1.send_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_on_cleanup_evicts_wrapper(self, sample_message, mock_tools):
+        """on_cleanup must remove the wrapper so a re-entered room rebuilds
+        fresh state (and so the cache cannot leak across detached sessions)."""
+        adapter = ClaudeSDKAdapter()
+        mock_client = MagicMock()
+        mock_client.query = AsyncMock()
+        mock_manager = AsyncMock()
+        mock_manager.get_or_create_session = AsyncMock(return_value=mock_client)
+        mock_manager.cleanup_session = AsyncMock()
+
+        with (
+            patch(
+                "thenvoi.adapters.claude_sdk.ClaudeSessionManager",
+                return_value=mock_manager,
+            ),
+            patch.object(adapter, "_process_response", new_callable=AsyncMock),
+        ):
+            await adapter.on_started(
+                agent_name="TestBot", agent_description="A test bot"
+            )
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=ClaudeSDKSessionState(text=""),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
+            assert "room-1" in adapter._room_tools
+
+            await adapter.on_cleanup("room-1")
+            assert "room-1" not in adapter._room_tools

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -2144,3 +2144,124 @@ class TestSendMessageDedupWiring:
 
             await adapter.on_cleanup("room-1")
             assert "room-1" not in adapter._room_tools
+
+    @pytest.mark.asyncio
+    async def test_distinct_rooms_get_distinct_wrappers(self, sample_message):
+        """Per-room isolation: identical ``(content, mentions)`` in two
+        different rooms must POST twice — once per room — because rooms
+        are independent conversations and the dedup window is a per-room
+        guard, not a global one.
+
+        Pins ``_room_tools`` keying behavior so a future refactor (e.g.
+        a per-session or singleton tools cache) cannot silently turn the
+        dedup wrapper into a tenant-wide message suppressor.
+        """
+        from thenvoi.integrations.claude_sdk.dedup_tools import DedupingAgentTools
+
+        adapter = ClaudeSDKAdapter()
+        mock_client = MagicMock()
+        mock_client.query = AsyncMock()
+        mock_manager = AsyncMock()
+        mock_manager.get_or_create_session = AsyncMock(return_value=mock_client)
+
+        tools_a = MagicMock()
+        tools_a.send_message = AsyncMock(return_value={"id": "a"})
+        tools_b = MagicMock()
+        tools_b.send_message = AsyncMock(return_value={"id": "b"})
+
+        with (
+            patch(
+                "thenvoi.adapters.claude_sdk.ClaudeSessionManager",
+                return_value=mock_manager,
+            ),
+            patch.object(adapter, "_process_response", new_callable=AsyncMock),
+        ):
+            await adapter.on_started(
+                agent_name="TestBot", agent_description="A test bot"
+            )
+            await adapter.on_message(
+                msg=sample_message,
+                tools=tools_a,
+                history=ClaudeSDKSessionState(text=""),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-a",
+            )
+            await adapter.on_message(
+                msg=sample_message,
+                tools=tools_b,
+                history=ClaudeSDKSessionState(text=""),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-b",
+            )
+
+        wrapper_a = adapter._room_tools["room-a"]
+        wrapper_b = adapter._room_tools["room-b"]
+        assert isinstance(wrapper_a, DedupingAgentTools)
+        assert isinstance(wrapper_b, DedupingAgentTools)
+        assert wrapper_a is not wrapper_b
+
+        # Identical sends in two distinct rooms must both reach their
+        # respective inner tools — dedup is per-room, not per-tenant.
+        await wrapper_a.send_message("hello", ["alice"])
+        await wrapper_b.send_message("hello", ["alice"])
+        assert tools_a.send_message.await_count == 1
+        assert tools_b.send_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_update_inner_skipped_when_tools_identity_unchanged(
+        self, sample_message
+    ):
+        """When the runtime hands the adapter the same tools object twice,
+        ``update_inner`` is a no-op and must be skipped — otherwise we'd
+        briefly contend on the wrapper's lock for no reason and could
+        wait behind an in-flight send."""
+        from thenvoi.integrations.claude_sdk.dedup_tools import DedupingAgentTools
+
+        adapter = ClaudeSDKAdapter()
+        mock_client = MagicMock()
+        mock_client.query = AsyncMock()
+        mock_manager = AsyncMock()
+        mock_manager.get_or_create_session = AsyncMock(return_value=mock_client)
+
+        tools = MagicMock()
+        tools.send_message = AsyncMock(return_value={"id": "x"})
+
+        with (
+            patch(
+                "thenvoi.adapters.claude_sdk.ClaudeSessionManager",
+                return_value=mock_manager,
+            ),
+            patch.object(adapter, "_process_response", new_callable=AsyncMock),
+        ):
+            await adapter.on_started(
+                agent_name="TestBot", agent_description="A test bot"
+            )
+            await adapter.on_message(
+                msg=sample_message,
+                tools=tools,
+                history=ClaudeSDKSessionState(text=""),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
+            wrapper = adapter._room_tools["room-1"]
+            assert isinstance(wrapper, DedupingAgentTools)
+
+            with patch.object(
+                wrapper, "update_inner", new_callable=AsyncMock
+            ) as mock_update:
+                await adapter.on_message(
+                    msg=sample_message,
+                    tools=tools,  # SAME instance
+                    history=ClaudeSDKSessionState(text=""),
+                    participants_msg=None,
+                    contacts_msg=None,
+                    is_session_bootstrap=False,
+                    room_id="room-1",
+                )
+                mock_update.assert_not_awaited()

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -2036,7 +2036,7 @@ class TestSendMessageDedupWiring:
 
     @pytest.mark.asyncio
     async def test_wrapper_persists_across_on_message_calls(self, sample_message):
-        """Cross-turn regression: the dominant INT-502 pattern is a duplicate
+        """Cross-turn regression: the dominant pattern is a duplicate
         tool call arriving *after* the original turn's Complete event. Since
         SimpleAdapter constructs a fresh AgentTools per inbound message, a
         wrapper rebuilt per on_message would drop the cache and let the
@@ -2048,7 +2048,7 @@ class TestSendMessageDedupWiring:
         and one after the second on_message — and assert the duplicate is
         suppressed across the turn boundary.
         """
-        from thenvoi.integrations.claude_sdk.dedup_tools import DedupingAgentTools
+        from band.integrations.claude_sdk.dedup_tools import DedupingAgentTools
 
         adapter = ClaudeSDKAdapter()
         mock_client = MagicMock()
@@ -2063,7 +2063,7 @@ class TestSendMessageDedupWiring:
 
         with (
             patch(
-                "thenvoi.adapters.claude_sdk.ClaudeSessionManager",
+                "band.adapters.claude_sdk.ClaudeSessionManager",
                 return_value=mock_manager,
             ),
             patch.object(adapter, "_process_response", new_callable=AsyncMock),
@@ -2087,9 +2087,21 @@ class TestSendMessageDedupWiring:
             await wrapper_after_turn1.send_message("hi", ["alice"])
             assert tools_turn1.send_message.await_count == 1
 
-            # Turn 2 arrives; SimpleAdapter builds a fresh AgentTools.
+            # Turn 2 arrives with a distinct platform message id;
+            # SimpleAdapter builds a fresh AgentTools.
+            turn2_message = PlatformMessage(
+                id="msg-456",
+                room_id=sample_message.room_id,
+                content=sample_message.content,
+                sender_id=sample_message.sender_id,
+                sender_type=sample_message.sender_type,
+                sender_name=sample_message.sender_name,
+                message_type=sample_message.message_type,
+                metadata=sample_message.metadata,
+                created_at=sample_message.created_at,
+            )
             await adapter.on_message(
-                msg=sample_message,
+                msg=turn2_message,
                 tools=tools_turn2,
                 history=ClaudeSDKSessionState(text=""),
                 participants_msg=None,
@@ -2123,7 +2135,7 @@ class TestSendMessageDedupWiring:
 
         with (
             patch(
-                "thenvoi.adapters.claude_sdk.ClaudeSessionManager",
+                "band.adapters.claude_sdk.ClaudeSessionManager",
                 return_value=mock_manager,
             ),
             patch.object(adapter, "_process_response", new_callable=AsyncMock),
@@ -2156,7 +2168,7 @@ class TestSendMessageDedupWiring:
         a per-session or singleton tools cache) cannot silently turn the
         dedup wrapper into a tenant-wide message suppressor.
         """
-        from thenvoi.integrations.claude_sdk.dedup_tools import DedupingAgentTools
+        from band.integrations.claude_sdk.dedup_tools import DedupingAgentTools
 
         adapter = ClaudeSDKAdapter()
         mock_client = MagicMock()
@@ -2171,7 +2183,7 @@ class TestSendMessageDedupWiring:
 
         with (
             patch(
-                "thenvoi.adapters.claude_sdk.ClaudeSessionManager",
+                "band.adapters.claude_sdk.ClaudeSessionManager",
                 return_value=mock_manager,
             ),
             patch.object(adapter, "_process_response", new_callable=AsyncMock),
@@ -2217,9 +2229,8 @@ class TestSendMessageDedupWiring:
     ):
         """When the runtime hands the adapter the same tools object twice,
         ``update_inner`` is a no-op and must be skipped — otherwise we'd
-        briefly contend on the wrapper's lock for no reason and could
-        wait behind an in-flight send."""
-        from thenvoi.integrations.claude_sdk.dedup_tools import DedupingAgentTools
+        briefly contend on the wrapper's lock for no reason."""
+        from band.integrations.claude_sdk.dedup_tools import DedupingAgentTools
 
         adapter = ClaudeSDKAdapter()
         mock_client = MagicMock()
@@ -2232,7 +2243,7 @@ class TestSendMessageDedupWiring:
 
         with (
             patch(
-                "thenvoi.adapters.claude_sdk.ClaudeSessionManager",
+                "band.adapters.claude_sdk.ClaudeSessionManager",
                 return_value=mock_manager,
             ),
             patch.object(adapter, "_process_response", new_callable=AsyncMock),

--- a/tests/adapters/test_claude_sdk_adapter.py
+++ b/tests/adapters/test_claude_sdk_adapter.py
@@ -203,13 +203,22 @@ class TestOnMessage:
                 room_id="room-123",
             )
 
-            assert adapter._room_tools["room-123"] is mock_tools
+            # By default the adapter wraps tools with DedupingAgentTools so
+            # MCP tool calls go through the dedup shim.  The wrapped
+            # instance is what gets stored and forwarded.
+            from band.integrations.claude_sdk.dedup_tools import (
+                DedupingAgentTools,
+            )
+
+            stored_tools = adapter._room_tools["room-123"]
+            assert isinstance(stored_tools, DedupingAgentTools)
+            assert stored_tools._inner is mock_tools
             assert adapter._session_context["room-123"] == ""
             mock_manager.get_or_create_session.assert_awaited_once_with(
                 "room-123", resume_session_id=None
             )
             mock_client.query.assert_awaited_once()
-            mock_process.assert_awaited_once_with(mock_client, "room-123", mock_tools)
+            mock_process.assert_awaited_once_with(mock_client, "room-123", stored_tools)
 
     @pytest.mark.asyncio
     async def test_loads_existing_history_on_bootstrap(
@@ -1906,3 +1915,121 @@ class TestPendingApprovalEviction:
         # Old future should have been evicted and declined
         assert old_future.done()
         assert old_future.result() == "decline"
+
+
+class TestSendMessageDedupWiring:
+    """Tests that on_message wires the dedup shim correctly."""
+
+    @pytest.mark.asyncio
+    async def test_wraps_tools_by_default(self, sample_message, mock_tools):
+        """By default, on_message stores a DedupingAgentTools wrapper."""
+        from band.integrations.claude_sdk.dedup_tools import DedupingAgentTools
+
+        adapter = ClaudeSDKAdapter()
+        mock_client = MagicMock()
+        mock_client.query = AsyncMock()
+        mock_manager = AsyncMock()
+        mock_manager.get_or_create_session = AsyncMock(return_value=mock_client)
+
+        with (
+            patch(
+                "band.adapters.claude_sdk.ClaudeSessionManager",
+                return_value=mock_manager,
+            ),
+            patch.object(adapter, "_process_response", new_callable=AsyncMock),
+        ):
+            await adapter.on_started(
+                agent_name="TestBot", agent_description="A test bot"
+            )
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=ClaudeSDKSessionState(text=""),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
+
+        stored = adapter._room_tools["room-1"]
+        assert isinstance(stored, DedupingAgentTools)
+        assert stored._inner is mock_tools
+
+    @pytest.mark.asyncio
+    async def test_ttl_zero_disables_wrapping(self, sample_message, mock_tools):
+        """ttl=0 keeps the raw tools — no shim — for operators who opt out."""
+        from band.integrations.claude_sdk.dedup_tools import DedupingAgentTools
+
+        adapter = ClaudeSDKAdapter(send_message_dedup_ttl_seconds=0)
+        mock_client = MagicMock()
+        mock_client.query = AsyncMock()
+        mock_manager = AsyncMock()
+        mock_manager.get_or_create_session = AsyncMock(return_value=mock_client)
+
+        with (
+            patch(
+                "band.adapters.claude_sdk.ClaudeSessionManager",
+                return_value=mock_manager,
+            ),
+            patch.object(adapter, "_process_response", new_callable=AsyncMock),
+        ):
+            await adapter.on_started(
+                agent_name="TestBot", agent_description="A test bot"
+            )
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=ClaudeSDKSessionState(text=""),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
+
+        stored = adapter._room_tools["room-1"]
+        assert stored is mock_tools
+        assert not isinstance(stored, DedupingAgentTools)
+
+    def test_negative_ttl_rejected(self):
+        with pytest.raises(ValueError):
+            ClaudeSDKAdapter(send_message_dedup_ttl_seconds=-1)
+
+    @pytest.mark.asyncio
+    async def test_duplicate_mcp_calls_collapse_via_room_tools(
+        self, sample_message, mock_tools
+    ):
+        """End-to-end: two MCP-style calls through the stored wrapper hit
+        the inner send_message exactly once."""
+        adapter = ClaudeSDKAdapter()
+        mock_client = MagicMock()
+        mock_client.query = AsyncMock()
+        mock_manager = AsyncMock()
+        mock_manager.get_or_create_session = AsyncMock(return_value=mock_client)
+
+        with (
+            patch(
+                "band.adapters.claude_sdk.ClaudeSessionManager",
+                return_value=mock_manager,
+            ),
+            patch.object(adapter, "_process_response", new_callable=AsyncMock),
+        ):
+            await adapter.on_started(
+                agent_name="TestBot", agent_description="A test bot"
+            )
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=ClaudeSDKSessionState(text=""),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
+
+        # Simulate the MCP backend resolving room_tools.get("room-1") on
+        # each tool call (exactly what _create_mcp_backend wires up).
+        stored = adapter._room_tools["room-1"]
+        await stored.send_message("hello", ["alice"])
+        await stored.send_message("hello", ["alice"])
+
+        assert mock_tools.send_message.await_count == 1

--- a/tests/integrations/claude_sdk/test_dedup_tools.py
+++ b/tests/integrations/claude_sdk/test_dedup_tools.py
@@ -1,0 +1,188 @@
+"""Tests for DedupingAgentTools (send_message dedup shim)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from band.integrations.claude_sdk.dedup_tools import (
+    DEFAULT_DEDUP_MAX_ENTRIES,
+    DEFAULT_DEDUP_TTL_SECONDS,
+    DedupingAgentTools,
+)
+
+
+def _make_inner() -> MagicMock:
+    """Inner AgentToolsProtocol stub. send_message returns a unique result."""
+    inner = MagicMock()
+    inner.send_message = AsyncMock(return_value={"id": "msg-1"})
+    inner.send_event = AsyncMock(return_value={"id": "evt-1"})
+    inner.add_participant = AsyncMock(return_value={"id": "u"})
+    inner.participants = ["p1", "p2"]
+    return inner
+
+
+class TestDedupingAgentToolsConstruction:
+    def test_invalid_ttl_rejected(self):
+        with pytest.raises(ValueError):
+            DedupingAgentTools(_make_inner(), ttl_seconds=0)
+        with pytest.raises(ValueError):
+            DedupingAgentTools(_make_inner(), ttl_seconds=-1)
+
+    def test_invalid_max_entries_rejected(self):
+        with pytest.raises(ValueError):
+            DedupingAgentTools(_make_inner(), max_entries=0)
+        with pytest.raises(ValueError):
+            DedupingAgentTools(_make_inner(), max_entries=-5)
+
+    def test_defaults_are_set(self):
+        wrapper = DedupingAgentTools(_make_inner())
+        assert wrapper._ttl_seconds == DEFAULT_DEDUP_TTL_SECONDS
+        assert wrapper._max_entries == DEFAULT_DEDUP_MAX_ENTRIES
+
+
+class TestSendMessageDedup:
+    @pytest.mark.asyncio
+    async def test_identical_calls_collapse_to_one_inner_post(self):
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner)
+
+        r1 = await wrapper.send_message("hello", ["alice"])
+        r2 = await wrapper.send_message("hello", ["alice"])
+
+        assert inner.send_message.await_count == 1
+        # Cached result is returned verbatim.
+        assert r1 == r2 == {"id": "msg-1"}
+
+    @pytest.mark.asyncio
+    async def test_distinct_content_does_not_dedup(self):
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner)
+
+        await wrapper.send_message("hello", ["alice"])
+        await wrapper.send_message("hello world", ["alice"])
+
+        assert inner.send_message.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_distinct_mentions_does_not_dedup(self):
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner)
+
+        await wrapper.send_message("hello", ["alice"])
+        await wrapper.send_message("hello", ["bob"])
+
+        assert inner.send_message.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_mention_order_does_not_matter(self):
+        """A retry that re-orders the mentions list is the same logical send."""
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner)
+
+        await wrapper.send_message("hi", ["alice", "bob"])
+        await wrapper.send_message("hi", ["bob", "alice"])
+
+        assert inner.send_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_dict_mentions_normalize_to_same_key(self):
+        """Both list[str] and list[dict] mention shapes share one cache key."""
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner)
+
+        await wrapper.send_message("hi", ["alice"])
+        await wrapper.send_message("hi", [{"handle": "alice", "id": "u-1"}])
+
+        assert inner.send_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_and_none_mentions_share_key(self):
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner)
+
+        await wrapper.send_message("hi", None)
+        await wrapper.send_message("hi", [])
+
+        assert inner.send_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_expiry_allows_resend(self, monkeypatch):
+        """After the TTL window, an identical send must go through again."""
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner, ttl_seconds=1.0)
+
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(
+            "band.integrations.claude_sdk.dedup_tools.time.monotonic",
+            lambda: clock["t"],
+        )
+
+        await wrapper.send_message("hi", ["alice"])
+        clock["t"] += 0.5
+        await wrapper.send_message("hi", ["alice"])  # within TTL → cached
+        clock["t"] += 1.0  # cross the TTL boundary
+        await wrapper.send_message("hi", ["alice"])
+
+        assert inner.send_message.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_serializes_concurrent_duplicates(self):
+        """Two coroutines racing on the same key must POST exactly once."""
+        inner = _make_inner()
+        # Block the first inner call long enough for the second to enter
+        # the wrapper and contend on the lock.
+        gate = asyncio.Event()
+
+        async def slow_send(content, mentions=None):
+            await gate.wait()
+            return {"id": "msg-1"}
+
+        inner.send_message.side_effect = slow_send
+        wrapper = DedupingAgentTools(inner)
+
+        t1 = asyncio.create_task(wrapper.send_message("hi", ["alice"]))
+        t2 = asyncio.create_task(wrapper.send_message("hi", ["alice"]))
+        # Let both tasks run up to their first await point.
+        await asyncio.sleep(0)
+        gate.set()
+        await asyncio.gather(t1, t2)
+
+        assert inner.send_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cache_bounded_by_max_entries(self):
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner, max_entries=3)
+
+        for i in range(5):
+            await wrapper.send_message(f"msg-{i}", ["alice"])
+
+        # Only the 3 most recent entries should remain. The first two
+        # should be re-sent (cache miss) on replay.
+        before = inner.send_message.await_count
+        await wrapper.send_message("msg-0", ["alice"])
+        await wrapper.send_message("msg-1", ["alice"])
+        assert inner.send_message.await_count == before + 2
+
+
+class TestTransparentPassthrough:
+    @pytest.mark.asyncio
+    async def test_other_methods_forward_unchanged(self):
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner)
+
+        await wrapper.send_event(content="ping", message_type="thought")
+        await wrapper.add_participant(handle="@svc/bot")
+
+        inner.send_event.assert_awaited_once_with(
+            content="ping", message_type="thought"
+        )
+        inner.add_participant.assert_awaited_once_with(handle="@svc/bot")
+
+    def test_attributes_forward_unchanged(self):
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner)
+        assert wrapper.participants == ["p1", "p2"]

--- a/tests/integrations/claude_sdk/test_dedup_tools.py
+++ b/tests/integrations/claude_sdk/test_dedup_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -175,14 +176,117 @@ class TestTransparentPassthrough:
         wrapper = DedupingAgentTools(inner)
 
         await wrapper.send_event(content="ping", message_type="thought")
-        await wrapper.add_participant(handle="@svc/bot")
+        await wrapper.add_participant("@svc/bot")
 
         inner.send_event.assert_awaited_once_with(
             content="ping", message_type="thought"
         )
-        inner.add_participant.assert_awaited_once_with(handle="@svc/bot")
+        inner.add_participant.assert_awaited_once_with("@svc/bot")
 
     def test_attributes_forward_unchanged(self):
         inner = _make_inner()
         wrapper = DedupingAgentTools(inner)
         assert wrapper.participants == ["p1", "p2"]
+
+
+class TestUpdateInner:
+    """update_inner() preserves the dedup cache across on_message calls.
+
+    The dominant INT-502 failure mode is a duplicate tool call landing
+    *after* the original turn's Complete event — i.e. a call that
+    arrives on a later on_message. If the adapter rebuilt the wrapper
+    on every on_message, the duplicate would miss the cache and POST a
+    second time. update_inner swaps just the inner reference so the
+    cache survives the turn boundary.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dedup_survives_inner_swap(self):
+        inner_a = _make_inner()
+        wrapper = DedupingAgentTools(inner_a)
+
+        # Turn 1: original send populates the cache via inner_a.
+        await wrapper.send_message("hi", ["alice"])
+        assert inner_a.send_message.await_count == 1
+
+        # Turn 2: SimpleAdapter would normally build a fresh AgentTools
+        # and the adapter rebuilds wrappers per call. With update_inner,
+        # the wrapper persists and the cache is intact.
+        inner_b = _make_inner()
+        await wrapper.update_inner(inner_b)
+
+        # The duplicate tool call from the previous turn fires now.
+        # It must hit the cache and NOT POST through inner_b.
+        await wrapper.send_message("hi", ["alice"])
+        assert inner_b.send_message.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_new_sends_use_new_inner(self):
+        """After swap, novel sends route to the new inner tools."""
+        inner_a = _make_inner()
+        wrapper = DedupingAgentTools(inner_a)
+        await wrapper.send_message("first", ["alice"])
+
+        inner_b = _make_inner()
+        await wrapper.update_inner(inner_b)
+
+        await wrapper.send_message("second", ["alice"])
+        assert inner_b.send_message.await_count == 1
+        # The first inner is no longer used after the swap.
+        assert inner_a.send_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_swap_waits_for_in_flight_send(self):
+        """update_inner takes the lock so it serializes with send_message.
+
+        If a send_message call is in flight against inner_a when
+        update_inner is called, the swap must wait for the in-flight
+        call to complete. Otherwise the in-flight call could see a
+        torn _inner reference mid-await.
+        """
+        inner_a = _make_inner()
+        gate = asyncio.Event()
+        observed_inner: list[Any] = []
+
+        async def slow_send(content, mentions=None):
+            observed_inner.append("a")
+            await gate.wait()
+            return {"id": "msg-a"}
+
+        inner_a.send_message.side_effect = slow_send
+        wrapper = DedupingAgentTools(inner_a)
+
+        send_task = asyncio.create_task(wrapper.send_message("hi", ["alice"]))
+        # Yield so send_task enters the lock and awaits the gate.
+        await asyncio.sleep(0)
+
+        inner_b = _make_inner()
+        swap_task = asyncio.create_task(wrapper.update_inner(inner_b))
+
+        # Swap must not have completed while send_message holds the lock.
+        await asyncio.sleep(0)
+        assert not swap_task.done()
+
+        gate.set()
+        await asyncio.gather(send_task, swap_task)
+        assert observed_inner == ["a"]
+
+
+class TestDedupHitLogging:
+    @pytest.mark.asyncio
+    async def test_duplicate_emits_warning(self, caplog):
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner)
+
+        await wrapper.send_message("hello", ["alice"])
+        with caplog.at_level(
+            "WARNING", logger="thenvoi.integrations.claude_sdk.dedup_tools"
+        ):
+            await wrapper.send_message("hello", ["alice"])
+
+        assert any(
+            "dedup" in rec.message.lower() and rec.levelname == "WARNING"
+            for rec in caplog.records
+        ), (
+            f"expected WARNING log on dedup hit, got: {[r.message for r in caplog.records]}"
+        )

--- a/tests/integrations/claude_sdk/test_dedup_tools.py
+++ b/tests/integrations/claude_sdk/test_dedup_tools.py
@@ -78,6 +78,18 @@ class TestSendMessageDedup:
         assert inner.send_message.await_count == 2
 
     @pytest.mark.asyncio
+    async def test_distinct_dedup_scope_does_not_dedup(self):
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner)
+
+        await wrapper.update_inner(inner, dedup_scope="platform-msg-1")
+        await wrapper.send_message("Done.", ["alice"])
+        await wrapper.update_inner(inner, dedup_scope="platform-msg-2")
+        await wrapper.send_message("Done.", ["alice"])
+
+        assert inner.send_message.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_mention_order_does_not_matter(self):
         """A retry that re-orders the mentions list is the same logical send."""
         inner = _make_inner()
@@ -134,7 +146,7 @@ class TestSendMessageDedup:
         """Two coroutines racing on the same key must POST exactly once."""
         inner = _make_inner()
         # Block the first inner call long enough for the second to enter
-        # the wrapper and contend on the lock.
+        # the wrapper and observe the in-flight task.
         gate = asyncio.Event()
 
         async def slow_send(content, mentions=None):
@@ -152,6 +164,32 @@ class TestSendMessageDedup:
         await asyncio.gather(t1, t2)
 
         assert inner.send_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_distinct_concurrent_sends_do_not_block_each_other(self):
+        inner = _make_inner()
+        slow_gate = asyncio.Event()
+        completed: list[str] = []
+
+        async def controlled_send(content, mentions=None):
+            if content == "slow":
+                await slow_gate.wait()
+            completed.append(content)
+            return {"id": content}
+
+        inner.send_message.side_effect = controlled_send
+        wrapper = DedupingAgentTools(inner)
+
+        slow_task = asyncio.create_task(wrapper.send_message("slow", ["alice"]))
+        await asyncio.sleep(0)
+        fast_result = await wrapper.send_message("fast", ["alice"])
+
+        assert fast_result == {"id": "fast"}
+        assert completed == ["fast"]
+
+        slow_gate.set()
+        await slow_task
+        assert completed == ["fast", "slow"]
 
     @pytest.mark.asyncio
     async def test_cache_bounded_by_max_entries(self):
@@ -190,14 +228,12 @@ class TestTransparentPassthrough:
 
 
 class TestUpdateInner:
-    """update_inner() preserves the dedup cache across on_message calls.
+    """update_inner() swaps tools without discarding cache state.
 
-    The dominant INT-502 failure mode is a duplicate tool call landing
-    *after* the original turn's Complete event — i.e. a call that
-    arrives on a later on_message. If the adapter rebuilt the wrapper
-    on every on_message, the duplicate would miss the cache and POST a
-    second time. update_inner swaps just the inner reference so the
-    cache survives the turn boundary.
+    The adapter keeps one wrapper per room so lingering MCP retries can still
+    resolve through ``_room_tools``. The adapter also supplies a per-message
+    dedup scope; tests that omit it exercise the backwards-compatible default
+    scope.
     """
 
     @pytest.mark.asyncio
@@ -236,13 +272,12 @@ class TestUpdateInner:
         assert inner_a.send_message.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_swap_waits_for_in_flight_send(self):
-        """update_inner takes the lock so it serializes with send_message.
+    async def test_swap_does_not_wait_for_in_flight_send(self):
+        """update_inner is not serialized behind platform I/O.
 
-        If a send_message call is in flight against inner_a when
-        update_inner is called, the swap must wait for the in-flight
-        call to complete. Otherwise the in-flight call could see a
-        torn _inner reference mid-await.
+        An in-flight send captures the inner tools before awaiting the POST, so
+        update_inner can install the next turn's tools immediately without
+        changing where that in-flight send lands.
         """
         inner_a = _make_inner()
         gate = asyncio.Event()
@@ -257,19 +292,19 @@ class TestUpdateInner:
         wrapper = DedupingAgentTools(inner_a)
 
         send_task = asyncio.create_task(wrapper.send_message("hi", ["alice"]))
-        # Yield so send_task enters the lock and awaits the gate.
+        # Yield so send_task registers the in-flight task and awaits the gate.
         await asyncio.sleep(0)
 
         inner_b = _make_inner()
         swap_task = asyncio.create_task(wrapper.update_inner(inner_b))
 
-        # Swap must not have completed while send_message holds the lock.
         await asyncio.sleep(0)
-        assert not swap_task.done()
+        assert swap_task.done()
 
         gate.set()
         await asyncio.gather(send_task, swap_task)
         assert observed_inner == ["a"]
+        assert inner_b.send_message.await_count == 0
 
 
 class TestDedupHitLogging:

--- a/tests/integrations/claude_sdk/test_dedup_tools.py
+++ b/tests/integrations/claude_sdk/test_dedup_tools.py
@@ -290,3 +290,113 @@ class TestDedupHitLogging:
         ), (
             f"expected WARNING log on dedup hit, got: {[r.message for r in caplog.records]}"
         )
+
+    @pytest.mark.asyncio
+    async def test_warning_includes_label_when_provided(self, caplog):
+        """The adapter passes ``label=room_id`` so an operator triaging a
+        dedup storm in production can map a warning back to one room.
+        Without it the log is ``suppressing duplicate send`` with no
+        identifier and is useless across a multi-room tenant.
+        """
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner, label="room-abc")
+
+        await wrapper.send_message("hello", ["alice"])
+        with caplog.at_level(
+            "WARNING", logger="thenvoi.integrations.claude_sdk.dedup_tools"
+        ):
+            await wrapper.send_message("hello", ["alice"])
+
+        assert any("room-abc" in rec.getMessage() for rec in caplog.records), (
+            f"expected room-abc label in warning, got: "
+            f"{[r.getMessage() for r in caplog.records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_warning_omits_label_brackets_when_unset(self, caplog):
+        """No label → no empty ``[]`` in the log line."""
+        inner = _make_inner()
+        wrapper = DedupingAgentTools(inner)
+
+        await wrapper.send_message("hello", ["alice"])
+        with caplog.at_level(
+            "WARNING", logger="thenvoi.integrations.claude_sdk.dedup_tools"
+        ):
+            await wrapper.send_message("hello", ["alice"])
+
+        for rec in caplog.records:
+            if "dedup" in rec.getMessage().lower():
+                assert "[]" not in rec.getMessage()
+
+
+class TestInnerSendFailure:
+    """Behavior when the wrapped ``send_message`` raises.
+
+    A failed POST should not poison the cache: the next attempt at the
+    same ``(content, mentions)`` must be allowed to reach the platform,
+    otherwise a transient platform error would silently swallow every
+    subsequent send for the next ``ttl_seconds``.  These tests pin that
+    contract so a future cache refactor cannot regress it without making
+    the change visible.
+    """
+
+    @pytest.mark.asyncio
+    async def test_inner_exception_propagates(self):
+        inner = _make_inner()
+        inner.send_message = AsyncMock(side_effect=RuntimeError("boom"))
+        wrapper = DedupingAgentTools(inner)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await wrapper.send_message("hi", ["alice"])
+
+    @pytest.mark.asyncio
+    async def test_inner_failure_does_not_poison_cache(self):
+        """A retry after a transient failure must reach the inner tools.
+
+        If the wrapper kept a cache entry for the failed call, a follow-up
+        retry would dedup against nothing useful and return a stale or
+        bogus value.  The current implementation only writes the cache
+        after a successful return, so the retry takes the cache-miss
+        branch and POSTs again — which is correct.
+        """
+        inner = _make_inner()
+        calls: list[int] = [0]
+
+        async def flaky(content, mentions=None):
+            calls[0] += 1
+            if calls[0] == 1:
+                raise RuntimeError("transient")
+            return {"id": "msg-recovered"}
+
+        inner.send_message = AsyncMock(side_effect=flaky)
+        wrapper = DedupingAgentTools(inner)
+
+        with pytest.raises(RuntimeError):
+            await wrapper.send_message("hi", ["alice"])
+
+        result = await wrapper.send_message("hi", ["alice"])
+        assert result == {"id": "msg-recovered"}
+        assert calls[0] == 2
+
+    @pytest.mark.asyncio
+    async def test_recovered_call_then_dedupes_subsequent_duplicate(self):
+        """After the recovery POST succeeds, the wrapper resumes deduping
+        subsequent duplicates against the recovered result."""
+        inner = _make_inner()
+        calls: list[int] = [0]
+
+        async def flaky(content, mentions=None):
+            calls[0] += 1
+            if calls[0] == 1:
+                raise RuntimeError("transient")
+            return {"id": "msg-recovered"}
+
+        inner.send_message = AsyncMock(side_effect=flaky)
+        wrapper = DedupingAgentTools(inner)
+
+        with pytest.raises(RuntimeError):
+            await wrapper.send_message("hi", ["alice"])
+        await wrapper.send_message("hi", ["alice"])  # recovery POST
+        await wrapper.send_message("hi", ["alice"])  # dedup hit
+
+        assert calls[0] == 2

--- a/tests/integrations/claude_sdk/test_dedup_tools.py
+++ b/tests/integrations/claude_sdk/test_dedup_tools.py
@@ -78,16 +78,17 @@ class TestSendMessageDedup:
         assert inner.send_message.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_distinct_dedup_scope_does_not_dedup(self):
-        inner = _make_inner()
-        wrapper = DedupingAgentTools(inner)
+    async def test_inner_swap_does_not_bypass_late_retry_dedup(self):
+        inner_a = _make_inner()
+        wrapper = DedupingAgentTools(inner_a)
 
-        await wrapper.update_inner(inner, dedup_scope="platform-msg-1")
         await wrapper.send_message("Done.", ["alice"])
-        await wrapper.update_inner(inner, dedup_scope="platform-msg-2")
+        inner_b = _make_inner()
+        await wrapper.update_inner(inner_b)
         await wrapper.send_message("Done.", ["alice"])
 
-        assert inner.send_message.await_count == 2
+        assert inner_a.send_message.await_count == 1
+        assert inner_b.send_message.await_count == 0
 
     @pytest.mark.asyncio
     async def test_mention_order_does_not_matter(self):
@@ -166,6 +167,76 @@ class TestSendMessageDedup:
         assert inner.send_message.await_count == 1
 
     @pytest.mark.asyncio
+    async def test_cancelled_waiter_does_not_poison_in_flight_cache(self):
+        """Caller cancellation must not leave a stale in-flight task.
+
+        Claude SDK transports can cancel a request while the underlying POST is
+        still running. The in-flight dedup entry should keep tracking that POST,
+        let the next identical caller await it, then move the successful result
+        into the completed-send cache.
+        """
+        inner = _make_inner()
+        gate = asyncio.Event()
+
+        async def slow_send(content, mentions=None):
+            await gate.wait()
+            return {"id": "msg-after-cancel"}
+
+        inner.send_message.side_effect = slow_send
+        wrapper = DedupingAgentTools(inner)
+
+        first_waiter = asyncio.create_task(wrapper.send_message("hi", ["alice"]))
+        await asyncio.sleep(0)
+        first_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first_waiter
+
+        second_waiter = asyncio.create_task(wrapper.send_message("hi", ["alice"]))
+        await asyncio.sleep(0)
+        gate.set()
+        result = await second_waiter
+
+        assert result == {"id": "msg-after-cancel"}
+        assert inner.send_message.await_count == 1
+        await wrapper.send_message("hi", ["alice"])
+        assert inner.send_message.await_count == 1
+        assert wrapper._in_flight == {}
+
+    @pytest.mark.asyncio
+    async def test_in_flight_send_expires_at_ttl(self, monkeypatch):
+        """A stalled POST must not extend the dedup window forever."""
+        inner = _make_inner()
+        gate = asyncio.Event()
+        calls: list[int] = []
+
+        async def slow_first_send(content, mentions=None):
+            calls.append(len(calls) + 1)
+            if len(calls) == 1:
+                await gate.wait()
+                return {"id": "first"}
+            return {"id": "second"}
+
+        inner.send_message.side_effect = slow_first_send
+        wrapper = DedupingAgentTools(inner, ttl_seconds=1.0)
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(
+            "band.integrations.claude_sdk.dedup_tools.time.monotonic",
+            lambda: clock["t"],
+        )
+
+        first_waiter = asyncio.create_task(wrapper.send_message("hi", ["alice"]))
+        await asyncio.sleep(0)
+        clock["t"] += 1.1
+
+        second_result = await wrapper.send_message("hi", ["alice"])
+        assert second_result == {"id": "second"}
+        assert inner.send_message.await_count == 2
+
+        gate.set()
+        assert await first_waiter == {"id": "first"}
+        assert wrapper._in_flight == {}
+
+    @pytest.mark.asyncio
     async def test_distinct_concurrent_sends_do_not_block_each_other(self):
         inner = _make_inner()
         slow_gate = asyncio.Event()
@@ -231,9 +302,8 @@ class TestUpdateInner:
     """update_inner() swaps tools without discarding cache state.
 
     The adapter keeps one wrapper per room so lingering MCP retries can still
-    resolve through ``_room_tools``. The adapter also supplies a per-message
-    dedup scope; tests that omit it exercise the backwards-compatible default
-    scope.
+    resolve through ``_room_tools`` after the next inbound message has installed
+    fresh per-message tools.
     """
 
     @pytest.mark.asyncio
@@ -315,7 +385,7 @@ class TestDedupHitLogging:
 
         await wrapper.send_message("hello", ["alice"])
         with caplog.at_level(
-            "WARNING", logger="thenvoi.integrations.claude_sdk.dedup_tools"
+            "WARNING", logger="band.integrations.claude_sdk.dedup_tools"
         ):
             await wrapper.send_message("hello", ["alice"])
 
@@ -338,7 +408,7 @@ class TestDedupHitLogging:
 
         await wrapper.send_message("hello", ["alice"])
         with caplog.at_level(
-            "WARNING", logger="thenvoi.integrations.claude_sdk.dedup_tools"
+            "WARNING", logger="band.integrations.claude_sdk.dedup_tools"
         ):
             await wrapper.send_message("hello", ["alice"])
 
@@ -355,7 +425,7 @@ class TestDedupHitLogging:
 
         await wrapper.send_message("hello", ["alice"])
         with caplog.at_level(
-            "WARNING", logger="thenvoi.integrations.claude_sdk.dedup_tools"
+            "WARNING", logger="band.integrations.claude_sdk.dedup_tools"
         ):
             await wrapper.send_message("hello", ["alice"])
 


### PR DESCRIPTION
## Summary

User-visible symptom: a single Claude SDK-driven LLM turn renders **two identical chat messages** in the room (and the customer is billed for two LLM calls). The duplicate appears *after* the `Complete` event, with logs showing one `Sending query` and one `Complete` for the turn.

The underlying trigger is event-loop starvation: under sustained Claude CLI load the Python event loop is starved of Phoenix WS heartbeats, the WS reconnects many times in a few minutes, and along the way Claude re-emits the same `band_send_message` MCP tool call for one LLM-intended send via several paths:

- MCP transport retry when the in-process handler takes too long to ack.
- Session resume after a Phoenix WS reconnect, while the previous response is still being streamed.
- Claude CLI producing a new turn after the original `Complete` event has already fired.

The event-loop starvation itself is being addressed separately in infrastructure and is not in this repo.

This PR is the **SDK-side defense** for the same failure: a tool-call MCP server should not produce two side effects for one logical call, no matter why the duplicate arrived.

## What changed

- New `src/band/integrations/claude_sdk/dedup_tools.py` containing `DedupingAgentTools`, a wrapper for the per-room `AgentToolsProtocol` that:
  - dedupes `send_message(content, mentions)` calls by `(content, frozenset(mentions))` inside a 30 s TTL window;
  - returns the cached result verbatim for any repeat;
  - forwards every other method through `__getattr__` so the wrapper does not silently become a stale interface when `AgentToolsProtocol` grows new methods;
  - serializes concurrent calls with an `asyncio.Lock` so two racing duplicates can never both miss the cache and both POST;
  - bounds the cache to 64 entries per room with LRU eviction;
  - logs a `WARNING` on every dedup hit so the failure mode stays visible in production logs.
- `ClaudeSDKAdapter.on_message` wraps the incoming `tools` with `DedupingAgentTools` (unless the operator opts out via `send_message_dedup_ttl_seconds=0`) and stores the wrapped instance in `self._room_tools[room_id]`. The MCP backend (`_create_mcp_backend`) already passes `get_tools=self._room_tools.get`, so every MCP tool invocation routes through the shim transparently — no MCP backend changes needed.
- New constructor parameter `send_message_dedup_ttl_seconds: float = DEFAULT_DEDUP_TTL_SECONDS` on `ClaudeSDKAdapter`, validated `>= 0`.

### Cross-turn persistence

The dominant pattern is a duplicate tool call landing **after** the original turn's `Complete` event — i.e. on a *subsequent* `on_message`. `SimpleAdapter` builds a fresh `AgentTools` per inbound message, so a wrapper rebuilt per call would drop the cache and let that post-`Complete` duplicate through. `DedupingAgentTools.update_inner()` swaps just the inner reference under the lock, preserving the cache across the turn boundary. The adapter only calls `update_inner` when the tools identity actually changed, to avoid a needless lock acquisition.

### Operator-debuggable warnings

`DedupingAgentTools` takes an optional `label` (the adapter passes `room_id`) that is interpolated into the dedup-hit warning. Without it the log line is indistinguishable across a multi-room tenant during a dedup storm.

### Failure-path semantics pinned

A failure of the inner `send_message` must not poison the cache — otherwise a transient platform 5xx would silently swallow every subsequent send for the next `ttl_seconds`. New tests pin that contract so a future cache refactor cannot regress it without making the change visible.

## Why this is scoped to ClaudeSDKAdapter only

The shim is intentionally not in `runtime/tools.AgentTools`. Other adapters (Anthropic, LangChain, Pydantic AI, Codex, etc.) drive HTTP/LLM calls directly from the runtime task and do not exhibit this failure mode. Penalising every adapter with a dedup window because one framework runs a heavy subprocess that can re-issue MCP calls would be wrong.

## What this PR is **not** trying to fix

- It does not fix the event-loop starvation. That stays owed to the infra team.
- It does not bump `ExecutionContext._max_processed_ids`. That was already raised to 500 on `dev`.
- It does not change `ClaudeSessionManager` or the WS resync path. Those already invalidate dead subprocess sessions correctly.

## Test plan

- [x] `tests/integrations/claude_sdk/test_dedup_tools.py`: keying (content, mention order, dict-vs-string mentions, None-vs-empty), TTL expiry via monkeypatched `time.monotonic`, lock serialization under two concurrent duplicate sends, LRU bound, transparent passthrough of `send_event` / `add_participant` / `participants`, `update_inner` cache survival and in-flight-send lock semantics, dedup-hit warning logging, `label` interpolation in warnings, and failure semantics (inner-raise propagates, cache not poisoned, recovery POST runs, post-recovery duplicates dedup).
- [x] `TestSendMessageDedupWiring` in `tests/adapters/test_claude_sdk_adapter.py`: default wrapping in `on_message`, `ttl=0` opt-out, negative-ttl `ValueError`, end-to-end dedup through the stored room-tools entry, cross-turn wrapper persistence with inner swap, cross-room isolation (identical sends in two rooms POST twice), `on_cleanup` evicts the wrapper, and `update_inner` is skipped on identity match.
- [x] `uv run pytest tests/integrations/claude_sdk/ tests/adapters/test_claude_sdk_adapter.py -q` — 126 passed.
- [x] `uv run ruff check` clean.
- [x] `uv run ruff format --check` clean.
- [x] `uv run pyrefly check` clean.

## Risk

Low. The wrapper is opt-out (set `send_message_dedup_ttl_seconds=0` to bypass). The 30 s TTL is shorter than any reasonable human user re-asking for the same content. Cache is per-room, bounded, and uses `asyncio.Lock`, so no cross-room interference or memory growth. Per-room isolation is locked down by `test_distinct_rooms_get_distinct_wrappers` so a future `_room_tools` refactor cannot silently turn the shim into a tenant-wide message suppressor.
