### PR TITLE
ci: add promote dev to main workflow and CI/CD docs

### DIFF
--- a/.github/workflows/promote-dev-to-main.yml
+++ b/.github/workflows/promote-dev-to-main.yml
@@ -3,8 +3,6 @@ name: Promote Dev to Main
 run-name: Promote dev to main by @${{ github.actor }}
 
 on:
-  push:
-    branches: [ci/promote-dev-to-main-workflow]   # TEMP test trigger — remove before merge
   workflow_dispatch:
     inputs:
       dry_run:
@@ -102,7 +100,7 @@ jobs:
           cat pr_body.md
 
       - name: Create Pull Request
-        if: steps.check_promotion.outputs.needs_promotion == 'true' && inputs.dry_run == false && github.event_name != 'push'   # TEMP guard — never create a PR during push test
+        if: steps.check_promotion.outputs.needs_promotion == 'true' && inputs.dry_run == false
         env:
           GH_TOKEN: ${{ steps.app_token_generator.outputs.token }}
         run: |

--- a/.github/workflows/promote-dev-to-main.yml
+++ b/.github/workflows/promote-dev-to-main.yml
@@ -23,6 +23,12 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: dev
+
       - name: Generate GitHub App Token
         id: app_token_generator
         uses: ./.github/actions/GithubToken
