### PR TITLE
docs(sdk): update default models from gpt-4o to gpt-5.4 [INT-511]

### DIFF
--- a/docker/letta/runner.py
+++ b/docker/letta/runner.py
@@ -10,7 +10,7 @@ Environment variables:
     LETTA_BASE_URL             Letta server URL (default: https://api.letta.com)
                                Set to http://localhost:8283 for self-hosted.
     LETTA_API_KEY              Letta API key (required for Cloud, optional for self-hosted)
-    LETTA_MODEL                Model ID (e.g., openai/gpt-4o)
+    LETTA_MODEL                Model ID (e.g., openai/gpt-5.4)
     LETTA_MODE                 Operating mode: per_room or shared (default: per_room)
     LETTA_PROJECT              Letta Cloud project name (optional, ignored for self-hosted)
     MCP_SERVER_URL             thenvoi-mcp server URL (default: http://localhost:8002/sse)

--- a/examples/langgraph/05_rag_as_tool.py
+++ b/examples/langgraph/05_rag_as_tool.py
@@ -126,7 +126,7 @@ User: "tell nvidia about reward hacking"
 
     # Create adapter with RAG tool
     adapter = LangGraphAdapter(
-        llm=ChatOpenAI(model="gpt-4o"),
+        llm=ChatOpenAI(model="gpt-5.4"),
         checkpointer=InMemorySaver(),
         additional_tools=[rag_tool],
         custom_section=rag_instructions,

--- a/src/thenvoi/adapters/crewai.py
+++ b/src/thenvoi/adapters/crewai.py
@@ -58,7 +58,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
 
     Example:
         adapter = CrewAIAdapter(
-            model="gpt-4o",
+            model="gpt-5.4",
             role="Research Assistant",
             goal="Help users find and analyze information",
             backstory="Expert researcher with deep knowledge across domains",
@@ -78,7 +78,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
 
     def __init__(
         self,
-        model: str = "gpt-4o",
+        model: str = "gpt-5.4",
         role: str | None = None,
         goal: str | None = None,
         backstory: str | None = None,
@@ -97,7 +97,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         """Initialize the CrewAI adapter.
 
         Args:
-            model: Model name (e.g., "gpt-4o", "gpt-4o-mini", "claude-3-5-sonnet").
+            model: Model name (e.g., "gpt-5.4", "gpt-5.4-mini", "claude-3-5-sonnet").
                    API keys are read from environment variables by CrewAI's LLM class.
             role: Agent's role in the crew (e.g., "Research Assistant")
             goal: Agent's primary goal or objective

--- a/src/thenvoi/adapters/langgraph.py
+++ b/src/thenvoi/adapters/langgraph.py
@@ -34,7 +34,7 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
 
     1. Simple (recommended for most users):
         adapter = LangGraphAdapter(
-            llm=ChatOpenAI(model="gpt-4o"),
+            llm=ChatOpenAI(model="gpt-5.4"),
             checkpointer=InMemorySaver(),
             custom_section="You are a helpful assistant.",
         )
@@ -50,7 +50,7 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
         from langgraph.checkpoint.memory import InMemorySaver
 
         adapter = LangGraphAdapter(
-            llm=ChatOpenAI(model="gpt-4o"),
+            llm=ChatOpenAI(model="gpt-5.4"),
             checkpointer=InMemorySaver(),
         )
         agent = Agent.create(adapter=adapter, agent_id="...", api_key="...")

--- a/src/thenvoi/adapters/letta.py
+++ b/src/thenvoi/adapters/letta.py
@@ -126,7 +126,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         adapter = LettaAdapter(
             config=LettaAdapterConfig(
                 api_key="your-letta-api-key",
-                model="openai/gpt-4o",
+                model="openai/gpt-5.4",
                 mcp_server_url="http://localhost:8002/sse",
             ),
 
@@ -134,7 +134,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         adapter = LettaAdapter(
             config=LettaAdapterConfig(
                 base_url="http://localhost:8283",
-                model="openai/gpt-4o",
+                model="openai/gpt-5.4",
                 mcp_server_url="http://localhost:8002/sse",
             ),
         )

--- a/src/thenvoi/adapters/pydantic_ai.py
+++ b/src/thenvoi/adapters/pydantic_ai.py
@@ -46,7 +46,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
     Example:
         adapter = PydanticAIAdapter(
-            model="openai:gpt-4o",
+            model="openai:gpt-5.4",
             custom_section="You are a helpful assistant.",
         )
         agent = Agent.create(adapter=adapter, agent_id="...", api_key="...")
@@ -73,7 +73,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         Initialize the Pydantic AI adapter.
 
         Args:
-            model: Pydantic AI model string (e.g., "openai:gpt-4o", "anthropic:claude-3-5-sonnet-latest")
+            model: Pydantic AI model string (e.g., "openai:gpt-5.4", "anthropic:claude-3-5-sonnet-latest")
             system_prompt: Optional custom system prompt (overrides default)
             custom_section: Optional custom section added to default system prompt
             enable_execution_reporting: Deprecated. Use features=AdapterFeatures(emit={Emit.EXECUTION}).

--- a/src/thenvoi/integrations/langgraph/__init__.py
+++ b/src/thenvoi/integrations/langgraph/__init__.py
@@ -10,7 +10,7 @@ Use the new composition-based pattern instead:
     from langgraph.checkpoint.memory import MemorySaver
 
     adapter = LangGraphAdapter(
-        llm=ChatOpenAI(model="gpt-4o"),
+        llm=ChatOpenAI(model="gpt-5.4"),
         checkpointer=MemorySaver(),
     )
     agent = Agent.create(adapter=adapter, agent_id="...", api_key="...")

--- a/src/thenvoi/integrations/pydantic_ai/__init__.py
+++ b/src/thenvoi/integrations/pydantic_ai/__init__.py
@@ -7,7 +7,7 @@ Use the new composition-based pattern instead:
     from thenvoi import Agent
     from thenvoi.adapters import PydanticAIAdapter
 
-    adapter = PydanticAIAdapter(model="openai:gpt-4o")
+    adapter = PydanticAIAdapter(model="openai:gpt-5.4")
     agent = Agent.create(adapter=adapter, agent_id="...", api_key="...")
     await agent.run()
 """

--- a/tests/adapters/test_crewai_adapter_soak.py
+++ b/tests/adapters/test_crewai_adapter_soak.py
@@ -82,7 +82,7 @@ async def test_soak_100_turns_3_rooms(crewai_mocks):
     module = importlib.import_module("thenvoi.adapters.crewai")
     CrewAIAdapter = module.CrewAIAdapter
 
-    adapter = CrewAIAdapter(model="gpt-4o-mini")
+    adapter = CrewAIAdapter(model="gpt-5.4-mini")
     fake_agent = MagicMock()
     fake_agent.kickoff_async = AsyncMock(return_value=MagicMock(raw="ok"))
     adapter._crewai_agent = fake_agent

--- a/tests/adapters/test_deprecation_shims.py
+++ b/tests/adapters/test_deprecation_shims.py
@@ -81,7 +81,7 @@ class TestUniversalBooleanShims:
 
         with pytest.warns(DeprecationWarning, match="enable_execution_reporting"):
             adapter = PydanticAIAdapter(
-                model="openai:gpt-4o", enable_execution_reporting=True
+                model="openai:gpt-5.4", enable_execution_reporting=True
             )
         assert Emit.EXECUTION in adapter.features.emit
 

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -121,8 +121,8 @@ class TestInitialization:
     def test_requires_model(self):
         """Should require model parameter."""
         # model is required - no default
-        adapter = PydanticAIAdapter(model="openai:gpt-4o")
-        assert adapter.model == "openai:gpt-4o"
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
+        assert adapter.model == "openai:gpt-5.4"
 
 
 class TestOnStarted:
@@ -131,7 +131,7 @@ class TestOnStarted:
     @pytest.mark.asyncio
     async def test_sets_agent_name_and_description(self, mock_pydantic_agent):
         """Should set agent_name and agent_description."""
-        adapter = PydanticAIAdapter(model="openai:gpt-4o")
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
 
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started(
@@ -144,7 +144,7 @@ class TestOnStarted:
     @pytest.mark.asyncio
     async def test_creates_pydantic_agent(self, mock_pydantic_agent):
         """Should create Pydantic AI agent after start."""
-        adapter = PydanticAIAdapter(model="openai:gpt-4o")
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
 
         assert adapter._agent is None
 
@@ -160,7 +160,7 @@ class TestOnStarted:
         """Should persist rendered prompt for capability-gating visibility."""
         with patch("thenvoi.adapters.pydantic_ai.Agent"):
             adapter = PydanticAIAdapter(
-                model="openai:gpt-4o",
+                model="openai:gpt-5.4",
                 features=AdapterFeatures(capabilities={Capability.MEMORY}),
             )
             await adapter.on_started(
@@ -173,7 +173,7 @@ class TestOnStarted:
     @pytest.mark.asyncio
     async def test_agent_has_tools_registered(self, mock_pydantic_agent):
         """Should register all platform tools on the agent."""
-        adapter = PydanticAIAdapter(model="openai:gpt-4o")
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
 
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started(
@@ -205,7 +205,7 @@ class TestOnMessage:
         self, sample_message, mock_tools, mock_pydantic_agent
     ):
         """Should initialize room history on first message."""
-        adapter = PydanticAIAdapter(model="openai:gpt-4o")
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
 
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started("TestBot", "Test bot")
@@ -232,7 +232,7 @@ class TestOnMessage:
         self, sample_message, mock_tools, mock_pydantic_agent
     ):
         """Should load historical messages on bootstrap."""
-        adapter = PydanticAIAdapter(model="openai:gpt-4o")
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
 
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started("TestBot", "Test bot")
@@ -269,7 +269,7 @@ class TestOnMessage:
         self, sample_message, mock_tools, mock_pydantic_agent
     ):
         """Should inject participants update when provided."""
-        adapter = PydanticAIAdapter(model="openai:gpt-4o")
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
 
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started("TestBot", "Test bot")
@@ -303,7 +303,7 @@ class TestOnMessage:
     ):
         """Should create agent lazily if on_started wasn't called."""
         adapter = PydanticAIAdapter(
-            model="openai:gpt-4o",
+            model="openai:gpt-5.4",
             custom_section="Test section",
         )
         # Don't call on_started - set agent_name directly for prompt rendering
@@ -335,7 +335,7 @@ class TestOnCleanup:
     @pytest.mark.asyncio
     async def test_cleans_up_room_history(self):
         """Should remove room history on cleanup."""
-        adapter = PydanticAIAdapter(model="openai:gpt-4o")
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
 
         # Add some history
         adapter._message_history["room-123"] = [
@@ -356,7 +356,7 @@ class TestHistoryManagement:
         self, sample_message, mock_tools, mock_pydantic_agent
     ):
         """Should update stored history with all messages from run."""
-        adapter = PydanticAIAdapter(model="openai:gpt-4o")
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
 
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started("TestBot", "Test bot")
@@ -387,7 +387,7 @@ class TestHistoryManagement:
         self, sample_message, mock_tools, mock_pydantic_agent
     ):
         """Should create history if not bootstrap and room doesn't exist."""
-        adapter = PydanticAIAdapter(model="openai:gpt-4o")
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
 
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started("TestBot", "Test bot")
@@ -419,7 +419,7 @@ class TestExecutionReporting:
     ):
         """Should emit tool_call events when enable_execution_reporting=True."""
         adapter = PydanticAIAdapter(
-            model="openai:gpt-4o",
+            model="openai:gpt-5.4",
             enable_execution_reporting=True,
         )
 
@@ -455,7 +455,7 @@ class TestExecutionReporting:
     ):
         """Should emit tool_result events when enable_execution_reporting=True."""
         adapter = PydanticAIAdapter(
-            model="openai:gpt-4o",
+            model="openai:gpt-5.4",
             enable_execution_reporting=True,
         )
 
@@ -492,7 +492,7 @@ class TestExecutionReporting:
         self, sample_message, mock_tools, mock_pydantic_agent
     ):
         """Should NOT emit events when enable_execution_reporting=False (default)."""
