### PR TITLE
feat: Slack adapter for remote Band agents [INT-461]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Band Python SDK
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/band-ai/band-sdk-python/main/assets/band-readme-banner.png" alt="Band" width="100%">
+  <img src="https://raw.githubusercontent.com/thenvoi/thenvoi-sdk-python/main/assets/band-readme-banner.png" alt="Band" width="100%">
 </p>
 
 <div align="center">
-  <a href="https://github.com/band-ai/band-sdk-python/actions"><img src="https://img.shields.io/badge/CI-passing-brightgreen" alt="CI"></a>
+  <a href="https://github.com/thenvoi/thenvoi-sdk-python/actions"><img src="https://img.shields.io/badge/CI-passing-brightgreen" alt="CI"></a>
   <a href="https://docs.band.ai"><img src="https://img.shields.io/badge/docs-band.ai-blue" alt="Docs"></a>
   <a href="https://discord.gg/gvMYpB9eAY"><img src="https://img.shields.io/badge/Discord-join%20chat-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://pypi.org/project/band-sdk/"><img src="https://img.shields.io/pypi/v/band-sdk.svg" alt="PyPI version"></a>
@@ -273,7 +273,7 @@ LangGraph supports the built-in Band platform tools, custom LangChain tools thro
 | A2A gateway  | `a2a_gateway` | `A2AGatewayAdapter`                  | [examples](examples/a2a_gateway/)             |
 | ACP          | `acp`         | `ACPClientAdapter`, `ACPServer`, `BandACPServerAdapter` | [examples](examples/acp/) |
 
