### PR TITLE
fix: handle Codex dynamicToolCall items

### DIFF
--- a/src/thenvoi/adapters/codex.py
+++ b/src/thenvoi/adapters/codex.py
@@ -1805,7 +1805,9 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         processing (e.g. a transient 403 from the load balancer).
         """
         item_type = item.get("type", "")
-        item_id = str(item.get("id") or "")
+        item_id = str(
+            item.get("id") or item.get("callId") or item.get("toolCallId") or ""
+        )
         metadata = {
             "codex_room_id": room_id,
             "codex_thread_id": thread_id,
@@ -1847,6 +1849,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             "webSearch",
             "imageView",
             "collabAgentToolCall",
+            "dynamicToolCall",
         }:
             if Emit.EXECUTION not in self.features.emit:
                 return
@@ -1962,7 +1965,73 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             )
             return name, collab_args, output
 
+        if item_type == "dynamicToolCall":
+            tool = item.get("tool") or item.get("name") or item.get("toolName")
+            if isinstance(tool, dict):
+                tool = tool.get("name") or tool.get("tool") or tool.get("toolName")
+            name = str(tool or "dynamic_tool")
+
+            raw_args = (
+                item.get("arguments")
+                if "arguments" in item
+                else item.get("args")
+                if "args" in item
+                else item.get("input")
+                if "input" in item
+                else item.get("inputJson", {})
+            )
+            args = CodexAdapter._coerce_tool_args(raw_args)
+
+            output = CodexAdapter._stringify_tool_output(
+                item.get("result"),
+                item.get("output"),
+                item.get("content"),
+                item.get("error"),
+                item.get("contentItems"),
+                default=str(item.get("status", "completed")),
+            )
+            return name, args, output
+
         return item_type, {}, "completed"
+
+    @staticmethod
+    def _coerce_tool_args(value: Any) -> dict[str, Any]:
+        """Return a dict for Codex tool args across protocol variants."""
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                return {"input": value}
+            if isinstance(parsed, dict):
+                return parsed
+            return {"input": parsed}
+        if value is None:
+            return {}
+        return {"input": value}
+
+    @staticmethod
+    def _stringify_tool_output(*values: Any, default: str) -> str:
+        """Return the first present tool output as displayable text."""
+        for value in values:
+            if value is None:
+                continue
+            if isinstance(value, str):
+                return value
+            if isinstance(value, list):
+                text_parts: list[str] = []
+                for item in value:
+                    if isinstance(item, dict):
+                        text = item.get("text")
+                        if isinstance(text, str):
+                            text_parts.append(text)
+                    elif isinstance(item, str):
+                        text_parts.append(item)
+                if text_parts:
+                    return "\n".join(text_parts)
+            return json.dumps(value, default=str)
+        return default
 
     @staticmethod
     def _extract_thought_text(item_type: str, item: dict[str, Any]) -> str:

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -2454,6 +2454,71 @@ class TestItemCompletedForwarding:
         assert "127.0.0.1 localhost" in result_data["output"]
 
     @pytest.mark.asyncio
+    async def test_item_completed_dynamicToolCall_emits_tool_events(self) -> None:
+        """dynamicToolCall emits tool_call + tool_result for Codex dynamic tools."""
+        events = [
+            _event_notification(
+                "item/completed",
+                {
+                    "item": {
+                        "type": "dynamicToolCall",
+                        "callId": "dyn-1",
+                        "tool": "read_file",
+                        "arguments": {"path": "src/app.py"},
+                        "result": {"content": "print('hello')"},
+                        "status": "completed",
+                    }
+                },
+            ),
+            _event_notification(
+                "turn/completed",
+                {
+                    "turn": {
+                        "id": "turn-1",
+                        "status": "completed",
+                        "items": [],
+                        "error": None,
+                    }
+                },
+            ),
+        ]
+        fake_client = FakeCodexClient(events=events)
+        adapter = CodexAdapter(
+            config=CodexAdapterConfig(transport="ws", enable_execution_reporting=True),
+            client_factory=lambda _config: fake_client,
+        )
+        tools = ToolSchemaFakeTools()
+
+        await adapter.on_started("Codex Agent", "A coding agent")
+        await adapter.on_message(
+            make_platform_message(),
+            tools,
+            CodexSessionState(),
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-1",
+        )
+
+        tool_call_events = [
+            e for e in tools.events_sent if e["message_type"] == "tool_call"
+        ]
+        tool_result_events = [
+            e for e in tools.events_sent if e["message_type"] == "tool_result"
+        ]
+        assert len(tool_call_events) == 1
+        assert len(tool_result_events) == 1
+
+        call_data = json.loads(tool_call_events[0]["content"])
+        assert call_data["name"] == "read_file"
+        assert call_data["args"]["path"] == "src/app.py"
+        assert call_data["tool_call_id"] == "dyn-1"
+
+        result_data = json.loads(tool_result_events[0]["content"])
+        assert "print('hello')" in result_data["output"]
+        assert result_data["tool_call_id"] == "dyn-1"
+
+    @pytest.mark.asyncio
     async def test_item_completed_reasoning_emits_thought(self) -> None:
         """reasoning item emits thought event when emit_thought_events=True."""
         events = [


### PR DESCRIPTION
## Summary
- Treat Codex `dynamicToolCall` completed items as tool-like execution events.
- Preserve dynamic tool call IDs from `id`, `callId`, or `toolCallId`.
- Extract tool name, args, and output defensively across likely Codex protocol field shapes.
- Add a regression test for `dynamicToolCall` forwarding.

## Why
Codex reviewer loops can hit `item/completed` events with `type: dynamicToolCall` during code-reading tasks. The adapter previously logged these as unhandled, so the reviewer loop lost tool execution reporting/context.

## Verification
- `.venv-codex-fix/bin/ruff format --check src/thenvoi/adapters/codex.py tests/adapters/test_codex_adapter.py`
- `.venv-codex-fix/bin/ruff check src/thenvoi/adapters/codex.py tests/adapters/test_codex_adapter.py`
- `.venv-codex-fix/bin/pytest tests/adapters/test_codex_adapter.py -k 'dynamicToolCall or item_completed_commandExecution or item_completed_mcpToolCall or item_completed_no_execution_reporting' -q`
