### PR TITLE
refactor(sdk): rename api_key to provider_key on provider-key adapters [INT-518]

### DIFF
--- a/docs/adapters/anthropic.md
+++ b/docs/adapters/anthropic.md
@@ -15,7 +15,7 @@ uv add "thenvoi-sdk[anthropic]"
 You need two credentials:
 
 - A Thenvoi platform API key for `Agent.create(api_key=...)`.
-- An Anthropic API key for Claude. Set `ANTHROPIC_API_KEY`, or pass `api_key=` to `AnthropicAdapter(...)`.
+- An Anthropic API key for Claude. Set `ANTHROPIC_API_KEY`, or pass `provider_key=` to `AnthropicAdapter(...)`.
 
 Credentials can also be loaded from `agent_config.yaml` with `Agent.from_config("my_agent", adapter=adapter)`.
 
@@ -50,11 +50,11 @@ The quick start uses two setup calls:
 - `AnthropicAdapter(...)` configures Claude through the Anthropic API: model, Anthropic API key, prompts, custom tools, feature flags, and token limits. The [Configuration Reference](#configuration-reference) below covers these parameters.
 - `Agent.create(...)` connects that configured adapter to Thenvoi. Use it for the Thenvoi agent identity, Thenvoi API key, platform URLs, session settings, contact-event handling, callbacks, and preprocessing.
 
-`api_key` appears in both places, but it means different things:
+These two credentials have different names by design:
 
 | Put it here | Value |
 |-------------|-------|
-| `AnthropicAdapter(api_key=...)` | Anthropic API key. Optional when `ANTHROPIC_API_KEY` is set. |
+| `AnthropicAdapter(provider_key=...)` | Anthropic API key. Optional when `ANTHROPIC_API_KEY` is set. |
 | `Agent.create(api_key=...)` | Thenvoi platform API key. Required unless you load it from config. |
 
 Common `Agent.create(...)` parameters:
@@ -89,7 +89,7 @@ This section covers `AnthropicAdapter(...)` constructor parameters. Pass these d
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `model` | `str` | `"claude-sonnet-4-5-20250929"` | Anthropic model ID. |
-| `api_key` | `str \| None` | `None` | Anthropic API key. When omitted, the Anthropic SDK reads `ANTHROPIC_API_KEY`. |
+| `provider_key` | `str \| None` | `None` | Anthropic API key. When omitted, the Anthropic SDK reads `ANTHROPIC_API_KEY`. |
 | `prompt` | `str \| None` | `None` | Custom instructions appended after Thenvoi's base collaboration instructions. |
 | `system_prompt` | `str \| None` | `None` | Replaces the whole system prompt. When set, `prompt`, `include_base_instructions`, and memory/contact instruction sections are bypassed. Tools are still exposed according to `features`, so include your own Thenvoi tool-use instructions. |
 | `include_base_instructions` | `bool` | `True` | Include Thenvoi's base collaboration instructions. Only used when `system_prompt` is not set. |

--- a/examples/gemini/01_basic_agent.py
+++ b/examples/gemini/01_basic_agent.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 async def main() -> None:
     # Create adapter with Gemini settings
-    # Requires GEMINI_API_KEY environment variable or pass api_key explicitly
+    # Requires GEMINI_API_KEY environment variable or pass provider_key explicitly
     adapter = GeminiAdapter(
         model="gemini-2.5-flash",
         prompt="You are a helpful assistant. Be concise and friendly.",

--- a/examples/letta/01_basic_agent.py
+++ b/examples/letta/01_basic_agent.py
@@ -74,7 +74,7 @@ async def main() -> None:
             # Letta Cloud by default; override with LETTA_BASE_URL for self-hosted
             base_url=os.getenv("LETTA_BASE_URL", "https://api.letta.com"),
             # Required for Letta Cloud, optional for self-hosted
-            api_key=os.getenv("LETTA_API_KEY"),
+            provider_key=os.getenv("LETTA_API_KEY"),
             # Letta Cloud project scoping (optional)
             project=os.getenv("LETTA_PROJECT"),
             # LLM model to use

--- a/src/thenvoi/adapters/anthropic.py
+++ b/src/thenvoi/adapters/anthropic.py
@@ -63,7 +63,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
     def __init__(
         self,
         model: str = "claude-sonnet-4-5-20250929",
-        api_key: str | None = None,
+        provider_key: str | None = None,
         system_prompt: str | None = None,
         prompt: str | None = None,
         max_tokens: int = 4096,
@@ -72,23 +72,34 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
         features: AdapterFeatures | None = None,
         include_base_instructions: bool = True,
         # --- Deprecated (one release, then remove) ---
+        api_key: str | None = None,
         anthropic_api_key: str | None = None,
         custom_section: str | None = None,
         enable_execution_reporting: bool = False,
         enable_memory_tools: bool = False,
     ):
-        # --- Selective: api_key rename ---
+        # --- Selective: provider_key rename ---
         if anthropic_api_key is not None:
             warnings.warn(
-                "anthropic_api_key is deprecated, use api_key instead",
+                "anthropic_api_key is deprecated, use provider_key instead",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            if api_key is not None:
+            if provider_key is not None or api_key is not None:
                 raise ThenvoiConfigError(
-                    "Cannot pass both api_key and anthropic_api_key"
+                    "Cannot pass anthropic_api_key together with provider_key or api_key"
                 )
-            api_key = anthropic_api_key
+            provider_key = anthropic_api_key
+
+        if api_key is not None:
+            warnings.warn(
+                "api_key is deprecated on AnthropicAdapter, use provider_key instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if provider_key is not None:
+                raise ThenvoiConfigError("Cannot pass both provider_key and api_key")
+            provider_key = api_key
 
         # --- Selective: prompt rename ---
         if custom_section is not None:
@@ -134,7 +145,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
         self.max_tokens = max_tokens
 
         # Anthropic client (uses ANTHROPIC_API_KEY env var if not provided)
-        self.client = AsyncAnthropic(api_key=api_key)
+        self.client = AsyncAnthropic(api_key=provider_key)
 
         # Per-room conversation history (Anthropic SDK is stateless)
         self._message_history: dict[str, list[dict[str, Any]]] = {}

--- a/src/thenvoi/adapters/gemini.py
+++ b/src/thenvoi/adapters/gemini.py
@@ -70,7 +70,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
     def __init__(
         self,
         model: str = "gemini-2.5-flash",
-        api_key: str | None = None,
+        provider_key: str | None = None,
         system_prompt: str | None = None,
         prompt: str | None = None,
         max_output_tokens: int | None = None,
@@ -84,21 +84,34 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
         features: AdapterFeatures | None = None,
         include_base_instructions: bool = True,
         # --- Deprecated (one release, then remove) ---
+        api_key: str | None = None,
         gemini_api_key: str | None = None,
         custom_section: str | None = None,
         enable_execution_reporting: bool = False,
         enable_memory_tools: bool = False,
     ) -> None:
-        # --- Selective: api_key rename ---
+        # --- Selective: provider_key rename ---
         if gemini_api_key is not None:
             warnings.warn(
-                "gemini_api_key is deprecated, use api_key instead",
+                "gemini_api_key is deprecated, use provider_key instead",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            if api_key is not None:
-                raise ThenvoiConfigError("Cannot pass both api_key and gemini_api_key")
-            api_key = gemini_api_key
+            if provider_key is not None or api_key is not None:
+                raise ThenvoiConfigError(
+                    "Cannot pass gemini_api_key together with provider_key or api_key"
+                )
+            provider_key = gemini_api_key
+
+        if api_key is not None:
+            warnings.warn(
+                "api_key is deprecated on GeminiAdapter, use provider_key instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if provider_key is not None:
+                raise ThenvoiConfigError("Cannot pass both provider_key and api_key")
+            provider_key = api_key
 
         # --- Selective: prompt rename ---
         if custom_section is not None:
@@ -148,7 +161,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
         self.retry_base_delay_s = retry_base_delay_s
         self.max_history_messages = max_history_messages
 
-        self._api_key = api_key
+        self._provider_key = provider_key
         self.client: genai.Client | None = None
         self._message_history: dict[str, GeminiMessages] = {}
         self._system_prompt: str = ""
@@ -334,7 +347,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
             return self.client
 
         try:
-            self.client = genai.Client(api_key=self._api_key)
+            self.client = genai.Client(api_key=self._provider_key)
         except ValueError as e:
             raise ValueError(
                 "Gemini client initialization failed. Either set GOOGLE_API_KEY "

--- a/src/thenvoi/adapters/letta.py
+++ b/src/thenvoi/adapters/letta.py
@@ -61,9 +61,9 @@ class LettaAdapterConfig:
     """Configuration for the Letta adapter.
 
     Works with both Letta Cloud and self-hosted Letta.  For Letta Cloud
-    (the default), provide an ``api_key`` and optionally set ``project``
+    (the default), provide a ``provider_key`` and optionally set ``project``
     to scope to a specific project.  For self-hosted, set ``base_url``
-    to your server (e.g. ``"http://localhost:8283"``) — no ``api_key``
+    to your server (e.g. ``"http://localhost:8283"``) — no ``provider_key``
     is required.
 
     Note: The ``mcp_server_url`` is called by the Letta server, not by
@@ -75,7 +75,8 @@ class LettaAdapterConfig:
 
     agent_id: str | None = None
     model: str | None = None
-    api_key: str | None = None  # Required for Letta Cloud, optional for self-hosted
+    provider_key: str | None = None  # Required for Letta Cloud; omit for self-hosted
+    api_key: str | None = None  # deprecated, use provider_key
     base_url: str = "https://api.letta.com"
     custom_section: str = ""
     include_base_instructions: bool = True
@@ -97,6 +98,18 @@ class LettaAdapterConfig:
     # Operating mode: per_room creates one Letta agent per room,
     # shared uses one agent with per-room Conversations for isolation.
     mode: Literal["per_room", "shared"] = "per_room"
+
+    def __post_init__(self) -> None:
+        if self.api_key is not None:
+            warnings.warn(
+                "api_key is deprecated on LettaAdapterConfig, use provider_key instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if self.provider_key is not None:
+                raise ThenvoiConfigError("Cannot pass both provider_key and api_key")
+            self.provider_key = self.api_key
+            self.api_key = None
 
 
 @dataclass
@@ -125,7 +138,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
     Example (Letta Cloud):
         adapter = LettaAdapter(
             config=LettaAdapterConfig(
-                api_key="your-letta-api-key",
+                provider_key="your-letta-api-key",
                 model="openai/gpt-5.4",
                 mcp_server_url="http://localhost:8002/sse",
             ),
@@ -243,8 +256,8 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         client_kwargs: dict[str, Any] = {
             "base_url": self.config.base_url,
         }
-        if self.config.api_key:
-            client_kwargs["api_key"] = self.config.api_key
+        if self.config.provider_key:
+            client_kwargs["api_key"] = self.config.provider_key
         if self.config.project:
             client_kwargs["project"] = self.config.project
         self._client = AsyncLetta(**client_kwargs)

--- a/tests/adapters/test_deprecation_shims.py
+++ b/tests/adapters/test_deprecation_shims.py
@@ -229,17 +229,53 @@ class TestSelectiveRenameShims:
         with pytest.warns(DeprecationWarning, match="anthropic_api_key"):
             AnthropicAdapter(anthropic_api_key="sk-test-key")
 
+    def test_anthropic_anthropic_api_key_resolves_to_provider_key(self) -> None:
+        from unittest.mock import patch
+
+        from thenvoi.adapters.anthropic import AnthropicAdapter
+
+        with patch("thenvoi.adapters.anthropic.AsyncAnthropic") as mock_cls:
+            with pytest.warns(DeprecationWarning, match="anthropic_api_key"):
+                AnthropicAdapter(anthropic_api_key="sk-old-key")
+        mock_cls.assert_called_once_with(api_key="sk-old-key")
+
+    def test_anthropic_api_key_warns(self) -> None:
+        from thenvoi.adapters.anthropic import AnthropicAdapter
+
+        with pytest.warns(
+            DeprecationWarning, match="api_key.*deprecated.*provider_key"
+        ):
+            AnthropicAdapter(api_key="sk-test-key")
+
+    def test_anthropic_api_key_resolves_to_provider_key(self) -> None:
+        from unittest.mock import patch
+
+        from thenvoi.adapters.anthropic import AnthropicAdapter
+
+        with patch("thenvoi.adapters.anthropic.AsyncAnthropic") as mock_cls:
+            with pytest.warns(
+                DeprecationWarning, match="api_key.*deprecated.*provider_key"
+            ):
+                AnthropicAdapter(api_key="sk-test-key")
+        mock_cls.assert_called_once_with(api_key="sk-test-key")
+
     def test_anthropic_custom_section_warns(self) -> None:
         from thenvoi.adapters.anthropic import AnthropicAdapter
 
         with pytest.warns(DeprecationWarning, match="custom_section"):
             AnthropicAdapter(custom_section="Be helpful.")
 
-    def test_anthropic_api_key_and_anthropic_api_key_conflict(self) -> None:
+    def test_anthropic_provider_key_and_api_key_conflict(self) -> None:
         from thenvoi.adapters.anthropic import AnthropicAdapter
 
         with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
-            AnthropicAdapter(api_key="sk-new", anthropic_api_key="sk-old")
+            AnthropicAdapter(provider_key="sk-new", api_key="sk-old")
+
+    def test_anthropic_anthropic_api_key_and_provider_key_conflict(self) -> None:
+        from thenvoi.adapters.anthropic import AnthropicAdapter
+
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass"):
+            AnthropicAdapter(provider_key="sk-new", anthropic_api_key="sk-old")
 
     def test_anthropic_prompt_and_custom_section_conflict(self) -> None:
         from thenvoi.adapters.anthropic import AnthropicAdapter
@@ -253,23 +289,73 @@ class TestSelectiveRenameShims:
         with pytest.warns(DeprecationWarning, match="gemini_api_key"):
             GeminiAdapter(gemini_api_key="AIza-test-key")
 
+    def test_gemini_gemini_api_key_resolves_to_provider_key(self) -> None:
+        from thenvoi.adapters.gemini import GeminiAdapter
+
+        with pytest.warns(DeprecationWarning, match="gemini_api_key"):
+            adapter = GeminiAdapter(gemini_api_key="AIza-old-key")
+        assert adapter._provider_key == "AIza-old-key"
+
+    def test_gemini_api_key_warns(self) -> None:
+        from thenvoi.adapters.gemini import GeminiAdapter
+
+        with pytest.warns(
+            DeprecationWarning, match="api_key.*deprecated.*provider_key"
+        ):
+            GeminiAdapter(api_key="AIza-test-key")
+
+    def test_gemini_api_key_resolves_to_provider_key(self) -> None:
+        from thenvoi.adapters.gemini import GeminiAdapter
+
+        with pytest.warns(
+            DeprecationWarning, match="api_key.*deprecated.*provider_key"
+        ):
+            adapter = GeminiAdapter(api_key="AIza-test-key")
+        assert adapter._provider_key == "AIza-test-key"
+
     def test_gemini_custom_section_warns(self) -> None:
         from thenvoi.adapters.gemini import GeminiAdapter
 
         with pytest.warns(DeprecationWarning, match="custom_section"):
             GeminiAdapter(custom_section="Be concise.")
 
-    def test_gemini_api_key_and_gemini_api_key_conflict(self) -> None:
+    def test_gemini_provider_key_and_api_key_conflict(self) -> None:
         from thenvoi.adapters.gemini import GeminiAdapter
 
         with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
-            GeminiAdapter(api_key="AIza-new", gemini_api_key="AIza-old")
+            GeminiAdapter(provider_key="AIza-new", api_key="AIza-old")
+
+    def test_gemini_gemini_api_key_and_provider_key_conflict(self) -> None:
+        from thenvoi.adapters.gemini import GeminiAdapter
+
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass"):
+            GeminiAdapter(provider_key="AIza-new", gemini_api_key="AIza-old")
 
     def test_gemini_prompt_and_custom_section_conflict(self) -> None:
         from thenvoi.adapters.gemini import GeminiAdapter
 
         with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
             GeminiAdapter(prompt="new", custom_section="old")
+
+
+class TestLettaApiKeyShim:
+    """LettaAdapterConfig.api_key must warn and resolve to provider_key."""
+
+    def test_letta_api_key_warns(self) -> None:
+        from thenvoi.adapters.letta import LettaAdapterConfig
+
+        with pytest.warns(
+            DeprecationWarning, match="api_key.*deprecated.*provider_key"
+        ):
+            config = LettaAdapterConfig(api_key="letta-key")
+        assert config.provider_key == "letta-key"
+        assert config.api_key is None
+
+    def test_letta_provider_key_and_api_key_conflict(self) -> None:
+        from thenvoi.adapters.letta import LettaAdapterConfig
+
+        with pytest.raises(ThenvoiConfigError, match="Cannot pass both"):
+            LettaAdapterConfig(provider_key="new-key", api_key="old-key")
 
 
 class TestOpencodeDeprecationShims:

--- a/tests/adapters/test_gemini_adapter.py
+++ b/tests/adapters/test_gemini_adapter.py
@@ -72,7 +72,7 @@ def _response_with_function_call(
 class TestOnStarted:
     @pytest.mark.asyncio
     async def test_renders_system_prompt(self):
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
         await adapter.on_started(agent_name="TestBot", agent_description="A test bot")
         assert adapter._system_prompt != ""
         assert "TestBot" in adapter._system_prompt
@@ -81,7 +81,7 @@ class TestOnStarted:
     async def test_uses_custom_system_prompt_when_provided(self):
         adapter = GeminiAdapter(
             system_prompt="Custom prompt here.",
-            gemini_api_key="test-key",
+            provider_key="test-key",
         )
         await adapter.on_started(agent_name="TestBot", agent_description="A test bot")
         assert adapter._system_prompt == "Custom prompt here."
@@ -90,7 +90,7 @@ class TestOnStarted:
 class TestOnMessage:
     @pytest.mark.asyncio
     async def test_initializes_history_on_bootstrap(self, sample_message, mock_tools):
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
         await adapter.on_started("TestBot", "Test bot")
 
         with patch.object(
@@ -112,7 +112,7 @@ class TestOnMessage:
     async def test_executes_tool_loop(self, sample_message, mock_tools):
         adapter = GeminiAdapter(
             enable_execution_reporting=True,
-            gemini_api_key="test-key",
+            provider_key="test-key",
         )
         await adapter.on_started("TestBot", "Test bot")
 
@@ -150,7 +150,7 @@ class TestOnMessage:
     ):
         adapter = GeminiAdapter(
             enable_execution_reporting=True,
-            gemini_api_key="test-key",
+            provider_key="test-key",
         )
         await adapter.on_started("TestBot", "Test bot")
         mock_tools.send_event.side_effect = Exception("403 Forbidden")
@@ -180,7 +180,7 @@ class TestOnMessage:
         mock_tools.execute_tool_call.assert_called_once()
 
     def test_extract_candidate_content_preserves_function_call_id_in_fallback(self):
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
         response = MagicMock()
         response.candidates = [MagicMock(content=None)]
         response.function_calls = [
@@ -205,7 +205,7 @@ class TestRetries:
         adapter = GeminiAdapter(
             max_retries=1,
             retry_base_delay_s=0,
-            gemini_api_key="test-key",
+            provider_key="test-key",
         )
         adapter._system_prompt = "system"
         adapter.client = MagicMock()
@@ -243,7 +243,7 @@ class TestCustomTools:
 
         adapter = GeminiAdapter(
             additional_tools=[(EchoInput, echo_tool)],
-            gemini_api_key="test-key",
+            provider_key="test-key",
         )
         function_calls = [
             types.FunctionCall(name="echo", args={"text": "hello"}, id="c1")
@@ -261,7 +261,7 @@ class TestCustomTools:
 class TestOnCleanup:
     @pytest.mark.asyncio
     async def test_removes_room_history(self):
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
         adapter._message_history["room-1"] = [
             types.Content(role="user", parts=[types.Part.from_text(text="hi")])
         ]
@@ -270,7 +270,7 @@ class TestOnCleanup:
 
     @pytest.mark.asyncio
     async def test_cleanup_twice_is_idempotent(self):
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
         adapter._message_history["room-1"] = []
         await adapter.on_cleanup("room-1")
         await adapter.on_cleanup("room-1")  # Should not raise
@@ -278,12 +278,12 @@ class TestOnCleanup:
 
     @pytest.mark.asyncio
     async def test_cleanup_unknown_room_is_noop(self):
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
         await adapter.on_cleanup("nonexistent-room")  # Should not raise
         assert "nonexistent-room" not in adapter._message_history
 
     def test_trim_history_caps_at_max(self):
-        adapter = GeminiAdapter(gemini_api_key="test-key", max_history_messages=5)
+        adapter = GeminiAdapter(provider_key="test-key", max_history_messages=5)
         adapter._message_history["room-1"] = [
             types.Content(role="user", parts=[types.Part.from_text(text=f"msg-{i}")])
             for i in range(10)
@@ -294,7 +294,7 @@ class TestOnCleanup:
         assert adapter._message_history["room-1"][0].parts[0].text == "msg-5"
 
     def test_trim_history_noop_when_under_limit(self):
-        adapter = GeminiAdapter(gemini_api_key="test-key", max_history_messages=50)
+        adapter = GeminiAdapter(provider_key="test-key", max_history_messages=50)
         adapter._message_history["room-1"] = [
             types.Content(role="user", parts=[types.Part.from_text(text="hi")])
         ]
@@ -302,7 +302,7 @@ class TestOnCleanup:
         assert len(adapter._message_history["room-1"]) == 1
 
     def test_trim_history_drops_leading_model_entry(self):
-        adapter = GeminiAdapter(gemini_api_key="test-key", max_history_messages=3)
+        adapter = GeminiAdapter(provider_key="test-key", max_history_messages=3)
         adapter._message_history["room-1"] = [
             types.Content(role="user", parts=[types.Part.from_text(text="msg-0")]),
             types.Content(role="model", parts=[types.Part.from_text(text="reply-0")]),
@@ -320,7 +320,7 @@ class TestOnCleanup:
         assert trimmed[1].parts[0].text == "reply-1"
 
     def test_trim_history_strips_orphaned_leading_tool_response_parts(self):
-        adapter = GeminiAdapter(gemini_api_key="test-key", max_history_messages=3)
+        adapter = GeminiAdapter(provider_key="test-key", max_history_messages=3)
         adapter._message_history["room-1"] = [
             types.Content(role="user", parts=[types.Part.from_text(text="msg-0")]),
             types.Content(
@@ -361,7 +361,7 @@ class TestOnCleanup:
 
     @pytest.mark.asyncio
     async def test_cleanup_before_any_messages(self):
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
         await adapter.on_started("TestBot", "Test bot")
         await adapter.on_cleanup("room-never-used")  # Should not raise
 
@@ -371,7 +371,7 @@ class TestValidationErrorHandling:
     async def test_validation_error_returns_friendly_message(self, mock_tools):
         from pydantic import ValidationError
 
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
 
         mock_tools.execute_tool_call = AsyncMock(
             side_effect=ValidationError.from_exception_data(
@@ -406,7 +406,7 @@ class TestMaxToolRounds:
     ):
         adapter = GeminiAdapter(
             max_tool_rounds=2,
-            gemini_api_key="test-key",
+            provider_key="test-key",
         )
         await adapter.on_started("TestBot", "Test bot")
 
@@ -438,7 +438,7 @@ class TestHttpxRetries:
         adapter = GeminiAdapter(
             max_retries=1,
             retry_base_delay_s=0,
-            gemini_api_key="test-key",
+            provider_key="test-key",
         )
         adapter._system_prompt = "system"
         adapter.client = MagicMock()
@@ -469,7 +469,7 @@ class TestHttpxRetries:
         adapter = GeminiAdapter(
             max_retries=1,
             retry_base_delay_s=0,
-            gemini_api_key="test-key",
+            provider_key="test-key",
         )
         adapter._system_prompt = "system"
         adapter.client = MagicMock()
@@ -500,7 +500,7 @@ class TestHttpxRetries:
         adapter = GeminiAdapter(
             max_retries=1,
             retry_base_delay_s=0,
-            gemini_api_key="test-key",
+            provider_key="test-key",
         )
         adapter._system_prompt = "system"
         adapter.client = MagicMock()
@@ -529,7 +529,7 @@ class TestParticipantsContactsInjection:
     async def test_participants_msg_injected_into_history(
         self, sample_message, mock_tools
     ):
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
         await adapter.on_started("TestBot", "Test bot")
 
         with patch.object(
@@ -551,7 +551,7 @@ class TestParticipantsContactsInjection:
 
     @pytest.mark.asyncio
     async def test_contacts_msg_injected_into_history(self, sample_message, mock_tools):
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
         await adapter.on_started("TestBot", "Test bot")
 
         with patch.object(
@@ -574,7 +574,7 @@ class TestParticipantsContactsInjection:
     async def test_both_participants_and_contacts_injected(
         self, sample_message, mock_tools
     ):
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
         await adapter.on_started("TestBot", "Test bot")
 
         with patch.object(
@@ -601,7 +601,7 @@ class TestParticipantsContactsInjection:
 
 class TestEmptyCandidates:
     def test_extract_candidate_content_returns_none_for_empty_response(self):
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
         response = MagicMock()
         response.candidates = []
         response.function_calls = []
@@ -610,7 +610,7 @@ class TestEmptyCandidates:
         assert content is None
 
     def test_extract_candidate_content_returns_none_when_no_candidates(self):
-        adapter = GeminiAdapter(gemini_api_key="test-key")
+        adapter = GeminiAdapter(provider_key="test-key")
         response = MagicMock()
         response.candidates = None
         response.function_calls = []

--- a/tests/adapters/test_letta_adapter.py
+++ b/tests/adapters/test_letta_adapter.py
@@ -136,7 +136,7 @@ class TestLettaAdapterInit:
         adapter = LettaAdapter()
         assert adapter.config == LettaAdapterConfig()
         assert adapter.config.base_url == "https://api.letta.com"
-        assert adapter.config.api_key is None
+        assert adapter.config.provider_key is None
         assert adapter.config.project is None
         assert adapter.config.mode == "per_room"
         assert adapter.config.mcp_server_url == "http://localhost:8002/sse"
@@ -145,14 +145,14 @@ class TestLettaAdapterInit:
     def test_custom_config(self) -> None:
         config = LettaAdapterConfig(
             base_url="http://custom:8283",
-            api_key="sk-test",
+            provider_key="sk-test",
             mode="shared",
             mcp_server_url="http://mcp:9000/sse",
             enable_execution_reporting=True,
         )
         adapter = LettaAdapter(config=config)
         assert adapter.config.base_url == "http://custom:8283"
-        assert adapter.config.api_key == "sk-test"
+        assert adapter.config.provider_key == "sk-test"
         assert adapter.config.mode == "shared"
         assert adapter.config.enable_execution_reporting is True
 
@@ -160,7 +160,7 @@ class TestLettaAdapterInit:
         """Default config targets Letta Cloud."""
         config = LettaAdapterConfig()
         assert config.base_url == "https://api.letta.com"
-        assert config.api_key is None
+        assert config.provider_key is None
         assert config.project is None
 
     def test_no_client_tools_attribute(self) -> None:
@@ -210,11 +210,11 @@ class TestLettaAdapterOnStarted:
 
     @pytest.mark.asyncio
     async def test_on_started_forwards_cloud_params(self) -> None:
-        """api_key and project are forwarded to AsyncLetta when configured."""
+        """provider_key and project are forwarded to AsyncLetta when configured."""
         adapter = LettaAdapter(
             config=LettaAdapterConfig(
                 base_url="https://api.letta.com",
-                api_key="letta-key-123",
+                provider_key="letta-key-123",
                 project="my-project",
             )
         )


### PR DESCRIPTION
## Summary

* Renames `api_key` → `provider_key` on `AnthropicAdapter`, `GeminiAdapter`, and `LettaAdapterConfig` to disambiguate the LLM provider credential from the Thenvoi platform key (`Agent.create(api_key=...)`).
* Keeps `api_key` (and the existing `anthropic_api_key` / `gemini_api_key`) as deprecated aliases with `DeprecationWarning` and conflict guards — no breaking change.
* Updates docs, examples, and tests; adds resolution-verification tests so the shim is guaranteed to forward the value, not just warn.

Closes [INT-518](https://linear.app/thenvoi/issue/INT-518/rename-adapter-api-key-to-provider-key).

### Deprecation chain

```
anthropic_api_key (deprecated) ─┐
                                ├─→ provider_key (current)
api_key           (deprecated) ─┘
```

### Out of scope (intentionally kept as `api_key`)

* `Agent.create(api_key=...)` — unambiguous in context, always the Thenvoi platform key.
* `A2AGatewayAdapter(api_key=...)` and `ThenvoiACPServerAdapter(api_key=...)` — these are Thenvoi REST auth keys, semantically the same as `Agent.create(api_key=...)`.

## Test plan

- [X] `uv run pytest tests/adapters/test_deprecation_shims.py -v` — 45 passed, 1 skipped
- [X] `uv run pytest tests/adapters/test_anthropic_adapter.py tests/adapters/test_gemini_adapter.py tests/adapters/test_letta_adapter.py -v` — 101 passed
- [X] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/` — 2935 passed (parlant failures pre-existing, unrelated)
- [X] `uv run ruff check . && uv run ruff format --check .` — clean
- [X] `uv run pyrefly check` on changed files — 0 errors
- [X] Manual sanity: confirm `AnthropicAdapter(provider_key=...)`, `AnthropicAdapter(api_key=...)` (warns), `AnthropicAdapter(anthropic_api_key=...)` (warns) all reach `AsyncAnthropic` correctly. Same for `GeminiAdapter` and `LettaAdapterConfig`.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)