### PR TITLE
ci: add main→dev back-merge workflow

### DIFF
--- a/.github/workflows/back-merge-main-to-dev.yml
+++ b/.github/workflows/back-merge-main-to-dev.yml
@@ -92,7 +92,17 @@ jobs:
             git checkout -B "$BRANCH" origin/main
           fi
 
-          git push --force-with-lease origin "$BRANCH"
+          # On a dry run, compute the merge locally but don't touch the remote.
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "Dry run: skipping push of $BRANCH."
+            exit 0
+          fi
+
+          # Plain --force (not --force-with-lease): this is a bot-owned throwaway
+          # branch that we recreate from scratch every run, and we never fetch its
+          # remote-tracking ref — so a lease would have nothing to compare against
+          # and would reject every push after the first.
+          git push --force origin "$BRANCH"
 
       - name: Generate PR description
         id: generate_pr

--- a/.github/workflows/back-merge-main-to-dev.yml
+++ b/.github/workflows/back-merge-main-to-dev.yml
@@ -1,0 +1,176 @@
+name: Back-merge Main to Dev
+
+run-name: Back-merge main to dev (${{ github.event_name }})
+
+# release-please cuts releases by committing the version bump + CHANGELOG
+# directly onto `main` (see release.yml). Those commits never exist on `dev`,
+# so `dev` drifts behind `main` after every release and dev->main PRs show
+# "This branch is out-of-date with the base branch". This workflow closes the
+# loop by opening a PR that merges those main-only commits back into `dev`.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (report what would happen without creating the PR)'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: back-merge-main-to-dev
+  cancel-in-progress: false
+
+jobs:
+  back-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Generate GitHub App Token
+        id: app_token_generator
+        uses: ./.github/actions/GithubToken
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          installation_id: ${{ secrets.INSTALLATION_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Fetch dev
+        run: git fetch origin dev
+
+      - name: Check if back-merge is needed
+        id: check
+        run: |
+          COMMITS_AHEAD=$(git rev-list --count origin/dev..origin/main)
+
+          if [ "$COMMITS_AHEAD" -eq 0 ]; then
+            echo "dev already contains every commit on main. Nothing to back-merge."
+            echo "needs_backmerge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "needs_backmerge=true" >> "$GITHUB_OUTPUT"
+          echo "commits_ahead=$COMMITS_AHEAD" >> "$GITHUB_OUTPUT"
+          echo "Found $COMMITS_AHEAD commit(s) on main missing from dev."
+
+      - name: Prepare back-merge branch
+        id: branch
+        if: steps.check.outputs.needs_backmerge == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app_token_generator.outputs.token }}
+        run: |
+          BRANCH="back-merge/main-to-dev"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+          # Start the branch from dev, then merge main into it. Resolving the
+          # merge here (rather than pushing main straight onto dev) keeps any
+          # conflicts off the protected dev branch and lets CI validate the
+          # result before it lands.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH" origin/dev
+
+          if git merge --no-edit origin/main; then
+            echo "conflicts=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "conflicts=true" >> "$GITHUB_OUTPUT"
+            # Capture the conflicting paths, then abort so we push a clean
+            # branch the PR author can rebase/resolve manually.
+            git diff --name-only --diff-filter=U > conflicts.txt || true
+            git merge --abort
+            # Push main as-is so the PR still surfaces the divergence.
+            git checkout -B "$BRANCH" origin/main
+          fi
+
+          git push --force-with-lease origin "$BRANCH"
+
+      - name: Generate PR description
+        id: generate_pr
+        if: steps.check.outputs.needs_backmerge == 'true'
+        run: |
+          {
+            echo "## Summary"
+            echo ""
+            echo "Back-merges ${{ steps.check.outputs.commits_ahead }} commit(s) that exist on \`main\` but not on \`dev\`."
+            echo "These are typically the release-please version bump + CHANGELOG commits produced by \`release.yml\`."
+            echo "Merging this keeps \`dev\` from drifting behind \`main\`."
+            echo ""
+            if [ "${{ steps.branch.outputs.conflicts }}" = "true" ]; then
+              echo "> ⚠️ **Merge conflicts detected.** This branch points at \`main\` as-is;"
+              echo "> resolve the conflicts against \`dev\` before merging. Conflicting files:"
+              echo ""
+              echo '```'
+              cat conflicts.txt 2>/dev/null || echo "(see CI)"
+              echo '```'
+              echo ""
+            fi
+            echo "## Commits Being Back-merged"
+            echo ""
+            git log origin/dev..origin/main --pretty=format:"- **%s** (%h) — %an, %ad" --date=short
+            echo ""
+            echo ""
+            echo "## Files Changed"
+            echo ""
+            echo '```'
+            git diff --stat origin/dev...origin/main
+            echo '```'
+            echo ""
+            echo "---"
+            echo ""
+            echo "**Back-merge Details**"
+            echo "- Source: \`main\` (production / release)"
+            echo "- Target: \`dev\`"
+            echo "- Commits: ${{ steps.check.outputs.commits_ahead }}"
+            echo "- Triggered by: ${{ github.event_name }}"
+            echo "- Workflow: [View Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          } > pr_body.md
+
+          echo "Generated PR description:"
+          cat pr_body.md
+
+      - name: Create or update Pull Request
+        if: steps.check.outputs.needs_backmerge == 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ steps.app_token_generator.outputs.token }}
+        run: |
+          BRANCH="${{ steps.branch.outputs.branch }}"
+
+          EXISTING=$(gh pr list --head "$BRANCH" --base dev --state open --json number --jq '.[0].number' || true)
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing PR #$EXISTING"
+            gh pr edit "$EXISTING" --body-file pr_body.md
+            echo "## ♻️ Updated existing back-merge PR #$EXISTING" >> "$GITHUB_STEP_SUMMARY"
+          else
+            gh pr create \
+              --base dev \
+              --head "$BRANCH" \
+              --title "chore: back-merge main into dev" \
+              --body-file pr_body.md
+            echo "## ✅ Opened back-merge PR (main -> dev)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Dry Run Summary
+        if: steps.check.outputs.needs_backmerge == 'true' && inputs.dry_run == true
+        run: |
+          {
+            echo "## 🔍 Dry Run — PR was NOT created"
+            echo ""
+            echo "The PR would have been created with the following description:"
+            echo ""
+            cat pr_body.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: No back-merge needed
+        if: steps.check.outputs.needs_backmerge == 'false'
+        run: |
+          echo "## ✅ dev is already up to date with main. No back-merge needed." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/back-merge-main-to-dev.yml
+++ b/.github/workflows/back-merge-main-to-dev.yml
@@ -45,6 +45,20 @@ jobs:
           installation_id: ${{ secrets.INSTALLATION_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      # Re-persist credentials as the App token so `git push` authenticates as
+      # the App rather than the default GITHUB_TOKEN. The first checkout (needed
+      # to reach the local ./.github/actions/GithubToken action) persists
+      # GITHUB_TOKEN as an http.extraheader that wins over any token in the
+      # remote URL, so re-checking out with the App token is the reliable way to
+      # swap it. This also lets the back-merge branch push trigger CI on the PR
+      # (GITHUB_TOKEN pushes do not trigger workflows; App-token pushes do).
+      - name: Re-checkout with App token
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ steps.app_token_generator.outputs.token }}
+
       - name: Fetch dev
         run: git fetch origin dev
 
@@ -66,8 +80,6 @@ jobs:
       - name: Prepare back-merge branch
         id: branch
         if: steps.check.outputs.needs_backmerge == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app_token_generator.outputs.token }}
         run: |
           BRANCH="back-merge/main-to-dev"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"

