### PR TITLE
fix(sdk): document gcloud ADC auth for Gemini and ADK [INT-519]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,6 +378,9 @@ resolves each in a separate fork.
 - `THENVOI_API_KEY_USER`: User API key for E2E WebSocket observer and trigger messages
 - `OPENAI_API_KEY`: OpenAI API key (for LangGraph examples)
 - `ANTHROPIC_API_KEY`: Anthropic API key (for Anthropic/Claude SDK examples)
+- `GOOGLE_API_KEY`: Google API key for Gemini Developer API (for Gemini/Google ADK examples)
+- `GOOGLE_GENAI_USE_VERTEXAI`: Set to `true` to use Vertex AI instead of Gemini Developer API
+- `GOOGLE_CLOUD_PROJECT`: Google Cloud project ID (required when using Vertex AI)
 - `E2E_TESTS_ENABLED`: Set to `true` to enable E2E tests (default: disabled)
 - `E2E_LLM_MODEL`: OpenAI model for E2E tests (default: `gpt-4o-mini`)
 - `E2E_ANTHROPIC_MODEL`: Anthropic model for E2E tests (default: `claude-3-haiku-20240307`)

--- a/examples/gemini/01_basic_agent.py
+++ b/examples/gemini/01_basic_agent.py
@@ -13,7 +13,12 @@ The adapter handles tool registration and function-calling loops automatically.
 
 Requires:
     - agent_config.yaml with gemini_agent credentials
-    - GEMINI_API_KEY environment variable
+    - Authentication via one of:
+      - GOOGLE_API_KEY or GEMINI_API_KEY environment variable (Gemini Developer API)
+      - gcloud CLI with Application Default Credentials (Vertex AI):
+          gcloud auth application-default login
+          export GOOGLE_GENAI_USE_VERTEXAI=true
+          export GOOGLE_CLOUD_PROJECT=your-project-id
 
 Run with:
     uv run examples/gemini/01_basic_agent.py

--- a/examples/google_adk/01_basic_agent.py
+++ b/examples/google_adk/01_basic_agent.py
@@ -12,8 +12,12 @@ This is the simplest way to create a Thenvoi agent using the Google Agent
 Development Kit (ADK) with Gemini models. The adapter handles conversation
 history, tool calling, and platform integration via ADK's built-in Runner.
 
-Requires GOOGLE_API_KEY (or GOOGLE_GENAI_API_KEY) environment variable for
-Gemini authentication, in addition to the Thenvoi credentials.
+Requires Thenvoi credentials plus one of:
+    - GOOGLE_API_KEY or GOOGLE_GENAI_API_KEY environment variable (Gemini Developer API)
+    - gcloud CLI with Application Default Credentials (Vertex AI):
+        gcloud auth application-default login
+        export GOOGLE_GENAI_USE_VERTEXAI=true
+        export GOOGLE_CLOUD_PROJECT=your-project-id
 
 Run with:
     uv run examples/google_adk/01_basic_agent.py

--- a/examples/google_adk/02_custom_instructions.py
+++ b/examples/google_adk/02_custom_instructions.py
@@ -11,8 +11,12 @@ Google ADK agent with custom instructions and model selection.
 Demonstrates how to configure the Google ADK adapter with a custom system
 prompt, model selection, and execution reporting.
 
-Requires GOOGLE_API_KEY (or GOOGLE_GENAI_API_KEY) environment variable for
-Gemini authentication, in addition to the Thenvoi credentials.
+Requires Thenvoi credentials plus one of:
+    - GOOGLE_API_KEY or GOOGLE_GENAI_API_KEY environment variable (Gemini Developer API)
+    - gcloud CLI with Application Default Credentials (Vertex AI):
+        gcloud auth application-default login
+        export GOOGLE_GENAI_USE_VERTEXAI=true
+        export GOOGLE_CLOUD_PROJECT=your-project-id
 
 Run with:
     uv run examples/google_adk/02_custom_instructions.py

--- a/examples/google_adk/03_custom_tools.py
+++ b/examples/google_adk/03_custom_tools.py
@@ -12,8 +12,12 @@ Demonstrates how to add custom tools alongside the platform tools using
 the ``additional_tools`` parameter. The adapter bridges them into ADK's
 BaseTool system automatically.
 
-Requires GOOGLE_API_KEY (or GOOGLE_GENAI_API_KEY) environment variable for
-Gemini authentication, in addition to the Thenvoi credentials.
+Requires Thenvoi credentials plus one of:
+    - GOOGLE_API_KEY or GOOGLE_GENAI_API_KEY environment variable (Gemini Developer API)
+    - gcloud CLI with Application Default Credentials (Vertex AI):
+        gcloud auth application-default login
+        export GOOGLE_GENAI_USE_VERTEXAI=true
+        export GOOGLE_CLOUD_PROJECT=your-project-id
 
 Run with:
     uv run examples/google_adk/03_custom_tools.py

--- a/src/thenvoi/adapters/gemini.py
+++ b/src/thenvoi/adapters/gemini.py
@@ -337,8 +337,9 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
             self.client = genai.Client(api_key=self._api_key)
         except ValueError as e:
             raise ValueError(
-                "Gemini client initialization failed. Provide GEMINI_API_KEY or "
-                "pass api_key explicitly."
+                "Gemini client initialization failed. Either set GOOGLE_API_KEY "
+                "/ GEMINI_API_KEY, or enable Vertex AI mode "
+                "(GOOGLE_GENAI_USE_VERTEXAI=true + GOOGLE_CLOUD_PROJECT)."
             ) from e
         return self.client
 


### PR DESCRIPTION
## Summary
- Update `GeminiAdapter` init error message to mention both API key and Vertex AI (`GOOGLE_GENAI_USE_VERTEXAI=true` + `GOOGLE_CLOUD_PROJECT`) auth paths
- Update all Gemini and Google ADK example docstrings to show gcloud Application Default Credentials as an alternative to `GOOGLE_API_KEY`
- Add `GOOGLE_API_KEY`, `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_CLOUD_PROJECT` to `AGENTS.md` environment variables section

## Test plan
- [ ] Verify `GeminiAdapter` raises updated error message when no credentials are configured
- [ ] Confirm example docstrings render correctly with the new auth instructions
- [ ] No code logic changes — docs and error message only

✌️