-        adapter = PydanticAIAdapter(model="openai:gpt-4o")  # Default is False
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")  # Default is False
 
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started("TestBot", "Test bot")
@@ -526,7 +526,7 @@ class TestExecutionReporting:
     ):
         """Should emit events for all tool calls in sequence."""
         adapter = PydanticAIAdapter(
-            model="openai:gpt-4o",
+            model="openai:gpt-5.4",
             enable_execution_reporting=True,
         )
 
@@ -580,7 +580,7 @@ class TestExecutionReporting:
     ):
         """Should continue running if send_event fails."""
         adapter = PydanticAIAdapter(
-            model="openai:gpt-4o",
+            model="openai:gpt-5.4",
             enable_execution_reporting=True,
         )
 
@@ -624,7 +624,7 @@ class TestCustomTools:
             return f"Echo: {message}"
 
         adapter = PydanticAIAdapter(
-            model="openai:gpt-4o",
+            model="openai:gpt-5.4",
             additional_tools=[my_tool],
         )
 
@@ -647,7 +647,7 @@ class TestCustomTools:
             return x + y
 
         adapter = PydanticAIAdapter(
-            model="openai:gpt-4o",
+            model="openai:gpt-5.4",
             additional_tools=[tool_one, tool_two, tool_three],
         )
 