@@ -30,13 +36,6 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           installation_id: ${{ secrets.INSTALLATION_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          token: ${{ steps.app_token_generator.outputs.token }}
-          ref: dev
 
       - name: Fetch main
         run: git fetch origin main

--- a/.github/workflows/promote-dev-to-main.yml
+++ b/.github/workflows/promote-dev-to-main.yml
@@ -11,6 +11,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: promote-dev-to-main
+  cancel-in-progress: false
+
 jobs:
   promote:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote-dev-to-main.yml
+++ b/.github/workflows/promote-dev-to-main.yml
@@ -3,6 +3,8 @@ name: Promote Dev to Main
 run-name: Promote dev to main by @${{ github.actor }}
 
 on:
+  push:
+    branches: [ci/promote-dev-to-main-workflow]   # TEMP test trigger — remove before merge
   workflow_dispatch:
     inputs:
       dry_run:
@@ -27,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: dev
+          ref: ci/promote-dev-to-main-workflow   # TEMP — restore to `dev` before merge
 
       - name: Generate GitHub App Token
         id: app_token_generator
@@ -100,7 +102,7 @@ jobs:
           cat pr_body.md
 
       - name: Create Pull Request
-        if: steps.check_promotion.outputs.needs_promotion == 'true' && inputs.dry_run == false
+        if: steps.check_promotion.outputs.needs_promotion == 'true' && inputs.dry_run == false && github.event_name != 'push'   # TEMP guard — never create a PR during push test
         env:
           GH_TOKEN: ${{ steps.app_token_generator.outputs.token }}
         run: |

--- a/.github/workflows/promote-dev-to-main.yml
+++ b/.github/workflows/promote-dev-to-main.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ci/promote-dev-to-main-workflow   # TEMP — restore to `dev` before merge
+          ref: dev
 
       - name: Generate GitHub App Token
         id: app_token_generator

--- a/.github/workflows/promote-dev-to-main.yml
+++ b/.github/workflows/promote-dev-to-main.yml
@@ -1,0 +1,125 @@
+name: Promote Dev to Main
+
+run-name: Promote dev to main by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (just generate the PR description without creating the PR)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Generate GitHub App Token
+        id: app_token_generator
+        uses: ./.github/actions/GithubToken
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          installation_id: ${{ secrets.INSTALLATION_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app_token_generator.outputs.token }}
+          ref: dev
+
+      - name: Fetch main
+        run: git fetch origin main
+
+      - name: Check if promotion is needed
+        id: check_promotion
+        run: |
+          COMMITS_AHEAD=$(git rev-list --count origin/main..dev)
+
+          if [ "$COMMITS_AHEAD" -eq 0 ]; then
+            echo "No commits to promote from dev to main"
+            echo "needs_promotion=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "needs_promotion=true" >> $GITHUB_OUTPUT
+          echo "commits_ahead=$COMMITS_AHEAD" >> $GITHUB_OUTPUT
+          echo "Found $COMMITS_AHEAD commits to promote from dev to main"
+
+      - name: Generate PR description
+        id: generate_pr
+        if: steps.check_promotion.outputs.needs_promotion == 'true'
+        run: |
+          {
+            echo "## Summary"
+            echo ""
+            echo "Promotes ${{ steps.check_promotion.outputs.commits_ahead }} commit(s) from \`dev\` to \`main\` (production / release)."
+            echo ""
+            echo "## Commits Being Promoted"
+            echo ""
+            git log origin/main..dev --pretty=format:"- **%s** (%h) — %an, %ad" --date=short
+            echo ""
+            echo ""
+            echo "## Files Changed"
+            echo ""
+            echo '```'
+            git diff --stat origin/main...dev
+            echo '```'
+            echo ""
+            echo "## Pull Requests Included"
+            echo ""
+            PRS=$(git log origin/main..dev --grep="#[0-9]\+" --pretty=format:"%s" | grep -oE "#[0-9]+" | sort -u || true)
+            if [ -n "$PRS" ]; then
+              echo "$PRS" | sed 's/^/- /'
+            else
+              echo "- No PR references found in commit messages"
+            fi
+            echo ""
+            echo "---"
+            echo ""
+            echo "**Promotion Details**"
+            echo "- Source: \`dev\`"
+            echo "- Target: \`main\` (production / release)"
+            echo "- Commits: ${{ steps.check_promotion.outputs.commits_ahead }}"
+            echo "- Triggered by: @${{ github.actor }}"
+            echo "- Workflow: [View Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            echo ""
+            echo "Merging this PR triggers \`release.yml\` (release-please) on \`main\`."
+          } > pr_body.md
+
+          echo "Generated PR description:"
+          cat pr_body.md
+
+      - name: Create Pull Request
+        if: steps.check_promotion.outputs.needs_promotion == 'true' && inputs.dry_run == false
+        env:
+          GH_TOKEN: ${{ steps.app_token_generator.outputs.token }}
+        run: |
+          gh pr create \
+            --base main \
+            --head dev \
+            --title "chore: promote dev to main" \
+            --body-file pr_body.md \
+            --assignee "${{ github.actor }}"
+
+      - name: Dry Run Summary
+        if: steps.check_promotion.outputs.needs_promotion == 'true' && inputs.dry_run == true
+        run: |
+          {
+            echo "## 🔍 Dry Run — PR was NOT created"
+            echo ""
+            echo "The PR would have been created with the following description:"
+            echo ""
+            cat pr_body.md
+          } >> $GITHUB_STEP_SUMMARY
+
+      - name: No promotion needed
+        if: steps.check_promotion.outputs.needs_promotion == 'false'
+        run: |
+          echo "## ✅ main is already up to date with dev. No promotion needed." >> $GITHUB_STEP_SUMMARY

--- a/docs/ci-cd-workflows.md
+++ b/docs/ci-cd-workflows.md
@@ -1,0 +1,108 @@
+# CI/CD Workflows Guide
+
+This document explains the GitHub Actions workflows and branch protection used in
+this repository.
+
+## Overview
+
+The repository uses a branch promotion model with two long-lived branches:
+
+```
+feature branches ──(squash)──▶ dev ──(merge)──▶ main (release)
+```
+
+- `dev` — integration branch. All feature work is squash-merged here.
+- `main` — release branch. Merges to `main` trigger an automated PyPI release
+  via release-please.
+
+There is no `staging` branch; promotion is a single hop `dev → main`.
+
+## Branch Protection (GitHub Rulesets)
+
+Protection is enforced with GitHub Rulesets, not classic branch protection.
+
+| Branch | Merge Method | Required Reviews | Stale Dismissed | Thread Resolution | Strict Checks |
+|--------|--------------|------------------|-----------------|-------------------|---------------|
+| `dev`  | Squash only  | 1                | No              | No                | No            |
+| `main` | Merge commit | 1                | Yes             | Yes               | Yes           |
+
+Both branches block deletion and non-fast-forward (force) pushes.
+
+**Required status checks (both branches):**
+
+- `lint`
+- `test (3.11)`
+- `test (3.12)`
+- `packaging`
+- `Validate PR Title`
+
+> `main` uses **strict** required status checks: the PR branch must be up to date
+> with `main` before it can merge.
+
+## PR Workflows
+
+### CI — `ci.yml`
+
+Runs on every PR to `dev` and `main`.
+
+- `lint` — `pre-commit run --all-files`
+- `test` — pytest on Python 3.11 and 3.12
+- `test-parlant` — parlant adapter/converter tests in an isolated extra
+- `packaging` — builds the wheel and verifies core and full imports
+
+### PR Title — `pr-title.yml`
+
+Validates the PR title against Conventional Commits (`Validate PR Title`).
+Skipped for bot actors (dependabot, release-please, the promote workflow's
+GitHub App). Promotion PRs are titled `chore: promote dev to main` so they remain
+valid Conventional Commits if the check does run.
+
+## Release Workflow
+
+### Release — `release.yml`
+
+Triggered on push to `main` (i.e. after a promotion PR merges).
+
+1. release-please opens/updates a release PR, or — when a release PR merges —
+   tags the release and updates the changelog and version.
+2. On a created release, publishes both `thenvoi-sdk` and `band-sdk` to PyPI.
+
+## Promotion Workflow
+
+### Promote Dev to Main — `promote-dev-to-main.yml`
+
+A manual (`workflow_dispatch`) workflow that opens the promotion PR for you.
+
+**How to use:**
+
+1. Go to **Actions → Promote Dev to Main**.
+2. Click **Run workflow**.
+3. Optionally enable **Dry run** to preview the PR description without creating a PR.
+4. Review and merge the created PR (normal review + checks still apply).
+
+**What it does:**
+
+1. Mints a GitHub App token (via the local `./.github/actions/GithubToken` action).
+2. Checks out `dev` and fetches `main`.
+3. Counts commits ahead (`origin/main..dev`). If zero, it reports "already up to
+   date" and creates nothing.
+4. Builds a PR description from git history — commit list, `git diff --stat`,
+   referenced PR numbers, and a metadata footer. (No external AI service is used.)
+5. Creates a PR from `dev` → `main` titled `chore: promote dev to main`, assigned
+   to whoever triggered the run — unless **Dry run** is enabled, in which case the
+   description is printed to the run summary and no PR is created.
+
+The workflow never merges; a human reviews and merges, so all rulesets apply.
+
+## Typical Development Flow
+
+1. Branch off `dev` (e.g. `feat/...-INT-123`).
+2. Open a PR to `dev` → CI + PR-title checks run.
+3. Get 1 approval, **squash** merge to `dev`.
+4. When ready to release, run **Promote Dev to Main** and merge the resulting PR.
+5. The merge to `main` triggers `release.yml`, which publishes to PyPI.
+
+> **Note on strict checks:** because `main` uses strict required status checks, a
+> release commit that release-please lands on `main` will leave `dev` behind. The
+> next `dev → main` promotion PR cannot merge until `dev` contains that commit, so
+> `main` must be brought back into `dev` before promoting again.


### PR DESCRIPTION
## Summary

Adds a one-click **Promote Dev to Main** workflow and documents the repo's CI/CD flow, mirroring the model used in `thenvoi-website` but with a single promotion hop (`dev → main`, no `staging`).

## Changes

- **`.github/workflows/promote-dev-to-main.yml`** — manual `workflow_dispatch` action that:
  - Mints a token via the local `./.github/actions/GithubToken` action
  - Counts commits ahead (`origin/main..dev`); exits cleanly if `main` is already up to date
  - Builds the PR body **from git history** (commit list, `git diff --stat`, referenced PR numbers, metadata footer) — no external AI / no new secrets
  - Opens a `dev → main` PR titled `chore: promote dev to main` (valid Conventional Commits, so it clears the `Validate PR Title` required check), assigned to the triggerer
  - Supports a **`dry_run`** toggle that prints the description to the run summary without creating a PR
  - Never merges — review + rulesets still gate the merge
- **`docs/ci-cd-workflows.md`** — documents `feature → dev → main`, the branch rulesets, all workflows, and how to run the promote action.

## Notes

- `main` uses **strict** required status checks, so after a release-please commit lands on `main`, `dev` must be brought up to date before the next promotion PR can merge. This is documented in the new doc; no automated `main → dev` sync was added (per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)