### PR TITLE
fix(sdk): avoid duplicate LangGraph platform tool events

### DIFF
--- a/src/band/adapters/langgraph.py
+++ b/src/band/adapters/langgraph.py
@@ -16,6 +16,7 @@ from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from band.converters.langchain import LangChainHistoryConverter, LangChainMessages
+from band.integrations.langgraph.langchain_tools import TOOL_EXECUTION_ERROR_PREFIX
 from band.runtime.prompts import render_system_prompt
 
 if TYPE_CHECKING:
@@ -24,6 +25,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Platform tools whose execution should not be reported as tool_call/tool_result
+# events because the tool call itself already creates visible platform output.
+_SILENT_REPORTING_TOOLS: frozenset[str] = frozenset(
+    {
+        "band_send_message",
+        "band_send_event",
+    }
+)
 
 _BOOTSTRAP_TRACKING_WARN_THRESHOLD = 1000
 
@@ -365,6 +374,9 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
                 return
 
             tool_name = event.get("name", "unknown")
+            if tool_name in _SILENT_REPORTING_TOOLS:
+                return
+
             data = event.get("data") if isinstance(event.get("data"), dict) else {}
             payload = {
                 "name": tool_name,
@@ -386,7 +398,30 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
 
             tool_name = event.get("name", "unknown")
             data = event.get("data") if isinstance(event.get("data"), dict) else {}
-            is_error = event_type == "on_tool_error" or bool(data.get("error"))
+            output = data.get("output", "")
+            wrapper_reported_error = isinstance(output, str) and output.startswith(
+                TOOL_EXECUTION_ERROR_PREFIX
+            )
+            is_error = (
+                event_type == "on_tool_error"
+                or bool(data.get("error"))
+                or wrapper_reported_error
+            )
+
+            if tool_name in _SILENT_REPORTING_TOOLS:
+                if not is_error:
+                    return
+
+                logger.info("[STREAM] platform tool error: %s", tool_name)
+                try:
+                    await tools.send_event(
+                        content=f"{tool_name} failed: {data.get('error') or output or 'unknown error'}",
+                        message_type="error",
+                    )
+                except Exception as e:
+                    logger.warning("Failed to send platform tool error event: %s", e)
+                return
+
             payload = {
                 "name": tool_name,
                 "output": data.get("error") or data.get("output", ""),

--- a/src/band/adapters/langgraph.py
+++ b/src/band/adapters/langgraph.py
@@ -18,6 +18,7 @@ from band.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from band.converters.langchain import LangChainHistoryConverter, LangChainMessages
 from band.integrations.langgraph.langchain_tools import TOOL_EXECUTION_ERROR_PREFIX
 from band.runtime.prompts import render_system_prompt
+from band.runtime.tools import TOOL_VALIDATION_ERROR_PREFIX
 
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
@@ -35,6 +36,17 @@ _SILENT_REPORTING_TOOLS: frozenset[str] = frozenset(
 )
 
 _BOOTSTRAP_TRACKING_WARN_THRESHOLD = 1000
+
+
+def _tool_output_text(output: Any) -> str:
+    content = getattr(output, "content", output)
+    if isinstance(content, str):
+        return content
+    return json.dumps(content, default=str)
+
+
+def _tool_output_has_error_status(output: Any) -> bool:
+    return getattr(output, "status", None) == "error"
 
 
 class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
@@ -399,13 +411,17 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
             tool_name = event.get("name", "unknown")
             data = event.get("data") if isinstance(event.get("data"), dict) else {}
             output = data.get("output", "")
-            wrapper_reported_error = isinstance(output, str) and output.startswith(
-                TOOL_EXECUTION_ERROR_PREFIX
+            output_text = _tool_output_text(output)
+            wrapper_reported_error = output_text.startswith(TOOL_EXECUTION_ERROR_PREFIX)
+            validation_reported_error = output_text.startswith(
+                f"{TOOL_VALIDATION_ERROR_PREFIX}{tool_name}:"
             )
             is_error = (
                 event_type == "on_tool_error"
                 or bool(data.get("error"))
+                or _tool_output_has_error_status(output)
                 or wrapper_reported_error
+                or validation_reported_error
             )
 
             if tool_name in _SILENT_REPORTING_TOOLS:
@@ -415,7 +431,7 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
                 logger.info("[STREAM] platform tool error: %s", tool_name)
                 try:
                     await tools.send_event(
-                        content=f"{tool_name} failed: {data.get('error') or output or 'unknown error'}",
+                        content=f"{tool_name} failed: {data.get('error') or output_text or 'unknown error'}",
                         message_type="error",
                     )
                 except Exception as e:
@@ -424,7 +440,7 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
 
             payload = {
                 "name": tool_name,
-                "output": data.get("error") or data.get("output", ""),
+                "output": data.get("error") or output_text,
                 "tool_call_id": event.get("run_id", "unknown"),
                 "is_error": is_error,
             }

--- a/src/band/integrations/langgraph/langchain_tools.py
+++ b/src/band/integrations/langgraph/langchain_tools.py
@@ -27,6 +27,8 @@ from band.runtime.tools import (
 
 logger = logging.getLogger(__name__)
 
+TOOL_EXECUTION_ERROR_PREFIX = "Error executing "
+
 
 _TOOL_CATEGORIES: dict[str, str] = {
     **{name: "chat" for name in CHAT_TOOL_NAMES},
@@ -119,7 +121,7 @@ def agent_tools_to_langchain(
                 # traceback (with paths, DB strings, tokens, etc.) only
                 # lives in the agent log.
                 logger.exception("Error executing platform tool %s", _tool_name)
-                return f"Error executing {_tool_name}: see agent logs."
+                return f"{TOOL_EXECUTION_ERROR_PREFIX}{_tool_name}: see agent logs."
 
         def validation_error_message(
             error: Any,

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -1082,13 +1082,16 @@ def iter_tool_definitions(
     return results
 
 
+TOOL_VALIDATION_ERROR_PREFIX = "Invalid arguments for "
+
+
 def format_tool_validation_error(tool_name: str, error: ValidationError) -> str:
     """Format Pydantic validation errors for LLM-readable tool feedback."""
     errors = [
         f"{'.'.join(str(x) for x in err['loc'])}: {err['msg']}"
         for err in error.errors()
     ]
-    return f"Invalid arguments for {tool_name}: {', '.join(errors)}"
+    return f"{TOOL_VALIDATION_ERROR_PREFIX}{tool_name}: {', '.join(errors)}"
 
 
 def validate_tool_arguments(
@@ -2119,7 +2122,7 @@ class AgentTools(AgentToolsProtocol):
 
         BandToolError is re-raised so framework wrappers can translate it
         into framework-native failure results. Unexpected exceptions are
-        caught and returned as error strings for the LLM.
+        logged and returned as generic error strings for the LLM.
 
         Args:
             tool_name: Name of the tool to execute
@@ -2166,8 +2169,9 @@ class AgentTools(AgentToolsProtocol):
             # Let BandToolError propagate so framework wrappers can
             # translate it into framework-native failure results.
             raise
-        except Exception as e:
-            return f"Error executing {tool_name}: {e}"
+        except Exception:
+            logger.exception("Error executing platform tool %s", tool_name)
+            return f"Error executing {tool_name}: see agent logs."
 
 
 class HumanTools:

--- a/tests/adapters/langgraph/test_message_input.py
+++ b/tests/adapters/langgraph/test_message_input.py
@@ -381,6 +381,70 @@ class TestOnMessage:
         assert "tool_result" in message_types
 
     @pytest.mark.asyncio
+    async def test_real_compiled_graph_reports_platform_tool_validation_errors(
+        self, sample_message, mock_tools
+    ):
+        from langgraph.graph import END, START, MessagesState, StateGraph
+        from langgraph.prebuilt import ToolNode
+
+        from band.integrations.langgraph.langchain_tools import agent_tools_to_langchain
+
+        send_message = next(
+            tool
+            for tool in agent_tools_to_langchain(mock_tools)
+            if tool.name == "band_send_message"
+        )
+
+        def request_tool(state: MessagesState) -> dict[str, list[AIMessage]]:
+            return {
+                "messages": [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "id": "call-real-platform-tool",
+                                "name": "band_send_message",
+                                "args": {"content": "hello"},
+                            }
+                        ],
+                    )
+                ]
+            }
+
+        builder = StateGraph(MessagesState)
+        builder.add_node("request_tool", request_tool)
+        builder.add_node("tools", ToolNode([send_message]))
+        builder.add_edge(START, "request_tool")
+        builder.add_edge("request_tool", "tools")
+        builder.add_edge("tools", END)
+        graph = builder.compile()
+
+        adapter = LangGraphAdapter(
+            graph=graph,
+            features=AdapterFeatures(emit=frozenset({Emit.EXECUTION})),
+        )
+        await adapter.on_started("TestBot", "Test bot")
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        mock_tools.execute_tool_call.assert_not_called()
+        mock_tools.send_event.assert_awaited_once()
+        call_kwargs = mock_tools.send_event.call_args.kwargs
+        assert call_kwargs["message_type"] == "error"
+        assert (
+            call_kwargs["content"]
+            == "band_send_message failed: Invalid arguments for band_send_message: mentions: Field required"
+        )
+
+    @pytest.mark.asyncio
     async def test_real_compiled_graph_can_opt_into_bootstrap_system_prompt(
         self, sample_message, mock_tools
     ):

--- a/tests/adapters/langgraph/test_stream_events.py
+++ b/tests/adapters/langgraph/test_stream_events.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import json
 
 import pytest
+from langchain_core.messages import ToolMessage
 
 from band.adapters.langgraph import LangGraphAdapter
 from band.core.types import AdapterFeatures, Emit
 from band.integrations.langgraph.langchain_tools import TOOL_EXECUTION_ERROR_PREFIX
+from band.runtime.tools import TOOL_VALIDATION_ERROR_PREFIX
 
 
 class TestStreamEventHandling:
@@ -137,6 +139,142 @@ class TestStreamEventHandling:
             call_kwargs["content"]
             == "band_send_message failed: Error executing band_send_message: see agent logs."
         )
+
+    @pytest.mark.asyncio
+    async def test_reports_platform_tool_toolmessage_wrapper_errors_as_error_events(
+        self, mock_tools, mock_llm, mock_checkpointer
+    ):
+        """Runtime tool failures may be returned as ToolMessage content."""
+        adapter = LangGraphAdapter(
+            llm=mock_llm,
+            checkpointer=mock_checkpointer,
+            features=AdapterFeatures(emit=frozenset({Emit.EXECUTION})),
+        )
+
+        event = {
+            "event": "on_tool_end",
+            "name": "band_send_message",
+            "run_id": "run-123",
+            "data": {
+                "output": ToolMessage(
+                    content=(
+                        f"{TOOL_EXECUTION_ERROR_PREFIX}band_send_message: "
+                        "see agent logs."
+                    ),
+                    tool_call_id="call-123",
+                )
+            },
+        }
+
+        await adapter._handle_stream_event(event, "room-123", mock_tools)
+
+        mock_tools.send_event.assert_awaited_once()
+        call_kwargs = mock_tools.send_event.call_args.kwargs
+        assert call_kwargs["message_type"] == "error"
+        assert (
+            call_kwargs["content"]
+            == "band_send_message failed: Error executing band_send_message: see agent logs."
+        )
+
+    @pytest.mark.asyncio
+    async def test_reports_platform_tool_validation_outputs_as_error_events(
+        self, mock_tools, mock_llm, mock_checkpointer
+    ):
+        """Platform tool validation failures arrive as tool_end output strings."""
+        adapter = LangGraphAdapter(
+            llm=mock_llm,
+            checkpointer=mock_checkpointer,
+            features=AdapterFeatures(emit=frozenset({Emit.EXECUTION})),
+        )
+
+        event = {
+            "event": "on_tool_end",
+            "name": "band_send_message",
+            "run_id": "run-123",
+            "data": {
+                "output": f"{TOOL_VALIDATION_ERROR_PREFIX}band_send_message: mentions: Field required"
+            },
+        }
+
+        await adapter._handle_stream_event(event, "room-123", mock_tools)
+
+        mock_tools.send_event.assert_awaited_once()
+        call_kwargs = mock_tools.send_event.call_args.kwargs
+        assert call_kwargs["message_type"] == "error"
+        assert (
+            call_kwargs["content"]
+            == "band_send_message failed: Invalid arguments for band_send_message: mentions: Field required"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reports_platform_tool_toolmessage_errors_as_error_events(
+        self, mock_tools, mock_llm, mock_checkpointer
+    ):
+        """Real LangGraph tool calls wrap failed outputs in ToolMessage objects."""
+        adapter = LangGraphAdapter(
+            llm=mock_llm,
+            checkpointer=mock_checkpointer,
+            features=AdapterFeatures(emit=frozenset({Emit.EXECUTION})),
+        )
+
+        event = {
+            "event": "on_tool_end",
+            "name": "band_send_message",
+            "run_id": "run-123",
+            "data": {
+                "output": ToolMessage(
+                    content=(
+                        f"{TOOL_VALIDATION_ERROR_PREFIX}band_send_message: "
+                        "mentions: Field required"
+                    ),
+                    tool_call_id="call-123",
+                    status="error",
+                )
+            },
+        }
+
+        await adapter._handle_stream_event(event, "room-123", mock_tools)
+
+        mock_tools.send_event.assert_awaited_once()
+        call_kwargs = mock_tools.send_event.call_args.kwargs
+        assert call_kwargs["message_type"] == "error"
+        assert (
+            call_kwargs["content"]
+            == "band_send_message failed: Invalid arguments for band_send_message: mentions: Field required"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reports_custom_tool_toolmessage_errors_as_tool_results(
+        self, mock_tools, mock_llm, mock_checkpointer
+    ):
+        """Non-platform tools still report ToolMessage failures as tool_results."""
+        adapter = LangGraphAdapter(
+            llm=mock_llm,
+            checkpointer=mock_checkpointer,
+            features=AdapterFeatures(emit=frozenset({Emit.EXECUTION})),
+        )
+
+        event = {
+            "event": "on_tool_end",
+            "name": "custom_search",
+            "run_id": "run-123",
+            "data": {
+                "output": ToolMessage(
+                    content="search failed",
+                    tool_call_id="call-123",
+                    status="error",
+                )
+            },
+        }
+
+        await adapter._handle_stream_event(event, "room-123", mock_tools)
+
+        mock_tools.send_event.assert_awaited_once()
+        call_kwargs = mock_tools.send_event.call_args.kwargs
+        assert call_kwargs["message_type"] == "tool_result"
+        payload = json.loads(call_kwargs["content"])
+        assert payload["is_error"] is True
+        assert payload["output"] == "search failed"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("tool_name", ["band_send_message", "band_send_event"])

--- a/tests/adapters/langgraph/test_stream_events.py
+++ b/tests/adapters/langgraph/test_stream_events.py
@@ -6,6 +6,7 @@ import pytest
 
 from band.adapters.langgraph import LangGraphAdapter
 from band.core.types import AdapterFeatures, Emit
+from band.integrations.langgraph.langchain_tools import TOOL_EXECUTION_ERROR_PREFIX
 
 
 class TestStreamEventHandling:
@@ -22,9 +23,9 @@ class TestStreamEventHandling:
 
         event = {
             "event": "on_tool_start",
-            "name": "band_send_message",
+            "name": "custom_search",
             "run_id": "run-123",
-            "data": {"input": {"content": "Hello"}},
+            "data": {"input": {"query": "Hello"}},
         }
 
         await adapter._handle_stream_event(event, "room-123", mock_tools)
@@ -44,7 +45,7 @@ class TestStreamEventHandling:
 
         event = {
             "event": "on_tool_end",
-            "name": "band_send_message",
+            "name": "custom_search",
             "run_id": "run-123",
             "data": {"output": "success"},
         }
@@ -68,9 +69,9 @@ class TestStreamEventHandling:
 
         event = {
             "event": "on_tool_error",
-            "name": "band_send_message",
+            "name": "custom_search",
             "run_id": "run-123",
-            "data": {"error": "missing mentions"},
+            "data": {"error": "missing query"},
         }
 
         await adapter._handle_stream_event(event, "room-123", mock_tools)
@@ -80,7 +81,86 @@ class TestStreamEventHandling:
         assert call_kwargs["message_type"] == "tool_result"
         payload = json.loads(call_kwargs["content"])
         assert payload["is_error"] is True
-        assert payload["output"] == "missing mentions"
+        assert payload["output"] == "missing query"
+
+    @pytest.mark.asyncio
+    async def test_reports_platform_tool_errors_as_error_events(
+        self, mock_tools, mock_llm, mock_checkpointer
+    ):
+        """Failed platform tools should not produce orphan tool_result events."""
+        adapter = LangGraphAdapter(
+            llm=mock_llm,
+            checkpointer=mock_checkpointer,
+            features=AdapterFeatures(emit=frozenset({Emit.EXECUTION})),
+        )
+
+        event = {
+            "event": "on_tool_error",
+            "name": "band_send_message",
+            "run_id": "run-123",
+            "data": {"error": "missing mentions"},
+        }
+
+        await adapter._handle_stream_event(event, "room-123", mock_tools)
+
+        mock_tools.send_event.assert_awaited_once()
+        call_kwargs = mock_tools.send_event.call_args.kwargs
+        assert call_kwargs["message_type"] == "error"
+        assert call_kwargs["content"] == "band_send_message failed: missing mentions"
+
+    @pytest.mark.asyncio
+    async def test_reports_platform_tool_wrapper_error_outputs_as_error_events(
+        self, mock_tools, mock_llm, mock_checkpointer
+    ):
+        """Platform tool wrapper failures arrive as tool_end output strings."""
+        adapter = LangGraphAdapter(
+            llm=mock_llm,
+            checkpointer=mock_checkpointer,
+            features=AdapterFeatures(emit=frozenset({Emit.EXECUTION})),
+        )
+
+        event = {
+            "event": "on_tool_end",
+            "name": "band_send_message",
+            "run_id": "run-123",
+            "data": {
+                "output": f"{TOOL_EXECUTION_ERROR_PREFIX}band_send_message: see agent logs."
+            },
+        }
+
+        await adapter._handle_stream_event(event, "room-123", mock_tools)
+
+        mock_tools.send_event.assert_awaited_once()
+        call_kwargs = mock_tools.send_event.call_args.kwargs
+        assert call_kwargs["message_type"] == "error"
+        assert (
+            call_kwargs["content"]
+            == "band_send_message failed: Error executing band_send_message: see agent logs."
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool_name", ["band_send_message", "band_send_event"])
+    @pytest.mark.parametrize("event_type", ["on_tool_start", "on_tool_end"])
+    async def test_skips_reporting_for_platform_tools_with_visible_output(
+        self, event_type, tool_name, mock_tools, mock_llm, mock_checkpointer
+    ):
+        """Visible platform tools should not be mirrored as execution events."""
+        adapter = LangGraphAdapter(
+            llm=mock_llm,
+            checkpointer=mock_checkpointer,
+            features=AdapterFeatures(emit=frozenset({Emit.EXECUTION})),
+        )
+
+        event = {
+            "event": event_type,
+            "name": tool_name,
+            "run_id": "run-123",
+            "data": {"output": "success"},
+        }
+
+        await adapter._handle_stream_event(event, "room-123", mock_tools)
+
+        mock_tools.send_event.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_ignores_other_events(self, mock_tools, mock_llm, mock_checkpointer):

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -994,7 +994,8 @@ class TestAgentToolsExecuteToolCall:
             "band_send_message", {"content": "Hello!", "mentions": ["User One"]}
         )
 
-        assert "Error executing" in result
+        assert result == "Error executing band_send_message: see agent logs."
+        assert "Network error" not in result
 
 
 class TestEmptyMentionsValidation:


### PR DESCRIPTION
## What changed

LangGraph execution reporting no longer mirrors successful `band_send_message` and `band_send_event` calls as extra `tool_call` / `tool_result` events.

Those platform tools already create visible output in Band, so reporting them again could duplicate messages in `graph_as_tool` flows.

Failed platform tool calls are still surfaced. If `band_send_message` or `band_send_event` fails, the adapter now emits one Band `error` event instead of suppressing the failure.

## Why

Successful platform tools should not produce duplicate execution output, but failed platform tools still need a visible error signal. This keeps the normal chat/event output clean while preserving failure visibility.

## Validation

```sh
uv run --extra dev pytest \
  tests/adapters/langgraph/test_stream_events.py \
  tests/integrations/langgraph/test_graph_tools.py \
  tests/integrations/test_langgraph_tools.py -q
# 25 passed, 1 warning

uv run ruff check src/band/adapters/langgraph.py tests/adapters/langgraph/test_stream_events.py
uv run ruff format --check src/band/adapters/langgraph.py tests/adapters/langgraph/test_stream_events.py
# both pass
```

New coverage verifies:

- custom tools still emit `tool_call` and `tool_result` events
- successful `band_send_message` / `band_send_event` reporting is suppressed
- failed platform tools emit a Band `error` event
- wrapper-reported platform tool failures are not hidden

Closes INT-490