@@ -662,7 +662,7 @@ class TestCustomTools:
             return f"Echo: {message}"
 
         adapter = PydanticAIAdapter(
-            model="openai:gpt-4o",
+            model="openai:gpt-5.4",
             additional_tools=[my_echo],
         )
 
@@ -693,7 +693,7 @@ class TestCustomTools:
             return a + b
 
         adapter = PydanticAIAdapter(
-            model="openai:gpt-4o",
+            model="openai:gpt-5.4",
             additional_tools=[calculator],
         )
 
@@ -723,7 +723,7 @@ class TestCustomTools:
             return f"Helped: {value}"
 
         adapter = PydanticAIAdapter(
-            model="openai:gpt-4o",
+            model="openai:gpt-5.4",
             additional_tools=[my_helper],
         )
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -88,7 +88,7 @@ class E2ESettings(ThenvoiTestSettings):
     _env_file_path = Path(__file__).parent.parent.parent / ".env.test"
 
     # E2E-specific settings (override via environment variables)
-    e2e_llm_model: str = "gpt-4o-mini"
+    e2e_llm_model: str = "gpt-5.4-mini"
     e2e_anthropic_model: str = "claude-3-haiku-20240307"
     e2e_timeout: int = 30
     e2e_tests_enabled: bool = False

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -284,7 +284,7 @@ def _google_adk_factory(**kw: Any) -> Any:
 # The conformance factory injects this value so the adapter can be instantiated
 # without a real API key.  ``expected_initial_values["model"]`` then verifies
 # the factory injection, NOT a real adapter default.