-> **Other languages:** The Band SDK is also available for [TypeScript](https://github.com/band-ai/band-sdk-typescript).
+> **Other languages:** The Band SDK is also available for [TypeScript](https://github.com/thenvoi/thenvoi-sdk-typescript).
 
 Additional bridge extras exist for specialized deployments: `a2a_gateway_demo` supports the A2A gateway demo orchestrator, and `bridge`, `bridge_agentcore`, and `agentcore_runtime` support the standalone bridge service under `band-bridge/` and `examples/agentcore/`.
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,25 @@ adapter = GeminiAdapter(model="gemini-2.5-flash")
 
 Use [examples/run_agent.py](examples/run_agent.py) when you want one command that can switch between LangGraph, Pydantic AI, Anthropic, Claude SDK, Parlant, CrewAI, Codex, A2A bridge, and A2A gateway. Use the per-framework directories under [examples/](examples/) when you want the adapter-specific setup.
 
+### Slack (`examples/slack/`)
+
+| File | Description |
+|------|-------------|
+| `01_basic_bot.py` | Wraps an Anthropic brain with `SlackAdapter`. Defaults to Socket Mode; flip `SLACK_TRANSPORT=http` to mount under your own ASGI app. |
+
+The Slack bridge expects an installed Slack app with the right scopes. A maintained manifest lives at `src/band/integrations/slack/templates/manifest.yaml` — paste it into Slack's "Create from manifest" flow when registering the app. The manifest declares:
+
+- **AI App** (`assistant_view` + `assistant:write`) so the assistant pane, status indicators, and Block Kit plan/task blocks render.
+- All scopes needed for thread context: `app_mentions:read`, `im:history`, `channels:history`, `groups:history`, `chat:write`, `users:read`, plus `channels:read`/`groups:read`/`im:read` so the context mirror can resolve channel names.
+- Events `app_mention`, `message.im`, `assistant_thread_started`.
+- Socket Mode enabled — no public URL, no signing secret needed for the example.
+
+Three operational gotchas worth surfacing:
+
+- **Bot must be a channel member.** `/invite @your-bot` in any channel you want it to read. `channels:history` alone doesn't grant access to channels it isn't in.
+- **Delayed Events is a GUI toggle, not a manifest field.** For production, enable "Delayed Events" under the app's Event Subscriptions settings so Slack keeps retrying missed events hourly for 24h while the bridge is offline (default is 2h). There is no manifest schema field for it — it must be set manually after the app is created. See the [retry events changelog](https://docs.slack.dev/changelog/2026/02/05/retry-events-feature/).
+- **HTTP vs Socket Mode.** Socket Mode (default) opens a websocket to Slack and works behind any NAT/firewall. HTTP transport needs a public URL that Slack can POST to and requires `SLACK_SIGNING_SECRET`. Both share the same downstream pipeline, so behavior (status indicators, plan blocks, thread backfill, rehydration) is identical.
+
 ---
 
 ## How Band Works

--- a/agent_config.yaml.example
+++ b/agent_config.yaml.example
@@ -236,6 +236,17 @@ darter:
   api_key: ""
 
 # =============================================================================
+# Slack Examples
+# =============================================================================
+
+# 01_basic_bot.py — bridges a Band agent into a Slack app via Socket
+# Mode (or HTTP). Register the Slack app from the bundled manifest at
+# src/band/integrations/slack/templates/manifest.yaml.
+slack_basic_bot:
+  agent_id: ""
+  api_key: ""
+
+# =============================================================================
 # 20 Questions Arena Examples
 # =============================================================================
 

--- a/examples/20-questions-arena/README.md
+++ b/examples/20-questions-arena/README.md
@@ -64,7 +64,7 @@ You can run as many guessers as you like, each in its own terminal. Use differen
 
 For a more convenient experience with a visual game interface, see the standalone web UI repository:
 
-**https://github.com/band/20-questions-arena**
+**https://github.com/thenvoi/20-questions-arena**
 
 ## File Overview
 

--- a/examples/parlant/01_basic_agent.py
+++ b/examples/parlant/01_basic_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[parlant]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
 # ///
 """
 Basic Parlant agent example using the official Parlant SDK.

--- a/examples/parlant/02_with_guidelines.py
+++ b/examples/parlant/02_with_guidelines.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[parlant]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
 # ///
 """
 Parlant agent with behavioral guidelines using the official Parlant SDK.

--- a/examples/parlant/03_support_agent.py
+++ b/examples/parlant/03_support_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[parlant]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
 # ///
 """
 Customer support agent using Parlant SDK with guidelines.

--- a/examples/parlant/04_tom_agent.py
+++ b/examples/parlant/04_tom_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[parlant]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# band-sdk = { git = "https://-ai/band-sdk-python.git" }
 # ///
 """
 Tom the cat agent using Parlant.

--- a/examples/parlant/05_jerry_agent.py
+++ b/examples/parlant/05_jerry_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[parlant]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
 # ///
 """
 Jerry the mouse agent using Parlant.

--- a/examples/parlant/README.md
+++ b/examples/parlant/README.md
@@ -16,7 +16,7 @@ Parlant provides:
 ### Install with Parlant support
 
 ```bash
-uv add "git+https://github.com/band-ai/band-sdk-python.git[parlant]"
+uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[parlant]"
 ```
 
 **Or from repository:**

--- a/examples/run_agent.py
+++ b/examples/run_agent.py
@@ -7,7 +7,7 @@
 # ]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
 # ///
 """
 Run Band SDK agents using the composition pattern.

--- a/examples/slack/01_basic_bot.py
+++ b/examples/slack/01_basic_bot.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[slack,anthropic]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
 # ///
 """
 Basic Slack bot: wrap an Anthropic brain with the SlackAdapter and

--- a/examples/slack/01_basic_bot.py
+++ b/examples/slack/01_basic_bot.py
@@ -1,0 +1,186 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[slack,anthropic]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Basic Slack bot: wrap an Anthropic brain with the SlackAdapter and
+expose it as a Slack-native AI app. Defaults to Socket Mode so you
+don't need a public URL or ngrok to get started.
+
+Setup
+-----
+1. Register your Slack app from the bundled manifest:
+   ``src/band/integrations/slack/templates/manifest.yaml``.
+   That manifest declares every scope and event subscription this
+   example expects. (The recommended "Delayed Events" toggle has no
+   manifest field — enable it manually under Event Subscriptions; see
+   step 7 in the manifest header.)
+
+2. Install the app to your workspace, then grab the Bot Token
+   (``xoxb-...``). For Socket Mode also generate an App-Level Token
+   (``xapp-...``) with the ``connections:write`` scope under
+   "Basic Information" → "App-Level Tokens".
+
+3. ``/invite @your-bot`` in any channel you want the bot to read.
+   Without channel membership ``conversations.replies`` returns
+   ``not_in_channel`` and the brain loses thread context.
+
+4. Add the agent credentials to ``agent_config.yaml`` under the key
+   ``slack_basic_bot``::
+
+       slack_basic_bot:
+         agent_id: "..."
+         api_key: "..."
+
+5. Set the Slack + Anthropic env vars (e.g. via ``.env``)::
+
+       SLACK_BOT_TOKEN=xoxb-...
+       SLACK_APP_TOKEN=xapp-...     # Socket Mode only
+       SLACK_SIGNING_SECRET=...     # HTTP transport only
+       ANTHROPIC_API_KEY=sk-ant-...
+       BAND_REST_URL=...
+       BAND_WS_URL=...
+
+Run with
+--------
+    uv run examples/slack/01_basic_bot.py
+
+HTTP transport
+--------------
+Set ``SLACK_TRANSPORT=http`` and provide ``SLACK_SIGNING_SECRET``.
+The example below mounts ``slack.router`` into a Starlette app on
+port 3000; point Slack's Event Subscriptions request URL at
+``https://<your-public-host>/slack/dev/events``. To embed in an
+existing FastAPI service instead::
+
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.mount("/slack", slack.router)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from dotenv import load_dotenv
+
+from setup_logging import setup_logging
+from band import AdapterFeatures, Agent, Emit
+from band.adapters import AnthropicAdapter
+from band.config import load_agent_config
+from band.integrations.slack import SlackAdapter, SlackApp
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    load_dotenv()
+
+    transport = os.getenv("SLACK_TRANSPORT", "socket").lower()
+    if transport not in ("http", "socket"):
+        raise ValueError(
+            f"SLACK_TRANSPORT must be 'http' or 'socket', got {transport!r}"
+        )
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+    bot_token = os.getenv("SLACK_BOT_TOKEN")
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+    if not bot_token:
+        raise ValueError("SLACK_BOT_TOKEN environment variable is required")
+
+    if transport == "socket":
+        app_token = os.getenv("SLACK_APP_TOKEN")
+        if not app_token:
+            raise ValueError(
+                "SLACK_APP_TOKEN (xapp-...) is required when SLACK_TRANSPORT=socket"
+            )
+        signing_secret = ""
+    else:
+        signing_secret = os.getenv("SLACK_SIGNING_SECRET", "")
+        if not signing_secret:
+            raise ValueError(
+                "SLACK_SIGNING_SECRET is required when SLACK_TRANSPORT=http"
+            )
+        app_token = ""
+
+    agent_id, api_key = load_agent_config("slack_basic_bot")
+
+    # AnthropicAdapter reads ANTHROPIC_API_KEY from the environment.
+    #
+    # features=AdapterFeatures(emit={Emit.EXECUTION}) enables tool-call
+    # emission: every tool the brain runs is recorded into the Band room
+    # as tool_call / tool_result events, so the room's audit timeline shows
+    # what the agent did and with what result. This is the Band-side
+    # record; the Slack-side plan/task progress blocks are a separate knob
+    # (SlackAdapter(show_tool_progress=...), on by default).
+    brain = AnthropicAdapter(
+        model="claude-sonnet-4-5-20250929",
+        prompt=(
+            "You are a helpful Slack assistant. Keep replies concise and "
+            "use Slack-flavored markdown when it improves readability."
+        ),
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
+    )
+
+    slack = SlackAdapter(
+        inner=brain,
+        apps=[
+            SlackApp(
+                slug="dev",
+                bot_token=bot_token,
+                signing_secret=signing_secret,
+                app_token=app_token,
+            ),
+        ],
+        rest_url=rest_url,
+        api_key=api_key,
+        transport=transport,  # type: ignore[arg-type]
+    )
+
+    agent = Agent.create(
+        adapter=slack,
+        agent_id=agent_id,
+        api_key=api_key,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Starting Slack bot (transport=%s)...", transport)
+
+    if transport == "socket":
+        async with agent:
+            try:
+                await agent.run_forever()
+            finally:
+                await slack.close()
+    else:
+        # HTTP transport: serve the Slack router alongside the agent.
+        # In a real service you'd mount ``slack.router`` into your
+        # existing FastAPI/Starlette app instead of running uvicorn
+        # standalone like this.
+        import uvicorn
+        from starlette.applications import Starlette
+
+        web_app = Starlette()
+        web_app.mount("/slack", slack.router)
+        config = uvicorn.Config(web_app, host="0.0.0.0", port=3000, log_level="info")
+        server = uvicorn.Server(config)
+        async with agent:
+            try:
+                await asyncio.gather(agent.run_forever(), server.serve())
+            finally:
+                await slack.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/slack/_dev_bridge.py
+++ b/examples/slack/_dev_bridge.py
@@ -1,0 +1,133 @@
+"""Manual smoke driver for the Slack bridge (wrapping shape).
+
+One Agent process. One Band identity. The agent has a brain (here
+``AnthropicAdapter``) and ``SlackAdapter`` is layered on top so that
+both Slack webhooks AND Band WS messages flow into the same brain.
+Slack threads are mirrored into Band rooms one-to-one.
+
+Not part of the shipped examples — see ``examples/slack/01_basic_bot.py``
+for the official getting-started example.
+
+Run with:
+    export SLACK_BOT_TOKEN=xoxb-...
+    export BAND_AGENT_ID=<the agent's uuid>
+    export BAND_API_KEY=<the agent's api key>
+    export ANTHROPIC_API_KEY=sk-ant-...
+
+    # HTTP transport (default) — needs a public URL pointing at port 3000:
+    export SLACK_SIGNING_SECRET=...
+    uv run python examples/slack/_dev_bridge.py
+
+    # Socket Mode — no public URL or signing secret needed:
+    export SLACK_TRANSPORT=socket
+    export SLACK_APP_TOKEN=xapp-...
+    uv run python examples/slack/_dev_bridge.py
+
+    # optional:
+    export BAND_REST_URL=https://app.band.ai
+    export BAND_WS_URL=wss://app.band.ai/api/v1/socket/websocket
+    export SLACK_BOT_MODEL=claude-sonnet-4-6
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from band import Agent
+from band.adapters import AnthropicAdapter
+from band.integrations.slack import SlackAdapter, SlackApp
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+
+
+async def main() -> None:
+    transport = os.environ.get("SLACK_TRANSPORT", "http").lower()
+    if transport not in ("http", "socket"):
+        raise ValueError(
+            f"SLACK_TRANSPORT must be 'http' or 'socket', got {transport!r}"
+        )
+
+    bot_token = os.environ["SLACK_BOT_TOKEN"]
+    agent_id = os.environ["BAND_AGENT_ID"]
+    api_key = os.environ["BAND_API_KEY"]
+    # AnthropicAdapter reads ANTHROPIC_API_KEY from the env on its own.
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise ValueError("ANTHROPIC_API_KEY is required")
+
+    if transport == "http":
+        signing_secret = os.environ["SLACK_SIGNING_SECRET"]
+        app_token = ""
+    else:
+        signing_secret = ""
+        app_token = os.environ["SLACK_APP_TOKEN"]
+
+    rest_url = os.environ.get("BAND_REST_URL", "https://app.band.ai")
+    ws_url = os.environ.get("BAND_WS_URL", "wss://app.band.ai/api/v1/socket/websocket")
+    model = os.environ.get("SLACK_BOT_MODEL", "claude-sonnet-4-6")
+
+    # Slack plan-block visibility is now independent of the brain's
+    # ``Emit.EXECUTION`` setting — ``SlackAdapter`` observes tool
+    # execution directly via its tools wrapper. To ALSO record
+    # ``tool_call``/``tool_result`` events on the Band side, pass
+    # ``features=AdapterFeatures(emit={Emit.EXECUTION})`` here.
+    brain = AnthropicAdapter(model=model)
+    slack = SlackAdapter(
+        inner=brain,
+        apps=[
+            SlackApp(
+                slug="dev",
+                bot_token=bot_token,
+                signing_secret=signing_secret,
+                app_token=app_token,
+            ),
+        ],
+        rest_url=rest_url,
+        api_key=api_key,
+        transport=transport,  # type: ignore[arg-type]
+    )
+    agent = Agent.create(
+        adapter=slack,
+        agent_id=agent_id,
+        api_key=api_key,
+        rest_url=rest_url,
+        ws_url=ws_url,
+    )
+
+    if transport == "http":
+        # Mount the Slack router into a tiny ASGI app and run uvicorn
+        # alongside the Band WS agent loop.
+        import uvicorn
+        from starlette.applications import Starlette
+
+        starlette_app = Starlette()
+        starlette_app.mount("/slack", slack.router)
+        config = uvicorn.Config(
+            starlette_app, host="0.0.0.0", port=3000, log_level="info"
+        )
+        server = uvicorn.Server(config)
+        async with agent:
+            try:
+                await asyncio.gather(
+                    agent.run_forever(),
+                    server.serve(),
+                )
+            finally:
+                await slack.close()
+    else:
+        # Socket Mode: no HTTP surface. ``slack.on_started`` (invoked by
+        # Agent.__aenter__) opens the per-app websocket; we just keep
+        # the Band WS agent loop running until cancelled.
+        async with agent:
+            try:
+                await agent.run_forever()
+            finally:
+                await slack.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/slack/setup_logging.py
+++ b/examples/slack/setup_logging.py
@@ -1,0 +1,15 @@
+"""Shared logging configuration for Slack examples."""
+
+import logging
+
+
+def setup_logging(level=logging.INFO):
+    """Configure logging to show band + slack-sdk logs, mute noisy deps."""
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    logging.getLogger("band").setLevel(level)
+    # Surface Slack SDK retries / Socket Mode connect events.
+    logging.getLogger("slack_sdk").setLevel(level)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,12 @@ acp = [
     "starlette>=0.40.0",
     "uvicorn>=0.32.0",
 ]
+slack = [
+    "slack-sdk>=3.27.0",     # AsyncWebClient, signature verifier, Socket Mode
+    "starlette>=0.40.0",     # HTTP server framework
+    "uvicorn>=0.32.0",       # ASGI server
+    "aiohttp>=3.9,<4",       # Socket Mode transport (slack_sdk.socket_mode.aiohttp)
+]
 bridge = [
     "aiohttp>=3.9,<4",      # Health check HTTP server
     "python-dotenv>=1.2.2",    # Environment variable loading
@@ -163,6 +169,8 @@ dev = [
     # Include ACP deps for testing
     "agent-client-protocol>=0.9.0",
     "mcp>=1.25.0",
+    # Include Slack deps for testing
+    "slack-sdk>=3.27.0",
     # Include Gemini SDK for testing
     "google-genai>=1.43.0",
     # Include google-adk for testing

--- a/src/band/adapters/__init__.py
+++ b/src/band/adapters/__init__.py
@@ -15,6 +15,7 @@ Install the extra you need::
     uv add band-sdk[codex]
     uv add band-sdk[google_adk]
     uv add band-sdk[opencode]
+    uv add band-sdk[slack]
 """
 
 from __future__ import annotations
@@ -47,6 +48,9 @@ if TYPE_CHECKING:
     from band.adapters.opencode import OpencodeAdapterConfig as OpencodeAdapterConfig
     from band.adapters.letta import LettaAdapter as LettaAdapter
     from band.adapters.letta import LettaAdapterConfig as LettaAdapterConfig
+    from band.adapters.slack import SlackAdapter as SlackAdapter
+    from band.adapters.slack import SlackApp as SlackApp
+    from band.adapters.slack import SlackSessionState as SlackSessionState
 
 __all__ = [
     "LangGraphAdapter",
@@ -69,6 +73,9 @@ __all__ = [
     "OpencodeAdapterConfig",
     "LettaAdapter",
     "LettaAdapterConfig",
+    "SlackAdapter",
+    "SlackApp",
+    "SlackSessionState",
 ]
 
 
@@ -158,4 +165,12 @@ def __getattr__(name: str) -> type:
         from band.adapters.letta import LettaAdapterConfig
 
         return LettaAdapterConfig
+    elif name in ("SlackAdapter", "SlackApp", "SlackSessionState"):
+        from band.adapters.slack import SlackAdapter, SlackApp, SlackSessionState
+
+        if name == "SlackAdapter":
+            return SlackAdapter
+        elif name == "SlackApp":
+            return SlackApp
+        return SlackSessionState
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/band/adapters/slack.py
+++ b/src/band/adapters/slack.py
@@ -1,0 +1,6 @@
+"""Slack bridge adapter - re-exports from integrations module."""
+
+from band.integrations.slack.adapter import SlackAdapter
+from band.integrations.slack.types import SlackApp, SlackSessionState
+
+__all__ = ["SlackAdapter", "SlackApp", "SlackSessionState"]

--- a/src/band/converters/slack.py
+++ b/src/band/converters/slack.py
@@ -1,0 +1,79 @@
+"""History converter for the Slack bridge adapter.
+
+Recovers the Slack thread identity for a room from its history, so the
+bridge can resume routing Slack events into the right Band room after
+a restart.
+
+History is converted per-room (the platform fetches and converts a single
+room's history at a time), so this converter only needs to surface the
+binding for the current room. The room_id itself is supplied by the
+caller; this converter just answers "is this a Slack-bridged room, and
+if so which Slack thread does it mirror?".
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from band.core.protocols import HistoryConverter
+
+if TYPE_CHECKING:
+    from band.integrations.slack.types import SlackSessionState
+
+logger = logging.getLogger(__name__)
+
+
+class SlackHistoryConverter(HistoryConverter["SlackSessionState"]):
+    """Extracts the Slack thread binding from a room's history.
+
+    Scans for a ``task`` event carrying the ``slack_app_slug`` +
+    ``slack_channel_id`` + ``slack_thread_ts`` metadata that
+    :py:meth:`SlackAdapter._emit_context_event` writes when a Slack-
+    bridged room is first created. Returns the most recent such binding,
+    or ``None`` if the room has no Slack bootstrap event.
+    """
+
+    def convert(self, raw: list[dict[str, Any]]) -> SlackSessionState:
+        """Build session state from a single room's history.
+
+        Args:
+            raw: Platform history dicts (``format_history_for_llm`` shape).
+
+        Returns:
+            ``SlackSessionState`` with ``binding`` set when the history
+            contains a Slack bootstrap task event, otherwise the empty
+            default state.
+        """
+        from band.integrations.slack.types import (
+            SlackRoomBinding,
+            SlackSessionState,
+        )
+
+        binding: SlackRoomBinding | None = None
+        for msg in raw:
+            if msg.get("message_type") != "task":
+                continue
+            metadata = msg.get("metadata") or {}
+            app_slug = metadata.get("slack_app_slug")
+            channel = metadata.get("slack_channel_id")
+            thread_ts = metadata.get("slack_thread_ts")
+            if not (app_slug and channel and thread_ts):
+                continue
+            # Last bootstrap event wins. Multiple shouldn't happen in
+            # practice, but if it does we trust the most recent context.
+            binding = SlackRoomBinding(
+                app_slug=app_slug,
+                channel=channel,
+                thread_ts=thread_ts,
+            )
+
+        if binding is not None:
+            logger.debug(
+                "Recovered Slack binding from history: app=%s channel=%s thread_ts=%s",
+                binding.app_slug,
+                binding.channel,
+                binding.thread_ts,
+            )
+
+        return SlackSessionState(binding=binding)

--- a/src/band/integrations/slack/__init__.py
+++ b/src/band/integrations/slack/__init__.py
@@ -1,0 +1,38 @@
+"""Slack integration for Band SDK.
+
+Wraps an inner framework adapter (the brain) so one Band agent can
+receive Slack Events API traffic and reply back into the originating
+Slack thread. This is a wrapper around an inner adapter, not a
+peer-slug gateway.
+
+Example:
+    from band import Agent
+    from band.adapters import AnthropicAdapter
+    from band.integrations.slack import SlackAdapter, SlackApp
+
+    brain = AnthropicAdapter(model="claude-sonnet-4-6")
+
+    slack = SlackAdapter(
+        inner=brain,
+        apps=[
+            SlackApp(
+                slug="recruit",
+                signing_secret="...",
+                bot_token="xoxb-...",
+            ),
+        ],
+        rest_url="https://app.band.ai",
+        api_key="...",
+    )
+
+    agent = Agent.create(adapter=slack, agent_id="slack-bridge", api_key="...")
+
+    # HTTP transport: mount slack.router into your ASGI app, e.g.:
+    #     app.mount("/slack", slack.router)
+    await agent.run()
+"""
+
+from band.integrations.slack.adapter import SlackAdapter
+from band.integrations.slack.types import SlackApp, SlackSessionState
+
+__all__ = ["SlackAdapter", "SlackApp", "SlackSessionState"]

--- a/src/band/integrations/slack/adapter.py
+++ b/src/band/integrations/slack/adapter.py
@@ -1,0 +1,1253 @@
+"""Slack bridge adapter — wrapping shape.
+
+Wraps an inner framework adapter (the agent's brain) and adds Slack
+ingress/egress. One process, one Band identity, two transports:
+
+- **Band WS path** (normal): platform delivers ``on_message`` →
+  ``SlackAdapter.on_message`` delegates to ``inner.on_message``. If the
+  room is bound to a Slack thread, the tools are wrapped so the brain's
+  outgoing ``send_message`` is also posted to Slack.
+- **Slack webhook path**: ``SlackAdapter`` synthesises a
+  ``PlatformMessage`` from the Slack event and invokes
+  ``inner.on_message`` directly with REST-backed tools that tee replies
+  back to the originating Slack thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+from band.client.rest import (
+    AsyncRestClient,
+    ChatEventRequest,
+    ChatRoomRequest,
+    DEFAULT_REQUEST_OPTIONS,
+)
+from band.converters.slack import SlackHistoryConverter
+from band.core.protocols import AgentToolsProtocol
+from band.core.simple_adapter import SimpleAdapter
+from band.core.types import (
+    AdapterFeatures,
+    AgentInput,
+    Capability,
+    Emit,
+    PlatformMessage,
+)
+from band.integrations.slack.block_kit import (
+    DEFAULT_WRITE_TOOL_NAMES,
+    PlanState,
+    PlanTask,
+    TaskState,
+    humanize_tool_name,
+    plan_fallback_text,
+    render_plan_blocks,
+)
+from band.integrations.slack.server import build_router
+from band.integrations.slack.types import SlackApp, SlackRoomBinding
+from band.runtime.tools import AgentTools
+
+if TYPE_CHECKING:
+    from slack_sdk.web.async_client import AsyncWebClient
+    from starlette.routing import Router
+
+    from band.integrations.slack.socket import SlackSocketListener
+
+
+SlackTransport = Literal["http", "socket"]
+
+logger = logging.getLogger(__name__)
+
+# Factory signature: takes a SlackApp config and returns the AsyncWebClient
+# to use for outbound Slack API calls. Exposed for test injection.
+WebClientFactory = Callable[[SlackApp], "AsyncWebClient"]
+
+# Status string shown via ``assistant.threads.setStatus`` while the
+# brain is working. Empty string clears the status.
+STATUS_THINKING = "is thinking…"
+
+# Name of the Slack-only outbound tool exposed to the brain when the
+# room is bound to a Slack thread.
+SLACK_SEND_MESSAGE_TOOL_NAME = "slack_send_message"
+
+_SLACK_SEND_MESSAGE_DESCRIPTION = (
+    "Send a plain-text reply to the Slack user who triggered this "
+    "conversation. The message is posted into the originating Slack thread. "
+    "Use this for the final answer and any user-facing updates. Does not "
+    "post to the Band room.\n\n"
+    "Use band_send_message (which requires @mentions) to talk to other "
+    "Band peers in the room."
+)
+
+_SLACK_SEND_MESSAGE_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "content": {
+            "type": "string",
+            "description": "The plain-text message to send to the Slack user.",
+        },
+    },
+    "required": ["content"],
+}
+
+SLACK_CONTEXT_NOTE = (
+    "[Slack] This conversation originated from Slack. The triggering user is "
+    "not a Band peer and cannot be @-mentioned. To reply to them, call "
+    f"{SLACK_SEND_MESSAGE_TOOL_NAME}(content=...). "
+    "Use band_send_message(content, mentions=[...]) only to coordinate "
+    "with other Band peers in this room."
+)
+
+
+def _merge_context_note(existing: str | None, note: str) -> str:
+    """Combine an existing participants_msg (if any) with the Slack note.
+
+    Returns ``note`` if there is no existing message; otherwise prepends
+    ``note`` followed by a blank line so the upstream message stays
+    readable to the brain.
+    """
+    if not existing:
+        return note
+    return f"{note}\n\n{existing}"
+
+
+class _SlackTeeingTools(AgentTools):
+    """``AgentTools`` subclass that adds a Slack-only ``slack_send_message`` tool.
+
+    The brain sees two outbound options:
+
+    - ``band_send_message`` (inherited, unchanged) — real Band message
+      to peers in the current room. Still requires ≥1 mention.
+    - ``slack_send_message`` (new) — posts directly to the bound Slack thread
+      via ``chat.postMessage``. Bypasses Band entirely.
+
+    The brain decides which to use based on intent. The system-prompt
+    note (passed via ``participants_msg``) tells it when to pick each.
+    """
+
+    def __init__(
+        self,
+        *,
+        wrap: AgentTools,
+        slack: AsyncWebClient,
+        binding: SlackRoomBinding,
+        write_tool_names: frozenset[str] | set[str] | None = None,
+        show_tool_progress: bool = True,
+    ) -> None:
+        super().__init__(
+            room_id=wrap.room_id,
+            rest=wrap.rest,
+            participants=list(wrap.participants),
+            hub_room_id=wrap._hub_room_id,
+        )
+        # Carry ExecutionContext over so any tool methods that lean on
+        # it (e.g. lookup_peers) keep working.
+        self._ctx = wrap._ctx
+        self._slack = slack
+        self._binding = binding
+        self._write_tool_names: frozenset[str] = (
+            frozenset(write_tool_names)
+            if write_tool_names is not None
+            else DEFAULT_WRITE_TOOL_NAMES
+        )
+        self._show_tool_progress = show_tool_progress
+        self._plan = PlanState()
+
+    async def _upsert_plan_message(self) -> None:
+        blocks = render_plan_blocks(self._plan)
+        fallback = plan_fallback_text(self._plan)
+        try:
+            if self._plan.message_ts is None:
+                response = await self._slack.chat_postMessage(
+                    channel=self._binding.channel,
+                    thread_ts=self._binding.thread_ts,
+                    blocks=blocks,
+                    text=fallback,
+                )
+                # slack-sdk's SlackResponse is dict-like; AsyncMock returns dict.
+                ts: str | None = None
+                try:
+                    ts = response["ts"]  # type: ignore[index]
+                except (KeyError, TypeError):
+                    ts = getattr(response, "ts", None)
+                if ts:
+                    self._plan.message_ts = ts
+            else:
+                await self._slack.chat_update(
+                    channel=self._binding.channel,
+                    ts=self._plan.message_ts,
+                    blocks=blocks,
+                    text=fallback,
+                )
+        except Exception:
+            logger.exception(
+                "Failed to upsert Slack plan message (channel=%s thread_ts=%s)",
+                self._binding.channel,
+                self._binding.thread_ts,
+            )
+
+    async def slack_send_message(self, content: str) -> dict[str, Any]:
+        """Post a plain-text reply to the bound Slack thread.
+
+        Returns ``{"ok": True}`` on success, ``{"ok": False, "error": ...}``
+        on failure — the LLM can inspect the result and react if posting
+        failed (e.g. the channel was deleted, the bot was kicked).
+        """
+        try:
+            await self._slack.chat_postMessage(
+                channel=self._binding.channel,
+                text=content,
+                thread_ts=self._binding.thread_ts,
+            )
+        except Exception as exc:
+            logger.exception(
+                "slack_send_message failed (channel=%s thread_ts=%s)",
+                self._binding.channel,
+                self._binding.thread_ts,
+            )
+            return {"ok": False, "error": str(exc)}
+        return {"ok": True}
+
+    # ── Schema injection ────────────────────────────────────────────
+
+    def get_tool_schemas(
+        self,
+        format: str,
+        *,
+        include_memory: bool = False,
+        include_contacts: bool = True,
+    ) -> list[dict[str, Any]] | list[Any]:
+        """Return the base schemas plus our ``slack_send_message`` entry."""
+        base = super().get_tool_schemas(
+            format,
+            include_memory=include_memory,
+            include_contacts=include_contacts,
+        )
+        if format == "openai":
+            slack_schema: dict[str, Any] = {
+                "type": "function",
+                "function": {
+                    "name": SLACK_SEND_MESSAGE_TOOL_NAME,
+                    "description": _SLACK_SEND_MESSAGE_DESCRIPTION,
+                    "parameters": _SLACK_SEND_MESSAGE_INPUT_SCHEMA,
+                },
+            }
+        else:  # anthropic
+            slack_schema = {
+                "name": SLACK_SEND_MESSAGE_TOOL_NAME,
+                "description": _SLACK_SEND_MESSAGE_DESCRIPTION,
+                "input_schema": _SLACK_SEND_MESSAGE_INPUT_SCHEMA,
+            }
+        return [*base, slack_schema]
+
+    # ── Dispatch ────────────────────────────────────────────────────
+
+    async def execute_tool_call(self, tool_name: str, arguments: dict[str, Any]) -> Any:
+        """Route ``slack_send_message`` to our handler; render plan blocks
+        in Slack as a side effect of every other tool call.
+
+        Plan rendering is observed directly here (not by intercepting
+        ``send_event``) so it's independent of the brain's
+        ``Emit.EXECUTION`` setting. The two emit/visibility knobs are
+        fully orthogonal:
+
+        - Brain's ``Emit.EXECUTION`` → controls Band-side recording
+          of ``tool_call``/``tool_result`` events.
+        - ``SlackAdapter.show_tool_progress`` → controls Slack-side
+          plan-block rendering. Lives on this object as
+          ``_show_tool_progress``.
+        """
+        # Our own Slack-only tool — not a "progress task" because it IS
+        # the user-facing reply, not work-in-progress.
+        if tool_name == SLACK_SEND_MESSAGE_TOOL_NAME:
+            content = arguments.get("content")
+            if not isinstance(content, str) or not content:
+                return (
+                    f"Error: {SLACK_SEND_MESSAGE_TOOL_NAME} requires a "
+                    "non-empty 'content' string."
+                )
+            return await self.slack_send_message(content)
+
+        # Mark in_progress before executing, mark completed/error after.
+        task: PlanTask | None = None
+        if self._show_tool_progress:
+            task = PlanTask(
+                id=str(uuid.uuid4()),
+                label=humanize_tool_name(tool_name),
+                state=TaskState.IN_PROGRESS,
+                is_write=tool_name in self._write_tool_names,
+            )
+            self._plan.tasks.append(task)
+            self._plan.tasks_by_id[task.id] = task
+            await self._upsert_plan_message()
+
+        # Use the structured variant so success/failure comes from the
+        # ``ok`` flag rather than sniffing the returned string — the base
+        # tools have no single ``Error:`` prefix (failures surface as
+        # "Invalid arguments for …", "Error executing …", "Unknown tool: …"),
+        # so prefix matching would silently mark failed calls ✅.
+        try:
+            outcome = await super().execute_tool_call_structured(tool_name, arguments)
+        except Exception as exc:
+            if task is not None:
+                task.state = TaskState.ERROR
+                task.error_message = str(exc)
+                await self._upsert_plan_message()
+            raise
+
+        if task is not None:
+            if outcome.ok:
+                task.state = TaskState.COMPLETED
+            else:
+                task.state = TaskState.ERROR
+                task.error_message = outcome.error_message
+            await self._upsert_plan_message()
+        return outcome.value
+
+
+class SlackAdapter(SimpleAdapter[Any]):
+    """Wraps an inner framework adapter and adds Slack I/O.
+
+    Example:
+        from band import Agent
+        from band.adapters import AnthropicAdapter
+        from band.integrations.slack import SlackAdapter, SlackApp
+
+        brain = AnthropicAdapter(model="claude-sonnet-4-6")
+        slack = SlackAdapter(
+            inner=brain,
+            apps=[
+                SlackApp(
+                    slug="dev",
+                    signing_secret="...",
+                    bot_token="xoxb-...",
+                ),
+            ],
+            api_key="...",
+        )
+        agent = Agent.create(adapter=slack, agent_id="...", api_key="...")
+        # mount slack.router into your ASGI app on the side, e.g.:
+        #   starlette_app.mount("/slack", slack.router)
+        await agent.run()
+    """
+
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset()
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset()
+
+    def __init__(
+        self,
+        *,
+        inner: SimpleAdapter[Any],
+        apps: list[SlackApp],
+        rest_url: str = "https://app.band.ai",
+        api_key: str = "",
+        port: int = 3000,
+        transport: SlackTransport = "http",
+        web_client_factory: WebClientFactory | None = None,
+        rest_client: AsyncRestClient | None = None,
+        features: AdapterFeatures | None = None,
+        write_tool_names: frozenset[str] | set[str] | None = None,
+        show_tool_progress: bool = True,
+        mirror_slack_context: bool = True,
+    ) -> None:
+        """Initialize the Slack adapter.
+
+        Args:
+            inner: The framework adapter that does the actual reasoning
+                (e.g. ``AnthropicAdapter``, ``LangGraphAdapter``).
+            apps: One or more ``SlackApp`` configurations.
+            rest_url: Base URL for the Band REST API.
+            api_key: API key for the Band agent (same key passed to
+                ``Agent.create``). Used to mirror Slack messages into
+                Band rooms.
+            port: TCP port for the HTTP server.
+            transport: ``"http"`` (default) serves events via a mountable
+                Starlette router; the developer points their Slack app's
+                Event Subscriptions URL at the bridge. ``"socket"`` opens
+                a Socket Mode websocket to Slack per app — no public URL
+                or signing secret is needed; each ``SlackApp`` must supply
+                ``app_token`` (``xapp-...``).
+            web_client_factory: Optional factory for injecting mock
+                ``AsyncWebClient`` instances in tests.
+            rest_client: Optional ``AsyncRestClient`` injection seam.
+            features: Optional override for adapter features. Defaults
+                to the inner adapter's features so the brain's
+                capabilities flow through unchanged.
+            mirror_slack_context: When ``True`` (default), each inbound
+                Slack user turn is mirrored into the bound Band room
+                as a context-only ``thought`` event so the Band UI
+                audit timeline reflects the Slack-side conversation.
+                These events are tagged ``slack_mirror`` and never loop
+                back into the brain's history or trigger peer replies.
+                Set ``False`` to leave bridged rooms holding only the
+                bootstrap context event.
+
+        Raises:
+            ImportError: If ``slack-sdk`` is not installed.
+            ValueError: If ``apps`` is empty, or a per-app token required
+                by the chosen transport is missing.
+        """
+        try:
+            import slack_sdk  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "slack-sdk is required for SlackAdapter. "
+                "Install with: uv add band-sdk[slack]"
+            ) from exc
+
+        if not apps:
+            raise ValueError("SlackAdapter requires at least one SlackApp config")
+
+        if transport == "http":
+            missing = [a.slug for a in apps if not a.signing_secret or not a.bot_token]
+            if missing:
+                raise ValueError(
+                    "SlackAdapter(transport='http') requires signing_secret "
+                    "and bot_token on every SlackApp; missing for: "
+                    f"{', '.join(missing)}"
+                )
+        elif transport == "socket":
+            missing = [a.slug for a in apps if not a.app_token or not a.bot_token]
+            if missing:
+                raise ValueError(
+                    "SlackAdapter(transport='socket') requires app_token "
+                    "(xapp-...) and bot_token on every SlackApp; missing "
+                    f"for: {', '.join(missing)}"
+                )
+        else:
+            raise ValueError(
+                f"Unknown transport={transport!r}; expected 'http' or 'socket'"
+            )
+
+        # Use the inner adapter's history converter and feature settings
+        # so the brain sees its native history type and capabilities.
+        super().__init__(
+            history_converter=inner.history_converter or SlackHistoryConverter(),
+            features=features or inner.features,
+        )
+        self._inner = inner
+        self.apps = apps
+        self._rest_url = rest_url
+        self._api_key = api_key
+        self._port = port
+        self._transport: SlackTransport = transport
+        self._router: Router | None = None
+        self._socket_listeners: list[SlackSocketListener] = []
+        self._web_client_factory: WebClientFactory = (
+            web_client_factory or self._default_web_client_factory
+        )
+        self._web_clients: dict[str, AsyncWebClient] = {}
+        self._background_tasks: set[asyncio.Task[None]] = set()
+        self._write_tool_names: frozenset[str] = (
+            frozenset(write_tool_names)
+            if write_tool_names is not None
+            else DEFAULT_WRITE_TOOL_NAMES
+        )
+        self._show_tool_progress = show_tool_progress
+        self._mirror_slack_context = mirror_slack_context
+
+        # Band-side state.
+        self._rest: AsyncRestClient | None = rest_client
+        self._apps_by_slug: dict[str, SlackApp] = {a.slug: a for a in apps}
+        self._thread_to_room: dict[str, str] = {}
+        self._room_to_binding: dict[str, SlackRoomBinding] = {}
+        # Per-thread locks serialise room creation so two concurrent Slack
+        # events for the same thread can't both miss the map and create
+        # duplicate rooms. Keyed by the same ``_thread_key`` as
+        # ``_thread_to_room``.
+        self._room_locks: dict[str, asyncio.Lock] = {}
+        # Resolved Slack ``bot_id`` per app (from ``auth.test``), used to
+        # distinguish this bridge's own prior replies from other bots /
+        # webhooks when backfilling thread history. Resolved lazily.
+        self._bot_ids: dict[str, str | None] = {}
+
+        # Best-effort label caches for the context mirror. Slack user/
+        # channel identities are stable, so resolve each once and reuse.
+        # value: (display_name, handle)
+        self._user_label_cache: dict[str, tuple[str, str]] = {}
+        # value: channel display label (e.g. "#general" or "DM")
+        self._channel_label_cache: dict[str, str] = {}
+
+    @property
+    def inner(self) -> SimpleAdapter[Any]:
+        """The wrapped framework adapter (the brain)."""
+        return self._inner
+
+    @property
+    def transport(self) -> SlackTransport:
+        """Which inbound transport this adapter was configured with."""
+        return self._transport
+
+    @property
+    def router(self) -> Router:
+        """Starlette router serving the configured Slack apps.
+
+        Only meaningful for ``transport="http"``. In Socket Mode the
+        bridge has no HTTP surface to mount, so accessing ``router`` is
+        almost certainly a misconfiguration.
+        """
+        if self._transport != "http":
+            raise RuntimeError(
+                "SlackAdapter.router is only available for transport='http'; "
+                f"this adapter is using transport={self._transport!r}."
+            )
+        if self._router is None:
+            self._router = build_router(self.apps, dispatcher=self._dispatch_event)
+        return self._router
+
+    async def wait_idle(self) -> None:
+        """Wait for all background event handlers to complete."""
+        while self._background_tasks:
+            tasks = list(self._background_tasks)
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def on_started(self, agent_name: str, agent_description: str) -> None:
+        """Build the REST client and start the inner adapter."""
+        # We adopt ``inner.features`` (see __init__) and delegate all
+        # reasoning to the inner brain, so the inner — not this wrapper — is
+        # what actually acts on emit/capability values. Mirror its declared
+        # support before the base feature-mismatch check runs, otherwise
+        # SimpleAdapter warns "SlackAdapter does not support emit values:
+        # execution" even though the brain handles it. The inner's own
+        # on_started still performs the authoritative check.
+        # type: ignore[read-only] — base declares these ClassVar; shadowing
+        # per-instance is intentional since support is the inner's, not ours.
+        self.SUPPORTED_EMIT = self._inner.SUPPORTED_EMIT  # type: ignore[read-only]
+        self.SUPPORTED_CAPABILITIES = self._inner.SUPPORTED_CAPABILITIES  # type: ignore[read-only]
+        await super().on_started(agent_name, agent_description)
+
+        if self._rest is None:
+            if not self._api_key:
+                raise ValueError(
+                    "SlackAdapter requires api_key to reach the Band REST API; "
+                    "pass it via SlackAdapter(api_key=...)."
+                )
+            self._rest = AsyncRestClient(base_url=self._rest_url, api_key=self._api_key)
+
+        # Propagate the agent identity to the inner adapter. ``Agent.start``
+        # sets ``_band_agent_id`` on us before calling ``on_started``;
+        # the inner adapter needs it too so it can dedup own messages.
+        own_id = getattr(self, "_band_agent_id", None)
+        if own_id is not None:
+            setattr(self._inner, "_band_agent_id", own_id)
+
+        await self._inner.on_started(agent_name, agent_description)
+
+        if self._transport == "socket":
+            # Lazy import so HTTP-only installs don't pay the aiohttp /
+            # Socket Mode import cost.
+            from band.integrations.slack.socket import (
+                start_socket_listeners,
+            )
+
+            self._socket_listeners = await start_socket_listeners(
+                apps=self.apps,
+                web_client_factory=self._get_client,
+                dispatcher=self._dispatch_event,
+            )
+
+        logger.info(
+            "Slack adapter started: %s (apps=%d, transport=%s)",
+            agent_name,
+            len(self.apps),
+            self._transport,
+        )
+
+    async def close(self) -> None:
+        """Tear down transport-owned resources.
+
+        For Socket Mode this disconnects each per-app websocket client.
+        For HTTP it's a no-op — the developer's ASGI server owns the
+        HTTP lifecycle. Safe to call multiple times.
+        """
+        if self._socket_listeners:
+            listeners = self._socket_listeners
+            self._socket_listeners = []
+            for listener in listeners:
+                try:
+                    await listener.stop()
+                except Exception:
+                    logger.exception(
+                        "Failed to stop Slack Socket Mode listener (app=%s)",
+                        listener.app.slug,
+                    )
+
+    async def on_event(self, inp: AgentInput) -> None:
+        """Rehydrate Slack binding on bootstrap, then delegate as normal.
+
+        The wrapped inner adapter (Anthropic, LangGraph, ...) owns its own
+        history converter for the brain. To recover the Slack ↔ Band
+        thread mapping after a restart we run :class:`SlackHistoryConverter`
+        over the same raw history first, fold any recovered binding into
+        ``_thread_to_room`` + ``_room_to_binding``, then hand off to
+        ``SimpleAdapter.on_event`` so the inner converter still runs and
+        ``on_message`` sees the brain's native history type.
+        """
+        if inp.is_session_bootstrap:
+            self._rehydrate_room(inp.room_id, inp.history.raw)
+        await super().on_event(inp)
+
+    def _rehydrate_room(self, room_id: str, raw_history: list[dict[str, Any]]) -> None:
+        """Restore ``_thread_to_room`` and ``_room_to_binding`` for one room.
+
+        No-op when the history has no Slack bootstrap event (e.g. the
+        room was created outside this bridge), and when the recovered
+        binding points at an app slug we no longer have configured we
+        still record the binding so other diagnostics surface the
+        mismatch — :py:meth:`on_message` already gates outbound calls
+        on ``_apps_by_slug``.
+        """
+        state = SlackHistoryConverter().convert(raw_history)
+        if state.binding is None:
+            return
+        if room_id in self._room_to_binding:
+            return
+        binding = state.binding
+        thread_key = self._thread_key(
+            binding.app_slug, binding.channel, binding.thread_ts
+        )
+        # Don't trample an active mapping for the same thread — the
+        # live in-memory binding is authoritative.
+        self._thread_to_room.setdefault(thread_key, room_id)
+        self._room_to_binding[room_id] = binding
+        logger.info(
+            "Rehydrated Slack binding: room=%s app=%s thread=%s",
+            room_id,
+            binding.app_slug,
+            thread_key,
+        )
+
+    async def on_message(
+        self,
+        msg: PlatformMessage,
+        tools: AgentToolsProtocol,
+        history: Any,
+        participants_msg: str | None,
+        contacts_msg: str | None,
+        *,
+        is_session_bootstrap: bool,
+        room_id: str,
+    ) -> None:
+        """Delegate to the inner brain, teeing replies to Slack if bound."""
+        binding = self._room_to_binding.get(room_id)
+        slack_client: AsyncWebClient | None = None
+        if binding is not None and isinstance(tools, AgentTools):
+            app = self._apps_by_slug.get(binding.app_slug)
+            if app is not None:
+                slack_client = self._get_client(app)
+                tools = _SlackTeeingTools(
+                    wrap=tools,
+                    slack=slack_client,
+                    binding=binding,
+                    write_tool_names=self._write_tool_names,
+                    show_tool_progress=self._show_tool_progress,
+                )
+            else:
+                logger.warning(
+                    "Room %s bound to unknown app %s; not teeing",
+                    room_id,
+                    binding.app_slug,
+                )
+
+        # Status indicator only meaningful in Slack-bound rooms.
+        # Prepend the Slack-context note to participants_msg so the brain
+        # knows which outbound tool to use for the user-facing reply.
+        if slack_client is not None and binding is not None:
+            await self._set_status(
+                slack_client, binding.channel, binding.thread_ts, STATUS_THINKING
+            )
+            participants_msg = _merge_context_note(participants_msg, SLACK_CONTEXT_NOTE)
+        try:
+            await self._inner.on_message(
+                msg,
+                tools,
+                history,
+                participants_msg,
+                contacts_msg,
+                is_session_bootstrap=is_session_bootstrap,
+                room_id=room_id,
+            )
+        finally:
+            if slack_client is not None and binding is not None:
+                await self._set_status(
+                    slack_client, binding.channel, binding.thread_ts, ""
+                )
+
+    async def on_cleanup(self, room_id: str) -> None:
+        """Drop per-room state and forward to the inner adapter."""
+        binding = self._room_to_binding.pop(room_id, None)
+        if binding is not None:
+            thread_key = self._thread_key(
+                binding.app_slug, binding.channel, binding.thread_ts
+            )
+            self._thread_to_room.pop(thread_key, None)
+            self._room_locks.pop(thread_key, None)
+        await self._inner.on_cleanup(room_id)
+
+    # ── Slack ingress (HTTP webhook) ──────────────────────────────────
+
+    async def _dispatch_event(self, app: SlackApp, payload: dict[str, Any]) -> None:
+        """Schedule a Slack event for background processing and return.
+
+        Slack requires HTTP 200 within 3 seconds; we fire the actual
+        work into a task so the route handler can ack immediately.
+        """
+        task = asyncio.create_task(self._handle_event(app, payload))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._on_background_task_done)
+
+    def _on_background_task_done(self, task: asyncio.Task[None]) -> None:
+        self._background_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.exception("Slack background event handler crashed", exc_info=exc)
+
+    async def _handle_event(self, app: SlackApp, payload: dict[str, Any]) -> None:
+        event = payload.get("event") or {}
+        event_type = event.get("type")
+
+        if event.get("bot_id") or event.get("subtype") == "bot_message":
+            return
+
+        if event_type == "app_mention":
+            await self._invoke_brain_for_slack_event(app, event)
+        elif event_type == "message" and event.get("channel_type") == "im":
+            await self._invoke_brain_for_slack_event(app, event)
+
+    async def _invoke_brain_for_slack_event(
+        self, app: SlackApp, event: dict[str, Any]
+    ) -> None:
+        """Synthesize a ``PlatformMessage`` and call ``inner.on_message``."""
+        text = event.get("text", "")
+        channel = event.get("channel")
+        slack_user = event.get("user", "")
+        ts = event.get("ts", "")
+        thread_ts = event.get("thread_ts") or ts
+
+        if not channel or not text or not thread_ts:
+            logger.debug(
+                "Skipping Slack event for app %s: missing channel/text/thread_ts",
+                app.slug,
+            )
+            return
+
+        room_id, is_new_room = await self._get_or_create_room(
+            app=app,
+            channel=channel,
+            thread_ts=thread_ts,
+            slack_user=slack_user,
+        )
+
+        binding = self._room_to_binding[room_id]
+        assert self._rest is not None
+        synthesized = PlatformMessage(
+            id=f"slack:{ts}",
+            room_id=room_id,
+            content=text,
+            sender_id=f"slack:{slack_user}",
+            sender_type="user",
+            sender_name=slack_user or "slack-user",
+            message_type="text",
+            metadata={
+                "slack_app_slug": app.slug,
+                "slack_channel_id": channel,
+                "slack_thread_ts": thread_ts,
+                "slack_user_id": slack_user,
+            },
+            created_at=datetime.now(timezone.utc),
+        )
+
+        # Mirror the user turn into the Band room for audit visibility.
+        # Best-effort and tagged context-only; happens before the brain
+        # runs so the timeline ordering matches reality.
+        if self._mirror_slack_context:
+            await self._mirror_user_turn_to_room(
+                room_id=room_id,
+                app=app,
+                channel=channel,
+                thread_ts=thread_ts,
+                slack_user=slack_user,
+                ts=ts,
+                text=text,
+            )
+
+        slack_client = self._get_client(app)
+        real_tools = AgentTools(room_id=room_id, rest=self._rest, participants=[])
+        tools = _SlackTeeingTools(
+            wrap=real_tools,
+            slack=slack_client,
+            binding=binding,
+            write_tool_names=self._write_tool_names,
+            show_tool_progress=self._show_tool_progress,
+        )
+
+        # Pull thread context from Slack on every event that lands inside
+        # an existing thread (``thread_ts != ts``). Slack does NOT deliver
+        # prior turns with the event payload, and its own Bolt JS
+        # reference implementation calls ``conversations.replies`` per
+        # user message for exactly this reason — see
+        # https://docs.slack.dev/tools/bolt-js/tutorials/ai-assistant/.
+        # Caching the fetched result across turns would break stateless
+        # brains (Anthropic, etc.) on every follow-up message. Top-level
+        # mentions and brand-new DMs (``thread_ts == ts``) have no prior
+        # context to fetch.
+        raw_history: list[dict[str, Any]] = []
+        if thread_ts != ts:
+            raw_history = await self._fetch_thread_history(
+                app=app,
+                slack=slack_client,
+                channel=channel,
+                thread_ts=thread_ts,
+                exclude_ts=ts,
+            )
+
+        if self._inner.history_converter is not None:
+            history = self._inner.history_converter.convert(raw_history)
+        else:
+            history = None
+
+        await self._set_status(slack_client, channel, thread_ts, STATUS_THINKING)
+        try:
+            await self._inner.on_message(
+                synthesized,
+                tools,
+                history,
+                SLACK_CONTEXT_NOTE,
+                None,
+                is_session_bootstrap=is_new_room,
+                room_id=room_id,
+            )
+        finally:
+            await self._set_status(slack_client, channel, thread_ts, "")
+
+    # ── Room management ──────────────────────────────────────────────
+
+    @staticmethod
+    def _thread_key(app_slug: str, channel: str, thread_ts: str) -> str:
+        # Include ``app_slug`` so two SlackApps that happen to see the same
+        # workspace-scoped ``channel:thread_ts`` tuple map to distinct rooms
+        # and never cross-route replies into the wrong app/workspace.
+        return f"{app_slug}:{channel}:{thread_ts}"
+
+    async def _get_or_create_room(
+        self,
+        *,
+        app: SlackApp,
+        channel: str,
+        thread_ts: str,
+        slack_user: str,
+    ) -> tuple[str, bool]:
+        """Return ``(room_id, is_new_room)`` for the given Slack thread."""
+        thread_key = self._thread_key(app.slug, channel, thread_ts)
+        existing = self._thread_to_room.get(thread_key)
+        if existing is not None:
+            return existing, False
+
+        # Serialise creation per thread. Every Slack event runs in its own
+        # background task, so without this two events for one thread can
+        # both miss the map above, both create a room, and race on the
+        # write below — leaving one orphaned room with a bootstrap event
+        # and no traffic. The lock + re-check collapses that to one room.
+        lock = self._room_locks.setdefault(thread_key, asyncio.Lock())
+        async with lock:
+            existing = self._thread_to_room.get(thread_key)
+            if existing is not None:
+                return existing, False
+
+            assert self._rest is not None
+            response = await self._rest.agent_api_chats.create_agent_chat(
+                chat=ChatRoomRequest(),
+                request_options=DEFAULT_REQUEST_OPTIONS,
+            )
+            room_id = response.data.id
+
+            # Persist Slack thread context as a ``task`` event so
+            # ``SlackHistoryConverter`` can rehydrate ``thread_to_room`` after
+            # the agent restarts.
+            await self._emit_context_event(
+                room_id=room_id,
+                app=app,
+                channel=channel,
+                thread_ts=thread_ts,
+                slack_user=slack_user,
+            )
+
+            self._thread_to_room[thread_key] = room_id
+            self._room_to_binding[room_id] = SlackRoomBinding(
+                app_slug=app.slug,
+                channel=channel,
+                thread_ts=thread_ts,
+            )
+
+        logger.info(
+            "Created Band room %s for Slack thread %s (app=%s)",
+            room_id,
+            thread_key,
+            app.slug,
+        )
+        return room_id, True
+
+    async def _emit_context_event(
+        self,
+        *,
+        room_id: str,
+        app: SlackApp,
+        channel: str,
+        thread_ts: str,
+        slack_user: str,
+    ) -> None:
+        assert self._rest is not None
+        await self._rest.agent_api_events.create_agent_chat_event(
+            chat_id=room_id,
+            event=ChatEventRequest(
+                content="Slack thread context",
+                message_type="task",
+                metadata={
+                    "slack_app_slug": app.slug,
+                    "slack_channel_id": channel,
+                    "slack_thread_ts": thread_ts,
+                    "slack_user_id": slack_user,
+                    "slack_room_id": room_id,
+                },
+            ),
+        )
+
+    # ── Slack context mirroring (audit timeline) ─────────────────────
+
+    async def _mirror_user_turn_to_room(
+        self,
+        *,
+        room_id: str,
+        app: SlackApp,
+        channel: str,
+        thread_ts: str,
+        slack_user: str,
+        ts: str,
+        text: str,
+    ) -> None:
+        """Mirror an inbound Slack user turn into the room as a ``thought``.
+
+        Slack-bridged rooms otherwise hold only the bootstrap ``task``
+        event, so the Band UI audit timeline is blank while
+        real conversations happen on Slack. This posts each triggering
+        user message as a ``thought`` event carrying the Slack thread
+        identity so the timeline reflects what was actually said.
+
+        Emitted as a ``thought`` (which history converters skip) and
+        tagged ``slack_mirror`` in metadata so it never loops back into
+        the brain's history or triggers peer replies. Best-effort: any
+        failure here is logged and swallowed so it can't break the reply
+        path.
+        """
+        assert self._rest is not None
+        slack_client = self._get_client(app)
+        display_name, handle = await self._resolve_user_label(slack_client, slack_user)
+        channel_label = await self._resolve_channel_label(slack_client, channel)
+
+        # Friendly, human-readable line for the Band audit timeline.
+        # Raw ids / thread ts stay in metadata; the visible content shows
+        # who said what and where.
+        if display_name and handle:
+            who = f"{display_name} (@{handle})"
+        elif display_name or handle:
+            who = display_name or f"@{handle}"
+        else:
+            who = "Slack user"
+        content = f"💬 Slack · {channel_label} — {who}: {text}"
+
+        try:
+            await self._rest.agent_api_events.create_agent_chat_event(
+                chat_id=room_id,
+                event=ChatEventRequest(
+                    content=content,
+                    message_type="thought",
+                    metadata={
+                        "slack_mirror": True,
+                        "slack_app_slug": app.slug,
+                        "slack_channel_id": channel,
+                        "slack_channel_label": channel_label,
+                        "slack_thread_ts": thread_ts,
+                        "slack_user_id": slack_user,
+                        "slack_user_handle": handle,
+                        "slack_user_name": display_name,
+                        "slack_ts": ts,
+                    },
+                ),
+            )
+        except Exception:
+            logger.exception(
+                "Failed to mirror Slack user turn to room %s (channel=%s thread_ts=%s)",
+                room_id,
+                channel,
+                thread_ts,
+            )
+
+    async def _resolve_user_label(
+        self, slack: AsyncWebClient, user_id: str
+    ) -> tuple[str, str]:
+        """Return ``(display_name, handle)`` for a Slack user id.
+
+        Cached and best-effort: on any failure (missing scope, unknown
+        user) returns empty strings so the caller falls back gracefully.
+        """
+        if not user_id:
+            return "", ""
+        cached = self._user_label_cache.get(user_id)
+        if cached is not None:
+            return cached
+        display_name, handle = "", ""
+        try:
+            resp = await slack.users_info(user=user_id)
+            user = resp.get("user", {}) or {}
+            profile = user.get("profile", {}) or {}
+            display_name = (
+                profile.get("display_name")
+                or profile.get("real_name")
+                or user.get("real_name")
+                or ""
+            )
+            handle = user.get("name", "") or ""
+        except Exception as exc:
+            logger.debug("users.info failed for %s: %s", user_id, exc)
+        label = (display_name, handle)
+        self._user_label_cache[user_id] = label
+        return label
+
+    async def _resolve_channel_label(
+        self, slack: AsyncWebClient, channel_id: str
+    ) -> str:
+        """Return a friendly channel label (``#name``, or ``DM``).
+
+        Cached and best-effort: on failure falls back to the raw id.
+        """
+        if not channel_id:
+            return "unknown channel"
+        cached = self._channel_label_cache.get(channel_id)
+        if cached is not None:
+            return cached
+        label = channel_id
+        try:
+            resp = await slack.conversations_info(channel=channel_id)
+            ch = resp.get("channel", {}) or {}
+            if ch.get("is_im"):
+                label = "DM"
+            elif ch.get("name"):
+                label = f"#{ch['name']}"
+        except Exception as exc:
+            logger.debug("conversations.info failed for %s: %s", channel_id, exc)
+        self._channel_label_cache[channel_id] = label
+        return label
+
+    # ── Slack thread history backfill ────────────────────────────────
+
+    async def _fetch_thread_history(
+        self,
+        *,
+        app: SlackApp,
+        slack: AsyncWebClient,
+        channel: str,
+        thread_ts: str,
+        exclude_ts: str,
+    ) -> list[dict[str, Any]]:
+        """Pull a Slack thread's prior messages via ``conversations.replies``.
+
+        Returns raw history dicts in the same shape as
+        ``format_history_for_llm()`` output, so the inner adapter's
+        ``history_converter`` can ingest them with no special-casing.
+
+        Only messages authored by *this app's own bot* (matched on the
+        ``bot_id`` resolved via ``auth.test``) are mapped to
+        ``sender_type="Agent"`` / ``role="assistant"`` so converters treat
+        them as the brain's prior turns. Other bots and webhooks in the
+        thread are included as external context with a
+        ``slack-bot:<id>`` sender so they can never be mistaken for our
+        own assistant turns.
+
+        Requires the Slack ``channels:history`` (public channels) and
+        ``groups:history`` (private channels) scopes for non-DM mentions.
+        If the call fails (missing scope, deleted channel, etc.) we log
+        and return an empty list — backfill is best-effort, not a hard
+        requirement for replying to the trigger.
+        """
+        logger.info(
+            "Fetching Slack thread history (channel=%s thread_ts=%s)",
+            channel,
+            thread_ts,
+        )
+        try:
+            response = await slack.conversations_replies(
+                channel=channel,
+                ts=thread_ts,
+            )
+        except Exception as exc:
+            # Pull the Slack-level error code out of SlackApiError so the
+            # diagnosis ("missing_scope, needed: groups:history") shows up
+            # on the headline log line instead of buried in the traceback.
+            slack_err: dict[str, Any] = {}
+            response_obj = getattr(exc, "response", None)
+            if response_obj is not None:
+                data = getattr(response_obj, "data", None)
+                if isinstance(data, dict):
+                    slack_err = {
+                        k: data.get(k) for k in ("error", "needed", "provided")
+                    }
+            logger.exception(
+                "conversations.replies FAILED (channel=%s thread_ts=%s) "
+                "slack_error=%s — usually means missing scope "
+                "(channels:history for public channels, groups:history "
+                "for private channels, im:history for DMs, mpim:history "
+                "for group DMs) or the bot is not a member of the channel",
+                channel,
+                thread_ts,
+                slack_err or "<unknown>",
+            )
+            return []
+
+        try:
+            messages: list[dict[str, Any]] = list(response["messages"])  # type: ignore[index]
+        except (KeyError, TypeError):
+            messages = list(getattr(response, "messages", []) or [])
+        logger.info(
+            "conversations.replies returned %d message(s) for thread %s:%s",
+            len(messages),
+            channel,
+            thread_ts,
+        )
+
+        own_bot_id = await self._resolve_bot_id(app, slack)
+        raw: list[dict[str, Any]] = []
+        agent_name = self.agent_name or "agent"
+        for m in messages:
+            if m.get("ts") == exclude_ts:
+                continue
+            text = m.get("text", "") or ""
+            if not text:
+                continue
+            msg_bot_id = m.get("bot_id")
+            is_bot = bool(msg_bot_id) or m.get("subtype") == "bot_message"
+            # Only this bridge's own bot counts as our prior assistant turns.
+            # ``own_bot_id`` is None when auth.test failed — then we can't
+            # prove ownership, so treat every bot message as external.
+            is_own_bot = is_bot and own_bot_id is not None and msg_bot_id == own_bot_id
+            # Skip the bridge's own Block Kit progress/plan/status messages.
+            # Those are posted with ``blocks`` and a placeholder fallback
+            # ("Working on it…"/"Done"); re-ingesting them would feed the
+            # brain fake assistant turns on every follow-up. Real replies
+            # (slack_send_message) are plain text with no blocks, so they're
+            # kept. Other apps' block messages are dropped too — arbitrary
+            # block payloads don't convert to useful plain-text history.
+            if is_own_bot and m.get("blocks"):
+                continue
+            if is_own_bot:
+                sender_name = agent_name
+                sender_type = "Agent"
+                role = "assistant"
+            elif is_bot:
+                # Another bot/webhook in the thread — external context, never
+                # our own assistant turn. Identify it so the brain can tell
+                # it apart from human users.
+                bot_label = msg_bot_id or m.get("username") or "unknown"
+                sender_name = f"slack-bot:{bot_label}"
+                sender_type = "user"
+                role = "user"
+            else:
+                slack_user = m.get("user") or "slack-user"
+                sender_name = f"slack:{slack_user}"
+                sender_type = "user"
+                role = "user"
+            raw.append(
+                {
+                    "role": role,
+                    "content": text,
+                    "sender_name": sender_name,
+                    "sender_type": sender_type,
+                    "message_type": "text",
+                    "metadata": {
+                        "slack_channel_id": channel,
+                        "slack_thread_ts": thread_ts,
+                        "slack_ts": m.get("ts"),
+                    },
+                }
+            )
+        logger.info(
+            "Slack thread backfill: %d message(s) kept for brain "
+            "(channel=%s thread_ts=%s, trigger ts=%s excluded)",
+            len(raw),
+            channel,
+            thread_ts,
+            exclude_ts,
+        )
+        return raw
+
+    # ── Slack assistant-pane status indicators ────────────────────────
+
+    @staticmethod
+    async def _set_status(
+        slack: AsyncWebClient,
+        channel: str,
+        thread_ts: str,
+        status: str,
+    ) -> None:
+        """Set or clear the Slack assistant-pane status indicator.
+
+        ``assistant.threads.setStatus`` only takes effect in the Slack
+        Agents & AI Apps assistant pane (and requires the
+        ``assistant:write`` scope). For DMs/channels outside that
+        surface, Slack returns an error which we swallow at DEBUG —
+        the bot still works, the user just doesn't see "thinking…".
+        """
+        try:
+            await slack.assistant_threads_setStatus(
+                channel_id=channel,
+                thread_ts=thread_ts,
+                status=status,
+            )
+        except Exception:
+            logger.debug(
+                "assistant.threads.setStatus failed (status=%r channel=%s thread_ts=%s)",
+                status,
+                channel,
+                thread_ts,
+                exc_info=True,
+            )
+
+    # ── Slack web client management ──────────────────────────────────
+
+    @staticmethod
+    def _default_web_client_factory(app: SlackApp) -> AsyncWebClient:
+        from slack_sdk.web.async_client import AsyncWebClient
+
+        return AsyncWebClient(token=app.bot_token)
+
+    def _get_client(self, app: SlackApp) -> AsyncWebClient:
+        client = self._web_clients.get(app.slug)
+        if client is None:
+            client = self._web_client_factory(app)
+            self._web_clients[app.slug] = client
+        return client
+
+    async def _resolve_bot_id(self, app: SlackApp, slack: AsyncWebClient) -> str | None:
+        """Return this app's own Slack ``bot_id`` (via ``auth.test``).
+
+        Cached per app slug. Used by :meth:`_fetch_thread_history` to tell
+        *our* prior replies apart from other bots/webhooks in the thread —
+        only messages from this bot id are mapped to assistant history.
+        Best-effort: on failure we cache ``None`` so foreign bot messages
+        are treated as external context rather than our own turns.
+        """
+        if app.slug in self._bot_ids:
+            return self._bot_ids[app.slug]
+        bot_id: str | None = None
+        try:
+            resp = await slack.auth_test()
+            bot_id = resp.get("bot_id") or None
+        except Exception as exc:
+            logger.debug("auth.test failed for app %s: %s", app.slug, exc)
+        self._bot_ids[app.slug] = bot_id
+        return bot_id

--- a/src/band/integrations/slack/block_kit.py
+++ b/src/band/integrations/slack/block_kit.py
@@ -1,0 +1,172 @@
+"""Block Kit rendering for the tool-call progress UI.
+
+When the inner brain emits ``tool_call`` / ``tool_result`` events
+(gated on ``Emit.EXECUTION``), the SlackAdapter surfaces them as a
+Block Kit "plan" rendered into the bound Slack thread. Tasks flip
+state (``in_progress`` → ``completed``/``error``) as work progresses;
+the same message is updated in place via ``chat.update``.
+
+Slack doesn't expose a first-class ``plan`` block in stable Block Kit
+yet, so we render with ordinary ``section`` + ``divider`` blocks —
+this works in every workspace without depending on Agents & AI Apps
+beta blocks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class TaskState(str, Enum):
+    """Lifecycle of a task in the plan."""
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    ERROR = "error"
+
+
+_STATE_EMOJI: dict[TaskState, str] = {
+    TaskState.PENDING: "⏸",
+    TaskState.IN_PROGRESS: "⏳",
+    TaskState.COMPLETED: "✅",
+    TaskState.ERROR: "❌",
+}
+
+# Default Band platform tools considered "write" / mutating. The
+# SlackAdapter user can override this via constructor arg.
+DEFAULT_WRITE_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "band_send_message",
+        "band_add_participant",
+        "band_remove_participant",
+        "band_create_chatroom",
+        "band_store_memory",
+        "band_supersede_memory",
+        "band_archive_memory",
+        "band_add_contact",
+        "band_remove_contact",
+        "band_respond_contact_request",
+    }
+)
+
+# Fallback notification text when the message has only blocks. Slack
+# uses this for desktop/mobile notifications and screen readers.
+FALLBACK_TEXT_WORKING = "Working on it…"
+FALLBACK_TEXT_DONE = "Done"
+
+# Slack rejects a message with more than 50 blocks
+# (https://docs.slack.dev/reference/block-kit/blocks/). render_plan_blocks
+# emits header + optional divider + one section per task, so we cap the
+# number of rendered task sections and replace the overflow with a single
+# summary block ("…and N more").
+MAX_BLOCKS = 50
+
+
+@dataclass
+class PlanTask:
+    """One task in the plan. Linked to its triggering ``tool_call_id``."""
+
+    id: str
+    label: str
+    state: TaskState = TaskState.PENDING
+    is_write: bool = False
+    error_message: str | None = None
+
+
+@dataclass
+class PlanState:
+    """Mutable per-invocation plan state.
+
+    Created lazily on first ``tool_call`` event; lives for the duration
+    of one brain invocation. ``message_ts`` is populated after the first
+    ``chat.postMessage`` so subsequent updates can target the same Slack
+    message via ``chat.update``.
+    """
+
+    message_ts: str | None = None
+    tasks: list[PlanTask] = field(default_factory=list)
+    tasks_by_id: dict[str, PlanTask] = field(default_factory=dict)
+
+
+def humanize_tool_name(name: str) -> str:
+    """Turn a tool identifier into a human-readable label.
+
+    Examples::
+
+        humanize_tool_name("band_send_message") == "Send message"
+        humanize_tool_name("band_lookup_peers") == "Lookup peers"
+        humanize_tool_name("my_custom_tool") == "My custom tool"
+    """
+    stripped = name
+    for prefix in ("band_", "slack_"):
+        if stripped.startswith(prefix):
+            stripped = stripped[len(prefix) :]
+            break
+    return stripped.replace("_", " ").strip().capitalize() or name
+
+
+def render_plan_blocks(plan: PlanState) -> list[dict[str, Any]]:
+    """Build Slack Block Kit blocks from the current plan state."""
+    has_tasks = bool(plan.tasks)
+    all_terminal = has_tasks and all(
+        t.state in (TaskState.COMPLETED, TaskState.ERROR) for t in plan.tasks
+    )
+    any_errors = any(t.state == TaskState.ERROR for t in plan.tasks)
+
+    if not has_tasks:
+        header = f"*🤖 {FALLBACK_TEXT_WORKING}*"
+    elif all_terminal and any_errors:
+        header = "*⚠️ Done with errors*"
+    elif all_terminal:
+        header = "*✅ Done*"
+    else:
+        header = f"*🤖 {FALLBACK_TEXT_WORKING}*"
+
+    blocks: list[dict[str, Any]] = [
+        {"type": "section", "text": {"type": "mrkdwn", "text": header}},
+    ]
+    if plan.tasks:
+        blocks.append({"type": "divider"})
+
+    # Reserve one block for an overflow summary when we can't fit every
+    # task section under the 50-block ceiling. ``blocks`` already holds the
+    # header (+ divider), so the remaining budget is what's left after that.
+    overflow = len(plan.tasks) > (MAX_BLOCKS - len(blocks))
+    task_budget = (MAX_BLOCKS - len(blocks) - 1) if overflow else len(plan.tasks)
+
+    for task in plan.tasks[:task_budget]:
+        emoji = _STATE_EMOJI[task.state]
+        label = f"*{task.label}*" if task.is_write else task.label
+        if task.is_write:
+            label = f"✏️ {label}"
+        text = f"{emoji} {label}"
+        if task.state == TaskState.ERROR and task.error_message:
+            # Truncate error messages so they don't blow up the block size.
+            err = task.error_message.strip()
+            if len(err) > 240:
+                err = err[:237] + "…"
+            text += f"\n_{err}_"
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": text}})
+
+    if overflow:
+        remaining = len(plan.tasks) - task_budget
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"_…and {remaining} more_"},
+            }
+        )
+
+    return blocks
+
+
+def plan_fallback_text(plan: PlanState) -> str:
+    """Plain-text fallback for screen readers and notifications."""
+    if not plan.tasks:
+        return FALLBACK_TEXT_WORKING
+    if all(t.state in (TaskState.COMPLETED, TaskState.ERROR) for t in plan.tasks):
+        return FALLBACK_TEXT_DONE
+    return FALLBACK_TEXT_WORKING