--- a/docs/ci-cd-workflows.md
+++ b/docs/ci-cd-workflows.md
@@ -94,6 +94,37 @@ A manual (`workflow_dispatch`) workflow that opens the promotion PR for you.
 
 The workflow never merges; a human reviews and merges, so all rulesets apply.
 
+## Back-merge Workflow
+
+### Back-merge Main to Dev — `back-merge-main-to-dev.yml`
+
+release-please cuts releases by committing the version bump + `CHANGELOG.md`
+directly onto `main`. Those commits never exist on `dev`, so after every release
+`dev` drifts behind `main` and the next `dev → main` PR shows *"This branch is
+out-of-date with the base branch"* (blocked by `main`'s strict status checks).
+This workflow closes the loop automatically.
+
+**Trigger:** runs on every push to `main` (so it catches release-please commits
+and any direct hotfix), and can also be run manually via `workflow_dispatch`
+(with an optional **Dry run**).
+
+**What it does:**
+
+1. Mints a GitHub App token (via `./.github/actions/GithubToken`).
+2. Counts commits on `main` missing from `dev` (`origin/dev..origin/main`). If
+   zero — e.g. right after a promotion PR merges — it reports "already up to
+   date" and creates nothing.
+3. Builds a `back-merge/main-to-dev` branch from `dev` and merges `main` into it.
+   If the merge is clean it pushes the resolved branch; if it conflicts, it
+   pushes `main` as-is and flags the conflicting files in the PR body so they can
+   be resolved against `dev`.
+4. Opens (or updates, if one is already open) a PR from `back-merge/main-to-dev`
+   → `dev`, titled `chore: back-merge main into dev`.
+
+Resolving the merge on a side branch keeps conflicts off the protected `dev`
+branch and lets CI validate before it lands. Like the promotion workflow, it
+never merges for you — a human reviews and merges, so all `dev` rulesets apply.
+
 ## Typical Development Flow
 
 1. Branch off `dev` (e.g. `feat/...-INT-123`).