-_PYDANTIC_AI_INJECTED_MODEL = "openai:gpt-4o"
+_PYDANTIC_AI_INJECTED_MODEL = "openai:gpt-5.4"
 
 
 def _build_anthropic_config() -> AdapterConfig:
@@ -351,7 +351,7 @@ def _build_crewai_config() -> AdapterConfig:
             "allow_delegation": _default_from_init(crewai_cls, "allow_delegation"),
         },
         custom_kwargs={
-            "model": "gpt-4o-mini",
+            "model": "gpt-5.4-mini",
             "role": "Research Analyst",
             "goal": "Find and analyze information",
             "backstory": "Expert researcher",
@@ -362,7 +362,7 @@ def _build_crewai_config() -> AdapterConfig:
             "allow_delegation": True,
         },
         custom_expected={
-            "model": "gpt-4o-mini",
+            "model": "gpt-5.4-mini",
             "role": "Research Analyst",
             "goal": "Find and analyze information",
             "backstory": "Expert researcher",

--- a/tests/integration/test_agent_contacts.py
+++ b/tests/integration/test_agent_contacts.py
@@ -76,7 +76,7 @@ class TestAgentCallbackFlow:
             on_event=capture_event,
         )
 
-        adapter = PydanticAIAdapter(model="openai:gpt-4o-mini")
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4-mini")
         agent = Agent.create(
             adapter=adapter,
             agent_id=agent_id,
@@ -112,7 +112,7 @@ class TestAgentBroadcastFlow:
             broadcast_changes=True,
         )
 