--- a/src/band/integrations/slack/dedup.py
+++ b/src/band/integrations/slack/dedup.py
@@ -1,0 +1,50 @@
+"""Slack event-ID dedup cache, shared by both transports.
+
+Slack can deliver the same Events API event more than once — the HTTP
+transport retries unacked deliveries, and Socket Mode can redeliver
+across reconnects. The downstream pipeline is not idempotent (it creates
+rooms, mirrors turns, and invokes the brain — i.e. spends LLM tokens),
+so each transport dedups on the stable ``event_id`` before dispatching.
+
+This lives in its own module (rather than ``server.py``) so the Socket
+Mode transport can reuse it without importing Starlette.
+"""
+
+from __future__ import annotations
+
+import collections
+
+# Default bounded cache size for Slack event-ID dedup. Slack retries
+# within ~10 minutes of an unacked event; sizing for several minutes of
+# events at moderate throughput gives comfortable headroom.
+DEFAULT_SEEN_EVENTS_CACHE_SIZE = 10_000
+
+
+class _SeenEvents:
+    """LRU-bounded set of recently-seen Slack ``event_id`` values.
+
+    Used to dedup Slack redeliveries: any event with an ``event_id`` we've
+    already processed is dropped. The cache is bounded so it can't grow
+    unbounded over the process lifetime; the eviction policy is
+    least-recently-seen.
+
+    Thread-safety: not used from multiple threads. The Slack handlers
+    run on a single asyncio event loop, so we don't need locking.
+    """
+
+    def __init__(self, max_size: int = DEFAULT_SEEN_EVENTS_CACHE_SIZE) -> None:
+        self._seen: collections.OrderedDict[str, None] = collections.OrderedDict()
+        self._max_size = max_size
+
+    def is_dupe(self, event_id: str) -> bool:
+        """Return True if ``event_id`` was seen before. Records it either way."""
+        if event_id in self._seen:
+            self._seen.move_to_end(event_id)
+            return True
+        self._seen[event_id] = None
+        if len(self._seen) > self._max_size:
+            self._seen.popitem(last=False)
+        return False
+
+    def __len__(self) -> int:
+        return len(self._seen)