@@ -101,8 +132,12 @@ The workflow never merges; a human reviews and merges, so all rulesets apply.
 3. Get 1 approval, **squash** merge to `dev`.
 4. When ready to release, run **Promote Dev to Main** and merge the resulting PR.
 5. The merge to `main` triggers `release.yml`, which publishes to PyPI.
+6. release-please's release commit on `main` triggers `back-merge-main-to-dev.yml`,
+   which opens a PR bringing that commit back into `dev`. Merge it to keep `dev`
+   in sync before the next promotion.
 
 > **Note on strict checks:** because `main` uses strict required status checks, a
-> release commit that release-please lands on `main` will leave `dev` behind. The
-> next `dev → main` promotion PR cannot merge until `dev` contains that commit, so
-> `main` must be brought back into `dev` before promoting again.
+> release commit that release-please lands on `main` will leave `dev` behind, and
+> the next `dev → main` promotion PR cannot merge until `dev` contains that commit.
+> `back-merge-main-to-dev.yml` handles this automatically by opening a `main → dev`
+> PR after each release — merge it before promoting again.


### PR DESCRIPTION
## Summary

Adds `back-merge-main-to-dev.yml` to fix the recurring **"This branch is out-of-date with the base branch"** state on `dev → main` PRs (e.g. #332).

**Root cause:** `release.yml` runs release-please on `main`, which commits the version bump + `CHANGELOG.md` *directly onto `main`*. Those commits never exist on `dev`, so `dev` drifts behind `main` after every release. Because `main` uses **strict** required status checks, the next promotion PR can't merge until `dev` catches up. The other Thenvoi repos (`thenvoi-platform`, `thenvoi-website`) don't hit this only because they have no release-please — nothing is ever committed directly to `main` there.

## What it does

- **Trigger:** push to `main` (catches every release-please commit + hotfixes), plus manual `workflow_dispatch` with a **Dry run** option.
- Counts commits on `main` missing from `dev`; no-ops when `dev` is already current (e.g. right after a promotion merges).
- Resolves the merge on a `back-merge/main-to-dev` side branch — keeping conflicts **off** the protected `dev` branch and letting CI validate before it lands. Clean merges are pushed resolved; conflicts push `main` as-is and list the conflicting files in the PR body.
- Opens (or updates, if already open) a PR `back-merge/main-to-dev → dev`, titled `chore: back-merge main into dev`.
- Never auto-merges — a human reviews and merges, so all `dev` rulesets apply (mirrors `promote-dev-to-main.yml`).

## Notes

- Matches existing conventions: GitHub App token via `./.github/actions/GithubToken`, PR-based, dry-run support, step summaries.
- No loop risk: the back-merge pushes to `dev`/a side branch; `release.yml` only triggers on `main`, and `promote-dev-to-main.yml` is manual-only.
- `docs/ci-cd-workflows.md` updated with a Back-merge section, and the existing "Note on strict checks" now points at the automation instead of describing a manual chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)