-        adapter = PydanticAIAdapter(model="openai:gpt-4o-mini")
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4-mini")
         agent = Agent.create(
             adapter=adapter,
             agent_id=agent_id,
@@ -144,7 +144,7 @@ class TestAgentGracefulShutdown:
             on_event=lambda e, t: None,
         )
 
-        adapter = PydanticAIAdapter(model="openai:gpt-4o-mini")
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4-mini")
         agent = Agent.create(
             adapter=adapter,
             agent_id=agent_id,

--- a/tests/integrations/acp/test_server.py
+++ b/tests/integrations/acp/test_server.py
@@ -403,7 +403,7 @@ class TestACPServerSetSessionModel:
         server = ACPServer(adapter)
 
         response = await server.set_session_model(
-            model_id="gpt-4o", session_id="session-1"
+            model_id="gpt-5.4", session_id="session-1"
         )
 
         assert response is not None

--- a/tests/test_capability_gating_e2e.py
+++ b/tests/test_capability_gating_e2e.py
@@ -106,7 +106,7 @@ class TestCapabilityGatingEndToEnd:
         from thenvoi.adapters.pydantic_ai import PydanticAIAdapter
 
         adapter = PydanticAIAdapter(
-            model="openai:gpt-4o",
+            model="openai:gpt-5.4",
             features=AdapterFeatures(capabilities={Capability.MEMORY}),
         )
         await adapter.on_started("test-agent", "A test agent")

--- a/thenvoi-bridge/langchain_agent_server.py
+++ b/thenvoi-bridge/langchain_agent_server.py
@@ -1,4 +1,4 @@
-"""Real LangChain agent server using gpt-4o-mini.
+"""Real LangChain agent server using gpt-5.4-mini.
 
 Serves a ``/invoke`` endpoint matching the LangServe format
 and a ``/health`` check for readiness probes.
@@ -38,7 +38,7 @@ def _get_llm() -> ChatOpenAI:
         api_key = os.environ.get("OPENAI_API_KEY")
         if not api_key:
             raise ValueError("OPENAI_API_KEY environment variable is required")
-        _llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+        _llm = ChatOpenAI(model="gpt-5.4-mini", temperature=0)
     return _llm
 
 


### PR DESCRIPTION
Closes INT-511

## Summary

- Replace all `gpt-4o` → `gpt-5.4` and `gpt-4o-mini` → `gpt-5.4-mini` references across the repo
- Covers examples, tests, source adapter defaults/docstrings, `thenvoi-bridge`, and `docker/letta`

## Test plan

- [ ] Run unit tests: `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/ -v`
- [ ] Spot-check that no `gpt-4o` references remain: `grep -rn "gpt-4o" . --include="*.py"`

✌️