### PR TITLE
fix(sdk): surface CrewAI silent completions

### DIFF
--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -403,6 +403,15 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
                     }
                 )
 
+            if not (reply_tracker is not None and reply_tracker.replied):
+                await self._report_error(
+                    tools,
+                    "CrewAI completed without sending a Band message. This usually "
+                    f"means repeated tool failures exhausted max_iter={self.max_iter} "
+                    "or the agent returned a final answer instead of using the "
+                    "band_send_message tool.",
+                )
+
             logger.info(
                 "Room %s: CrewAI agent completed (output_length=%s)",
                 room_id,

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -415,6 +415,98 @@ class TestErrorHandling:
         mock_tools.send_event.assert_called()
 
     @pytest.mark.asyncio
+    async def test_reports_error_when_crewai_completes_without_reply(
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+    ):
+        """A normal CrewAI return is still silent unless band_send_message ran."""
+        mock_result = MagicMock()
+        mock_result.raw = "I could not complete the request."
+        mock_crewai_agent.kickoff_async.return_value = mock_result
+
+        adapter = CrewAIAdapter()
+        await adapter.on_started("TestBot", "Test bot")
+        adapter._crewai_agent = mock_crewai_agent
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        mock_tools.send_event.assert_awaited_once()
+        event_kwargs = mock_tools.send_event.await_args.kwargs
+        assert event_kwargs["message_type"] == "error"
+        assert "completed without sending a Band message" in event_kwargs["content"]
+        assert "max_iter=20" in event_kwargs["content"]
+        assert "band_send_message" in event_kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_reports_error_when_crewai_returns_none_without_reply(
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+    ):
+        """A falsey CrewAI completion is still silent unless band_send_message ran."""
+        mock_crewai_agent.kickoff_async.return_value = None
+
+        adapter = CrewAIAdapter()
+        await adapter.on_started("TestBot", "Test bot")
+        adapter._crewai_agent = mock_crewai_agent
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        mock_tools.send_event.assert_awaited_once()
+        event_kwargs = mock_tools.send_event.await_args.kwargs
+        assert event_kwargs["message_type"] == "error"
+        assert "completed without sending a Band message" in event_kwargs["content"]
+
+    @pytest.mark.asyncio
+    async def test_does_not_report_completion_error_after_reply(
+        self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
+    ):
+        """A turn is not silent when band_send_message already replied."""
+        import importlib
+
+        module = importlib.import_module("band.adapters.crewai")
+
+        mock_result = MagicMock()
+        mock_result.raw = "I already sent the user-facing reply."
+
+        async def _kickoff(_messages):
+            tracker = module._reply_tracker_var.get()
+            if tracker is not None:
+                tracker.replied = True
+            return mock_result
+
+        mock_crewai_agent.kickoff_async = AsyncMock(side_effect=_kickoff)
+
+        adapter = CrewAIAdapter()
+        await adapter.on_started("TestBot", "Test bot")
+        adapter._crewai_agent = mock_crewai_agent
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        mock_tools.send_event.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_suppresses_empty_final_answer_after_reply(
         self, CrewAIAdapter, sample_message, mock_tools, mock_crewai_agent
     ):


### PR DESCRIPTION
## What changed

The CrewAI adapter now emits a Band `error` event when a CrewAI turn finishes without successfully sending a user-visible Band message.

This covers silent completion cases such as:

- CrewAI exhausting `max_iter` after repeated tool failures
- CrewAI returning a final answer instead of calling `band_send_message`
- CrewAI returning a falsey or `None` result

The adapter uses its per-turn reply tracker to decide whether a Band reply was actually sent. If `band_send_message` already succeeded, no completion error is emitted.

## Why

Before this change, a CrewAI agent could be mentioned, spend iterations, complete the turn, and leave the room with no message or error. Surfacing a Band `error` event makes that failure visible without sending a normal chat reply or waking other agents.

## Validation

```sh
uv run --extra dev-crewai pytest tests/adapters/test_crewai_adapter.py -q
# 73 passed, 11 warnings

uv run ruff check src/band/adapters/crewai.py tests/adapters/test_crewai_adapter.py
uv run ruff format --check src/band/adapters/crewai.py tests/adapters/test_crewai_adapter.py
# both pass
```

New coverage verifies:

- non-empty CrewAI completion without a Band reply emits an error event
- `None` completion without a Band reply emits an error event
- turns that already sent a Band reply do not emit the completion error

Closes INT-489
