### PR TITLE
fix(examples): use Pydantic model in custom tool handlers [INT-514]

### DIFF
--- a/examples/google_adk/03_custom_tools.py
+++ b/examples/google_adk/03_custom_tools.py
@@ -57,7 +57,7 @@ class CalculatorInput(BaseModel):
     right: float = Field(description="The second number")
 
 
-def calculator(operation: str, left: float, right: float) -> str:
+def calculator(input: CalculatorInput) -> str:
     """Execute a calculator operation."""
     ops = {
         "add": lambda a, b: a + b,
@@ -65,10 +65,10 @@ def calculator(operation: str, left: float, right: float) -> str:
         "multiply": lambda a, b: a * b,
         "divide": lambda a, b: "Error: division by zero" if b == 0 else a / b,
     }
-    fn = ops.get(operation)
+    fn = ops.get(input.operation)
     if fn is None:
-        return f"Unknown operation '{operation}'. Use: add, subtract, multiply, divide"
-    result = fn(left, right)
+        return f"Unknown operation '{input.operation}'. Use: add, subtract, multiply, divide"
+    result = fn(input.left, input.right)
     return str(result)
 
 
@@ -78,9 +78,9 @@ class WeatherInput(BaseModel):
     city: str = Field(description="Name of the city")
 
 
-def weather(city: str) -> str:
+def weather(input: WeatherInput) -> str:
     """Return mock weather data."""
-    return f"Weather in {city}: Sunny, 22 °C"
+    return f"Weather in {input.city}: Sunny, 22 °C"
 
 
 async def main() -> None:


### PR DESCRIPTION
## Summary
- Custom tool handlers in `examples/google_adk/03_custom_tools.py` used individual kwargs (`calculator(operation, left, right)`) instead of a single Pydantic model argument
- The SDK's `execute_custom_tool` passes the validated model as a positional arg, so multi-param handlers crash with `TypeError: missing positional arguments`
- Updated `calculator` and `weather` handlers to accept their Pydantic model directly

## Test plan
- [x] Calculator: 42 × 17 = 714
- [x] Divide by zero: graceful error message
- [x] Weather tool: still works

Closes INT-514

🤖 Generated with [Claude Code](https://claude.com/claude-code)