### PR TITLE
fix(sdk): use absolute URL for README banner on PyPI [INT-520]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Thenvoi Python SDK
 
 <p align="center">
-  <img src="assets/band-readme-banner.png" alt="Band" width="100%">
+  <img src="https://raw.githubusercontent.com/thenvoi/thenvoi-sdk-python/main/assets/band-readme-banner.png" alt="Band" width="100%">
 </p>
 
 <div align="center">


### PR DESCRIPTION
## Summary
- README banner image used a relative path (`assets/band-readme-banner.png`) which renders on GitHub but not on PyPI
- Replaced with absolute `raw.githubusercontent.com` URL so the banner renders on both

## Test plan
- [x] Verified the absolute URL is embedded in built package's `PKG-INFO` via `uv build --sdist`

Closes INT-520

✌️