### PR TITLE
ci: use standard SemVer for release-please version bumps

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,8 +5,6 @@
     ".": {
       "package-name": "thenvoi-sdk-python",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "extra-files": [
         "src/thenvoi/__init__.py",
         {


### PR DESCRIPTION
## What

Removes the two pre-major flags from `release-please-config.json`:

- `bump-minor-pre-major`
- `bump-patch-for-minor-pre-major`

## Why

These flags made release-please use conservative pre-1.0 versioning while the package sits at `0.x`. We want standard SemVer instead. With both flags gone (defaulting to `false`), bumps follow conventional commits normally regardless of the `0.x` version:

| Commit | Bump | From `0.2.9` |
|---|---|---|
| `fix:` | patch | `0.2.10` |
| `feat:` | minor | `0.3.0` |
| `feat!:` / `BREAKING CHANGE:` | major | `1.0.0` |

## ⚠️ Note

The package is currently at `0.2.9`, so the **next breaking-change commit will bump straight to `1.0.0`**, which conventionally declares the public API stable. That's the intended standard-SemVer behavior, but worth calling out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)