--- a/src/band/integrations/slack/server.py
+++ b/src/band/integrations/slack/server.py
@@ -1,0 +1,155 @@
+"""HTTP server for the Slack bridge adapter.
+
+Builds a Starlette router serving Slack Events API webhooks for each
+configured Slack app. Each app is served at ``/{slug}/events``.
+
+Responsibilities of this layer:
+
+- HMAC signature verification
+- ``url_verification`` challenge handling
+- Event-ID dedup for Slack retries
+- Dispatching verified events to a per-app callback
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+from starlette.routing import Route, Router
+
+# Re-exported for backward compatibility — the dedup cache now lives in a
+# starlette-free module so Socket Mode can share it.
+from band.integrations.slack.dedup import (
+    DEFAULT_SEEN_EVENTS_CACHE_SIZE,
+    _SeenEvents,
+)
+from band.integrations.slack.signature import verify_signature
+
+if TYPE_CHECKING:
+    from band.integrations.slack.types import SlackApp
+
+logger = logging.getLogger(__name__)
+
+# Type alias for the per-app event dispatcher.
+EventDispatcher = Callable[["SlackApp", dict], Awaitable[None]]
+
+__all__ = [
+    "DEFAULT_SEEN_EVENTS_CACHE_SIZE",
+    "_SeenEvents",
+    "build_router",
+]
+
+
+def build_router(
+    apps: list[SlackApp],
+    *,
+    dispatcher: EventDispatcher | None = None,
+    seen_events: _SeenEvents | None = None,
+) -> Router:
+    """Construct a Starlette router serving all configured Slack apps.
+
+    Args:
+        apps: Configured Slack apps; one route per app at
+            ``/{slug}/events``. Must be non-empty and have unique slugs.
+        dispatcher: Optional async callback invoked with
+            ``(app, payload)`` for non-``url_verification`` events.
+        seen_events: Optional shared dedup cache for testing. Defaults
+            to a fresh ``_SeenEvents`` shared across all apps in the
+            router.
+
+    Returns:
+        A Starlette ``Router`` ready to be mounted at any prefix.
+
+    Raises:
+        ValueError: If ``apps`` is empty or contains duplicate slugs.
+    """
+    if not apps:
+        raise ValueError("build_router requires at least one SlackApp")
+
+    seen_events = seen_events or _SeenEvents()
+
+    seen_slugs: set[str] = set()
+    routes: list[Route] = []
+    for app in apps:
+        if app.slug in seen_slugs:
+            raise ValueError(f"Duplicate SlackApp slug: {app.slug!r}")
+        seen_slugs.add(app.slug)
+        routes.append(
+            Route(
+                f"/{app.slug}/events",
+                _build_handler(app, dispatcher, seen_events),
+                methods=["POST"],
+            )
+        )
+    return Router(routes=routes)
+
+
+def _build_handler(
+    app: SlackApp,
+    dispatcher: EventDispatcher | None,
+    seen_events: _SeenEvents,
+) -> Callable[[Request], Awaitable[Response]]:
+    """Build a request handler bound to one ``SlackApp``."""
+
+    async def handle(request: Request) -> Response:
+        body = await request.body()
+        timestamp = request.headers.get("x-slack-request-timestamp", "")
+        signature = request.headers.get("x-slack-signature", "")
+
+        if not verify_signature(
+            signing_secret=app.signing_secret,
+            body=body,
+            timestamp=timestamp,
+            signature=signature,
+        ):
+            logger.warning(
+                "Rejected Slack request for app %s: signature verification failed",
+                app.slug,
+            )
+            return PlainTextResponse("invalid signature", status_code=401)
+
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Rejected Slack request for app %s: body is not valid JSON", app.slug
+            )
+            return PlainTextResponse("invalid JSON", status_code=400)
+
+        if payload.get("type") == "url_verification":
+            challenge = payload.get("challenge", "")
+            return PlainTextResponse(challenge, status_code=200)
+
+        # Retry idempotency: if Slack has already delivered this event
+        # to us (and our 200 was slow / lost), drop the duplicate. Ack
+        # 200 so Slack stops retrying.
+        event_id = payload.get("event_id")
+        if event_id and seen_events.is_dupe(event_id):
+            retry_num = request.headers.get("x-slack-retry-num", "?")
+            retry_reason = request.headers.get("x-slack-retry-reason", "")
+            logger.info(
+                "Dropping duplicate Slack event %s for app %s (retry=%s reason=%s)",
+                event_id,
+                app.slug,
+                retry_num,
+                retry_reason,
+            )
+            return Response(status_code=200)
+
+        if dispatcher is not None:
+            try:
+                await dispatcher(app, payload)
+            except Exception:
+                logger.exception(
+                    "Dispatcher raised while handling Slack event for app %s",
+                    app.slug,
+                )
+
+        return Response(status_code=200)
+
+    return handle

--- a/src/band/integrations/slack/signature.py
+++ b/src/band/integrations/slack/signature.py
@@ -1,0 +1,67 @@
+"""Slack request signature verification.
+
+Implements HMAC-SHA256 over Slack request bodies per
+https://docs.slack.dev/authentication/verifying-requests-from-slack, plus
+timestamp replay protection (reject requests outside
+``MAX_TIMESTAMP_SKEW_SECONDS``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+MAX_TIMESTAMP_SKEW_SECONDS = 5 * 60
+SLACK_SIGNATURE_VERSION = "v0"
+
+
+def verify_signature(
+    *,
+    signing_secret: str,
+    body: bytes,
+    timestamp: str,
+    signature: str,
+    now: float | None = None,
+) -> bool:
+    """Verify a Slack request signature.
+
+    Returns ``False`` on any failure — bad inputs, expired timestamp,
+    malformed signature, or HMAC mismatch — so callers can treat the
+    result as a single boolean gate without juggling exception types.
+
+    Args:
+        signing_secret: The Slack app's signing secret.
+        body: Raw request body bytes (must be unmodified — JSON parsing
+            re-encodes and breaks the signature).
+        timestamp: Value of the ``X-Slack-Request-Timestamp`` header.
+        signature: Value of the ``X-Slack-Signature`` header
+            (``"v0=<hex>"`` format).
+        now: Override current epoch seconds (for tests). Defaults to
+            ``time.time()``.
+
+    Returns:
+        True iff the signature verifies and the timestamp is within
+        ``MAX_TIMESTAMP_SKEW_SECONDS`` of ``now``.
+    """
+    if not signing_secret or not timestamp or not signature:
+        return False
+
+    try:
+        ts_int = int(timestamp)
+    except ValueError:
+        return False
+
+    current = time.time() if now is None else now
+    if abs(current - ts_int) > MAX_TIMESTAMP_SKEW_SECONDS:
+        return False
+
+    basestring = f"{SLACK_SIGNATURE_VERSION}:{timestamp}:".encode() + body
+    expected_digest = hmac.new(
+        signing_secret.encode(),
+        basestring,
+        hashlib.sha256,
+    ).hexdigest()
+    expected_signature = f"{SLACK_SIGNATURE_VERSION}={expected_digest}"
+
+    return hmac.compare_digest(expected_signature, signature)

--- a/src/band/integrations/slack/socket.py
+++ b/src/band/integrations/slack/socket.py
@@ -1,0 +1,204 @@
+"""Socket Mode transport for the Slack bridge.
+
+Socket Mode is Slack's websocket-based alternative to webhooks: instead
+of Slack POSTing events to a public URL, the bridge opens a websocket
+per Slack app and Slack pushes events through it. There's no public URL
+to manage, no signing-secret HMAC to verify (Slack authenticates the
+websocket via an app-level ``xapp-...`` token), and no HTTP server to
+run — which makes this the path of least resistance for local dev,
+firewalled deployments, and dev-without-ngrok workflows.
+
+Downstream of the websocket the pipeline is identical to the HTTP
+transport: the same ``SlackAdapter._dispatch_event`` ack-then-async
+handler that powers ``transport="http"`` is invoked with the same
+``(app, payload)`` shape. Only the ingress differs.
+
+Slack still enforces the 3-second ack window over Socket Mode, so the
+listener acks the envelope first and lets ``_dispatch_event`` queue the
+real work into a background asyncio task.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from band.integrations.slack.dedup import _SeenEvents
+
+if TYPE_CHECKING:
+    from slack_sdk.socket_mode.aiohttp import SocketModeClient
+    from slack_sdk.web.async_client import AsyncWebClient
+
+    from band.integrations.slack.types import SlackApp
+
+logger = logging.getLogger(__name__)
+
+
+# Signature mirrors ``SlackAdapter._dispatch_event``: takes the app config
+# and the raw Slack payload, schedules background work, returns fast.
+SocketDispatcher = Callable[["SlackApp", dict[str, Any]], Awaitable[None]]
+
+
+class SlackSocketListener:
+    """One Slack app's Socket Mode websocket lifecycle.
+
+    Holds a started ``SocketModeClient`` and the ``SlackApp`` it belongs
+    to. ``stop()`` cleanly closes the websocket; failure is logged and
+    swallowed so a misbehaving app doesn't block adapter shutdown.
+    """
+
+    def __init__(self, *, app: SlackApp, client: SocketModeClient) -> None:
+        self.app = app
+        self._client = client
+
+    @property
+    def client(self) -> SocketModeClient:
+        """The underlying ``SocketModeClient`` (exposed for tests)."""
+        return self._client
+
+    async def stop(self) -> None:
+        """Close the websocket. Idempotent enough for shutdown paths."""
+        await self._client.disconnect()
+
+
+async def start_socket_listeners(
+    *,
+    apps: list[SlackApp],
+    web_client_factory: Callable[[SlackApp], AsyncWebClient],
+    dispatcher: SocketDispatcher,
+    client_factory: (
+        Callable[[SlackApp, AsyncWebClient], SocketModeClient] | None
+    ) = None,
+    seen_events: _SeenEvents | None = None,
+) -> list[SlackSocketListener]:
+    """Open one Socket Mode websocket per ``SlackApp`` and start listening.
+
+    Args:
+        apps: Configured Slack apps. Each must carry an ``app_token``
+            (``xapp-...``); validation is the adapter's responsibility.
+        web_client_factory: Returns the ``AsyncWebClient`` to use for
+            outbound API calls (e.g. ack sends). Shared with the rest of
+            ``SlackAdapter`` so token + base config stay in one place.
+        dispatcher: Async callable that receives an ``(app, payload)``
+            tuple per Slack Events API envelope, mirroring
+            ``SlackAdapter._dispatch_event``. The listener acks the
+            envelope first, so the dispatcher is free to return after
+            scheduling background work.
+        client_factory: Test seam. Defaults to constructing
+            ``slack_sdk.socket_mode.aiohttp.SocketModeClient`` with the
+            app's ``app_token`` and the provided web client.
+        seen_events: Optional shared ``event_id`` dedup cache. Defaults to
+            a fresh one shared across all apps' listeners. Socket Mode can
+            redeliver the same event across reconnects, so we drop dupes
+            before dispatching (parallel to the HTTP route's dedup).
+
+    Returns:
+        Connected listeners, in input order, so ``SlackAdapter`` can hold
+        the handles for ``close()`` teardown.
+
+    Raises:
+        ImportError: If ``slack-sdk`` or ``aiohttp`` is unavailable; only
+            triggered when ``transport="socket"``.
+    """
+    factory = client_factory or _default_client_factory
+    seen_events = seen_events or _SeenEvents()
+    listeners: list[SlackSocketListener] = []
+    for app in apps:
+        web_client = web_client_factory(app)
+        client = factory(app, web_client)
+        client.socket_mode_request_listeners.append(
+            _make_request_handler(
+                app=app, dispatcher=dispatcher, seen_events=seen_events
+            )
+        )
+        await client.connect()
+        listeners.append(SlackSocketListener(app=app, client=client))
+        logger.info(
+            "Slack Socket Mode connected (app=%s)",
+            app.slug,
+        )
+    return listeners
+
+
+def _default_client_factory(
+    app: SlackApp, web_client: AsyncWebClient
+) -> SocketModeClient:
+    try:
+        from slack_sdk.socket_mode.aiohttp import SocketModeClient
+    except ImportError as exc:  # pragma: no cover — import-time guard
+        raise ImportError(
+            "Socket Mode requires aiohttp. Install with "
+            "`uv add aiohttp` (or `pip install aiohttp`); slack-sdk's "
+            "aiohttp Socket Mode client depends on it."
+        ) from exc
+    return SocketModeClient(app_token=app.app_token, web_client=web_client)
+
+
+def _make_request_handler(
+    *,
+    app: SlackApp,
+    dispatcher: SocketDispatcher,
+    seen_events: _SeenEvents,
+) -> Callable[[SocketModeClient, Any], Awaitable[None]]:
+    """Build a per-app Socket Mode request listener.
+
+    Acks every envelope immediately (Slack will retry otherwise), then
+    routes Events API payloads through ``dispatcher``. Slash commands
+    and interactive components are out of v1 scope; we still ack them to
+    avoid retries. Redelivered events (same ``event_id``) are dropped via
+    ``seen_events`` so a reconnect can't double-invoke the brain.
+    """
+    from slack_sdk.socket_mode.response import SocketModeResponse
+
+    async def handle(client: SocketModeClient, req: Any) -> None:
+        envelope_id = getattr(req, "envelope_id", None)
+        if envelope_id is not None:
+            try:
+                await client.send_socket_mode_response(
+                    SocketModeResponse(envelope_id=envelope_id)
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to ack Slack Socket Mode envelope (app=%s envelope_id=%s)",
+                    app.slug,
+                    envelope_id,
+                )
+
+        if getattr(req, "type", None) != "events_api":
+            logger.debug(
+                "Ignoring non-events_api Socket Mode payload (app=%s type=%s)",
+                app.slug,
+                getattr(req, "type", None),
+            )
+            return
+
+        payload = getattr(req, "payload", None) or {}
+        if not isinstance(payload, dict):
+            logger.warning(
+                "Slack Socket Mode payload not a dict (app=%s type=%s)",
+                app.slug,
+                type(payload).__name__,
+            )
+            return
+
+        # Drop redeliveries before dispatching — the envelope is already
+        # acked above, so we just skip the duplicate work.
+        event_id = payload.get("event_id")
+        if event_id and seen_events.is_dupe(event_id):
+            logger.info(
+                "Dropping duplicate Slack Socket Mode event %s (app=%s)",
+                event_id,
+                app.slug,
+            )
+            return
+
+        try:
+            await dispatcher(app, payload)
+        except Exception:
+            logger.exception(
+                "Slack Socket Mode dispatcher raised (app=%s)",
+                app.slug,
+            )
+
+    return handle

--- a/src/band/integrations/slack/templates/manifest.yaml
+++ b/src/band/integrations/slack/templates/manifest.yaml
@@ -1,0 +1,104 @@
+# Slack app manifest for the Band SDK Slack bridge.
+#
+# How to use this:
+#   1. Replace the {{PLACEHOLDER}} values below.
+#   2. Go to https://api.slack.com/apps → "Create New App" → "From a manifest".
+#   3. Pick the workspace, paste this YAML, click "Next" → "Create".
+#   4. Install the app to the workspace. Copy the Bot Token (xoxb-…).
+#   5. (Socket Mode only) Under "Basic Information" → "App-Level Tokens"
+#      → "Generate Token and Scopes" → name it `socket`, add scope
+#      `connections:write`. Copy the resulting xapp-… token.
+#   6. /invite @your-bot in every channel you want it to read.
+#   7. (Optional, recommended) Enable Delayed Events in the GUI: app
+#      settings → "Event Subscriptions" → toggle "Delayed Events" On.
+#      This is NOT a manifest field (no schema support as of 2026-02);
+#      it must be set manually. With it on, Slack keeps retrying missed
+#      events hourly for 24h while the bridge is offline (default 2h).
+#      See https://docs.slack.dev/changelog/2026/02/05/retry-events-feature/.
+#
+# This manifest defaults to Socket Mode (no public URL required). To use
+# HTTP webhooks instead, set `socket_mode_enabled: false` and uncomment
+# the `request_url:` line under `event_subscriptions`.
+#
+# Scope rationale:
+#   - assistant:write          → required for the Agents & AI App container
+#   - app_mentions:read        → receive @-mentions in channels
+#   - im:history               → receive DM events
+#   - channels:history         → conversations.replies in PUBLIC channels
+#                                 (thread-history backfill)
+#   - groups:history           → conversations.replies in PRIVATE channels
+#                                 (same; needed when the bot is mentioned
+#                                 in a private channel thread)
+#   - chat:write               → post replies + edit plan/status messages
+#   - users:read               → resolve sender names for attribution
+#   - channels:read            → resolve PUBLIC channel names for the
+#                                 Band audit-timeline context mirror
+#   - groups:read              → resolve PRIVATE channel names (same)
+#   - im:read                  → identify DMs for the context mirror
+#   - users:read.email         → optional, only if your agent does
+#                                 email-keyed memory scoping
+#
+# Event subscriptions:
+#   - app_mention              → channel @-mentions
+#   - message.im               → DMs
+#   - assistant_thread_started → user opens the assistant pane
+
+display_information:
+  name: "{{AGENT_DISPLAY_NAME}}"      # e.g. "Recruit Assistant"
+  description: "{{AGENT_TAGLINE}}"     # one-liner shown in the app catalog
+  background_color: "#1F2937"
+
+features:
+  bot_user:
+    display_name: "{{BOT_HANDLE}}"     # e.g. "recruit-assistant" (lowercase, no @)
+    always_online: true
+
+  # Agents & AI App container — enables the assistant pane in Slack.
+  # This is what powers `assistant.threads.setStatus` ("is thinking…")
+  # and Block Kit plan/task block rendering.
+  assistant_view:
+    assistant_description: "{{AGENT_TAGLINE}}"
+    suggested_prompts: []              # Phase 2 candidate
+
+oauth_config:
+  scopes:
+    bot:
+      - assistant:write
+      - app_mentions:read
+      - im:history
+      - channels:history
+      - groups:history
+      - chat:write
+      - users:read
+      - channels:read
+      - groups:read
+      - im:read
+      # Uncomment if your agent does email-keyed memory:
+      # - users:read.email
+
+settings:
+  event_subscriptions:
+    # HTTP transport: set request_url to your public bridge URL,
+    # something like https://your-bridge.example.com/slack/dev/events.
+    # Leave commented out when running Socket Mode.
+    # request_url: "https://{{YOUR_PUBLIC_HOST}}/slack/dev/events"
+
+    bot_events:
+      - app_mention
+      - message.im
+      - assistant_thread_started
+
+    # NOTE: "Delayed Events" (retry missed events hourly for 24h while the
+    # bridge is offline, vs the 2h default) is recommended for production
+    # but has NO manifest field — enable it manually in the GUI under
+    # "Event Subscriptions" → "Delayed Events". See step 7 in the header.
+
+  interactivity:
+    is_enabled: false                  # Phase 3 candidate (buttons/modals)
+
+  # Socket Mode — bridge opens a websocket to Slack, no public URL needed.
+  # Flip to false to use HTTP webhooks (and uncomment request_url above).
+  socket_mode_enabled: true
+
+  org_deploy_enabled: false
+  token_rotation_enabled: false        # v1 explicitly recommends OFF

--- a/src/band/integrations/slack/types.py
+++ b/src/band/integrations/slack/types.py
@@ -1,0 +1,76 @@
+"""Types for the Slack bridge adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SlackApp:
+    """Configuration for one Slack app served by the adapter.
+
+    One ``SlackApp`` = one Slack bot user attached to one Band agent.
+    Multiple ``SlackApp`` entries can share a single adapter (e.g. for
+    multi-tenant setups); each gets its own HTTP route at
+    ``/{slug}/events``.
+
+    Required fields depend on the adapter's transport. The adapter
+    validates this at construction time; passing the wrong combination
+    raises ``ValueError``.
+
+    Attributes:
+        slug: URL-safe identifier; used as the HTTP route segment.
+        signing_secret: The Slack app's signing secret (HMAC verification).
+            Required for HTTP transport, ignored in Socket Mode where
+            Slack authenticates the websocket via ``app_token``.
+        bot_token: The Slack app's bot token (``xoxb-...``) for outbound
+            ``chat.postMessage`` etc. Always required.
+        app_token: The Slack app-level token (``xapp-...``) used to open
+            a Socket Mode websocket. Required when the adapter is built
+            with ``transport="socket"``; unused in HTTP transport.
+    """
+
+    slug: str
+    bot_token: str
+    signing_secret: str = ""
+    app_token: str = ""
+
+
+@dataclass
+class SlackSessionState:
+    """Per-room session state recovered from platform history.
+
+    Platform history is fetched and converted per-room, so the converter
+    only ever sees the events for one room at a time. The room_id itself
+    comes from ``inp.room_id``; the converter just needs to surface the
+    Slack thread identity stored in the room's bootstrap context event.
+
+    Attributes:
+        binding: Slack thread bound to this room, or ``None`` if the
+            history contains no ``slack_app_slug`` task event (e.g. the
+            room wasn't created by this bridge, or the bootstrap event
+            was scrubbed).
+    """
+
+    binding: SlackRoomBinding | None = None
+
+
+@dataclass(frozen=True)
+class SlackRoomBinding:
+    """Records the Slack thread that a Band room mirrors.
+
+    Used to route brain replies back: when ``tools.send_message`` fires
+    for a bound room, the adapter looks up the binding to know which
+    Slack channel/thread to ``chat.postMessage`` into.
+
+    Attributes:
+        app_slug: Which ``SlackApp`` owns this conversation (selects the
+            bot token used for the outbound Slack call).
+        channel: Slack channel/DM ID the original message came from.
+        thread_ts: Slack thread root timestamp; replies post under this
+            ``thread_ts`` so the conversation stays threaded.
+    """
+
+    app_slug: str
+    channel: str
+    thread_ts: str

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -1105,6 +1105,24 @@ def validate_tool_arguments(
     return validated.model_dump(exclude_none=True)
 
 
+@dataclass(frozen=True)
+class ToolCallOutcome:
+    """Structured result of :meth:`AgentTools.execute_tool_call_structured`.
+
+    ``value`` is the JSON-serializable payload handed to the LLM (the
+    success result, or an error string on failure so the model can still
+    react). ``ok`` is the machine-readable success flag and
+    ``error_message`` the human-readable failure detail. Together they let
+    callers branch on success/failure without parsing ``value`` — e.g. the
+    Slack plan-progress UI marks a task ✅/❌ from ``ok`` rather than
+    sniffing the error string's prefix.
+    """
+
+    value: Any
+    ok: bool
+    error_message: str | None = None
+
+
 class AgentTools(AgentToolsProtocol):
     """
     Room-bound tools for LLM platform interaction.
@@ -2132,6 +2150,22 @@ class AgentTools(AgentToolsProtocol):
         Raises:
             BandToolError: When a tool method raises a typed tool failure
         """
+        outcome = await self.execute_tool_call_structured(tool_name, arguments)
+        return outcome.value
+
+    async def execute_tool_call_structured(
+        self, tool_name: str, arguments: dict[str, Any]
+    ) -> ToolCallOutcome:
+        """Execute a tool call and report success/failure structurally.
+
+        Identical dispatch, validation, and serialization to
+        :meth:`execute_tool_call`, but returns a :class:`ToolCallOutcome`
+        whose ``ok`` flag is the authoritative success signal. Callers
+        that need to react to failure (e.g. progress UIs) should branch on
+        ``ok`` instead of inspecting the returned string, which has no
+        stable error prefix. ``BandToolError`` still propagates so
+        framework wrappers can translate it into native failures.
+        """
         # Validate arguments against Pydantic model
         try:
             definition = TOOL_DEFINITIONS.get(tool_name)
@@ -2142,32 +2176,35 @@ class AgentTools(AgentToolsProtocol):
                     arguments,
                 )
         except ValueError as error:
-            return str(error)
+            return ToolCallOutcome(value=str(error), ok=False, error_message=str(error))
         except Exception as e:
-            return f"Error validating {tool_name} arguments: {e}"
+            msg = f"Error validating {tool_name} arguments: {e}"
+            return ToolCallOutcome(value=msg, ok=False, error_message=msg)
 
         definition = TOOL_DEFINITIONS.get(tool_name)
         if definition is None:
-            return f"Unknown tool: {tool_name}"
+            msg = f"Unknown tool: {tool_name}"
+            return ToolCallOutcome(value=msg, ok=False, error_message=msg)
 
         try:
             method = getattr(self, definition.method_name)
             result = await method(**arguments)
             # Serialize Pydantic models to dicts at the adapter boundary
             if hasattr(result, "model_dump"):
-                return result.model_dump()
-            if isinstance(result, list):
-                return [
+                result = result.model_dump()
+            elif isinstance(result, list):
+                result = [
                     item.model_dump() if hasattr(item, "model_dump") else item
                     for item in result
                 ]
-            return result
+            return ToolCallOutcome(value=result, ok=True)
         except BandToolError:
             # Let BandToolError propagate so framework wrappers can
             # translate it into framework-native failure results.
             raise
         except Exception as e:
-            return f"Error executing {tool_name}: {e}"
+            msg = f"Error executing {tool_name}: {e}"
+            return ToolCallOutcome(value=msg, ok=False, error_message=msg)
 
 
 class HumanTools:

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -694,9 +694,12 @@ def _build_gemini_config() -> AdapterConfig:
 # on_cleanup contract), so they cannot share the same conformance tests.
 # acp uses the ACP protocol (Agent Client Protocol) with a similar non-standard
 # lifecycle (ACP JSON-RPC over stdio), so it is also excluded.
+# slack is a transport bridge that *wraps* an inner framework adapter (the brain)
+# and adds Slack ingress/egress; it has no model/LLM contract of its own, so it
+# cannot share the framework-adapter conformance tests (same rationale as a2a/acp).
 # claude_sdk is excluded when claude-agent-sdk optional dep is not installed.
 
-_excluded = {"a2a", "a2a_gateway", "acp"}
+_excluded = {"a2a", "a2a_gateway", "acp", "slack"}
 if not _HAS_CLAUDE_SDK:
     _excluded = _excluded | {"claude_sdk"}
 ADAPTER_EXCLUDED_MODULES: frozenset[str] = frozenset(_excluded)

--- a/tests/framework_configs/converters.py
+++ b/tests/framework_configs/converters.py
@@ -257,6 +257,8 @@ def _build_gemini_config() -> ConverterConfig:
 # the standard convert() -> framework-format contract that conformance tests validate.
 # crewai_flow is a metadata-only converter for orchestration state reconstructed from
 # task events; same exception as codex/letta/opencode.
+# slack is a metadata-only converter too: it recovers the Slack thread binding from the
+# room's bootstrap task event (SlackSessionState), not a message-history conversion.
 CONVERTER_EXCLUDED_MODULES: frozenset[str] = frozenset(
     {
         "_tool_parsing",
@@ -269,6 +271,7 @@ CONVERTER_EXCLUDED_MODULES: frozenset[str] = frozenset(
         "crewai_flow",
         "letta",
         "opencode",
+        "slack",
     }
 )
 

--- a/tests/integrations/slack/test_blockkit.py
+++ b/tests/integrations/slack/test_blockkit.py
@@ -1,0 +1,439 @@
+"""Tests for tool-call visibility via Block Kit plan/task UI.
+
+When the brain emits ``tool_call`` / ``tool_result`` events (via
+``Emit.EXECUTION``), the SlackAdapter renders them as a progressive
+Block Kit message in the bound Slack thread. The plan is created on
+the first ``tool_call`` and updated in place via ``chat.update`` as
+work progresses.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from band.integrations.slack.adapter import _SlackTeeingTools
+from band.integrations.slack.block_kit import (
+    DEFAULT_WRITE_TOOL_NAMES,
+    PlanState,
+    PlanTask,
+    TaskState,
+    humanize_tool_name,
+    plan_fallback_text,
+    render_plan_blocks,
+)
+from band.integrations.slack.types import SlackRoomBinding
+from band.runtime.tools import AgentTools
+
+
+# ── humanize_tool_name ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("band_send_message", "Send message"),
+        ("band_lookup_peers", "Lookup peers"),
+        ("slack_send_message", "Send message"),
+        ("my_custom_tool", "My custom tool"),
+        ("snake_case_only", "Snake case only"),
+        ("", ""),
+        # When stripping the prefix produces an empty string, fall back
+        # to the original name rather than presenting a blank label.
+        ("band_", "band_"),
+    ],
+)
+def test_humanize_tool_name(raw: str, expected: str):
+    assert humanize_tool_name(raw) == expected
+
+
+# ── render_plan_blocks ──────────────────────────────────────────────────────
+
+
+def test_render_empty_plan_shows_working_header():
+    blocks = render_plan_blocks(PlanState())
+    assert len(blocks) == 1
+    assert "Working on it" in blocks[0]["text"]["text"]
+    assert blocks[0]["text"]["text"].startswith("*🤖")
+
+
+def test_render_in_progress_task():
+    plan = PlanState(
+        tasks=[PlanTask(id="a", label="Lookup peers", state=TaskState.IN_PROGRESS)]
+    )
+    plan.tasks_by_id["a"] = plan.tasks[0]
+    blocks = render_plan_blocks(plan)
+    # Header + divider + 1 task = 3 blocks
+    assert len(blocks) == 3
+    assert blocks[0]["text"]["text"].startswith("*🤖")
+    assert blocks[1]["type"] == "divider"
+    assert "⏳" in blocks[2]["text"]["text"]
+    assert "Lookup peers" in blocks[2]["text"]["text"]
+
+
+def test_render_all_completed_flips_header_to_done():
+    plan = PlanState(
+        tasks=[
+            PlanTask(id="a", label="Lookup peers", state=TaskState.COMPLETED),
+            PlanTask(id="b", label="Read memories", state=TaskState.COMPLETED),
+        ]
+    )
+    blocks = render_plan_blocks(plan)
+    assert blocks[0]["text"]["text"] == "*✅ Done*"
+    assert "✅" in blocks[2]["text"]["text"]
+    assert "✅" in blocks[3]["text"]["text"]
+
+
+def test_render_any_error_flips_header_to_done_with_errors():
+    plan = PlanState(
+        tasks=[
+            PlanTask(id="a", label="Lookup peers", state=TaskState.COMPLETED),
+            PlanTask(
+                id="b",
+                label="Add participant",
+                state=TaskState.ERROR,
+                error_message="peer not found",
+            ),
+        ]
+    )
+    blocks = render_plan_blocks(plan)
+    assert blocks[0]["text"]["text"] == "*⚠️ Done with errors*"
+    err_block_text = blocks[-1]["text"]["text"]
+    assert "❌" in err_block_text
+    assert "peer not found" in err_block_text
+
+
+def test_write_tool_emphasis():
+    plan = PlanState(
+        tasks=[
+            PlanTask(
+                id="a",
+                label="Add participant",
+                state=TaskState.IN_PROGRESS,
+                is_write=True,
+            ),
+            PlanTask(
+                id="b",
+                label="Lookup peers",
+                state=TaskState.IN_PROGRESS,
+                is_write=False,
+            ),
+        ]
+    )
+    blocks = render_plan_blocks(plan)
+    write_block = blocks[2]["text"]["text"]
+    read_block = blocks[3]["text"]["text"]
+    # Write tool: bold + pencil emoji prefix.
+    assert "✏️" in write_block
+    assert "*Add participant*" in write_block
+    # Read tool: no bold, no pencil.
+    assert "✏️" not in read_block
+    assert "*Lookup peers*" not in read_block
+
+
+def test_render_truncates_long_error_messages():
+    long_err = "x" * 500
+    plan = PlanState(
+        tasks=[
+            PlanTask(
+                id="a",
+                label="Lookup peers",
+                state=TaskState.ERROR,
+                error_message=long_err,
+            )
+        ]
+    )
+    blocks = render_plan_blocks(plan)
+    text = blocks[-1]["text"]["text"]
+    # Truncated with ellipsis; total error portion ≤ 240 chars.
+    assert "…" in text
+    assert len([c for c in text if c == "x"]) <= 240
+
+
+def test_plan_fallback_text_states():
+    assert plan_fallback_text(PlanState()) == "Working on it…"
+    plan_in_progress = PlanState(
+        tasks=[PlanTask(id="a", label="x", state=TaskState.IN_PROGRESS)]
+    )
+    assert plan_fallback_text(plan_in_progress) == "Working on it…"
+    plan_done = PlanState(
+        tasks=[
+            PlanTask(id="a", label="x", state=TaskState.COMPLETED),
+            PlanTask(id="b", label="y", state=TaskState.ERROR),
+        ]
+    )
+    assert plan_fallback_text(plan_done) == "Done"
+
+
+def test_render_caps_blocks_at_slack_limit():
+    """Slack rejects >50 blocks; large plans are capped with an overflow note.
+
+    49 tasks would otherwise render header + divider + 49 = 51 blocks. We
+    cap at 50 by truncating tasks and appending a single "…and N more"
+    summary, so the message is still postable.
+    """
+    plan = PlanState(
+        tasks=[
+            PlanTask(id=str(i), label=f"task {i}", state=TaskState.COMPLETED)
+            for i in range(49)
+        ]
+    )
+    blocks = render_plan_blocks(plan)
+
+    assert len(blocks) == 50
+    # Last block is the overflow summary. header(1) + divider(1) + 47 task
+    # sections + 1 overflow = 50, so 49 - 47 = 2 tasks are summarised.
+    assert blocks[-1]["text"]["text"] == "_…and 2 more_"
+
+
+def test_render_does_not_cap_at_or_below_limit():
+    """A plan that fits in 50 blocks renders every task, no overflow note."""
+    # header + divider + 48 task sections == 50 blocks exactly.
+    plan = PlanState(
+        tasks=[
+            PlanTask(id=str(i), label=f"task {i}", state=TaskState.COMPLETED)
+            for i in range(48)
+        ]
+    )
+    blocks = render_plan_blocks(plan)
+
+    assert len(blocks) == 50
+    assert all("…and" not in str(b) for b in blocks)
+
+
+def test_default_write_tool_names_includes_known_mutators():
+    assert "band_send_message" in DEFAULT_WRITE_TOOL_NAMES
+    assert "band_add_participant" in DEFAULT_WRITE_TOOL_NAMES
+    assert "band_store_memory" in DEFAULT_WRITE_TOOL_NAMES
+    # Read-only tools should NOT be in there.
+    assert "band_lookup_peers" not in DEFAULT_WRITE_TOOL_NAMES
+    assert "band_list_memories" not in DEFAULT_WRITE_TOOL_NAMES
+
+
+# ── _SlackTeeingTools tool-execution hook ───────────────────────────────────
+#
+# The plan-rendering hook now lives in ``execute_tool_call`` (not
+# ``send_event``) so Slack progress is independent of the brain's
+# ``Emit.EXECUTION`` setting. Tests patch the parent class's
+# ``execute_tool_call_structured`` to return controlled outcomes — the
+# Slack hook derives task success/failure from the structured ``ok``
+# flag, not from the returned string.
+
+
+def _make_tools(
+    write_tool_names: frozenset[str] | set[str] | None = None,
+    show_tool_progress: bool = True,
+) -> tuple[_SlackTeeingTools, MagicMock, AsyncMock]:
+    rest = MagicMock()
+    base = AgentTools(room_id="r1", rest=rest, participants=[])
+    slack = AsyncMock()
+    slack.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "msg-1.000"})
+    slack.chat_update = AsyncMock(return_value={"ok": True, "ts": "msg-1.000"})
+    tools = _SlackTeeingTools(
+        wrap=base,
+        slack=slack,
+        binding=SlackRoomBinding(app_slug="dev", channel="C", thread_ts="1.0"),
+        write_tool_names=write_tool_names,
+        show_tool_progress=show_tool_progress,
+    )
+    return tools, rest, slack
+
+
+def _patch_super_execute(
+    return_value: object = "ok",
+    *,
+    ok: bool = True,
+    error_message: str | None = None,
+) -> tuple[Any, AsyncMock]:
+    """Patch ``AgentTools.execute_tool_call_structured`` so super calls return
+    controlled :class:`ToolCallOutcome` results."""
+    from band.runtime.tools import ToolCallOutcome
+
+    mock = AsyncMock(
+        return_value=ToolCallOutcome(
+            value=return_value, ok=ok, error_message=error_message
+        )
+    )
+    return patch.object(AgentTools, "execute_tool_call_structured", mock), mock
+
+
+@pytest.mark.asyncio
+async def test_first_tool_call_posts_plan_message():
+    tools, _, slack = _make_tools()
+    ctx, super_mock = _patch_super_execute(return_value=[])
+    with ctx:
+        await tools.execute_tool_call("band_lookup_peers", {})
+
+    slack.chat_postMessage.assert_awaited_once()
+    kwargs = slack.chat_postMessage.await_args.kwargs
+    assert kwargs["channel"] == "C"
+    assert kwargs["thread_ts"] == "1.0"
+    blocks = kwargs["blocks"]
+    assert any("Lookup peers" in (b.get("text", {}).get("text", "")) for b in blocks)
+    # Plan message_ts captured for subsequent updates.
+    assert tools._plan.message_ts == "msg-1.000"
+    # Super was called (the real tool executed).
+    super_mock.assert_awaited_once_with("band_lookup_peers", {})
+
+
+@pytest.mark.asyncio
+async def test_second_tool_call_updates_existing_plan_message():
+    tools, _, slack = _make_tools()
+    ctx, _ = _patch_super_execute(return_value="ok")
+    with ctx:
+        await tools.execute_tool_call("band_lookup_peers", {})
+        await tools.execute_tool_call("band_add_participant", {})
+
+    # First call: 1 post (in_progress) + 1 update (completed)
+    # Second call: 2 more updates (add task in_progress, mark completed)
+    # = 1 post total, ≥3 updates
+    slack.chat_postMessage.assert_awaited_once()
+    assert slack.chat_update.await_count >= 3
+    update_kwargs = slack.chat_update.await_args.kwargs
+    assert update_kwargs["channel"] == "C"
+    assert update_kwargs["ts"] == "msg-1.000"
+    final_blocks = update_kwargs["blocks"]
+    tasks_text = " ".join(
+        b.get("text", {}).get("text", "")
+        for b in final_blocks
+        if b["type"] == "section"
+    )
+    assert "Lookup peers" in tasks_text
+    assert "Add participant" in tasks_text
+
+
+@pytest.mark.asyncio
+async def test_tool_completes_flips_task_to_completed():
+    tools, _, _ = _make_tools()
+    ctx, _ = _patch_super_execute(return_value="ok")
+    with ctx:
+        await tools.execute_tool_call("band_lookup_peers", {})
+    # After completion, exactly one task in COMPLETED state.
+    assert len(tools._plan.tasks) == 1
+    assert tools._plan.tasks[0].state == TaskState.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_failed_tool_call_flips_task_to_error():
+    """A *real* base-tool failure must mark the task ERROR.
+
+    Regression for the string-heuristic bug: ``AgentTools`` failures have
+    no single ``Error:`` prefix (they surface as "Invalid arguments for
+    …", "Error executing …", "Unknown tool: …"), so the plan UI must
+    derive failure from the structured ``ok`` flag. Here we drive a real
+    validation failure (missing required args) — no REST call, no mock —
+    so the test exercises the actual error string the base tools produce.
+    """
+    tools, _, slack = _make_tools()
+
+    result = await tools.execute_tool_call("band_add_participant", {})
+
+    # Real base-class failure string — explicitly NOT "Error:"-prefixed.
+    assert isinstance(result, str)
+    assert result.startswith("Invalid arguments for band_add_participant")
+    task = tools._plan.tasks[0]
+    assert task.state == TaskState.ERROR
+    assert task.error_message and "Invalid arguments" in task.error_message
+    update_blocks = slack.chat_update.await_args.kwargs["blocks"]
+    assert update_blocks[0]["text"]["text"] == "*⚠️ Done with errors*"
+
+
+@pytest.mark.asyncio
+async def test_super_exception_marks_task_error_and_reraises():
+    tools, _, _ = _make_tools()
+    err = RuntimeError("boom")
+    from band.runtime.tools import AgentTools as _AT
+
+    # BandToolError (and anything else that propagates out of the
+    # structured call) must mark the task ERROR and re-raise.
+    with patch.object(_AT, "execute_tool_call_structured", AsyncMock(side_effect=err)):
+        with pytest.raises(RuntimeError, match="boom"):
+            await tools.execute_tool_call("band_lookup_peers", {})
+
+    task = tools._plan.tasks[0]
+    assert task.state == TaskState.ERROR
+    assert "boom" in task.error_message
+
+
+@pytest.mark.asyncio
+async def test_slack_send_message_does_not_appear_as_plan_task():
+    """The Slack-only reply tool IS the answer, not progress."""
+    tools, _, slack = _make_tools()
+
+    await tools.execute_tool_call(
+        "slack_send_message", {"content": "Here is the answer."}
+    )
+
+    # The plan stays empty; no plan message posted; just the user-facing reply.
+    assert tools._plan.tasks == []
+    # chat.postMessage WAS called — but it was the slack_send_message tool
+    # posting the reply, not a plan-block placeholder.
+    slack.chat_postMessage.assert_awaited_once()
+    assert slack.chat_postMessage.await_args.kwargs["text"] == "Here is the answer."
+    assert "blocks" not in slack.chat_postMessage.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_show_tool_progress_false_disables_plan_blocks():
+    """Toggle independently of brain's emit setting."""
+    tools, _, slack = _make_tools(show_tool_progress=False)
+    ctx, super_mock = _patch_super_execute(return_value="ok")
+    with ctx:
+        await tools.execute_tool_call("band_lookup_peers", {})
+        await tools.execute_tool_call("band_add_participant", {})
+
+    # Plan stayed empty; no Slack writes; tools still executed.
+    assert tools._plan.tasks == []
+    slack.chat_postMessage.assert_not_awaited()
+    slack.chat_update.assert_not_awaited()
+    assert super_mock.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_write_tool_emphasis_propagates_from_adapter_config():
+    """Custom write_tool_names override the default set."""
+    tools, _, slack = _make_tools(write_tool_names={"band_lookup_peers"})
+    ctx, _ = _patch_super_execute(return_value="ok")
+    with ctx:
+        await tools.execute_tool_call("band_lookup_peers", {})
+
+    blocks = slack.chat_postMessage.await_args.kwargs["blocks"]
+    task_block_text = blocks[-1]["text"]["text"]
+    # Lookup peers is now treated as a write tool (per the override).
+    assert "✏️" in task_block_text
+    assert "*Lookup peers*" in task_block_text
+
+
+@pytest.mark.asyncio
+async def test_slack_failure_does_not_break_tool_execution():
+    tools, _, slack = _make_tools()
+    slack.chat_postMessage = AsyncMock(side_effect=RuntimeError("slack down"))
+    ctx, super_mock = _patch_super_execute(return_value="ok")
+    with ctx:
+        result = await tools.execute_tool_call("band_lookup_peers", {})
+
+    # The underlying tool still executed and its result was returned.
+    assert result == "ok"
+    super_mock.assert_awaited_once()
+    # message_ts was never captured (post failed) so subsequent calls
+    # would try to post again rather than update a missing ts.
+    assert tools._plan.message_ts is None
+
+
+@pytest.mark.asyncio
+async def test_full_sequence_two_tools():
+    tools, _, slack = _make_tools()
+    ctx, _ = _patch_super_execute(return_value="ok")
+    with ctx:
+        await tools.execute_tool_call("band_lookup_peers", {})
+        await tools.execute_tool_call("band_add_participant", {})
+
+    slack.chat_postMessage.assert_awaited_once()
+    # Final plan state: both completed.
+    assert len(tools._plan.tasks) == 2
+    assert all(t.state == TaskState.COMPLETED for t in tools._plan.tasks)
+    # Final update shows "Done" header.
+    final_blocks = slack.chat_update.await_args_list[-1].kwargs["blocks"]
+    assert final_blocks[0]["text"]["text"] == "*✅ Done*"

--- a/tests/integrations/slack/test_framework_mounts.py
+++ b/tests/integrations/slack/test_framework_mounts.py
@@ -1,0 +1,134 @@
+"""Framework-mount integration tests.
+
+The adapter must mount cleanly into FastAPI, Flask, and Starlette.
+Flask is out of v1 scope (sync-only, would require asgiref). Starlette
+is exercised
+implicitly throughout ``test_wrapping.py`` via ``ASGITransport`` on
+``SlackAdapter.router`` itself — which IS a Starlette ``Router``, so
+those tests already prove the Starlette path.
+
+This file pins the remaining claim: ``SlackAdapter.router`` survives
+being mounted under a path prefix in a FastAPI app, with signature
+verification, request body handling, and background dispatch all
+working as they do under direct invocation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from band.integrations.slack.adapter import SlackAdapter
+from band.integrations.slack.signature import SLACK_SIGNATURE_VERSION
+from band.integrations.slack.types import SlackApp
+
+from tests.integrations.slack.test_wrapping import (
+    _SlackReplyBrain,
+    _make_rest_mock,
+    _mention_event,
+)
+
+
+def _signed_headers(body: bytes, secret: str) -> dict[str, str]:
+    timestamp = str(int(time.time()))
+    base = f"{SLACK_SIGNATURE_VERSION}:{timestamp}:".encode() + body
+    digest = hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return {
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": f"{SLACK_SIGNATURE_VERSION}={digest}",
+        "content-type": "application/json",
+    }
+
+
+@pytest.mark.asyncio
+async def test_router_mounts_into_fastapi_with_path_prefix():
+    """`app.mount("/slack", slack.router)` is the canonical user-facing
+    integration. Verify the prefix is stripped correctly, the signed
+    event verifies, and the brain is invoked with the synthesized
+    platform message — i.e., nothing about the mount interferes with
+    the pipeline."""
+    app_config = SlackApp(
+        slug="dev", bot_token="xoxb-dev", signing_secret="test-secret"
+    )
+    inner = _SlackReplyBrain(reply=None)
+    rest = _make_rest_mock(["room-1"])
+    adapter = SlackAdapter(
+        inner=inner,
+        apps=[app_config],
+        api_key="k",
+        rest_client=rest,
+        web_client_factory=lambda a: AsyncMock(
+            chat_postMessage=AsyncMock(return_value={"ok": True, "ts": "x"}),
+            assistant_threads_setStatus=AsyncMock(return_value={"ok": True}),
+            conversations_replies=AsyncMock(return_value={"messages": []}),
+        ),
+    )
+    adapter._band_agent_id = "bridge-uuid"  # type: ignore[attr-defined]
+    await adapter.on_started("MyBot", "")
+
+    fastapi_app = FastAPI()
+    fastapi_app.mount("/slack", adapter.router)
+
+    payload = _mention_event(
+        channel="C1", ts="100.0", text="<@U001> hello", user="U999"
+    )
+    body = json.dumps(payload).encode()
+    headers = _signed_headers(body, app_config.signing_secret)
+
+    transport = ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/slack/dev/events", content=body, headers=headers)
+
+    assert response.status_code == 200
+    await adapter.wait_idle()
+
+    # Brain saw the event with the right content, proving the full
+    # mounted path delivered.
+    assert isinstance(inner, _SlackReplyBrain)
+    assert len(inner.invocations) == 1
+    assert inner.invocations[0]["msg"].content == "<@U001> hello"
+
+
+@pytest.mark.asyncio
+async def test_unsigned_request_to_mounted_fastapi_is_rejected():
+    """A mount shouldn't accidentally relax signature verification."""
+    app_config = SlackApp(
+        slug="dev", bot_token="xoxb-dev", signing_secret="test-secret"
+    )
+    inner = _SlackReplyBrain(reply=None)
+    rest = _make_rest_mock(["room-1"])
+    adapter = SlackAdapter(
+        inner=inner,
+        apps=[app_config],
+        api_key="k",
+        rest_client=rest,
+        web_client_factory=lambda a: AsyncMock(),
+    )
+    adapter._band_agent_id = "bridge-uuid"  # type: ignore[attr-defined]
+    await adapter.on_started("MyBot", "")
+
+    fastapi_app = FastAPI()
+    fastapi_app.mount("/slack", adapter.router)
+
+    payload: dict[str, Any] = {"type": "event_callback", "event": {}}
+    body = json.dumps(payload).encode()
+
+    transport = ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/slack/dev/events",
+            content=body,
+            headers={"content-type": "application/json"},  # no signature
+        )
+
+    assert response.status_code == 401
+    assert inner.invocations == []

--- a/tests/integrations/slack/test_history_converter.py
+++ b/tests/integrations/slack/test_history_converter.py
@@ -1,0 +1,144 @@
+"""Unit tests for ``SlackHistoryConverter`` (session rehydration).
+
+The converter's only job is to recover the Slack thread identity for
+one room from that room's platform history. Tests cover the happy path,
+the "no Slack context" case, missing-field defenses, and the
+"last-bootstrap-wins" tiebreak.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from band.converters.slack import SlackHistoryConverter
+from band.integrations.slack.types import SlackRoomBinding
+
+
+def _task_event(
+    *,
+    app_slug: str = "dev",
+    channel: str = "C1",
+    thread_ts: str = "100.0",
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "slack_app_slug": app_slug,
+        "slack_channel_id": channel,
+        "slack_thread_ts": thread_ts,
+        "slack_user_id": "U1",
+        "slack_room_id": "room-X",
+    }
+    if extra:
+        metadata.update(extra)
+    return {
+        "role": "user",
+        "content": "Slack thread context",
+        "sender_name": "agent",
+        "sender_type": "Agent",
+        "message_type": "task",
+        "metadata": metadata,
+    }
+
+
+def _text_message(content: str = "hi") -> dict[str, Any]:
+    return {
+        "role": "user",
+        "content": content,
+        "sender_name": "alice",
+        "sender_type": "user",
+        "message_type": "text",
+        "metadata": {},
+    }
+
+
+def test_returns_binding_when_bootstrap_event_present():
+    state = SlackHistoryConverter().convert(
+        [
+            _text_message("earlier reply"),
+            _task_event(app_slug="dev", channel="C42", thread_ts="123.45"),
+            _text_message("later reply"),
+        ]
+    )
+    assert state.binding == SlackRoomBinding(
+        app_slug="dev",
+        channel="C42",
+        thread_ts="123.45",
+    )
+
+
+def test_returns_none_when_no_slack_context():
+    state = SlackHistoryConverter().convert(
+        [_text_message("hello"), _text_message("world")]
+    )
+    assert state.binding is None
+
+
+def test_returns_none_for_empty_history():
+    assert SlackHistoryConverter().convert([]).binding is None
+
+
+def test_ignores_non_task_events_with_slack_metadata():
+    """A regular message that happens to carry slack metadata isn't a
+    bootstrap event and must not produce a binding."""
+    state = SlackHistoryConverter().convert(
+        [
+            {
+                "role": "user",
+                "content": "hi",
+                "sender_name": "alice",
+                "sender_type": "user",
+                "message_type": "text",
+                "metadata": {
+                    "slack_app_slug": "dev",
+                    "slack_channel_id": "C1",
+                    "slack_thread_ts": "1.0",
+                },
+            }
+        ]
+    )
+    assert state.binding is None
+
+
+def test_skips_task_event_missing_required_fields():
+    state = SlackHistoryConverter().convert(
+        [
+            {
+                "role": "user",
+                "content": "Slack thread context",
+                "sender_name": "agent",
+                "sender_type": "Agent",
+                "message_type": "task",
+                "metadata": {"slack_app_slug": "dev"},  # no channel/thread_ts
+            }
+        ]
+    )
+    assert state.binding is None
+
+
+def test_last_bootstrap_wins_when_history_has_multiple():
+    state = SlackHistoryConverter().convert(
+        [
+            _task_event(app_slug="dev", channel="C1", thread_ts="1.0"),
+            _task_event(app_slug="other", channel="C2", thread_ts="2.0"),
+        ]
+    )
+    assert state.binding == SlackRoomBinding(
+        app_slug="other", channel="C2", thread_ts="2.0"
+    )
+
+
+def test_handles_missing_metadata_field():
+    """Some history entries may omit ``metadata`` entirely; treat as empty."""
+    state = SlackHistoryConverter().convert(
+        [
+            {
+                "role": "user",
+                "content": "x",
+                "sender_name": "alice",
+                "sender_type": "user",
+                "message_type": "task",
+                # no "metadata" key at all
+            }
+        ]
+    )
+    assert state.binding is None

--- a/tests/integrations/slack/test_metrics.py
+++ b/tests/integrations/slack/test_metrics.py
@@ -1,0 +1,140 @@
+"""Quantitative success-metric tests for the Slack adapter.
+
+The target: adapter overhead < 50 ms p95 added latency from "event
+received" to "SDK invoked" (excluding agent runtime time). This file
+pins that quantitatively so an accidentally-synchronous addition to
+``_dispatch_event`` (e.g. a blocking REST call) shows up as a failure
+rather than a Slack timeout in production.
+
+What's measured: round-trip time from POST send to HTTP 200 ack. The
+brain is a fast no-op stub fired into a background task; the timed
+window is dominated by signature verification, JSON parse, and task
+scheduling — i.e. the adapter's overhead.
+
+Why the threshold is generous: CI runners are often 2–5× slower than a
+local laptop. We assert p95 < 100 ms to leave headroom while still
+being well under the 50 ms target in practice (typical observed
+p95 is in the low single-digit ms on a 2024-era developer machine).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from band.integrations.slack.adapter import SlackAdapter
+from band.integrations.slack.signature import SLACK_SIGNATURE_VERSION
+from band.integrations.slack.types import SlackApp
+
+from tests.integrations.slack.test_wrapping import (
+    _SlackReplyBrain,
+    _make_rest_mock,
+    _mention_event,
+)
+
+
+# Lenient p95 bar; see module docstring. Target is 50 ms; this is
+# 2× headroom for CI noise.
+P95_OVERHEAD_MS_MAX = 100.0
+
+# Sample count. ~200 keeps the test under a couple of seconds wall time
+# even on slow hardware while still giving a stable p95 estimate.
+SAMPLES = 200
+
+
+def _sign(secret: str, body: bytes, timestamp: str) -> str:
+    base = f"{SLACK_SIGNATURE_VERSION}:{timestamp}:".encode() + body
+    digest = hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return f"{SLACK_SIGNATURE_VERSION}={digest}"
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Linear-interpolated percentile. Avoids a numpy dep for one number."""
+    if not values:
+        raise ValueError("empty sample")
+    s = sorted(values)
+    k = (len(s) - 1) * pct
+    lo = int(k)
+    hi = min(lo + 1, len(s) - 1)
+    if lo == hi:
+        return s[lo]
+    return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+
+@pytest.mark.asyncio
+async def test_adapter_overhead_p95_under_threshold():
+    """Adapter-side latency p95 must stay well below the target bar."""
+    app_config = SlackApp(
+        slug="dev", bot_token="xoxb-dev", signing_secret="test-secret"
+    )
+    # A no-op brain so the timed window measures the adapter, not the LLM.
+    inner = _SlackReplyBrain(reply=None)
+    rest = _make_rest_mock([f"room-{i}" for i in range(SAMPLES + 5)])
+    adapter = SlackAdapter(
+        inner=inner,
+        apps=[app_config],
+        api_key="k",
+        rest_client=rest,
+        web_client_factory=lambda a: AsyncMock(
+            chat_postMessage=AsyncMock(return_value={"ok": True, "ts": "x"}),
+            assistant_threads_setStatus=AsyncMock(return_value={"ok": True}),
+            conversations_replies=AsyncMock(return_value={"messages": []}),
+        ),
+    )
+    adapter._band_agent_id = "bridge-uuid"  # type: ignore[attr-defined]
+    await adapter.on_started("MyBot", "")
+
+    transport = ASGITransport(app=adapter.router)
+    latencies_ms: list[float] = []
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for i in range(SAMPLES):
+            # Distinct channel/ts each iteration so room-creation paths
+            # exercise the real branch rather than the cached fast-path.
+            payload = _mention_event(
+                channel=f"C{i % 8}",
+                ts=f"{1700000000 + i}.000{i:03d}",
+                text="<@U001> ping",
+                user="U999",
+            )
+            body = json.dumps(payload).encode()
+            timestamp = str(int(time.time()))
+            signature = _sign(app_config.signing_secret, body, timestamp)
+
+            t0 = time.perf_counter()
+            response = await client.post(
+                "/dev/events",
+                content=body,
+                headers={
+                    "x-slack-request-timestamp": timestamp,
+                    "x-slack-signature": signature,
+                    "content-type": "application/json",
+                },
+            )
+            latencies_ms.append((time.perf_counter() - t0) * 1000.0)
+            assert response.status_code == 200
+
+    # Let background tasks drain before teardown so warnings don't pollute.
+    await adapter.wait_idle()
+
+    p50 = _percentile(latencies_ms, 0.50)
+    p95 = _percentile(latencies_ms, 0.95)
+    p99 = _percentile(latencies_ms, 0.99)
+
+    # Surfaced on test failure for diagnosis; pytest shows it on -v.
+    print(
+        f"\nSlack adapter overhead over {SAMPLES} samples: "
+        f"p50={p50:.2f} ms  p95={p95:.2f} ms  p99={p99:.2f} ms"
+    )
+
+    assert p95 < P95_OVERHEAD_MS_MAX, (
+        f"Slack adapter overhead p95={p95:.2f} ms exceeded the "
+        f"{P95_OVERHEAD_MS_MAX} ms safety bar (target is 50 ms). "
+        "Did something synchronous land in the request path?"
+    )

--- a/tests/integrations/slack/test_retry_idempotency.py
+++ b/tests/integrations/slack/test_retry_idempotency.py
@@ -1,0 +1,359 @@
+"""Tests for Slack retry idempotency.
+
+Per Slack's Events API, if we don't return 200 within 3 seconds, Slack
+retries the same ``event_id`` up to three times. We need to:
+
+1. Detect the retry (same ``event_id``)
+2. Ack 200 anyway so Slack stops
+3. NOT dispatch the duplicate to the brain / Band side
+
+The target: ``100% of Slack retries handled without duplicate agent
+invocation``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from httpx import ASGITransport
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from band.integrations.slack.server import (
+    DEFAULT_SEEN_EVENTS_CACHE_SIZE,
+    _SeenEvents,
+    build_router,
+)
+from band.integrations.slack.signature import SLACK_SIGNATURE_VERSION
+from band.integrations.slack.types import SlackApp
+
+
+# ── Unit tests on _SeenEvents ────────────────────────────────────────────────
+
+
+def test_seen_events_records_first_occurrence_as_new():
+    cache = _SeenEvents()
+    assert cache.is_dupe("Ev123") is False
+    assert len(cache) == 1
+
+
+def test_seen_events_detects_repeat_as_dupe():
+    cache = _SeenEvents()
+    cache.is_dupe("Ev123")
+    assert cache.is_dupe("Ev123") is True
+    assert cache.is_dupe("Ev123") is True
+
+
+def test_seen_events_distinguishes_ids():
+    cache = _SeenEvents()
+    cache.is_dupe("A")
+    cache.is_dupe("B")
+    assert cache.is_dupe("A") is True
+    assert cache.is_dupe("B") is True
+    assert cache.is_dupe("C") is False
+
+
+def test_seen_events_evicts_lru_when_over_capacity():
+    cache = _SeenEvents(max_size=3)
+    cache.is_dupe("A")
+    cache.is_dupe("B")
+    cache.is_dupe("C")
+    cache.is_dupe("D")  # evicts A
+    assert len(cache) == 3
+    # B/C/D retained.
+    assert cache.is_dupe("B") is True
+    assert cache.is_dupe("C") is True
+    assert cache.is_dupe("D") is True
+    # A evicted: looks "new" again.
+    assert cache.is_dupe("A") is False
+
+
+def test_seen_events_touching_resets_lru_position():
+    cache = _SeenEvents(max_size=3)
+    cache.is_dupe("A")
+    cache.is_dupe("B")
+    cache.is_dupe("C")
+    cache.is_dupe("A")  # touches A → A is now most-recent
+    cache.is_dupe("D")  # evicts B (oldest), not A
+    assert cache.is_dupe("A") is True
+    assert cache.is_dupe("B") is False  # evicted
+
+
+def test_seen_events_default_cache_size_is_ten_thousand():
+    assert DEFAULT_SEEN_EVENTS_CACHE_SIZE == 10_000
+
+
+# ── Integration tests via HTTP route ─────────────────────────────────────────
+
+
+def _sign(secret: str, body: bytes, timestamp: str) -> str:
+    base = f"{SLACK_SIGNATURE_VERSION}:{timestamp}:".encode() + body
+    digest = hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return f"{SLACK_SIGNATURE_VERSION}={digest}"
+
+
+def _app(slug: str = "dev", secret: str = "test-secret") -> SlackApp:
+    return SlackApp(slug=slug, signing_secret=secret, bot_token=f"xoxb-{slug}")
+
+
+def _make_test_client(
+    apps: list[SlackApp], dispatcher: Any = None
+) -> tuple[TestClient, list[tuple[str, dict]]]:
+    """Build a sync TestClient + capture list for dispatcher invocations."""
+    captured: list[tuple[str, dict]] = []
+
+    async def default_dispatcher(slack_app: SlackApp, payload: dict) -> None:
+        captured.append((slack_app.slug, payload))
+
+    router = build_router(apps, dispatcher=dispatcher or default_dispatcher)
+    starlette_app = Starlette()
+    starlette_app.mount("/", router)
+    return TestClient(starlette_app), captured
+
+
+def _post_event(
+    client: TestClient,
+    app: SlackApp,
+    payload: dict,
+    *,
+    retry_num: str | None = None,
+    retry_reason: str | None = None,
+) -> httpx.Response:
+    body = json.dumps(payload).encode()
+    timestamp = str(int(time.time()))
+    headers = {
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": _sign(app.signing_secret, body, timestamp),
+        "content-type": "application/json",
+    }
+    if retry_num is not None:
+        headers["x-slack-retry-num"] = retry_num
+    if retry_reason is not None:
+        headers["x-slack-retry-reason"] = retry_reason
+    return client.post(f"/{app.slug}/events", content=body, headers=headers)
+
+
+def _event_payload(event_id: str = "Ev0001", text: str = "<@U> hi") -> dict:
+    return {
+        "type": "event_callback",
+        "event_id": event_id,
+        "event": {
+            "type": "app_mention",
+            "channel": "C123",
+            "ts": "1700000000.000100",
+            "text": text,
+            "user": "U999",
+        },
+    }
+
+
+def test_same_event_id_three_times_dispatches_exactly_once():
+    """The core idempotency guarantee: 3 retries → 1 dispatch."""
+    app = _app()
+    client, captured = _make_test_client([app])
+
+    payload = _event_payload(event_id="EvABC")
+
+    # First: legitimate event, no retry headers.
+    r1 = _post_event(client, app, payload)
+    # Then two retries with increasing retry-num.
+    r2 = _post_event(client, app, payload, retry_num="1", retry_reason="http_timeout")
+    r3 = _post_event(client, app, payload, retry_num="2", retry_reason="http_timeout")
+
+    # All three must ack 200 so Slack stops retrying.
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r3.status_code == 200
+
+    # But only the first should have reached the dispatcher.
+    assert len(captured) == 1
+    assert captured[0][1]["event_id"] == "EvABC"
+
+
+def test_different_event_ids_all_dispatch():
+    app = _app()
+    client, captured = _make_test_client([app])
+
+    _post_event(client, app, _event_payload(event_id="Ev1"))
+    _post_event(client, app, _event_payload(event_id="Ev2"))
+    _post_event(client, app, _event_payload(event_id="Ev3"))
+
+    assert len(captured) == 3
+    assert [c[1]["event_id"] for c in captured] == ["Ev1", "Ev2", "Ev3"]
+
+
+def test_missing_event_id_still_dispatches_each_time():
+    """If a payload lacks ``event_id``, we have no way to dedup — dispatch."""
+    app = _app()
+    client, captured = _make_test_client([app])
+
+    payload = _event_payload()
+    payload.pop("event_id")
+
+    _post_event(client, app, payload)
+    _post_event(client, app, payload)
+
+    assert len(captured) == 2
+
+
+def test_url_verification_unaffected_by_dedup():
+    """url_verification has no event_id; the dedup path must not trigger."""
+    app = _app()
+    client, _ = _make_test_client([app])
+
+    body = json.dumps({"type": "url_verification", "challenge": "abc123"}).encode()
+    timestamp = str(int(time.time()))
+    response = client.post(
+        f"/{app.slug}/events",
+        content=body,
+        headers={
+            "x-slack-request-timestamp": timestamp,
+            "x-slack-signature": _sign(app.signing_secret, body, timestamp),
+            "content-type": "application/json",
+        },
+    )
+    assert response.status_code == 200
+    assert response.text == "abc123"
+
+    # Second identical url_verification still echoes the challenge.
+    response2 = client.post(
+        f"/{app.slug}/events",
+        content=body,
+        headers={
+            "x-slack-request-timestamp": timestamp,
+            "x-slack-signature": _sign(app.signing_secret, body, timestamp),
+            "content-type": "application/json",
+        },
+    )
+    assert response2.status_code == 200
+    assert response2.text == "abc123"
+
+
+def test_dedup_is_shared_across_apps_in_same_router():
+    """One router-wide cache. Same event_id across apps is unlikely, but if
+    it happens, we still ack 200 — better safe than spamming the brain."""
+    app_a = _app(slug="a", secret="sa")
+    app_b = _app(slug="b", secret="sb")
+    client, captured = _make_test_client([app_a, app_b])
+
+    payload = _event_payload(event_id="EvShared")
+    r1 = _post_event(client, app_a, payload)
+    r2 = _post_event(client, app_b, payload)
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    # First reached app A; the cross-app duplicate was dropped.
+    assert [c[0] for c in captured] == ["a"]
+
+
+def test_retry_returns_200_even_when_dispatcher_would_be_slow():
+    """The retry ack path doesn't invoke the dispatcher at all."""
+    slow_dispatcher = AsyncMock(side_effect=AssertionError("must not be called"))
+    app = _app()
+
+    # Manually wire the slow dispatcher so we can assert it isn't touched
+    # on the retry call.
+    router = build_router(
+        [app],
+        dispatcher=AsyncMock(return_value=None),  # original event accepted
+    )
+    starlette_app = Starlette()
+    starlette_app.mount("/", router)
+    client = TestClient(starlette_app)
+
+    payload = _event_payload(event_id="EvSlow")
+    _post_event(client, app, payload)  # primes the dedup cache
+
+    # Now swap in the "must not be called" dispatcher and retry.
+    # We have to re-route via the underlying router, which already
+    # closed over the original dispatcher — so this test instead just
+    # confirms the retry returns 200 and that captured count stayed at
+    # 1, which we cover in test_same_event_id_three_times_dispatches_exactly_once.
+    response = _post_event(client, app, payload, retry_num="1")
+    assert response.status_code == 200
+    slow_dispatcher.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_full_pipeline_three_retries_one_brain_invocation():
+    """End-to-end via the full SlackAdapter wrapping shape: 3 retries
+    must produce exactly one inner brain invocation and one Band
+    room (not three)."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from band.core.simple_adapter import SimpleAdapter
+    from band.integrations.slack.adapter import SlackAdapter
+
+    class _Brain(SimpleAdapter[Any]):
+        def __init__(self) -> None:
+            super().__init__(history_converter=None)
+            self.count = 0
+
+        async def on_message(self, *args: Any, **kwargs: Any) -> None:
+            self.count += 1
+
+        async def on_cleanup(self, room_id: str) -> None:
+            return None
+
+    rest = MagicMock()
+
+    async def create_chat(*, chat, **_kwargs):
+        return SimpleNamespace(data=SimpleNamespace(id="room-1"))
+
+    rest.agent_api_chats.create_agent_chat = AsyncMock(side_effect=create_chat)
+    rest.agent_api_events.create_agent_chat_event = AsyncMock()
+    rest.agent_api_messages.create_agent_chat_message = AsyncMock()
+
+    brain = _Brain()
+    apps = [_app()]
+    adapter = SlackAdapter(
+        inner=brain,
+        apps=apps,
+        api_key="k",
+        rest_client=rest,
+        web_client_factory=lambda a: AsyncMock(chat_postMessage=AsyncMock()),
+    )
+    adapter._band_agent_id = "bridge-uuid"  # type: ignore[attr-defined]
+    await adapter.on_started("bot", "")
+
+    payload = _event_payload(event_id="EvE2E")
+    transport = ASGITransport(app=adapter.router)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for retry in [None, "1", "2"]:
+            body = json.dumps(payload).encode()
+            ts = str(int(time.time()))
+            headers = {
+                "x-slack-request-timestamp": ts,
+                "x-slack-signature": _sign(apps[0].signing_secret, body, ts),
+                "content-type": "application/json",
+            }
+            if retry is not None:
+                headers["x-slack-retry-num"] = retry
+            response = await client.post(
+                f"/{apps[0].slug}/events", content=body, headers=headers
+            )
+            assert response.status_code == 200
+
+    await adapter.wait_idle()
+
+    # Exactly one brain invocation.
+    assert brain.count == 1
+    # Exactly one room created.
+    rest.agent_api_chats.create_agent_chat.assert_awaited_once()
+    # Exactly two events for the single processed turn: the bootstrap
+    # context (task) event and the user-turn mirror (thought).
+    # Retries don't duplicate either.
+    assert rest.agent_api_events.create_agent_chat_event.await_count == 2
+    event_types = sorted(
+        c.kwargs["event"].message_type
+        for c in rest.agent_api_events.create_agent_chat_event.await_args_list
+    )
+    assert event_types == ["task", "thought"]

--- a/tests/integrations/slack/test_server.py
+++ b/tests/integrations/slack/test_server.py
@@ -1,0 +1,267 @@
+"""Tests for the Slack bridge Starlette server."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from band.integrations.slack.server import build_router
+from band.integrations.slack.signature import SLACK_SIGNATURE_VERSION
+from band.integrations.slack.types import SlackApp
+
+
+def _sign(secret: str, body: bytes, timestamp: str) -> str:
+    base = f"{SLACK_SIGNATURE_VERSION}:{timestamp}:".encode() + body
+    digest = hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return f"{SLACK_SIGNATURE_VERSION}={digest}"
+
+
+def _make_client(apps: list[SlackApp], dispatcher=None) -> TestClient:
+    router = build_router(apps, dispatcher=dispatcher)
+    app = Starlette()
+    app.mount("/", router)
+    return TestClient(app)
+
+
+def _app(slug: str = "recruit", secret: str = "test-signing-secret") -> SlackApp:
+    return SlackApp(
+        slug=slug,
+        signing_secret=secret,
+        bot_token="xoxb-test",
+    )
+
+
+def test_url_verification_returns_challenge():
+    app = _app()
+    client = _make_client([app])
+    body = json.dumps(
+        {"type": "url_verification", "challenge": "abc123-challenge"}
+    ).encode()
+    timestamp = str(int(time.time()))
+    signature = _sign(app.signing_secret, body, timestamp)
+
+    response = client.post(
+        "/recruit/events",
+        content=body,
+        headers={
+            "x-slack-request-timestamp": timestamp,
+            "x-slack-signature": signature,
+            "content-type": "application/json",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.text == "abc123-challenge"
+
+
+def test_invalid_signature_returns_401():
+    app = _app()
+    client = _make_client([app])
+    body = b'{"type":"event_callback"}'
+    timestamp = str(int(time.time()))
+
+    response = client.post(
+        "/recruit/events",
+        content=body,
+        headers={
+            "x-slack-request-timestamp": timestamp,
+            "x-slack-signature": "v0=deadbeefdeadbeef",
+            "content-type": "application/json",
+        },
+    )
+
+    assert response.status_code == 401
+
+
+def test_missing_signature_header_returns_401():
+    app = _app()
+    client = _make_client([app])
+    body = b'{"type":"event_callback"}'
+
+    response = client.post(
+        "/recruit/events",
+        content=body,
+        headers={
+            "x-slack-request-timestamp": str(int(time.time())),
+            "content-type": "application/json",
+        },
+    )
+
+    assert response.status_code == 401
+
+
+def test_missing_timestamp_header_returns_401():
+    app = _app()
+    client = _make_client([app])
+    body = b'{"type":"event_callback"}'
+
+    response = client.post(
+        "/recruit/events",
+        content=body,
+        headers={
+            "x-slack-signature": "v0=deadbeef",
+            "content-type": "application/json",
+        },
+    )
+
+    assert response.status_code == 401
+
+
+def test_unknown_slug_returns_404():
+    app = _app()
+    client = _make_client([app])
+
+    response = client.post("/unknown/events", content=b"{}")
+    assert response.status_code == 404
+
+
+def test_valid_event_invokes_dispatcher_and_acks_200():
+    app = _app()
+    received: list[dict] = []
+
+    async def dispatcher(received_app, payload):
+        received.append({"app_slug": received_app.slug, "payload": payload})
+
+    client = _make_client([app], dispatcher=dispatcher)
+    body = json.dumps(
+        {"type": "event_callback", "event": {"type": "app_mention"}}
+    ).encode()
+    timestamp = str(int(time.time()))
+    signature = _sign(app.signing_secret, body, timestamp)
+
+    response = client.post(
+        "/recruit/events",
+        content=body,
+        headers={
+            "x-slack-request-timestamp": timestamp,
+            "x-slack-signature": signature,
+            "content-type": "application/json",
+        },
+    )
+
+    assert response.status_code == 200
+    assert len(received) == 1
+    assert received[0]["app_slug"] == "recruit"
+    assert received[0]["payload"]["event"]["type"] == "app_mention"
+
+
+def test_invalid_json_returns_400_after_signature_passes():
+    app = _app()
+    client = _make_client([app])
+    body = b"not valid json"
+    timestamp = str(int(time.time()))
+    signature = _sign(app.signing_secret, body, timestamp)
+
+    response = client.post(
+        "/recruit/events",
+        content=body,
+        headers={
+            "x-slack-request-timestamp": timestamp,
+            "x-slack-signature": signature,
+            "content-type": "application/json",
+        },
+    )
+
+    assert response.status_code == 400
+
+
+def test_multi_app_routing_uses_per_app_secret():
+    app_a = _app(slug="a", secret="secret-a")
+    app_b = _app(slug="b", secret="secret-b")
+    client = _make_client([app_a, app_b])
+
+    body = json.dumps({"type": "url_verification", "challenge": "ok"}).encode()
+    timestamp = str(int(time.time()))
+
+    # Signing for app A but posting to app B's route must fail.
+    cross = _sign(app_a.signing_secret, body, timestamp)
+    bad_response = client.post(
+        "/b/events",
+        content=body,
+        headers={
+            "x-slack-request-timestamp": timestamp,
+            "x-slack-signature": cross,
+            "content-type": "application/json",
+        },
+    )
+    assert bad_response.status_code == 401
+
+    # And signing with the matching secret on its own route succeeds.
+    correct = _sign(app_b.signing_secret, body, timestamp)
+    good_response = client.post(
+        "/b/events",
+        content=body,
+        headers={
+            "x-slack-request-timestamp": timestamp,
+            "x-slack-signature": correct,
+            "content-type": "application/json",
+        },
+    )
+    assert good_response.status_code == 200
+    assert good_response.text == "ok"
+
+
+def test_build_router_rejects_empty_apps():
+    with pytest.raises(ValueError, match="at least one"):
+        build_router([])
+
+
+def test_build_router_rejects_duplicate_slugs():
+    apps = [_app(slug="x"), _app(slug="x")]
+    with pytest.raises(ValueError, match="Duplicate"):
+        build_router(apps)
+
+
+def test_dispatcher_exception_does_not_break_ack():
+    app = _app()
+
+    async def boom(received_app, payload):
+        raise RuntimeError("dispatcher exploded")
+
+    client = _make_client([app], dispatcher=boom)
+    body = json.dumps(
+        {"type": "event_callback", "event": {"type": "app_mention"}}
+    ).encode()
+    timestamp = str(int(time.time()))
+    signature = _sign(app.signing_secret, body, timestamp)
+
+    response = client.post(
+        "/recruit/events",
+        content=body,
+        headers={
+            "x-slack-request-timestamp": timestamp,
+            "x-slack-signature": signature,
+            "content-type": "application/json",
+        },
+    )
+
+    # Slack must get a 200 even if our handler crashes downstream; we
+    # log the exception and retry semantics live elsewhere.
+    assert response.status_code == 200
+
+
+def test_adapter_router_property_exposes_starlette_router():
+    from typing import Any
+    from unittest.mock import MagicMock
+
+    from band.core.simple_adapter import SimpleAdapter
+    from band.integrations.slack.adapter import SlackAdapter
+
+    class _NoopInner(SimpleAdapter[Any]):
+        async def on_message(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+    adapter = SlackAdapter(
+        inner=_NoopInner(),
+        apps=[_app()],
+        rest_client=MagicMock(),
+    )
+    router = adapter.router
+    # Property caches the router instance.
+    assert adapter.router is router

--- a/tests/integrations/slack/test_signature.py
+++ b/tests/integrations/slack/test_signature.py
@@ -1,0 +1,215 @@
+"""Tests for Slack request signature verification."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+import pytest
+
+from band.integrations.slack.signature import (
+    MAX_TIMESTAMP_SKEW_SECONDS,
+    SLACK_SIGNATURE_VERSION,
+    verify_signature,
+)
+
+SIGNING_SECRET = "test-signing-secret"
+
+
+def _sign(secret: str, body: bytes, timestamp: str) -> str:
+    """Compute the canonical ``v0=<hex>`` signature for a payload."""
+    base = f"{SLACK_SIGNATURE_VERSION}:{timestamp}:".encode() + body
+    digest = hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return f"{SLACK_SIGNATURE_VERSION}={digest}"
+
+
+def test_valid_signature_within_skew_window():
+    body = b'{"type":"event_callback"}'
+    now = 1_700_000_000.0
+    timestamp = str(int(now))
+    signature = _sign(SIGNING_SECRET, body, timestamp)
+
+    assert verify_signature(
+        signing_secret=SIGNING_SECRET,
+        body=body,
+        timestamp=timestamp,
+        signature=signature,
+        now=now,
+    )
+
+
+def test_signature_rejects_when_body_tampered():
+    now = 1_700_000_000.0
+    timestamp = str(int(now))
+    signature = _sign(SIGNING_SECRET, b"original", timestamp)
+
+    assert not verify_signature(
+        signing_secret=SIGNING_SECRET,
+        body=b"tampered",
+        timestamp=timestamp,
+        signature=signature,
+        now=now,
+    )
+
+
+def test_signature_rejects_wrong_signing_secret():
+    body = b"hello"
+    now = 1_700_000_000.0
+    timestamp = str(int(now))
+    signature = _sign("different-secret", body, timestamp)
+
+    assert not verify_signature(
+        signing_secret=SIGNING_SECRET,
+        body=body,
+        timestamp=timestamp,
+        signature=signature,
+        now=now,
+    )
+
+
+def test_signature_rejects_when_signature_garbage():
+    body = b"hello"
+    now = 1_700_000_000.0
+    timestamp = str(int(now))
+
+    assert not verify_signature(
+        signing_secret=SIGNING_SECRET,
+        body=body,
+        timestamp=timestamp,
+        signature="v0=not-a-real-hex-digest",
+        now=now,
+    )
+
+
+def test_signature_rejects_when_prefix_missing():
+    body = b"hello"
+    now = 1_700_000_000.0
+    timestamp = str(int(now))
+    valid = _sign(SIGNING_SECRET, body, timestamp)
+    # Strip the "v0=" prefix to simulate a malformed header.
+    bare_hex = valid.removeprefix("v0=")
+
+    assert not verify_signature(
+        signing_secret=SIGNING_SECRET,
+        body=body,
+        timestamp=timestamp,
+        signature=bare_hex,
+        now=now,
+    )
+
+
+def test_signature_rejects_expired_timestamp():
+    body = b"hello"
+    now = 1_700_000_000.0
+    # Sign with a timestamp older than the skew window.
+    old_ts = str(int(now - MAX_TIMESTAMP_SKEW_SECONDS - 1))
+    signature = _sign(SIGNING_SECRET, body, old_ts)
+
+    assert not verify_signature(
+        signing_secret=SIGNING_SECRET,
+        body=body,
+        timestamp=old_ts,
+        signature=signature,
+        now=now,
+    )
+
+
+def test_signature_rejects_future_timestamp_beyond_skew():
+    body = b"hello"
+    now = 1_700_000_000.0
+    future_ts = str(int(now + MAX_TIMESTAMP_SKEW_SECONDS + 1))
+    signature = _sign(SIGNING_SECRET, body, future_ts)
+
+    assert not verify_signature(
+        signing_secret=SIGNING_SECRET,
+        body=body,
+        timestamp=future_ts,
+        signature=signature,
+        now=now,
+    )
+
+
+def test_signature_accepts_at_skew_boundary():
+    body = b"hello"
+    now = 1_700_000_000.0
+    edge_ts = str(int(now - MAX_TIMESTAMP_SKEW_SECONDS))
+    signature = _sign(SIGNING_SECRET, body, edge_ts)
+
+    assert verify_signature(
+        signing_secret=SIGNING_SECRET,
+        body=body,
+        timestamp=edge_ts,
+        signature=signature,
+        now=now,
+    )
+
+
+def test_signature_rejects_malformed_timestamp():
+    body = b"hello"
+    now = 1_700_000_000.0
+    timestamp = "not-an-integer"
+    signature = _sign(SIGNING_SECRET, body, timestamp)
+
+    assert not verify_signature(
+        signing_secret=SIGNING_SECRET,
+        body=body,
+        timestamp=timestamp,
+        signature=signature,
+        now=now,
+    )
+
+
+@pytest.mark.parametrize(
+    "signing_secret,timestamp,signature",
+    [
+        ("", "1700000000", "v0=deadbeef"),
+        ("secret", "", "v0=deadbeef"),
+        ("secret", "1700000000", ""),
+    ],
+)
+def test_signature_rejects_missing_inputs(signing_secret, timestamp, signature):
+    assert not verify_signature(
+        signing_secret=signing_secret,
+        body=b"hello",
+        timestamp=timestamp,
+        signature=signature,
+        now=1_700_000_000.0,
+    )
+
+
+def test_signature_uses_constant_time_compare():
+    # We can't directly assert hmac.compare_digest is used, but we can
+    # confirm a signature with the right length but wrong content is
+    # rejected — the same as a totally bogus signature. This guards
+    # against a naive "==" implementation accidentally short-circuiting
+    # on a partial prefix match.
+    body = b"hello"
+    now = 1_700_000_000.0
+    timestamp = str(int(now))
+    valid = _sign(SIGNING_SECRET, body, timestamp)
+    almost = valid[:-2] + ("ff" if valid[-2:] != "ff" else "00")
+
+    assert not verify_signature(
+        signing_secret=SIGNING_SECRET,
+        body=body,
+        timestamp=timestamp,
+        signature=almost,
+        now=now,
+    )
+
+
+def test_signature_uses_real_clock_when_now_not_passed():
+    # When no `now` is passed, the function reads time.time(); a fresh
+    # signature with a current timestamp should verify.
+    import time
+
+    body = b"hello"
+    timestamp = str(int(time.time()))
+    signature = _sign(SIGNING_SECRET, body, timestamp)
+
+    assert verify_signature(
+        signing_secret=SIGNING_SECRET,
+        body=body,
+        timestamp=timestamp,
+        signature=signature,
+    )

--- a/tests/integrations/slack/test_socket_transport.py
+++ b/tests/integrations/slack/test_socket_transport.py
@@ -1,0 +1,485 @@
+"""Tests for the Socket Mode transport.
+
+Covers:
+
+- Constructor validation per transport (HTTP needs signing_secret,
+  Socket Mode needs app_token).
+- ``router`` is unavailable when transport='socket'.
+- Socket Mode lifecycle: connect on ``on_started``, disconnect on
+  ``close()``; failure-on-stop is logged not raised.
+- An ``events_api`` Socket Mode envelope is acked AND routed through
+  the same ``_dispatch_event`` path as the HTTP transport.
+- Non-events_api envelopes are acked and ignored.
+- Bot-authored events still dropped on the socket path (parity with HTTP).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from types import SimpleNamespace
+
+import pytest
+
+from band.integrations.slack.adapter import SlackAdapter
+from band.integrations.slack.dedup import _SeenEvents
+from band.integrations.slack.socket import (
+    SlackSocketListener,
+    start_socket_listeners,
+)
+from band.integrations.slack.types import SlackApp
+
+from tests.integrations.slack.test_wrapping import (
+    _SlackReplyBrain,
+    _make_rest_mock,
+)
+
+
+# ── Fixtures / helpers ──────────────────────────────────────────────────────
+
+
+def _socket_app(slug: str = "dev") -> SlackApp:
+    return SlackApp(
+        slug=slug,
+        bot_token=f"xoxb-{slug}",
+        app_token=f"xapp-{slug}",
+    )
+
+
+def _http_app(slug: str = "dev") -> SlackApp:
+    return SlackApp(
+        slug=slug,
+        bot_token=f"xoxb-{slug}",
+        signing_secret="test-secret",
+    )
+
+
+class _FakeSocketModeClient:
+    """Stand-in for ``slack_sdk.socket_mode.aiohttp.SocketModeClient``.
+
+    Captures registered listeners, exposes ``connect`` / ``disconnect`` /
+    ``send_socket_mode_response`` as AsyncMocks so the test can fire a
+    synthetic envelope at the listener and assert what happened.
+    """
+
+    def __init__(self) -> None:
+        self.socket_mode_request_listeners: list[Any] = []
+        self.connect = AsyncMock()
+        self.disconnect = AsyncMock()
+        self.send_socket_mode_response = AsyncMock()
+
+
+def _build_adapter_with_socket(
+    *,
+    apps: list[SlackApp] | None = None,
+    inner: _SlackReplyBrain | None = None,
+) -> tuple[
+    SlackAdapter,
+    _SlackReplyBrain,
+    dict[str, _FakeSocketModeClient],
+    dict[str, AsyncMock],
+    Any,
+]:
+    apps = apps or [_socket_app()]
+    inner = inner or _SlackReplyBrain(reply=None)
+
+    web_mocks: dict[str, AsyncMock] = {}
+    for app in apps:
+        client = AsyncMock()
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "x"})
+        client.assistant_threads_setStatus = AsyncMock(return_value={"ok": True})
+        client.conversations_replies = AsyncMock(return_value={"messages": []})
+        web_mocks[app.slug] = client
+
+    rest = _make_rest_mock(["room-1", "room-2"])
+    adapter = SlackAdapter(
+        inner=inner,
+        apps=apps,
+        api_key="k",
+        transport="socket",
+        rest_client=rest,
+        web_client_factory=lambda a: web_mocks[a.slug],
+    )
+    adapter._band_agent_id = "bridge-uuid"  # type: ignore[attr-defined]
+
+    socket_clients: dict[str, _FakeSocketModeClient] = {
+        a.slug: _FakeSocketModeClient() for a in apps
+    }
+    return adapter, inner, socket_clients, web_mocks, rest
+
+
+def _events_api_request(
+    *,
+    envelope_id: str = "env-1",
+    event: dict[str, Any] | None = None,
+    event_id: str | None = None,
+) -> SimpleNamespace:
+    """A minimal SocketModeRequest stand-in. The real class has more on
+    it, but our listener only touches ``envelope_id``, ``type``, and
+    ``payload``."""
+    payload: dict[str, Any] = {
+        "type": "event_callback",
+        "event": event
+        or {
+            "type": "app_mention",
+            "channel": "C123",
+            "ts": "1700000000.0001",
+            "thread_ts": "1700000000.0001",
+            "text": "<@U001> hello",
+            "user": "U999",
+        },
+    }
+    if event_id is not None:
+        payload["event_id"] = event_id
+    return SimpleNamespace(envelope_id=envelope_id, type="events_api", payload=payload)
+
+
+# ── Constructor validation ──────────────────────────────────────────────────
+
+
+def test_http_transport_requires_signing_secret():
+    bad = SlackApp(slug="x", bot_token="xoxb", signing_secret="")
+    with pytest.raises(ValueError, match="signing_secret"):
+        SlackAdapter(
+            inner=_SlackReplyBrain(),
+            apps=[bad],
+            api_key="k",
+            rest_client=MagicMock(),
+        )
+
+
+def test_socket_transport_requires_app_token():
+    bad = SlackApp(slug="x", bot_token="xoxb", signing_secret="ignored")
+    with pytest.raises(ValueError, match="app_token"):
+        SlackAdapter(
+            inner=_SlackReplyBrain(),
+            apps=[bad],
+            api_key="k",
+            transport="socket",
+            rest_client=MagicMock(),
+        )
+
+
+def test_socket_transport_accepts_apps_without_signing_secret():
+    """Signing secret is unused over the websocket — must not be required."""
+    adapter = SlackAdapter(
+        inner=_SlackReplyBrain(),
+        apps=[_socket_app()],
+        api_key="k",
+        transport="socket",
+        rest_client=MagicMock(),
+        web_client_factory=lambda a: AsyncMock(),
+    )
+    assert adapter.transport == "socket"
+
+
+def test_unknown_transport_rejected():
+    with pytest.raises(ValueError, match="Unknown transport"):
+        SlackAdapter(
+            inner=_SlackReplyBrain(),
+            apps=[_http_app()],
+            api_key="k",
+            transport="banana",  # type: ignore[arg-type]
+            rest_client=MagicMock(),
+        )
+
+
+def test_router_unavailable_in_socket_mode():
+    adapter = SlackAdapter(
+        inner=_SlackReplyBrain(),
+        apps=[_socket_app()],
+        api_key="k",
+        transport="socket",
+        rest_client=MagicMock(),
+        web_client_factory=lambda a: AsyncMock(),
+    )
+    with pytest.raises(RuntimeError, match="transport='http'"):
+        _ = adapter.router
+
+
+# ── start_socket_listeners ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_socket_listeners_connects_one_per_app():
+    apps = [_socket_app("dev"), _socket_app("prod")]
+    fakes: dict[str, _FakeSocketModeClient] = {
+        a.slug: _FakeSocketModeClient() for a in apps
+    }
+
+    def factory(app: SlackApp, web_client: Any) -> _FakeSocketModeClient:
+        return fakes[app.slug]
+
+    dispatcher = AsyncMock()
+    listeners = await start_socket_listeners(
+        apps=apps,
+        web_client_factory=lambda a: AsyncMock(),
+        dispatcher=dispatcher,
+        client_factory=factory,
+    )
+
+    assert len(listeners) == 2
+    for slug, fake in fakes.items():
+        assert fake.connect.await_count == 1
+        assert len(fake.socket_mode_request_listeners) == 1
+    assert {listener.app.slug for listener in listeners} == {"dev", "prod"}
+
+
+@pytest.mark.asyncio
+async def test_socket_listener_acks_and_dispatches_events_api():
+    apps = [_socket_app("dev")]
+    fake = _FakeSocketModeClient()
+    dispatcher = AsyncMock()
+    await start_socket_listeners(
+        apps=apps,
+        web_client_factory=lambda a: AsyncMock(),
+        dispatcher=dispatcher,
+        client_factory=lambda app, wc: fake,
+    )
+
+    handler = fake.socket_mode_request_listeners[0]
+    req = _events_api_request(envelope_id="env-42")
+    await handler(fake, req)
+
+    # Ack first, dispatch second.
+    fake.send_socket_mode_response.assert_awaited_once()
+    response_arg = fake.send_socket_mode_response.await_args.args[0]
+    assert response_arg.envelope_id == "env-42"
+
+    dispatcher.assert_awaited_once()
+    app_arg, payload_arg = dispatcher.await_args.args
+    assert app_arg.slug == "dev"
+    assert payload_arg["event"]["type"] == "app_mention"
+
+
+@pytest.mark.asyncio
+async def test_socket_listener_ignores_non_events_api_but_still_acks():
+    apps = [_socket_app("dev")]
+    fake = _FakeSocketModeClient()
+    dispatcher = AsyncMock()
+    await start_socket_listeners(
+        apps=apps,
+        web_client_factory=lambda a: AsyncMock(),
+        dispatcher=dispatcher,
+        client_factory=lambda app, wc: fake,
+    )
+    handler = fake.socket_mode_request_listeners[0]
+
+    slash = SimpleNamespace(
+        envelope_id="env-slash", type="slash_commands", payload={"command": "/x"}
+    )
+    await handler(fake, slash)
+
+    fake.send_socket_mode_response.assert_awaited_once()
+    dispatcher.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_socket_listener_swallows_dispatcher_exception():
+    """A crashing dispatcher must not propagate up to slack-sdk's loop."""
+    apps = [_socket_app("dev")]
+    fake = _FakeSocketModeClient()
+    boom = AsyncMock(side_effect=RuntimeError("kaboom"))
+    await start_socket_listeners(
+        apps=apps,
+        web_client_factory=lambda a: AsyncMock(),
+        dispatcher=boom,
+        client_factory=lambda app, wc: fake,
+    )
+
+    handler = fake.socket_mode_request_listeners[0]
+    # Should NOT raise.
+    await handler(fake, _events_api_request())
+    boom.assert_awaited_once()
+
+
+# ── SlackAdapter lifecycle (transport='socket') ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_started_connects_socket_listeners(monkeypatch):
+    adapter, _, socket_clients, _, _ = _build_adapter_with_socket()
+
+    captured: dict[str, Any] = {}
+
+    async def fake_start_socket_listeners(
+        *, apps, web_client_factory, dispatcher, client_factory=None
+    ):
+        captured["dispatcher"] = dispatcher
+        listeners = []
+        for app in apps:
+            fake = socket_clients[app.slug]
+            fake.socket_mode_request_listeners.append(lambda *_a, **_kw: None)
+            await fake.connect()
+            listeners.append(SlackSocketListener(app=app, client=fake))
+        return listeners
+
+    monkeypatch.setattr(
+        "band.integrations.slack.socket.start_socket_listeners",
+        fake_start_socket_listeners,
+    )
+
+    await adapter.on_started("MyBot", "")
+
+    for fake in socket_clients.values():
+        assert fake.connect.await_count == 1
+    assert callable(captured["dispatcher"])
+    assert len(adapter._socket_listeners) == 1
+
+
+@pytest.mark.asyncio
+async def test_close_disconnects_all_listeners():
+    adapter, _, socket_clients, _, _ = _build_adapter_with_socket(
+        apps=[_socket_app("dev"), _socket_app("prod")],
+    )
+    # Manually wire up listeners as if on_started had run.
+    for slug, fake in socket_clients.items():
+        app = next(a for a in adapter.apps if a.slug == slug)
+        adapter._socket_listeners.append(SlackSocketListener(app=app, client=fake))
+
+    await adapter.close()
+    for fake in socket_clients.values():
+        assert fake.disconnect.await_count == 1
+    assert adapter._socket_listeners == []
+
+
+@pytest.mark.asyncio
+async def test_close_logs_but_does_not_raise_on_disconnect_failure(caplog):
+    adapter, _, socket_clients, _, _ = _build_adapter_with_socket()
+    fake = next(iter(socket_clients.values()))
+    fake.disconnect = AsyncMock(side_effect=RuntimeError("boom"))
+    app = adapter.apps[0]
+    adapter._socket_listeners.append(SlackSocketListener(app=app, client=fake))
+
+    with caplog.at_level("ERROR"):
+        await adapter.close()
+    assert any("Failed to stop" in r.message for r in caplog.records)
+    assert adapter._socket_listeners == []
+
+
+@pytest.mark.asyncio
+async def test_close_is_safe_when_no_listeners():
+    adapter = SlackAdapter(
+        inner=_SlackReplyBrain(),
+        apps=[_http_app()],
+        api_key="k",
+        rest_client=MagicMock(),
+    )
+    await adapter.close()  # Must not raise.
+
+
+# ── End-to-end: Socket Mode envelope through SlackAdapter ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_events_api_envelope_routes_through_dispatch_event(monkeypatch):
+    """A Socket Mode envelope reaches ``SlackAdapter._dispatch_event`` with
+    the same ``(app, payload)`` shape the HTTP webhook produces."""
+    adapter, inner, socket_clients, web_mocks, _ = _build_adapter_with_socket()
+    fake = next(iter(socket_clients.values()))
+
+    async def fake_start_socket_listeners(
+        *, apps, web_client_factory, dispatcher, client_factory=None
+    ):
+        listeners = []
+        for app in apps:
+            client = socket_clients[app.slug]
+            # Build the real per-app handler.
+            from band.integrations.slack.socket import _make_request_handler
+
+            client.socket_mode_request_listeners.append(
+                _make_request_handler(
+                    app=app, dispatcher=dispatcher, seen_events=_SeenEvents()
+                )
+            )
+            await client.connect()
+            listeners.append(SlackSocketListener(app=app, client=client))
+        return listeners
+
+    monkeypatch.setattr(
+        "band.integrations.slack.socket.start_socket_listeners",
+        fake_start_socket_listeners,
+    )
+
+    await adapter.on_started("MyBot", "")
+    handler = fake.socket_mode_request_listeners[0]
+    await handler(fake, _events_api_request())
+    await adapter.wait_idle()
+
+    # Same downstream as HTTP: room created, brain invoked.
+    assert len(inner.invocations) == 1
+    assert inner.invocations[0]["msg"].content == "<@U001> hello"
+    # Ack was sent.
+    fake.send_socket_mode_response.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_socket_listener_drops_bot_events(monkeypatch):
+    """Bot-authored events must be ignored on the Socket path too."""
+    adapter, inner, socket_clients, _, _ = _build_adapter_with_socket()
+    fake = next(iter(socket_clients.values()))
+
+    async def fake_start_socket_listeners(
+        *, apps, web_client_factory, dispatcher, client_factory=None
+    ):
+        from band.integrations.slack.socket import _make_request_handler
+
+        for app in apps:
+            fake.socket_mode_request_listeners.append(
+                _make_request_handler(
+                    app=app, dispatcher=dispatcher, seen_events=_SeenEvents()
+                )
+            )
+            await fake.connect()
+        return [SlackSocketListener(app=adapter.apps[0], client=fake)]
+
+    monkeypatch.setattr(
+        "band.integrations.slack.socket.start_socket_listeners",
+        fake_start_socket_listeners,
+    )
+
+    await adapter.on_started("MyBot", "")
+    handler = fake.socket_mode_request_listeners[0]
+    bot_req = _events_api_request(
+        event={
+            "type": "message",
+            "channel_type": "im",
+            "channel": "D1",
+            "ts": "1.0",
+            "text": "echo: previous",
+            "bot_id": "B1",
+        },
+    )
+    await handler(fake, bot_req)
+    await adapter.wait_idle()
+
+    assert inner.invocations == []
+    # Still acked though, so Slack doesn't retry.
+    fake.send_socket_mode_response.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_socket_listener_drops_duplicate_event_id():
+    """A redelivered event (same event_id) is acked but dispatched once.
+
+    Socket Mode can replay events across reconnects; like the HTTP route,
+    the listener dedups on ``event_id`` so the brain isn't invoked twice.
+    """
+    from unittest.mock import AsyncMock
+
+    from band.integrations.slack.socket import _make_request_handler
+
+    dispatcher = AsyncMock()
+    client = SimpleNamespace(send_socket_mode_response=AsyncMock())
+    app = SlackApp(slug="dev", bot_token="xoxb-x", app_token="xapp-x")
+    handler = _make_request_handler(
+        app=app, dispatcher=dispatcher, seen_events=_SeenEvents()
+    )
+
+    await handler(client, _events_api_request(envelope_id="e1", event_id="Ev123"))
+    await handler(client, _events_api_request(envelope_id="e2", event_id="Ev123"))
+
+    # Both envelopes acked (so Slack stops), but the brain runs once.
+    assert client.send_socket_mode_response.await_count == 2
+    dispatcher.assert_awaited_once()
+    assert dispatcher.await_args.args[1]["event_id"] == "Ev123"

--- a/tests/integrations/slack/test_status.py
+++ b/tests/integrations/slack/test_status.py
@@ -1,0 +1,329 @@
+"""Tests for Slack assistant-pane status indicators.
+
+The adapter calls ``assistant.threads.setStatus("is thinking…")`` before
+invoking the brain and clears the status (``""``) afterwards. The
+``setStatus`` API is part of Slack's Agents & AI Apps surface; in
+non-assistant contexts (regular channels) Slack returns an error which
+we swallow at DEBUG so the bot still works.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from band.core.simple_adapter import SimpleAdapter
+from band.core.types import PlatformMessage
+from band.integrations.slack.adapter import STATUS_THINKING, SlackAdapter
+from band.integrations.slack.signature import SLACK_SIGNATURE_VERSION
+from band.integrations.slack.types import SlackApp
+from band.runtime.tools import AgentTools
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _sign(secret: str, body: bytes, timestamp: str) -> str:
+    base = f"{SLACK_SIGNATURE_VERSION}:{timestamp}:".encode() + body
+    digest = hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return f"{SLACK_SIGNATURE_VERSION}={digest}"
+
+
+def _app(slug: str = "dev") -> SlackApp:
+    return SlackApp(slug=slug, signing_secret="test-secret", bot_token=f"xoxb-{slug}")
+
+
+def _make_rest_mock(room_id: str = "room-1") -> MagicMock:
+    rest = MagicMock()
+    rest.agent_api_chats.create_agent_chat = AsyncMock(
+        return_value=SimpleNamespace(data=SimpleNamespace(id=room_id))
+    )
+    rest.agent_api_events.create_agent_chat_event = AsyncMock()
+    rest.agent_api_messages.create_agent_chat_message = AsyncMock()
+    return rest
+
+
+class _ReplyingBrain(SimpleAdapter[Any]):
+    def __init__(self, reply: str = "answer") -> None:
+        super().__init__(history_converter=None)
+        self.reply = reply
+        self.invocations = 0
+
+    async def on_message(
+        self, msg, tools, history, p, c, *, is_session_bootstrap, room_id
+    ):
+        self.invocations += 1
+        if self.reply and hasattr(tools, "slack_send_message"):
+            await tools.slack_send_message(self.reply)
+
+    async def on_cleanup(self, room_id: str) -> None:
+        return None
+
+
+class _CrashingBrain(SimpleAdapter[Any]):
+    def __init__(self) -> None:
+        super().__init__(history_converter=None)
+
+    async def on_message(
+        self, msg, tools, history, p, c, *, is_session_bootstrap, room_id
+    ):
+        raise RuntimeError("brain crashed")
+
+    async def on_cleanup(self, room_id: str) -> None:
+        return None
+
+
+def _make_adapter(
+    *,
+    inner: SimpleAdapter[Any] | None = None,
+    slack_client: AsyncMock | None = None,
+) -> tuple[SlackAdapter, AsyncMock, MagicMock]:
+    inner = inner or _ReplyingBrain()
+    if slack_client is None:
+        # Build a fresh client with sensible defaults. If the caller
+        # passes their own client (with custom side_effects), we keep it
+        # untouched so the test's mock behavior survives.
+        slack_client = AsyncMock()
+        slack_client.chat_postMessage = AsyncMock(return_value={"ok": True})
+        slack_client.assistant_threads_setStatus = AsyncMock(return_value={"ok": True})
+
+    rest = _make_rest_mock()
+    adapter = SlackAdapter(
+        inner=inner,
+        apps=[_app()],
+        api_key="k",
+        rest_client=rest,
+        web_client_factory=lambda _a: slack_client,
+    )
+    adapter._band_agent_id = "bridge-uuid"  # type: ignore[attr-defined]
+    return adapter, slack_client, rest
+
+
+async def _post_slack_event(
+    adapter: SlackAdapter,
+    app: SlackApp,
+    payload: dict[str, Any],
+) -> httpx.Response:
+    body = json.dumps(payload).encode()
+    timestamp = str(int(time.time()))
+    signature = _sign(app.signing_secret, body, timestamp)
+    transport = ASGITransport(app=adapter.router)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        return await client.post(
+            f"/{app.slug}/events",
+            content=body,
+            headers={
+                "x-slack-request-timestamp": timestamp,
+                "x-slack-signature": signature,
+                "content-type": "application/json",
+            },
+        )
+
+
+def _mention_event(
+    channel: str = "C123",
+    ts: str = "1700000000.000100",
+    text: str = "<@U> hi",
+) -> dict[str, Any]:
+    return {
+        "type": "event_callback",
+        "event": {
+            "type": "app_mention",
+            "channel": channel,
+            "ts": ts,
+            "text": text,
+            "user": "U999",
+        },
+    }
+
+
+# ── Slack webhook path ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_slack_event_sets_thinking_status_then_clears_it():
+    adapter, slack, _ = _make_adapter()
+    await adapter.on_started("Bot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(adapter, app, _mention_event())
+    await adapter.wait_idle()
+
+    calls = slack.assistant_threads_setStatus.await_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs == {
+        "channel_id": "C123",
+        "thread_ts": "1700000000.000100",
+        "status": STATUS_THINKING,
+    }
+    assert calls[1].kwargs == {
+        "channel_id": "C123",
+        "thread_ts": "1700000000.000100",
+        "status": "",
+    }
+
+
+@pytest.mark.asyncio
+async def test_status_thinking_is_set_before_brain_invocation():
+    """The status must be set *before* the brain runs (so the user sees
+    'thinking…' during the slow LLM call), and cleared after."""
+    timeline: list[str] = []
+
+    class _RecordingBrain(SimpleAdapter[Any]):
+        def __init__(self) -> None:
+            super().__init__(history_converter=None)
+
+        async def on_message(self, *args: Any, **kwargs: Any) -> None:
+            timeline.append("brain_invoked")
+
+        async def on_cleanup(self, room_id: str) -> None:
+            return None
+
+    slack = AsyncMock()
+
+    async def record_set(*, channel_id, thread_ts, status):
+        timeline.append(f"setStatus={status!r}")
+        return {"ok": True}
+
+    slack.assistant_threads_setStatus = AsyncMock(side_effect=record_set)
+    slack.chat_postMessage = AsyncMock(return_value={"ok": True})
+
+    adapter, _, _ = _make_adapter(inner=_RecordingBrain(), slack_client=slack)
+    await adapter.on_started("Bot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(adapter, app, _mention_event())
+    await adapter.wait_idle()
+
+    assert timeline == [
+        f"setStatus={STATUS_THINKING!r}",
+        "brain_invoked",
+        "setStatus=''",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_status_is_cleared_even_when_brain_raises():
+    adapter, slack, _ = _make_adapter(inner=_CrashingBrain())
+    await adapter.on_started("Bot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(adapter, app, _mention_event())
+    await adapter.wait_idle()
+
+    # Two setStatus calls: open + clear, even though the brain crashed.
+    statuses = [
+        c.kwargs["status"] for c in slack.assistant_threads_setStatus.await_args_list
+    ]
+    assert statuses == [STATUS_THINKING, ""]
+
+
+@pytest.mark.asyncio
+async def test_setstatus_failure_is_swallowed():
+    """setStatus 404/403 (non-assistant channel, missing scope) is logged
+    and ignored — the brain still runs."""
+    slack = AsyncMock()
+    slack.assistant_threads_setStatus = AsyncMock(
+        side_effect=RuntimeError("not_an_assistant_thread")
+    )
+    slack.chat_postMessage = AsyncMock(return_value={"ok": True})
+
+    brain = _ReplyingBrain(reply="still works")
+    adapter, _, rest = _make_adapter(inner=brain, slack_client=slack)
+    await adapter.on_started("Bot", "")
+    app = adapter.apps[0]
+
+    response = await _post_slack_event(adapter, app, _mention_event())
+    await adapter.wait_idle()
+
+    assert response.status_code == 200
+    assert brain.invocations == 1
+    # The brain still posted its reply via chat.postMessage.
+    slack.chat_postMessage.assert_awaited_once()
+
+
+# ── Band WS path ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ws_message_in_bound_room_also_sets_and_clears_status():
+    adapter, slack, rest = _make_adapter()
+    await adapter.on_started("Bot", "")
+    app = adapter.apps[0]
+
+    # Seed a bound room via the Slack webhook path.
+    await _post_slack_event(adapter, app, _mention_event(channel="C1", ts="100.0"))
+    await adapter.wait_idle()
+    slack.assistant_threads_setStatus.reset_mock()
+    slack.chat_postMessage.reset_mock()
+
+    # Now simulate a WS-delivered peer message in the same room.
+    real_tools = AgentTools(room_id="room-1", rest=rest, participants=[])
+    msg = PlatformMessage(
+        id="m2",
+        room_id="room-1",
+        content="peer joined and asked something",
+        sender_id="peer-x",
+        sender_type="peer",
+        sender_name="Peer X",
+        message_type="text",
+        metadata={},
+        created_at=datetime.now(timezone.utc),
+    )
+    await adapter.on_message(
+        msg,
+        real_tools,
+        None,
+        None,
+        None,
+        is_session_bootstrap=False,
+        room_id="room-1",
+    )
+
+    statuses = [
+        c.kwargs["status"] for c in slack.assistant_threads_setStatus.await_args_list
+    ]
+    assert statuses == [STATUS_THINKING, ""]
+
+
+@pytest.mark.asyncio
+async def test_ws_message_in_unbound_room_does_not_touch_status():
+    """Status indicator is only meaningful for Slack-mirrored rooms."""
+    # Non-replying brain so we don't trip AgentTools' mention validator
+    # on the unbound-room path.
+    adapter, slack, rest = _make_adapter(inner=_ReplyingBrain(reply=""))
+    await adapter.on_started("Bot", "")
+
+    real_tools = AgentTools(room_id="unrelated-room", rest=MagicMock(), participants=[])
+    msg = PlatformMessage(
+        id="m1",
+        room_id="unrelated-room",
+        content="hi",
+        sender_id="peer",
+        sender_type="peer",
+        sender_name="Peer",
+        message_type="text",
+        metadata={},
+        created_at=datetime.now(timezone.utc),
+    )
+    await adapter.on_message(
+        msg,
+        real_tools,
+        None,
+        None,
+        None,
+        is_session_bootstrap=False,
+        room_id="unrelated-room",
+    )
+
+    slack.assistant_threads_setStatus.assert_not_awaited()

--- a/tests/integrations/slack/test_wrapping.py
+++ b/tests/integrations/slack/test_wrapping.py
@@ -1,0 +1,1652 @@
+"""Tests for the wrapping-shape SlackAdapter.
+
+Architecture under test:
+
+- ``SlackAdapter`` wraps an ``inner`` framework adapter (the brain).
+- The brain sees two outbound tools when the room is Slack-bound:
+  - ``band_send_message`` — real Band message (requires mentions)
+  - ``slack_send_message`` — posts to the bound Slack thread, Slack-only
+- A Slack event → adapter creates/finds a Band room → synthesizes a
+  ``PlatformMessage`` → invokes ``inner.on_message`` with the new
+  ``_SlackTeeingTools`` and a Slack-context note via ``participants_msg``.
+- No event mirroring of inbound Slack messages or brain replies. The
+  Band room stays empty unless the brain decides to delegate to a peer
+  via ``band_send_message``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import time
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from band.core.simple_adapter import SimpleAdapter
+from band.core.types import (
+    AdapterFeatures,
+    AgentInput,
+    Capability,
+    Emit,
+    HistoryProvider,
+    PlatformMessage,
+)
+from band.integrations.slack.adapter import (
+    SLACK_CONTEXT_NOTE,
+    SLACK_SEND_MESSAGE_TOOL_NAME,
+    SlackAdapter,
+    _SlackTeeingTools,
+)
+from band.integrations.slack.signature import SLACK_SIGNATURE_VERSION
+from band.integrations.slack.types import SlackApp, SlackRoomBinding
+from band.runtime.tools import AgentTools
+
+
+# ── Test doubles ─────────────────────────────────────────────────────────────
+
+
+class _RawHistoryConverter:
+    """Identity converter — returns the raw history list unchanged.
+
+    Lets tests inspect exactly what the SlackAdapter synthesized for the
+    brain before any framework-specific reshaping.
+    """
+
+    def convert(self, raw: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return list(raw)
+
+
+class _SlackReplyBrain(SimpleAdapter[Any]):
+    """Brain that replies to Slack via the new ``slack_send_message`` tool.
+
+    Calls ``await tools.slack_send_message(reply)`` directly to mimic how
+    a real framework adapter would dispatch the tool the LLM picked.
+    """
+
+    def __init__(
+        self,
+        reply: str | None = "Here is the answer.",
+        history_converter: Any = None,
+    ) -> None:
+        super().__init__(history_converter=history_converter)
+        self.reply = reply
+        self.invocations: list[dict[str, Any]] = []
+        self.started: tuple[str, str] | None = None
+        self.cleaned_up: list[str] = []
+
+    async def on_started(self, agent_name: str, agent_description: str) -> None:
+        await super().on_started(agent_name, agent_description)
+        self.started = (agent_name, agent_description)
+
+    async def on_message(
+        self,
+        msg: PlatformMessage,
+        tools: Any,
+        history: Any,
+        participants_msg: str | None,
+        contacts_msg: str | None,
+        *,
+        is_session_bootstrap: bool,
+        room_id: str,
+    ) -> None:
+        self.invocations.append(
+            {
+                "msg": msg,
+                "tools": tools,
+                "history": history,
+                "participants_msg": participants_msg,
+                "contacts_msg": contacts_msg,
+                "is_session_bootstrap": is_session_bootstrap,
+                "room_id": room_id,
+            }
+        )
+        if self.reply is not None and hasattr(tools, "slack_send_message"):
+            await tools.slack_send_message(self.reply)
+
+    async def on_cleanup(self, room_id: str) -> None:
+        self.cleaned_up.append(room_id)
+
+
+def _make_rest_mock(room_ids: list[str]) -> MagicMock:
+    rest = MagicMock()
+    create_chat_calls = {"i": 0}
+
+    async def create_chat(*, chat, **_kwargs):
+        i = create_chat_calls["i"]
+        create_chat_calls["i"] += 1
+        return SimpleNamespace(data=SimpleNamespace(id=room_ids[i]))
+
+    rest.agent_api_chats.create_agent_chat = AsyncMock(side_effect=create_chat)
+    rest.agent_api_events.create_agent_chat_event = AsyncMock()
+    rest.agent_api_messages.create_agent_chat_message = AsyncMock(
+        return_value=SimpleNamespace(data=SimpleNamespace(id="msg-id"))
+    )
+    rest.agent_api_participants.add_agent_chat_participant = AsyncMock()
+    return rest
+
+
+def _slack_app(slug: str = "dev") -> SlackApp:
+    return SlackApp(
+        slug=slug,
+        signing_secret="test-secret",
+        bot_token=f"xoxb-{slug}",
+    )
+
+
+def _make_adapter(
+    *,
+    inner: SimpleAdapter[Any] | None = None,
+    apps: list[SlackApp] | None = None,
+    room_ids: list[str] | None = None,
+    bridge_agent_id: str = "bridge-uuid",
+    **adapter_kwargs: Any,
+) -> tuple[
+    SlackAdapter,
+    _SlackReplyBrain | SimpleAdapter[Any],
+    dict[str, AsyncMock],
+    MagicMock,
+]:
+    inner = inner or _SlackReplyBrain()
+    apps = apps or [_slack_app()]
+    room_ids = room_ids or ["room-1"]
+
+    web_mocks: dict[str, AsyncMock] = {}
+    for app in apps:
+        client = AsyncMock()
+        client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "x"})
+        client.assistant_threads_setStatus = AsyncMock(return_value={"ok": True})
+        # This app's own bot identity (resolved via auth.test). Defaults to
+        # "B999" so the thread-backfill tests that post bot replies with
+        # ``bot_id="B999"`` are treated as *this bridge's* prior turns.
+        client.auth_test = AsyncMock(return_value={"bot_id": "B999", "user_id": "UBOT"})
+        # Default: thread has no prior messages. Tests can override per
+        # client (e.g. ``web_mocks["dev"].conversations_replies = ...``).
+        client.conversations_replies = AsyncMock(return_value={"messages": []})
+
+        # Context-mirror label resolution. Defaults resolve any user to
+        # display "Alice"/handle "alice", and derive a channel label from
+        # the id (``C123`` -> ``#c123``; ids starting with ``D`` -> DM).
+        client.users_info = AsyncMock(
+            return_value={
+                "user": {
+                    "name": "alice",
+                    "real_name": "Alice A",
+                    "profile": {"display_name": "Alice", "real_name": "Alice A"},
+                }
+            }
+        )
+
+        def _conv_info(*, channel: str, **_kw: Any) -> dict[str, Any]:
+            if channel.startswith("D"):
+                return {"channel": {"is_im": True}}
+            return {"channel": {"name": channel.lower()}}
+
+        client.conversations_info = AsyncMock(side_effect=_conv_info)
+        web_mocks[app.slug] = client
+
+    rest = _make_rest_mock(room_ids)
+    adapter = SlackAdapter(
+        inner=inner,
+        apps=apps,
+        api_key="k",
+        rest_client=rest,
+        web_client_factory=lambda a: web_mocks[a.slug],
+        **adapter_kwargs,
+    )
+    adapter._band_agent_id = bridge_agent_id  # type: ignore[attr-defined]
+    return adapter, inner, web_mocks, rest
+
+
+def _sign(secret: str, body: bytes, timestamp: str) -> str:
+    base = f"{SLACK_SIGNATURE_VERSION}:{timestamp}:".encode() + body
+    digest = hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return f"{SLACK_SIGNATURE_VERSION}={digest}"
+
+
+async def _post_slack_event(
+    adapter: SlackAdapter, app: SlackApp, payload: dict[str, Any]
+) -> httpx.Response:
+    body = json.dumps(payload).encode()
+    timestamp = str(int(time.time()))
+    signature = _sign(app.signing_secret, body, timestamp)
+    transport = ASGITransport(app=adapter.router)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        return await client.post(
+            f"/{app.slug}/events",
+            content=body,
+            headers={
+                "x-slack-request-timestamp": timestamp,
+                "x-slack-signature": signature,
+                "content-type": "application/json",
+            },
+        )
+
+
+def _mention_event(
+    *,
+    channel: str = "C123",
+    ts: str = "1700000000.0001",
+    text: str = "<@U001> hello",
+    thread_ts: str | None = None,
+    user: str = "U999",
+) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "channel": channel,
+        "ts": ts,
+        "text": text,
+        "user": user,
+    }
+    if thread_ts is not None:
+        event["thread_ts"] = thread_ts
+    return {"type": "event_callback", "event": event}
+
+
+# ── on_started ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_started_propagates_to_inner_and_sets_agent_id():
+    adapter, inner, _, _ = _make_adapter()
+    assert isinstance(inner, _SlackReplyBrain)
+
+    await adapter.on_started("MyBot", "describes me")
+
+    assert inner.started == ("MyBot", "describes me")
+    assert getattr(inner, "_band_agent_id", None) == "bridge-uuid"
+
+
+@pytest.mark.asyncio
+async def test_on_started_requires_api_key_when_no_rest_client_injected():
+    inner = _SlackReplyBrain()
+    adapter = SlackAdapter(inner=inner, apps=[_slack_app()])
+    with pytest.raises(ValueError, match="requires api_key"):
+        await adapter.on_started("MyBot", "")
+
+
+class _EmitBrain(_SlackReplyBrain):
+    """Inner brain that declares (and is configured to use) execution emit."""
+
+    SUPPORTED_EMIT = frozenset({Emit.EXECUTION})
+    SUPPORTED_CAPABILITIES = frozenset({Capability.MEMORY})
+
+
+@pytest.mark.asyncio
+async def test_on_started_mirrors_inner_support_no_spurious_warning(caplog):
+    """SlackAdapter must not warn that it 'does not support' what the brain does.
+
+    We adopt ``inner.features`` and delegate reasoning to the inner, so the
+    base feature-mismatch check has to run against the inner's declared
+    support — not the wrapper's empty defaults.
+    """
+    inner = _EmitBrain(reply=None)
+    inner.features = AdapterFeatures(
+        emit=frozenset({Emit.EXECUTION}),
+        capabilities=frozenset({Capability.MEMORY}),
+    )
+    adapter, _, _, _ = _make_adapter(inner=inner)
+
+    with caplog.at_level("WARNING"):
+        await adapter.on_started("MyBot", "")
+
+    # Wrapper now reflects the inner's declared support.
+    assert adapter.SUPPORTED_EMIT == frozenset({Emit.EXECUTION})
+    assert adapter.SUPPORTED_CAPABILITIES == frozenset({Capability.MEMORY})
+    # No misleading "does not support" warning for values the brain handles.
+    assert not any("does not support" in r.getMessage() for r in caplog.records), [
+        r.getMessage() for r in caplog.records
+    ]
+
+
+# ── Slack ingress (HTTP webhook → brain invocation) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_slack_event_creates_room_invokes_brain_and_replies_via_tool():
+    adapter, inner, web_mocks, rest = _make_adapter(
+        inner=_SlackReplyBrain(reply="Hello, world."),
+        room_ids=["room-1"],
+    )
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    response = await _post_slack_event(
+        adapter,
+        app,
+        _mention_event(
+            channel="C123",
+            ts="1700000000.000100",
+            text="<@U001> ping",
+            user="U999",
+        ),
+    )
+    assert response.status_code == 200
+    await adapter.wait_idle()
+
+    # Band room was created (delegation infrastructure).
+    rest.agent_api_chats.create_agent_chat.assert_awaited_once()
+
+    # Two events emitted: the bootstrap context (task) event, then the
+    # user-turn mirror (thought) event. NO brain-reply mirror event —
+    # only the inbound user turn is mirrored.
+    emitted = [
+        c.kwargs["event"]
+        for c in rest.agent_api_events.create_agent_chat_event.await_args_list
+    ]
+    assert [e.message_type for e in emitted] == ["task", "thought"]
+    context_evt = emitted[0]
+    assert context_evt.metadata["slack_channel_id"] == "C123"
+    # The mirror is a context-only thought carrying the Slack thread id.
+    mirror_evt = emitted[1]
+    assert mirror_evt.metadata["slack_mirror"] is True
+    assert mirror_evt.metadata["slack_thread_ts"] == "1700000000.000100"
+    assert mirror_evt.metadata["slack_user_id"] == "U999"
+    # Friendly format: resolved channel name + user handle/name + text.
+    # The raw thread ts lives in metadata only, not the visible content.
+    assert "1700000000.000100" not in mirror_evt.content
+    assert "#c123" in mirror_evt.content
+    assert "Alice (@alice)" in mirror_evt.content
+    assert "<@U001> ping" in mirror_evt.content
+    assert mirror_evt.metadata["slack_channel_label"] == "#c123"
+    assert mirror_evt.metadata["slack_user_handle"] == "alice"
+
+    # No regular Band messages posted — the brain replied via Slack only.
+    rest.agent_api_messages.create_agent_chat_message.assert_not_awaited()
+
+    # Brain invoked with clean synthesized PlatformMessage + Slack-context note.
+    assert isinstance(inner, _SlackReplyBrain)
+    assert len(inner.invocations) == 1
+    inv = inner.invocations[0]
+    assert inv["msg"].content == "<@U001> ping"
+    assert inv["msg"].sender_id == "slack:U999"
+    assert inv["msg"].metadata["slack_channel_id"] == "C123"
+    assert inv["participants_msg"] == SLACK_CONTEXT_NOTE
+    assert inv["is_session_bootstrap"] is True
+    # Tools are the teeing subclass.
+    assert isinstance(inv["tools"], _SlackTeeingTools)
+
+    # Brain's reply went to Slack only.
+    web_mocks[app.slug].chat_postMessage.assert_awaited_once_with(
+        channel="C123",
+        text="Hello, world.",
+        thread_ts="1700000000.000100",
+    )
+
+
+@pytest.mark.asyncio
+async def test_second_event_in_same_thread_reuses_room():
+    adapter, inner, _, rest = _make_adapter(room_ids=["room-1", "room-2"])
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(
+        adapter, app, _mention_event(channel="C1", ts="100.0", text="first")
+    )
+    await adapter.wait_idle()
+    await _post_slack_event(
+        adapter,
+        app,
+        _mention_event(channel="C1", ts="200.0", thread_ts="100.0", text="follow-up"),
+    )
+    await adapter.wait_idle()
+
+    assert rest.agent_api_chats.create_agent_chat.await_count == 1
+    assert isinstance(inner, _SlackReplyBrain)
+    assert inner.invocations[0]["is_session_bootstrap"] is True
+    assert inner.invocations[1]["is_session_bootstrap"] is False
+
+
+@pytest.mark.asyncio
+async def test_same_thread_tuple_across_apps_maps_to_distinct_rooms():
+    """Two SlackApps sharing a channel/thread tuple must get separate rooms.
+
+    The room lookup key includes ``app.slug``, so a workspace-scoped
+    ``channel:thread_ts`` collision between two apps can't cross-route
+    replies into the wrong app/workspace.
+    """
+    apps = [_slack_app("alpha"), _slack_app("beta")]
+    adapter, inner, _, rest = _make_adapter(
+        apps=apps, room_ids=["room-alpha", "room-beta"]
+    )
+    await adapter.on_started("MyBot", "")
+
+    # Identical channel + thread_ts, delivered to two different apps.
+    await _post_slack_event(
+        adapter, apps[0], _mention_event(channel="C1", ts="100.0", text="hi alpha")
+    )
+    await adapter.wait_idle()
+    await _post_slack_event(
+        adapter, apps[1], _mention_event(channel="C1", ts="100.0", text="hi beta")
+    )
+    await adapter.wait_idle()
+
+    # Two distinct rooms, one per app — not a single shared room.
+    assert rest.agent_api_chats.create_agent_chat.await_count == 2
+    assert adapter._thread_to_room == {
+        "alpha:C1:100.0": "room-alpha",
+        "beta:C1:100.0": "room-beta",
+    }
+    assert adapter._room_to_binding["room-alpha"].app_slug == "alpha"
+    assert adapter._room_to_binding["room-beta"].app_slug == "beta"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_events_same_thread_create_one_room():
+    """Two simultaneous events for one thread must not create duplicate rooms.
+
+    Each Slack event runs in its own background task. Without per-thread
+    serialisation both could miss ``_thread_to_room`` and create a room.
+    A gated ``create_agent_chat`` forces the overlap deterministically.
+    """
+    adapter, inner, _, rest = _make_adapter(room_ids=["room-1", "room-2"])
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    gate = asyncio.Event()
+    create_calls = {"n": 0}
+
+    async def gated_create(*, chat, **_kwargs):
+        create_calls["n"] += 1
+        # Block the first creator inside the critical section so a second
+        # task (if not serialised) would race in behind it.
+        await gate.wait()
+        return SimpleNamespace(data=SimpleNamespace(id=f"room-{create_calls['n']}"))
+
+    rest.agent_api_chats.create_agent_chat = AsyncMock(side_effect=gated_create)
+
+    # Fire two events for the same channel/thread directly into the handler
+    # so both background coroutines are in flight at once.
+    t1 = asyncio.create_task(
+        adapter._invoke_brain_for_slack_event(
+            app,
+            _mention_event(channel="C1", ts="100.0", thread_ts="100.0", text="a")[
+                "event"
+            ],
+        )
+    )
+    t2 = asyncio.create_task(
+        adapter._invoke_brain_for_slack_event(
+            app,
+            _mention_event(channel="C1", ts="101.0", thread_ts="100.0", text="b")[
+                "event"
+            ],
+        )
+    )
+    await asyncio.sleep(0)  # let both reach the lock / create call
+    gate.set()
+    await asyncio.gather(t1, t2)
+
+    # The lock collapses both events onto a single room creation.
+    assert rest.agent_api_chats.create_agent_chat.await_count == 1
+    assert list(adapter._thread_to_room.values()) == ["room-1"]
+
+
+@pytest.mark.asyncio
+async def test_dm_event_creates_room_and_invokes_brain():
+    adapter, inner, _, rest = _make_adapter()
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(
+        adapter,
+        app,
+        {
+            "type": "event_callback",
+            "event": {
+                "type": "message",
+                "channel_type": "im",
+                "channel": "D123",
+                "ts": "1700000000.0",
+                "text": "ping",
+                "user": "U999",
+            },
+        },
+    )
+    await adapter.wait_idle()
+
+    rest.agent_api_chats.create_agent_chat.assert_awaited_once()
+    assert isinstance(inner, _SlackReplyBrain)
+    assert len(inner.invocations) == 1
+    assert inner.invocations[0]["msg"].content == "ping"
+
+
+@pytest.mark.asyncio
+async def test_bot_authored_messages_are_ignored():
+    adapter, inner, _, rest = _make_adapter()
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(
+        adapter,
+        app,
+        {
+            "type": "event_callback",
+            "event": {
+                "type": "message",
+                "channel_type": "im",
+                "channel": "D1",
+                "ts": "1.0",
+                "text": "echo: previous",
+                "bot_id": "B1",
+            },
+        },
+    )
+    await adapter.wait_idle()
+
+    rest.agent_api_chats.create_agent_chat.assert_not_awaited()
+    assert isinstance(inner, _SlackReplyBrain)
+    assert inner.invocations == []
+
+
+@pytest.mark.asyncio
+async def test_unsupported_event_type_is_ignored():
+    adapter, inner, _, rest = _make_adapter()
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    response = await _post_slack_event(
+        adapter,
+        app,
+        {
+            "type": "event_callback",
+            "event": {"type": "team_join", "user": {"id": "U001"}},
+        },
+    )
+    assert response.status_code == 200
+    await adapter.wait_idle()
+    rest.agent_api_chats.create_agent_chat.assert_not_awaited()
+    assert isinstance(inner, _SlackReplyBrain)
+    assert inner.invocations == []
+
+
+# ── Band WS path (on_message delegation) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_message_delegates_to_inner_for_unbound_room():
+    """A peer-to-peer message in a room we never bound to Slack."""
+    adapter, inner, _, _ = _make_adapter(inner=_SlackReplyBrain(reply=None))
+    await adapter.on_started("MyBot", "")
+
+    fake_real_tools = AgentTools(
+        room_id="unrelated-room",
+        rest=MagicMock(),
+        participants=[],
+    )
+
+    msg = PlatformMessage(
+        id="m1",
+        room_id="unrelated-room",
+        content="hi from peer",
+        sender_id="peer-xyz",
+        sender_type="peer",
+        sender_name="Peer",
+        message_type="text",
+        metadata={},
+        created_at=datetime.now(timezone.utc),
+    )
+    await adapter.on_message(
+        msg,
+        fake_real_tools,
+        None,
+        None,
+        None,
+        is_session_bootstrap=False,
+        room_id="unrelated-room",
+    )
+
+    assert isinstance(inner, _SlackReplyBrain)
+    assert len(inner.invocations) == 1
+    # Unbound: raw tools, no Slack context note.
+    assert not isinstance(inner.invocations[0]["tools"], _SlackTeeingTools)
+    assert inner.invocations[0]["participants_msg"] is None
+
+
+@pytest.mark.asyncio
+async def test_on_message_wraps_tools_and_injects_note_for_bound_room():
+    """When a peer messages in a Slack-bound room, brain gets the tee + note."""
+    adapter, inner, web_mocks, rest = _make_adapter()
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    # Seed a Slack-bound room.
+    await _post_slack_event(
+        adapter, app, _mention_event(channel="C1", ts="100.0", text="initial")
+    )
+    await adapter.wait_idle()
+    assert isinstance(inner, _SlackReplyBrain)
+    assert len(inner.invocations) == 1
+    web_mocks[app.slug].chat_postMessage.reset_mock()
+
+    # Now simulate a WS-delivered peer message in the same bound room.
+    real_tools = AgentTools(room_id="room-1", rest=rest, participants=[])
+    msg = PlatformMessage(
+        id="m2",
+        room_id="room-1",
+        content="peer joined and said hi",
+        sender_id="peer-x",
+        sender_type="peer",
+        sender_name="Peer X",
+        message_type="text",
+        metadata={},
+        created_at=datetime.now(timezone.utc),
+    )
+    await adapter.on_message(
+        msg,
+        real_tools,
+        None,
+        None,
+        None,
+        is_session_bootstrap=False,
+        room_id="room-1",
+    )
+
+    assert len(inner.invocations) == 2
+    inv = inner.invocations[1]
+    assert isinstance(inv["tools"], _SlackTeeingTools)
+    assert inv["participants_msg"] == SLACK_CONTEXT_NOTE
+    # Brain's reply ('Here is the answer.') went to Slack.
+    web_mocks[app.slug].chat_postMessage.assert_awaited_once_with(
+        channel="C1", text="Here is the answer.", thread_ts="100.0"
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_message_merges_existing_participants_msg_with_context_note():
+    """Caller-provided participants_msg is preserved when we inject our note."""
+    adapter, inner, _, rest = _make_adapter(inner=_SlackReplyBrain(reply=None))
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(
+        adapter, app, _mention_event(channel="C1", ts="100.0", text="hi")
+    )
+    await adapter.wait_idle()
+    assert isinstance(inner, _SlackReplyBrain)
+    inner.invocations.clear()
+
+    real_tools = AgentTools(room_id="room-1", rest=rest, participants=[])
+    msg = PlatformMessage(
+        id="m3",
+        room_id="room-1",
+        content="peer text",
+        sender_id="peer-y",
+        sender_type="peer",
+        sender_name="Peer Y",
+        message_type="text",
+        metadata={},
+        created_at=datetime.now(timezone.utc),
+    )
+    await adapter.on_message(
+        msg,
+        real_tools,
+        None,
+        "@joe joined the room",
+        None,
+        is_session_bootstrap=False,
+        room_id="room-1",
+    )
+
+    merged = inner.invocations[0]["participants_msg"]
+    assert SLACK_CONTEXT_NOTE in merged
+    assert "@joe joined the room" in merged
+
+
+# ── on_cleanup ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_cleanup_drops_binding_and_calls_inner():
+    adapter, inner, _, _ = _make_adapter()
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(adapter, app, _mention_event(channel="C1", ts="100.0"))
+    await adapter.wait_idle()
+    assert "room-1" in adapter._room_to_binding
+
+    await adapter.on_cleanup("room-1")
+
+    assert "room-1" not in adapter._room_to_binding
+    assert "dev:C1:100.0" not in adapter._thread_to_room
+    assert isinstance(inner, _SlackReplyBrain)
+    assert inner.cleaned_up == ["room-1"]
+
+
+# ── Invariants we still want ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ack_returns_before_brain_finishes():
+    """Slack ack must beat the brain's slow LLM call."""
+
+    class _SlowBrain(SimpleAdapter[Any]):
+        def __init__(self) -> None:
+            super().__init__(history_converter=None)
+            self.finished = asyncio.Event()
+
+        async def on_message(
+            self, msg, tools, history, p, c, *, is_session_bootstrap, room_id
+        ):
+            await asyncio.sleep(0.3)
+            self.finished.set()
+
+        async def on_cleanup(self, room_id: str) -> None:
+            return None
+
+    brain = _SlowBrain()
+    adapter, _, _, _ = _make_adapter(inner=brain)
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    start = time.monotonic()
+    response = await _post_slack_event(
+        adapter, app, _mention_event(channel="C1", ts="100.0")
+    )
+    elapsed = time.monotonic() - start
+
+    assert response.status_code == 200
+    assert not brain.finished.is_set()
+    assert elapsed < 0.2
+
+    await adapter.wait_idle()
+    assert brain.finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_brain_exception_does_not_break_subsequent_events():
+    """A crashing brain on event #1 shouldn't poison event #2."""
+    calls: list[str] = []
+
+    class _CrashingBrain(SimpleAdapter[Any]):
+        def __init__(self) -> None:
+            super().__init__(history_converter=None)
+
+        async def on_message(
+            self, msg, tools, history, p, c, *, is_session_bootstrap, room_id
+        ):
+            calls.append(msg.content)
+            if len(calls) == 1:
+                raise RuntimeError("transient brain error")
+
+        async def on_cleanup(self, room_id: str) -> None:
+            return None
+
+    adapter, _, _, _ = _make_adapter(inner=_CrashingBrain(), room_ids=["r1", "r2"])
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(
+        adapter, app, _mention_event(channel="C1", ts="100.0", text="first")
+    )
+    await adapter.wait_idle()
+    await _post_slack_event(
+        adapter, app, _mention_event(channel="C2", ts="200.0", text="second")
+    )
+    await adapter.wait_idle()
+
+    assert calls == ["first", "second"]
+
+
+# ── _SlackTeeingTools — new behavior ─────────────────────────────────────────
+
+
+def _make_tee_tools(
+    slack: AsyncMock | None = None,
+) -> tuple[_SlackTeeingTools, MagicMock, AsyncMock]:
+    rest = MagicMock()
+    rest.agent_api_events.create_agent_chat_event = AsyncMock()
+    rest.agent_api_messages.create_agent_chat_message = AsyncMock(
+        return_value=SimpleNamespace(data=SimpleNamespace(id="m"))
+    )
+    base = AgentTools(room_id="r1", rest=rest, participants=[])
+    if slack is None:
+        # Only set defaults when constructing a fresh mock; a caller-provided
+        # ``slack`` may have custom side_effects we mustn't overwrite.
+        slack = AsyncMock()
+        slack.chat_postMessage = AsyncMock(return_value={"ok": True})
+    tools = _SlackTeeingTools(
+        wrap=base,
+        slack=slack,
+        binding=SlackRoomBinding(app_slug="dev", channel="C", thread_ts="1.0"),
+    )
+    return tools, rest, slack
+
+
+@pytest.mark.asyncio
+async def test_slack_send_message_posts_to_slack_only():
+    tools, rest, slack = _make_tee_tools()
+    result = await tools.slack_send_message("hello")
+
+    assert result == {"ok": True}
+    slack.chat_postMessage.assert_awaited_once_with(
+        channel="C", text="hello", thread_ts="1.0"
+    )
+    # Crucially: nothing posted to Band REST.
+    rest.agent_api_events.create_agent_chat_event.assert_not_awaited()
+    rest.agent_api_messages.create_agent_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_slack_send_message_returns_error_dict_on_failure():
+    slack = AsyncMock()
+    slack.chat_postMessage = AsyncMock(side_effect=RuntimeError("kaboom"))
+    tools, _, _ = _make_tee_tools(slack=slack)
+
+    result = await tools.slack_send_message("hello")
+    assert result["ok"] is False
+    assert "kaboom" in result["error"]
+
+
+def test_get_anthropic_tool_schemas_includes_slack_send_message():
+    tools, _, _ = _make_tee_tools()
+    schemas = tools.get_anthropic_tool_schemas()
+    names = [s["name"] for s in schemas]
+    assert SLACK_SEND_MESSAGE_TOOL_NAME in names
+    # The standard Band tools are still present (sanity check).
+    assert "band_send_message" in names
+
+
+def test_get_openai_tool_schemas_includes_slack_send_message():
+    tools, _, _ = _make_tee_tools()
+    schemas = tools.get_openai_tool_schemas()
+    names = [s["function"]["name"] for s in schemas]
+    assert SLACK_SEND_MESSAGE_TOOL_NAME in names
+    assert "band_send_message" in names
+
+
+def test_base_agent_tools_does_not_include_slack_tool():
+    """The slack tool is only exposed via the teeing subclass."""
+    rest = MagicMock()
+    base = AgentTools(room_id="r", rest=rest, participants=[])
+    schemas = base.get_anthropic_tool_schemas()
+    names = [s["name"] for s in schemas]
+    assert SLACK_SEND_MESSAGE_TOOL_NAME not in names
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_call_routes_slack_send_message():
+    tools, _, slack = _make_tee_tools()
+    result = await tools.execute_tool_call(
+        SLACK_SEND_MESSAGE_TOOL_NAME, {"content": "hi from llm"}
+    )
+    assert result == {"ok": True}
+    slack.chat_postMessage.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_call_rejects_empty_content():
+    tools, _, slack = _make_tee_tools()
+    result = await tools.execute_tool_call(
+        SLACK_SEND_MESSAGE_TOOL_NAME, {"content": ""}
+    )
+    assert isinstance(result, str)
+    assert "requires a non-empty 'content'" in result
+    slack.chat_postMessage.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_call_delegates_non_slack_tools_to_super():
+    """Tools other than ``slack_send_message`` flow through to AgentTools.
+
+    The tee derives task success/failure from the structured outcome, so
+    it delegates via ``execute_tool_call_structured`` and returns its
+    ``value``.
+    """
+    from unittest.mock import patch
+
+    from band.runtime.tools import ToolCallOutcome
+
+    tools, _, _ = _make_tee_tools()
+    super_mock = AsyncMock(return_value=ToolCallOutcome(value="ok", ok=True))
+    with patch.object(AgentTools, "execute_tool_call_structured", super_mock):
+        result = await tools.execute_tool_call("band_lookup_peers", {})
+
+    assert result == "ok"
+    super_mock.assert_awaited_once_with("band_lookup_peers", {})
+
+
+@pytest.mark.asyncio
+async def test_send_message_no_longer_overridden_uses_real_band_path():
+    """The base AgentTools.send_message behavior is restored (mention required)."""
+    from band.core.exceptions import BandToolError
+
+    tools, _, slack = _make_tee_tools()
+    # Mentionless message hits the platform's "≥1 mention required" guard.
+    with pytest.raises(BandToolError, match="mention is required"):
+        await tools.send_message("hi", mentions=None)
+    # No Slack tee for band_send_message path.
+    slack.chat_postMessage.assert_not_awaited()
+
+
+# ── Channel-mention coverage + thread history backfill ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_channel_top_level_mention_does_not_fetch_thread_history():
+    """(a) Top-level @mention in a channel: thread_ts == ts, no backfill."""
+    brain = _SlackReplyBrain(reply=None, history_converter=_RawHistoryConverter())
+    adapter, inner, web_mocks, _ = _make_adapter(inner=brain)
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(
+        adapter,
+        app,
+        _mention_event(channel="C123", ts="100.0", text="<@U001> hi"),
+    )
+    await adapter.wait_idle()
+
+    web_mocks[app.slug].conversations_replies.assert_not_awaited()
+    assert isinstance(inner, _SlackReplyBrain)
+    assert inner.invocations[0]["history"] == []
+
+
+@pytest.mark.asyncio
+async def test_channel_mention_in_existing_thread_pulls_history():
+    """(b) @mention inside an existing thread: pull conversations.replies once."""
+    brain = _SlackReplyBrain(reply=None, history_converter=_RawHistoryConverter())
+    adapter, inner, web_mocks, _ = _make_adapter(inner=brain)
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    # Slack returns the full thread when we ask. Includes a human-only
+    # exchange that happened before the trigger plus the trigger itself
+    # (which we must filter out).
+    web_mocks[app.slug].conversations_replies = AsyncMock(
+        return_value={
+            "messages": [
+                {"ts": "100.0", "user": "U001", "text": "hey team"},
+                {"ts": "101.0", "user": "U002", "text": "anyone seen the report?"},
+                {"ts": "102.0", "user": "U003", "text": "<@BOT> summarize"},
+            ]
+        }
+    )
+
+    await _post_slack_event(
+        adapter,
+        app,
+        _mention_event(
+            channel="C123",
+            ts="102.0",
+            thread_ts="100.0",
+            text="<@BOT> summarize",
+            user="U003",
+        ),
+    )
+    await adapter.wait_idle()
+
+    web_mocks[app.slug].conversations_replies.assert_awaited_once_with(
+        channel="C123",
+        ts="100.0",
+    )
+
+    assert isinstance(inner, _SlackReplyBrain)
+    history = inner.invocations[0]["history"]
+    # Trigger excluded; remaining pre-mention turns preserved in order.
+    assert [h["content"] for h in history] == ["hey team", "anyone seen the report?"]
+    assert all(h["role"] == "user" for h in history)
+    assert all(h["sender_type"] == "user" for h in history)
+    assert [h["sender_name"] for h in history] == ["slack:U001", "slack:U002"]
+
+
+@pytest.mark.asyncio
+async def test_subsequent_mention_in_same_thread_refetches_history():
+    """(c) Slack does not deliver thread context with each event; the adapter
+    must refetch on every threaded mention so stateless brains see the
+    growing conversation. Slack's own Bolt JS reference does the same.
+    The same Band room is reused (no second ``create_agent_chat``)."""
+    brain = _SlackReplyBrain(reply=None, history_converter=_RawHistoryConverter())
+    adapter, _, web_mocks, rest = _make_adapter(
+        inner=brain,
+        room_ids=["room-1", "room-2"],
+    )
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    web_mocks[app.slug].conversations_replies = AsyncMock(
+        return_value={
+            "messages": [
+                {"ts": "50.0", "user": "U001", "text": "earlier discussion"},
+                {"ts": "100.0", "user": "U002", "text": "<@BOT> first mention"},
+            ]
+        }
+    )
+
+    # First mention mid-thread → fetch.
+    await _post_slack_event(
+        adapter,
+        app,
+        _mention_event(
+            channel="C1",
+            ts="100.0",
+            thread_ts="50.0",
+            text="<@BOT> first mention",
+            user="U002",
+        ),
+    )
+    await adapter.wait_idle()
+    assert web_mocks[app.slug].conversations_replies.await_count == 1
+
+    # Second mention in the same thread → refetch (Slack's recommended
+    # pattern), but same Band room.
+    await _post_slack_event(
+        adapter,
+        app,
+        _mention_event(
+            channel="C1",
+            ts="200.0",
+            thread_ts="50.0",
+            text="<@BOT> follow up",
+            user="U002",
+        ),
+    )
+    await adapter.wait_idle()
+    assert web_mocks[app.slug].conversations_replies.await_count == 2
+    # Only one Band room created across both mentions.
+    assert rest.agent_api_chats.create_agent_chat.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_bot_replies_in_thread_history_become_assistant_role():
+    """Self-replies in the fetched thread are tagged as assistant turns."""
+    brain = _SlackReplyBrain(reply=None, history_converter=_RawHistoryConverter())
+    adapter, inner, web_mocks, _ = _make_adapter(inner=brain)
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    web_mocks[app.slug].conversations_replies = AsyncMock(
+        return_value={
+            "messages": [
+                {"ts": "100.0", "user": "U001", "text": "hi bot"},
+                {
+                    "ts": "101.0",
+                    "user": "UBOT",
+                    "bot_id": "B999",
+                    "text": "hello, how can I help?",
+                },
+                {"ts": "102.0", "user": "U001", "text": "<@BOT> what time is it?"},
+            ]
+        }
+    )
+
+    await _post_slack_event(
+        adapter,
+        app,
+        _mention_event(
+            channel="C1",
+            ts="102.0",
+            thread_ts="100.0",
+            text="<@BOT> what time is it?",
+            user="U001",
+        ),
+    )
+    await adapter.wait_idle()
+
+    assert isinstance(inner, _SlackReplyBrain)
+    history = inner.invocations[0]["history"]
+    assert len(history) == 2
+    user_turn, bot_turn = history
+    assert user_turn["role"] == "user"
+    assert user_turn["sender_type"] == "user"
+    assert user_turn["content"] == "hi bot"
+    # Bot turn is preserved as assistant context, labeled with this agent's
+    # name so framework converters route it as a prior self-turn.
+    assert bot_turn["role"] == "assistant"
+    assert bot_turn["sender_type"] == "Agent"
+    assert bot_turn["sender_name"] == "MyBot"
+    assert bot_turn["content"] == "hello, how can I help?"
+
+
+@pytest.mark.asyncio
+async def test_bridge_progress_blocks_excluded_from_thread_history():
+    """The bridge's own Block Kit plan/status messages must not pollute history.
+
+    Progress messages are posted with ``blocks`` and a placeholder
+    fallback ("Working on it…"/"Done"). They carry ``bot_id`` like a real
+    reply, so without filtering they'd be re-ingested as fake assistant
+    turns on every follow-up. Plain-text bot replies must still survive.
+    """
+    brain = _SlackReplyBrain(reply=None, history_converter=_RawHistoryConverter())
+    adapter, inner, web_mocks, _ = _make_adapter(inner=brain)
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    web_mocks[app.slug].conversations_replies = AsyncMock(
+        return_value={
+            "messages": [
+                {"ts": "100.0", "user": "U001", "text": "hi bot"},
+                # Real plain-text reply — keep.
+                {
+                    "ts": "101.0",
+                    "user": "UBOT",
+                    "bot_id": "B999",
+                    "text": "hello, how can I help?",
+                },
+                # Block Kit progress message — drop (has blocks + fallback).
+                {
+                    "ts": "101.5",
+                    "user": "UBOT",
+                    "bot_id": "B999",
+                    "text": "Done",
+                    "blocks": [
+                        {"type": "section", "text": {"type": "mrkdwn", "text": "✅"}}
+                    ],
+                },
+                {"ts": "102.0", "user": "U001", "text": "<@BOT> what time is it?"},
+            ]
+        }
+    )
+
+    await _post_slack_event(
+        adapter,
+        app,
+        _mention_event(
+            channel="C1",
+            ts="102.0",
+            thread_ts="100.0",
+            text="<@BOT> what time is it?",
+            user="U001",
+        ),
+    )
+    await adapter.wait_idle()
+
+    assert isinstance(inner, _SlackReplyBrain)
+    history = inner.invocations[0]["history"]
+    # Only the user turn + the plain-text bot reply; the "Done" plan block
+    # is excluded.
+    contents = [m["content"] for m in history]
+    assert contents == ["hi bot", "hello, how can I help?"]
+    assert "Done" not in contents
+
+
+@pytest.mark.asyncio
+async def test_foreign_bot_replies_are_external_not_assistant():
+    """Another bot/webhook in the thread must not become our assistant turn.
+
+    Only messages from *this* app's bot id (resolved via auth.test, "B999"
+    in the fixture) map to assistant history. A different bot id is kept as
+    external context with a ``slack-bot:<id>`` sender so it can never be
+    mistaken for the bridge's own prior answer.
+    """
+    brain = _SlackReplyBrain(reply=None, history_converter=_RawHistoryConverter())
+    adapter, inner, web_mocks, _ = _make_adapter(inner=brain)
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    web_mocks[app.slug].conversations_replies = AsyncMock(
+        return_value={
+            "messages": [
+                {"ts": "100.0", "user": "U001", "text": "hi"},
+                # A *different* bot than ours (ours is B999).
+                {
+                    "ts": "101.0",
+                    "user": "UOTHER",
+                    "bot_id": "B_OTHER",
+                    "text": "I am a different bot",
+                },
+                {"ts": "102.0", "user": "U001", "text": "<@BOT> what time is it?"},
+            ]
+        }
+    )
+
+    await _post_slack_event(
+        adapter,
+        app,
+        _mention_event(
+            channel="C1",
+            ts="102.0",
+            thread_ts="100.0",
+            text="<@BOT> what time is it?",
+            user="U001",
+        ),
+    )
+    await adapter.wait_idle()
+
+    assert isinstance(inner, _SlackReplyBrain)
+    history = inner.invocations[0]["history"]
+    foreign = next(m for m in history if m["content"] == "I am a different bot")
+    assert foreign["role"] == "user"
+    assert foreign["sender_type"] == "user"
+    assert foreign["sender_name"] == "slack-bot:B_OTHER"
+    # And it is NOT attributed to this agent.
+    assert foreign["sender_name"] != "MyBot"
+
+
+@pytest.mark.asyncio
+async def test_fresh_dm_does_not_fetch_thread_history():
+    """A brand-new DM (thread_ts == ts, new room) must not call replies."""
+    brain = _SlackReplyBrain(reply=None, history_converter=_RawHistoryConverter())
+    adapter, inner, web_mocks, _ = _make_adapter(inner=brain)
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(
+        adapter,
+        app,
+        {
+            "type": "event_callback",
+            "event": {
+                "type": "message",
+                "channel_type": "im",
+                "channel": "D1",
+                "ts": "1700000000.0",
+                "text": "ping",
+                "user": "U999",
+            },
+        },
+    )
+    await adapter.wait_idle()
+
+    web_mocks[app.slug].conversations_replies.assert_not_awaited()
+    assert isinstance(inner, _SlackReplyBrain)
+    assert inner.invocations[0]["history"] == []
+
+
+@pytest.mark.asyncio
+async def test_thread_history_fetch_failure_falls_back_to_empty_history():
+    """A failed conversations.replies must not break the trigger reply."""
+    brain = _SlackReplyBrain(reply=None, history_converter=_RawHistoryConverter())
+    adapter, inner, web_mocks, _ = _make_adapter(inner=brain)
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    web_mocks[app.slug].conversations_replies = AsyncMock(
+        side_effect=RuntimeError("missing_scope: channels:history")
+    )
+
+    await _post_slack_event(
+        adapter,
+        app,
+        _mention_event(
+            channel="C1",
+            ts="200.0",
+            thread_ts="100.0",
+            text="<@BOT> summarize",
+            user="U001",
+        ),
+    )
+    await adapter.wait_idle()
+
+    web_mocks[app.slug].conversations_replies.assert_awaited_once()
+    assert isinstance(inner, _SlackReplyBrain)
+    assert len(inner.invocations) == 1
+    assert inner.invocations[0]["history"] == []
+
+
+# ── Session rehydration via history ─────────────────────────────────────────
+
+
+def _slack_bootstrap_task_event(
+    *,
+    app_slug: str = "dev",
+    channel: str = "C1",
+    thread_ts: str = "100.0",
+    room_id: str = "room-1",
+) -> dict[str, Any]:
+    return {
+        "role": "user",
+        "content": "Slack thread context",
+        "sender_name": "agent",
+        "sender_type": "Agent",
+        "message_type": "task",
+        "metadata": {
+            "slack_app_slug": app_slug,
+            "slack_channel_id": channel,
+            "slack_thread_ts": thread_ts,
+            "slack_user_id": "U1",
+            "slack_room_id": room_id,
+        },
+    }
+
+
+def _agent_input_with_history(
+    *,
+    room_id: str,
+    raw_history: list[dict[str, Any]],
+    bootstrap: bool,
+    tools: AgentTools,
+) -> AgentInput:
+    msg = PlatformMessage(
+        id="m-bootstrap",
+        room_id=room_id,
+        content="peer reply",
+        sender_id="peer-x",
+        sender_type="peer",
+        sender_name="Peer X",
+        message_type="text",
+        metadata={},
+        created_at=datetime.now(timezone.utc),
+    )
+    return AgentInput(
+        msg=msg,
+        tools=tools,
+        history=HistoryProvider(raw=raw_history),
+        participants_msg=None,
+        contacts_msg=None,
+        is_session_bootstrap=bootstrap,
+        room_id=room_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_event_rehydrates_room_binding_on_bootstrap():
+    """First WS-delivered message in a previously-bridged room restores state."""
+    adapter, inner, _, rest = _make_adapter(inner=_SlackReplyBrain(reply=None))
+    await adapter.on_started("MyBot", "")
+
+    inp = _agent_input_with_history(
+        room_id="room-resumed",
+        raw_history=[
+            _slack_bootstrap_task_event(
+                app_slug="dev",
+                channel="C42",
+                thread_ts="999.5",
+                room_id="room-resumed",
+            ),
+        ],
+        bootstrap=True,
+        tools=AgentTools(room_id="room-resumed", rest=rest, participants=[]),
+    )
+
+    await adapter.on_event(inp)
+
+    assert adapter._thread_to_room == {"dev:C42:999.5": "room-resumed"}
+    assert adapter._room_to_binding["room-resumed"] == SlackRoomBinding(
+        app_slug="dev", channel="C42", thread_ts="999.5"
+    )
+    # Delegation still happens — the inner brain saw the bootstrap message.
+    assert isinstance(inner, _SlackReplyBrain)
+    assert len(inner.invocations) == 1
+    assert inner.invocations[0]["room_id"] == "room-resumed"
+
+
+@pytest.mark.asyncio
+async def test_on_event_does_not_rehydrate_when_not_bootstrap():
+    """Non-bootstrap messages must never replay history rehydration."""
+    adapter, _, _, rest = _make_adapter(inner=_SlackReplyBrain(reply=None))
+    await adapter.on_started("MyBot", "")
+
+    inp = _agent_input_with_history(
+        room_id="room-99",
+        raw_history=[
+            _slack_bootstrap_task_event(
+                app_slug="dev", channel="C99", thread_ts="9.0", room_id="room-99"
+            ),
+        ],
+        bootstrap=False,
+        tools=AgentTools(room_id="room-99", rest=rest, participants=[]),
+    )
+
+    await adapter.on_event(inp)
+
+    assert "C99:9.0" not in adapter._thread_to_room
+    assert "room-99" not in adapter._room_to_binding
+
+
+@pytest.mark.asyncio
+async def test_on_event_rehydrate_is_noop_without_slack_context():
+    """A bootstrap on a room that has no Slack history must leave state untouched."""
+    adapter, _, _, rest = _make_adapter(inner=_SlackReplyBrain(reply=None))
+    await adapter.on_started("MyBot", "")
+
+    inp = _agent_input_with_history(
+        room_id="non-slack-room",
+        raw_history=[
+            {
+                "role": "user",
+                "content": "hi",
+                "sender_name": "alice",
+                "sender_type": "user",
+                "message_type": "text",
+                "metadata": {},
+            }
+        ],
+        bootstrap=True,
+        tools=AgentTools(room_id="non-slack-room", rest=rest, participants=[]),
+    )
+
+    await adapter.on_event(inp)
+
+    assert adapter._thread_to_room == {}
+    assert "non-slack-room" not in adapter._room_to_binding
+
+
+@pytest.mark.asyncio
+async def test_rehydration_then_slack_event_reuses_room_without_new_chat():
+    """After rehydration, a Slack event in that thread must NOT create a
+    new Band room or emit a new bootstrap context event. Thread
+    history is still refetched — that's Slack's recommended pattern and
+    is independent of room reuse."""
+    adapter, inner, _, rest = _make_adapter(
+        inner=_SlackReplyBrain(reply=None, history_converter=_RawHistoryConverter()),
+    )
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    # Simulate restart: WS delivers a bootstrap message in an existing
+    # Slack-bridged room. Rehydration restores the binding.
+    bootstrap_inp = _agent_input_with_history(
+        room_id="room-resumed",
+        raw_history=[
+            _slack_bootstrap_task_event(
+                app_slug=app.slug,
+                channel="C77",
+                thread_ts="500.0",
+                room_id="room-resumed",
+            ),
+        ],
+        bootstrap=True,
+        tools=AgentTools(room_id="room-resumed", rest=rest, participants=[]),
+    )
+    await adapter.on_event(bootstrap_inp)
+
+    # Reset Band REST mocks so we can assert no new chat is created.
+    rest.agent_api_chats.create_agent_chat.reset_mock()
+    rest.agent_api_events.create_agent_chat_event.reset_mock()
+
+    # Slack event lands in the rehydrated thread.
+    await _post_slack_event(
+        adapter,
+        app,
+        _mention_event(
+            channel="C77",
+            ts="600.0",
+            thread_ts="500.0",
+            text="<@BOT> still there?",
+            user="U7",
+        ),
+    )
+    await adapter.wait_idle()
+
+    rest.agent_api_chats.create_agent_chat.assert_not_awaited()
+    # No new bootstrap task event (room already exists), but the
+    # user-turn mirror still fires — exactly one thought event.
+    assert rest.agent_api_events.create_agent_chat_event.await_count == 1
+    mirror_evt = rest.agent_api_events.create_agent_chat_event.await_args.kwargs[
+        "event"
+    ]
+    assert mirror_evt.message_type == "thought"
+    assert mirror_evt.metadata["slack_mirror"] is True
+    # Brain saw the Slack-triggered event in the rehydrated room.
+    assert isinstance(inner, _SlackReplyBrain)
+    slack_invocations = [i for i in inner.invocations if i["room_id"] == "room-resumed"]
+    assert any(inv["msg"].content == "<@BOT> still there?" for inv in slack_invocations)
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_does_not_overwrite_existing_binding():
+    """If the in-memory state already has a binding for the room, history
+    rehydration must defer to it."""
+    adapter, _, _, rest = _make_adapter(inner=_SlackReplyBrain(reply=None))
+    await adapter.on_started("MyBot", "")
+
+    live = SlackRoomBinding(app_slug="dev", channel="C-live", thread_ts="1.0")
+    adapter._room_to_binding["room-X"] = live
+    adapter._thread_to_room["dev:C-live:1.0"] = "room-X"
+
+    inp = _agent_input_with_history(
+        room_id="room-X",
+        raw_history=[
+            _slack_bootstrap_task_event(
+                app_slug="dev",
+                channel="C-stale",
+                thread_ts="9.0",
+                room_id="room-X",
+            ),
+        ],
+        bootstrap=True,
+        tools=AgentTools(room_id="room-X", rest=rest, participants=[]),
+    )
+    await adapter.on_event(inp)
+
+    assert adapter._room_to_binding["room-X"] == live
+    assert "dev:C-stale:9.0" not in adapter._thread_to_room
+
+
+@pytest.mark.asyncio
+async def test_context_event_metadata_includes_slack_room_id():
+    """The bootstrap task event must carry ``slack_room_id`` so the converter
+    can recover the binding from history alone."""
+    adapter, _, _, rest = _make_adapter(inner=_SlackReplyBrain(reply=None))
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(
+        adapter,
+        app,
+        _mention_event(channel="C123", ts="100.0", text="<@BOT> hi"),
+    )
+    await adapter.wait_idle()
+
+    # Pick the bootstrap task event specifically — the user-turn mirror
+    # (a thought) is also emitted and would otherwise be await_args.
+    task_events = [
+        c.kwargs["event"]
+        for c in rest.agent_api_events.create_agent_chat_event.await_args_list
+        if c.kwargs["event"].message_type == "task"
+    ]
+    assert len(task_events) == 1
+    event_arg = task_events[0]
+    assert event_arg.metadata["slack_room_id"] == "room-1"
+    assert event_arg.metadata["slack_app_slug"] == app.slug
+    assert event_arg.metadata["slack_channel_id"] == "C123"
+    assert event_arg.metadata["slack_thread_ts"] == "100.0"
+
+
+# ── Slack context mirroring (audit timeline) ────────────────────────────────
+
+
+def _thought_events(rest: MagicMock) -> list[Any]:
+    return [
+        c.kwargs["event"]
+        for c in rest.agent_api_events.create_agent_chat_event.await_args_list
+        if c.kwargs["event"].message_type == "thought"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_user_turn_mirrored_as_thought_with_thread_id():
+    """A DM user turn is mirrored as a context-only thought carrying the
+    Slack thread id, and no real Band message is posted (no peer loop)."""
+    adapter, _, _, rest = _make_adapter(inner=_SlackReplyBrain(reply=None))
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(
+        adapter,
+        app,
+        {
+            "type": "event_callback",
+            "event": {
+                "type": "message",
+                "channel_type": "im",
+                "channel": "D999",
+                "ts": "1700000000.5",
+                "text": "what's the weather?",
+                "user": "U42",
+            },
+        },
+    )
+    await adapter.wait_idle()
+
+    thoughts = _thought_events(rest)
+    assert len(thoughts) == 1
+    mirror = thoughts[0]
+    assert mirror.message_type == "thought"
+    assert mirror.metadata["slack_mirror"] is True
+    assert mirror.metadata["slack_thread_ts"] == "1700000000.5"
+    assert mirror.metadata["slack_user_id"] == "U42"
+    # DM channel resolves to the "DM" label; thread ts stays in metadata.
+    assert "1700000000.5" not in mirror.content
+    assert "DM" in mirror.content
+    assert "what's the weather?" in mirror.content
+    # Mirror must NOT post a real message (which would trigger peers/loop).
+    rest.agent_api_messages.create_agent_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mirroring_disabled_emits_no_thought():
+    """With mirror_slack_context=False only the bootstrap task event fires."""
+    adapter, _, _, rest = _make_adapter(
+        inner=_SlackReplyBrain(reply=None),
+        mirror_slack_context=False,
+    )
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(
+        adapter, app, _mention_event(channel="C1", ts="100.0", text="<@BOT> hi")
+    )
+    await adapter.wait_idle()
+
+    assert _thought_events(rest) == []
+    # Only the bootstrap context (task) event is emitted.
+    assert rest.agent_api_events.create_agent_chat_event.await_count == 1
+    assert (
+        rest.agent_api_events.create_agent_chat_event.await_args.kwargs[
+            "event"
+        ].message_type
+        == "task"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mirror_failure_does_not_break_reply():
+    """A failing mirror event is swallowed; the brain still replies to Slack."""
+    adapter, inner, web_mocks, rest = _make_adapter(
+        inner=_SlackReplyBrain(reply="still works"),
+    )
+
+    async def fail_only_thought(*, chat_id: str, event: Any, **_kw: Any) -> Any:
+        # Bootstrap (task) must succeed so the room is created; only the
+        # mirror (thought) blows up.
+        if event.message_type == "thought":
+            raise RuntimeError("boom")
+        return SimpleNamespace(data=SimpleNamespace(id="evt"))
+
+    rest.agent_api_events.create_agent_chat_event = AsyncMock(
+        side_effect=fail_only_thought
+    )
+    await adapter.on_started("MyBot", "")
+    app = adapter.apps[0]
+
+    await _post_slack_event(
+        adapter, app, _mention_event(channel="C1", ts="100.0", text="<@BOT> hi")
+    )
+    await adapter.wait_idle()
+
+    # Brain ran and replied to Slack despite the mirror (and bootstrap) failing.
+    assert isinstance(inner, _SlackReplyBrain)
+    assert len(inner.invocations) == 1
+    web_mocks[app.slug].chat_postMessage.assert_awaited_once_with(
+        channel="C1", text="still works", thread_ts="100.0"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -558,6 +558,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "python-dotenv" },
     { name = "ruff" },
+    { name = "slack-sdk" },
     { name = "starlette" },
     { name = "uvicorn" },
     { name = "werkzeug" },
@@ -610,6 +611,12 @@ pydantic-ai = [
     { name = "openai" },
     { name = "pydantic-ai-slim", extra = ["anthropic"], marker = "extra == 'extra-8-band-sdk-pydantic-ai' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant')" },
 ]
+slack = [
+    { name = "aiohttp" },
+    { name = "slack-sdk" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -622,6 +629,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'bridge'", specifier = ">=3.9,<4" },
     { name = "aiohttp", marker = "extra == 'bridge-agentcore'", specifier = ">=3.9,<4" },
     { name = "aiohttp", marker = "extra == 'dev'", specifier = ">=3.9,<4" },
+    { name = "aiohttp", marker = "extra == 'slack'", specifier = ">=3.9,<4" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.75.0" },
     { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.75.0" },
     { name = "beautifulsoup4", marker = "extra == 'dev'", specifier = ">=4.12.0" },
@@ -707,21 +715,25 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "ruff", marker = "extra == 'dev-crewai'", specifier = ">=0.8.0" },
+    { name = "slack-sdk", marker = "extra == 'dev'", specifier = ">=3.27.0" },
+    { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27.0" },
     { name = "starlette", marker = "extra == 'a2a-gateway'", specifier = ">=0.40.0" },
     { name = "starlette", marker = "extra == 'a2a-gateway-demo'", specifier = ">=0.40.0" },
     { name = "starlette", marker = "extra == 'acp'", specifier = ">=0.40.0" },
     { name = "starlette", marker = "extra == 'dev'", specifier = ">=0.40.0" },
+    { name = "starlette", marker = "extra == 'slack'", specifier = ">=0.40.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "uvicorn", marker = "extra == 'a2a-gateway'", specifier = ">=0.32.0" },
     { name = "uvicorn", marker = "extra == 'a2a-gateway-demo'", specifier = ">=0.32.0" },
     { name = "uvicorn", marker = "extra == 'acp'", specifier = ">=0.32.0" },
     { name = "uvicorn", marker = "extra == 'agentcore-runtime'", specifier = ">=0.29" },
     { name = "uvicorn", marker = "extra == 'dev'", specifier = ">=0.32.0" },
+    { name = "uvicorn", marker = "extra == 'slack'", specifier = ">=0.32.0" },
     { name = "websockets", marker = "extra == 'codex'", specifier = ">=13.0" },
     { name = "werkzeug", marker = "extra == 'dev'", specifier = ">=3.1.6" },
     { name = "werkzeug", marker = "extra == 'parlant'", specifier = ">=3.1.6" },
 ]
-provides-extras = ["codex", "opencode", "letta", "pydantic-ai", "anthropic", "langgraph", "claude-sdk", "parlant", "crewai", "gemini", "a2a", "a2a-gateway", "a2a-gateway-demo", "acp", "bridge", "bridge-agentcore", "agentcore-runtime", "google-adk", "dev", "dev-crewai"]
+provides-extras = ["codex", "opencode", "letta", "pydantic-ai", "anthropic", "langgraph", "claude-sdk", "parlant", "crewai", "gemini", "a2a", "a2a-gateway", "a2a-gateway-demo", "acp", "slack", "bridge", "bridge-agentcore", "agentcore-runtime", "google-adk", "dev", "dev-crewai"]
 
 [[package]]
 name = "bcrypt"
@@ -8038,6 +8050,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slack-sdk"
+version = "3.42.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/00/16258bfa547559b2c936b50c882b4f0a36ebf6b69639eb763d8fa5e8d6cb/slack_sdk-3.42.0.tar.gz", hash = "sha256:873db9e1f632ac650ffdbf9d8ba825f3e9e7e576a1e4f9604ccb2a15b3727e3d", size = 252136, upload-time = "2026-05-18T17:50:44.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/ef/8a1556bd4843443993fc116783790a7cc553601a37f7d965ec26eef95e76/slack_sdk-3.42.0-py2.py3-none-any.whl", hash = "sha256:eb39aff97e476e10cc5a8ac29bd2e79a9959e880d9fe0c03b4e8f05b2ac996ff", size = 315469, upload-time = "2026-05-18T17:50:41.972Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a first-class **Slack adapter** so a remote Band agent can be exposed as a Slack-native AI App. Implements Phase 1 (MVP) of [INT-461](https://linear.app/thenvoi/issue/INT-461).

This **supersedes #331** — same feature, rebased onto the Band rebrand on `dev` and with all of that PR's review feedback incorporated. #331 can be closed in favour of this branch.

**Architecture — wrapping, not gateway.** `SlackAdapter` wraps an `inner: SimpleAdapter` (the brain — Anthropic, LangGraph, etc.) and decorates `on_message`. One Band service identity, one process.

- Two outbound tools: `band_send_message` (real peer message) and `slack_send_message` (plain reply to the bound Slack thread).
- Thread context backfill: refetches `conversations.replies` per turn (no caching) so the brain sees full thread history.
- Session rehydration from the bootstrap `task` event binding.
- HTTP (Starlette/FastAPI) **and** Socket Mode transports.

## Review fixes carried over from #331

| Area | Fix |
|------|-----|
| Room routing | Lookup key now includes `app.slug` — two SlackApps sharing a `channel:thread_ts` tuple map to distinct rooms; no cross-workspace reply routing |
| Thread history | Own `bot_id` resolved via `auth.test`; only this bridge's plain-text replies map to assistant history. Other bots/webhooks are kept as external context with a `slack-bot:<id>` sender |
| Room creation race | Per-thread `asyncio.Lock` + re-check collapses concurrent events for one thread onto a single room (no duplicate/orphaned rooms) |
| Packaging | `aiohttp` added to the `[slack]` extra (Socket Mode imports it) |
| Block Kit | `render_plan_blocks` capped at Slack's 50-block limit with an overflow summary |
| Docs | Package docstring example corrected to the real `inner=...` wrapping shape |

Each fix has a regression test (multi-app isolation, foreign-bot, two-task concurrency, 49-task block cap, etc.).

## Supporting SDK change

`AgentTools.execute_tool_call_structured` + `ToolCallOutcome` give the Slack progress UI a machine-readable `ok` flag instead of sniffing error-string prefixes. `execute_tool_call` now delegates to it (behaviour-preserving).

## What's included

- HMAC signature verification + URL verification, retry idempotency
- Per-thread Band room mapping, peer reply → Slack threading
- Status indicators (`assistant.threads.setStatus`) + Block Kit `plan`/`task` tool-call visibility
- Slack thread history backfill (`channels:history` / `groups:history`)
- Session rehydration on bootstrap; Slack context mirroring into the Band room
- Framework mount helpers + Socket Mode transport
- Manifest template, getting-started example (`examples/slack/01_basic_bot.py`), README section
- `slack` adapter + converter excluded from framework conformance (transport bridge / metadata-only converter)

## Test plan

- [x] `uv run pytest tests/integrations/slack/ -v` — 140 passed
- [x] `uv run pytest tests/framework_conformance/ tests/framework_configs/` — 338 passed
- [x] `uv run ruff check . && uv run ruff format . --check`
- [x] `uv run pyrefly check` — 0 errors
- [ ] Manual: restart-bridge backfill/rehydration smoke (`examples/slack/_dev_bridge.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)