### PR TITLE
feat(sdk): adapters report boolean activity (working) state to the platform [INT-831]

### DIFF
--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -102,6 +102,11 @@ class BandLink:
         # Durable terminal disconnect reason for the current connection lifecycle.
         self._last_disconnect_reason: WebSocketDisconnectReason | None = None
 
+        # Debounce flag for activity-report failures: keep-alive runs at a few
+        # seconds per room, so a down endpoint would otherwise flood the log on
+        # every refresh. Log the first failure and the recovery, suppress repeats.
+        self._activity_report_failing = False
+
     @property
     def is_connected(self) -> bool:
         return self._is_connected
@@ -546,6 +551,44 @@ class BandLink:
         except Exception as e:
             logger.warning("Failed to mark message %s as failed: %s", message_id, e)
             return False
+        return True
+
+    async def report_activity(self, room_id: str, working: bool) -> bool:
+        """
+        Report the agent's boolean working state for a room's execution.
+
+        Sends ``working: true`` while a reasoning cycle is active (refreshed on a
+        keep-alive cadence) and ``working: false`` when it ends. Failures are
+        swallowed and returned as ``False`` — the platform's TTL is the backstop,
+        so activity reporting must never break message processing.
+        """
+        try:
+            await self.rest.agent_api_activity.report_agent_chat_activity(
+                chat_id=room_id,
+                working=working,
+                request_options=DEFAULT_REQUEST_OPTIONS,
+            )
+        except Exception as e:
+            if not self._activity_report_failing:
+                self._activity_report_failing = True
+                logger.warning(
+                    "Failed to report activity (working=%s) for room %s: %s; "
+                    "suppressing repeat warnings until recovery",
+                    working,
+                    room_id,
+                    e,
+                )
+            else:
+                logger.debug(
+                    "Activity report still failing (working=%s) for room %s: %s",
+                    working,
+                    room_id,
+                    e,
+                )
+            return False
+        if self._activity_report_failing:
+            self._activity_report_failing = False
+            logger.info("Activity reporting recovered for room %s", room_id)
         return True
 
     async def get_next_message(self, room_id: str) -> PlatformMessage | None:

--- a/src/band/platform/link.py
+++ b/src/band/platform/link.py
@@ -553,7 +553,9 @@ class BandLink:
             return False
         return True
 
-    async def report_activity(self, room_id: str, working: bool) -> bool:
+    async def report_activity(
+        self, room_id: str, working: bool, *, timeout_seconds: int = 2
+    ) -> bool:
         """
         Report the agent's boolean working state for a room's execution.
 
@@ -561,12 +563,21 @@ class BandLink:
         keep-alive cadence) and ``working: false`` when it ends. Failures are
         swallowed and returned as ``False`` — the platform's TTL is the backstop,
         so activity reporting must never break message processing.
+
+        The call is time-bounded by ``timeout_seconds`` (a per-POST deadline, not
+        the client default) so a slow/half-open endpoint can never wedge the
+        reasoning loop's teardown or stall the keep-alive. Retries are disabled:
+        a dropped keep-alive is re-sent on the next cadence tick, and a dropped
+        ``false`` is cleared by the platform TTL, so retrying only adds latency.
         """
         try:
             await self.rest.agent_api_activity.report_agent_chat_activity(
                 chat_id=room_id,
                 working=working,
-                request_options=DEFAULT_REQUEST_OPTIONS,
+                request_options={
+                    "timeout_in_seconds": timeout_seconds,
+                    "max_retries": 0,
+                },
             )
         except Exception as e:
             if not self._activity_report_failing:

--- a/src/band/runtime/execution.py
+++ b/src/band/runtime/execution.py
@@ -49,6 +49,7 @@ from .types import (
 )
 from .retry_tracker import MessageRetryTracker
 from ._context_serialization import context_item_to_dict
+from .working_state import WorkingStateReporter
 
 if TYPE_CHECKING:
     from band.platform.link import BandLink
@@ -211,6 +212,18 @@ class ExecutionContext:
         self._on_participant_added = on_participant_added
         self._on_participant_removed = on_participant_removed
         self.hub_room_id = hub_room_id
+
+        # Per-room boolean working-state reporter. Disabled for the contact-hub
+        # room: it's internal housekeeping, not a peer-facing conversation, so no
+        # counterpart watches a "Reasoning…" indicator there.
+        self._working_reporter = WorkingStateReporter(
+            self._report_working_state,
+            keep_alive_seconds=self.config.working_keep_alive_seconds,
+            max_working_state_seconds=self.config.max_working_state_seconds,
+            enabled=(
+                self.config.enable_working_state and self.room_id != self.hub_room_id
+            ),
+        )
 
         # Per-room state
         self.queue: asyncio.Queue[PlatformEvent] = asyncio.Queue()
@@ -466,6 +479,11 @@ class ExecutionContext:
         except asyncio.CancelledError:
             pass
         self._process_loop_task = None
+
+        # Defensively clear any lingering working-state keep-alive so a removed
+        # room can't leak its refresh task. Idempotent: a no-op if not active
+        # (the per-cycle finally normally clears it already).
+        await self._working_reporter.stop()
         return graceful
 
     async def _wait_for_idle(self, timeout: float) -> bool:
@@ -1265,8 +1283,9 @@ class ExecutionContext:
                 ),
             )
 
-            # Call execution handler
-            await self._on_execute(self, event)
+            # Call execution handler (backlog messages are always reasoning
+            # cycles, so always report the working signal).
+            await self._execute_message_cycle(event)
 
             # SUCCESS: Mark as processed on server
             durable_processed = await self.link.mark_processed(self.room_id, msg_id)
@@ -1327,6 +1346,29 @@ class ExecutionContext:
         # Re-add non-duplicates
         for item in items:
             self.queue.put_nowait(item)
+
+    async def _report_working_state(self, working: bool) -> bool:
+        """Report the room's boolean working state (wired into the reporter)."""
+        return await self.link.report_activity(
+            self.room_id,
+            working,
+            timeout_seconds=self.config.working_request_timeout_seconds,
+        )
+
+    async def _execute_message_cycle(self, event: PlatformEvent) -> None:
+        """Run the adapter for a message reasoning cycle, bracketed by the
+        working-state signal.
+
+        ``start()`` emits working:true (+ keep-alive); ``stop()`` in the finally
+        emits the authoritative working:false on success, exception, and cancel —
+        mirroring the ``_set_state('idle')`` placement. The reporter is a no-op
+        when disabled or for the hub room, so call sites need no extra gating.
+        """
+        await self._working_reporter.start()
+        try:
+            await self._on_execute(self, event)
+        finally:
+            await self._working_reporter.stop()
 
     async def _process_event(self, event: PlatformEvent) -> bool:
         """
@@ -1463,8 +1505,12 @@ class ExecutionContext:
                 self.remove_participant(event.payload.id)
                 await self._notify_participant_removed(event)
 
-            # Call execution handler
-            await self._on_execute(self, event)
+            # Call execution handler. Only message-driven cycles report the
+            # working signal; participant add/remove events are housekeeping.
+            if isinstance(event, MessageEvent):
+                await self._execute_message_cycle(event)
+            else:
+                await self._on_execute(self, event)
 
             # For messages: mark as processed on server
             if isinstance(event, MessageEvent) and msg_id:

--- a/src/band/runtime/types.py
+++ b/src/band/runtime/types.py
@@ -74,6 +74,13 @@ class AgentConfig:
     auto_subscribe_existing_rooms: bool = True
 
 
+# Platform-side TTL (seconds) for the boolean working-state indicator. The
+# adapter must refresh well within this window; if refreshes stop (crash, hang,
+# disconnect) the platform clears the indicator. Mirrors the Ticket B contract
+# (TTL <= 10s). Used only to derive the keep-alive cadence guard below.
+PLATFORM_WORKING_STATE_TTL_SECONDS: float = 10.0
+
+
 @dataclass
 class SessionConfig:
     """Configuration for execution context."""
@@ -91,11 +98,61 @@ class SessionConfig:
     # round. Must be > 0; zero or negative turns Phase 2 into a REST hot loop.
     idle_resync_seconds: float = 60.0
 
+    # --- Working-state (boolean "is the agent reasoning") reporting ---
+    # Kill-switch: disable all working-state reporting instantly if needed.
+    enable_working_state: bool = True
+    # Keep-alive cadence: how often working:true is refreshed while a cycle runs.
+    # Must be < TTL/2 so a single missed/slow ping still lands inside the TTL.
+    working_keep_alive_seconds: float = 3.0
+    # Per-POST deadline for each activity report (must be < cadence so a slow
+    # POST can't pile onto the next keep-alive tick).
+    working_request_timeout_seconds: int = 2
+    # Optional upper bound on how long we keep asserting working:true for one
+    # cycle. When exceeded we stop refreshing (platform TTL clears it); we never
+    # cancel the reasoning. None = unbounded. NOT a hang-killer.
+    max_working_state_seconds: float | None = None
+
     def __post_init__(self) -> None:
         if self.idle_resync_seconds <= 0:
             raise ValueError(
                 "idle_resync_seconds must be > 0 (got %s)" % self.idle_resync_seconds
             )
+
+        # Working-state invariants only matter when reporting is enabled.
+        if self.enable_working_state:
+            ttl_half = PLATFORM_WORKING_STATE_TTL_SECONDS / 2
+            if self.working_keep_alive_seconds <= 0:
+                raise ValueError(
+                    "working_keep_alive_seconds must be > 0 (got %s)"
+                    % self.working_keep_alive_seconds
+                )
+            if self.working_keep_alive_seconds >= ttl_half:
+                raise ValueError(
+                    "working_keep_alive_seconds must be < TTL/2 (%s) to keep TTL "
+                    "headroom (got %s)" % (ttl_half, self.working_keep_alive_seconds)
+                )
+            if self.working_request_timeout_seconds <= 0:
+                raise ValueError(
+                    "working_request_timeout_seconds must be > 0 (got %s)"
+                    % self.working_request_timeout_seconds
+                )
+            if self.working_request_timeout_seconds >= self.working_keep_alive_seconds:
+                raise ValueError(
+                    "working_request_timeout_seconds (%s) must be < "
+                    "working_keep_alive_seconds (%s) so a slow POST can't stack"
+                    % (
+                        self.working_request_timeout_seconds,
+                        self.working_keep_alive_seconds,
+                    )
+                )
+            if (
+                self.max_working_state_seconds is not None
+                and self.max_working_state_seconds <= 0
+            ):
+                raise ValueError(
+                    "max_working_state_seconds must be > 0 when set (got %s)"
+                    % self.max_working_state_seconds
+                )
 
 
 @dataclass

--- a/src/band/runtime/working_state.py
+++ b/src/band/runtime/working_state.py
@@ -1,0 +1,143 @@
+"""Boolean working-state keep-alive reporter.
+
+Owns the per-room "is the agent working" signal for a single reasoning cycle:
+sends ``working: true`` when a cycle starts, refreshes it on a keep-alive
+cadence while the cycle is active, and sends an authoritative ``working: false``
+when the cycle ends. The platform applies a short TTL, so if refreshes stop for
+any reason (crash, disconnect, loop-block) the indicator clears on its own — the
+keep-alive is a *liveness* signal, not a correctness signal.
+
+The reporter is transport-agnostic: it is given an async ``report(working)``
+callback (wired to ``BandLink.report_activity`` by the runtime) and never raises
+into the caller's reasoning loop.
+
+Contract: ``report`` MUST be time-bounded. The reporter awaits it (including the
+authoritative false-send during teardown), so an unbounded callback could wedge
+cycle teardown and cancellation propagation. ``BandLink.report_activity`` applies
+a per-POST timeout to satisfy this.
+
+Cadence accuracy: the keep-alive sleeps ``keep_alive_seconds`` and *then* reports,
+so the effective interval between successful refreshes is
+``keep_alive_seconds + report-latency``. The platform-TTL headroom is preserved by
+the ``cadence < TTL/2`` guard on ``SessionConfig`` (with the per-POST timeout kept
+below the cadence), so even one missed/slow ping stays within the TTL window.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+ReportFn = Callable[[bool], Awaitable[object]]
+
+
+class WorkingStateReporter:
+    """Manages the boolean working signal for one execution (agent + room)."""
+
+    def __init__(
+        self,
+        report: ReportFn,
+        *,
+        keep_alive_seconds: float = 3.0,
+        max_working_state_seconds: float | None = None,
+        enabled: bool = True,
+    ) -> None:
+        if keep_alive_seconds <= 0:
+            raise ValueError(
+                "keep_alive_seconds must be > 0 (got %s)" % keep_alive_seconds
+            )
+        self._report = report
+        self._keep_alive_seconds = keep_alive_seconds
+        self._max_working_state_seconds = max_working_state_seconds
+        self._enabled = enabled
+
+        self._active = False
+        self._started_at: float | None = None
+        self._task: asyncio.Task[None] | None = None
+        # Serializes every report() call (true / keep-alive / false) so they can
+        # never overlap on the wire — guarantees the platform sees them in order
+        # (boolean payload carries no sequence number to disambiguate).
+        self._lock = asyncio.Lock()
+
+    async def start(self) -> None:
+        """Begin a reasoning cycle: send ``working: true`` and arm keep-alive."""
+        if not self._enabled or self._active:
+            # Re-entrant start while active is a no-op: the signal is already
+            # alive and the keep-alive task is already running.
+            return
+        self._active = True
+        self._started_at = asyncio.get_running_loop().time()
+        await self._safe_report(True)
+        self._task = asyncio.create_task(
+            self._keep_alive(), name="working-state-keepalive"
+        )
+
+    async def stop(self) -> None:
+        """End the reasoning cycle: cancel keep-alive and send ``working: false``.
+
+        The false-send is shielded so that when the cycle ends via cancellation
+        (the caller is being cancelled), the authoritative ``false`` still lands
+        instead of being swallowed by the propagating ``CancelledError``.
+        """
+        if not self._enabled or not self._active:
+            return
+        self._active = False
+        task, self._task = self._task, None
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        send = asyncio.ensure_future(self._safe_report(False))
+        try:
+            await asyncio.shield(send)
+        except asyncio.CancelledError:
+            # We were cancelled while awaiting; let the false-send finish so the
+            # platform clears the indicator immediately rather than via TTL.
+            # Accepted gap: a *second* cancel landing during this await can abandon
+            # it, leaving `send` detached. `send` is time-bounded (the report
+            # callback has a per-POST deadline) so it still completes on the loop;
+            # and the platform TTL backstops the clear regardless. Not handled
+            # explicitly — the double-cancel teardown window is vanishingly rare.
+            await send
+            raise
+
+    async def _keep_alive(self) -> None:
+        """Re-send ``working: true`` on cadence until stopped or capped."""
+        while True:
+            await asyncio.sleep(self._keep_alive_seconds)
+            if not self._active:
+                return
+            if self._cap_reached():
+                # Stop lying past the cap: let the platform TTL flip the state.
+                # We do NOT cancel the cycle and do NOT send false here — stop()
+                # remains the authoritative clear when the cycle truly ends.
+                logger.info(
+                    "working-state max duration (%ss) reached; pausing keep-alive "
+                    "pings (platform TTL will clear the indicator)",
+                    self._max_working_state_seconds,
+                )
+                return
+            await self._safe_report(True)
+
+    def _cap_reached(self) -> bool:
+        if self._max_working_state_seconds is None or self._started_at is None:
+            return False
+        elapsed = asyncio.get_running_loop().time() - self._started_at
+        return elapsed >= self._max_working_state_seconds
+
+    async def _safe_report(self, working: bool) -> None:
+        """Report under the serialization lock; never raise."""
+        async with self._lock:
+            try:
+                await self._report(working)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception(
+                    "working-state report failed (working=%s); swallowing", working
+                )

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -813,3 +813,126 @@ class TestGetStaleProcessingMessages:
 
         assert [message.id for message in messages] == ["msg-1"]
         link.rest.agent_api_messages.list_agent_messages.assert_awaited_once()
+
+
+class TestReportActivity:
+    """Tests for BandLink.report_activity (boolean working-state reporting)."""
+
+    @pytest.mark.asyncio
+    async def test_reports_working_true(self):
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        link.rest.agent_api_activity.report_agent_chat_activity = AsyncMock()
+
+        result = await link.report_activity("room-1", True)
+
+        assert result is True
+        call = link.rest.agent_api_activity.report_agent_chat_activity
+        call.assert_awaited_once()
+        assert call.call_args.kwargs["chat_id"] == "room-1"
+        assert call.call_args.kwargs["working"] is True
+
+    @pytest.mark.asyncio
+    async def test_reports_working_false(self):
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        link.rest.agent_api_activity.report_agent_chat_activity = AsyncMock()
+
+        result = await link.report_activity("room-1", False)
+
+        assert result is True
+        call = link.rest.agent_api_activity.report_agent_chat_activity
+        assert call.call_args.kwargs["working"] is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_not_found(self):
+        from band_rest import NotFoundError
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        link.rest.agent_api_activity.report_agent_chat_activity = AsyncMock(
+            side_effect=NotFoundError(headers={}, body="no active execution")
+        )
+
+        result = await link.report_activity("room-1", True)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_unauthorized(self):
+        from band_rest import UnauthorizedError
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        link.rest.agent_api_activity.report_agent_chat_activity = AsyncMock(
+            side_effect=UnauthorizedError(headers={}, body="bad key")
+        )
+
+        result = await link.report_activity("room-1", True)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_unprocessable_entity(self):
+        from band_rest import UnprocessableEntityError
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        link.rest.agent_api_activity.report_agent_chat_activity = AsyncMock(
+            side_effect=UnprocessableEntityError(headers={}, body="bad uuid")
+        )
+
+        result = await link.report_activity("room-1", True)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_network_error(self):
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        link.rest.agent_api_activity.report_agent_chat_activity = AsyncMock(
+            side_effect=Exception("network down")
+        )
+
+        result = await link.report_activity("room-1", True)
+
+        assert result is False
+
+    def test_real_client_exposes_activity_method(self):
+        """Guard: the real REST client must actually expose the activity method.
+
+        The AsyncMock-based tests above auto-fabricate attributes, so they would
+        stay green even if `agent_api_activity.report_agent_chat_activity`
+        disappeared or was renamed in a band_rest bump. This test pins the
+        real wire contract: instantiate the real client and assert the method
+        exists and is callable.
+        """
+        from band_rest import AsyncRestClient
+
+        client = AsyncRestClient(api_key="test-key", base_url="https://test.com")
+        method = getattr(client.agent_api_activity, "report_agent_chat_activity", None)
+        assert callable(method)
+
+    @pytest.mark.asyncio
+    async def test_repeated_failures_warn_once_then_recover(self, caplog):
+        import logging
+
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        link.rest.agent_api_activity.report_agent_chat_activity = AsyncMock(
+            side_effect=Exception("down")
+        )
+
+        with caplog.at_level(logging.WARNING, logger="band.platform.link"):
+            assert await link.report_activity("room-1", True) is False
+            assert await link.report_activity("room-1", True) is False
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1  # debounced: only the first failure warns
+
+        # Recovery logs once at INFO and re-arms the warning.
+        link.rest.agent_api_activity.report_agent_chat_activity = AsyncMock()
+        with caplog.at_level(logging.INFO, logger="band.platform.link"):
+            caplog.clear()
+            assert await link.report_activity("room-1", True) is True
+        assert any("recovered" in r.message.lower() for r in caplog.records)

--- a/tests/platform/test_link.py
+++ b/tests/platform/test_link.py
@@ -833,6 +833,20 @@ class TestReportActivity:
         assert call.call_args.kwargs["working"] is True
 
     @pytest.mark.asyncio
+    async def test_passes_per_post_timeout_and_no_retries(self):
+        link = BandLink(agent_id="agent-123", api_key="test-key")
+        link.rest = MagicMock()
+        link.rest.agent_api_activity.report_agent_chat_activity = AsyncMock()
+
+        await link.report_activity("room-1", True, timeout_seconds=2)
+
+        opts = link.rest.agent_api_activity.report_agent_chat_activity.call_args.kwargs[
+            "request_options"
+        ]
+        assert opts["timeout_in_seconds"] == 2
+        assert opts["max_retries"] == 0
+
+    @pytest.mark.asyncio
     async def test_reports_working_false(self):
         link = BandLink(agent_id="agent-123", api_key="test-key")
         link.rest = MagicMock()

--- a/tests/runtime/test_execution_working_state.py
+++ b/tests/runtime/test_execution_working_state.py
@@ -1,0 +1,219 @@
+"""Integration tests: ExecutionContext wiring of the working-state reporter."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from band.platform.event import ReconnectedEvent
+from band.runtime.execution import ExecutionContext
+from band.runtime.types import PlatformMessage, SessionConfig
+from tests.conftest import (
+    make_message_event,
+    make_participant_added_event,
+)
+
+
+@pytest.fixture
+def mock_link():
+    link = MagicMock()
+    link.agent_id = "agent-123"
+    link.rest = MagicMock()
+
+    participant1 = MagicMock()
+    participant1.id = "user-1"
+    participant1.name = "User One"
+    participant1.type = "User"
+    link.rest.agent_api_participants = MagicMock()
+    link.rest.agent_api_participants.list_agent_chat_participants = AsyncMock(
+        return_value=MagicMock(data=[participant1])
+    )
+    link.rest.agent_api_context = MagicMock()
+    link.rest.agent_api_context.get_agent_chat_context = AsyncMock(
+        return_value=MagicMock(data=[])
+    )
+
+    link.mark_processing = AsyncMock(return_value=True)
+    link.mark_processed = AsyncMock(return_value=True)
+    link.mark_failed = AsyncMock(return_value=True)
+    link.get_next_message = AsyncMock(return_value=None)
+    link.get_stale_processing_messages = AsyncMock(return_value=[])
+    link.report_activity = AsyncMock(return_value=True)
+    return link
+
+
+def _working_values(link) -> list[bool]:
+    """Sequence of `working` booleans passed to link.report_activity."""
+    return [
+        c.args[1] if len(c.args) > 1 else c.kwargs["working"]
+        for c in link.report_activity.call_args_list
+    ]
+
+
+# Keep cadence high enough that no keep-alive fires during a fast test cycle,
+# but below the TTL/2 guard.
+_FAST = SessionConfig(working_keep_alive_seconds=4.0)
+
+
+def _backlog_message(
+    room_id: str = "room-123", msg_id: str = "msg-b1"
+) -> PlatformMessage:
+    return PlatformMessage(
+        id=msg_id,
+        room_id=room_id,
+        content="hi",
+        sender_id="user-1",
+        sender_type="User",
+        sender_name="User One",
+        message_type="text",
+        metadata={},
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+class TestWiring:
+    @pytest.mark.asyncio
+    async def test_message_event_reports_true_then_false(self, mock_link, mock_handler):
+        ctx = ExecutionContext("room-123", mock_link, mock_handler, config=_FAST)
+
+        await ctx._process_event(make_message_event(room_id="room-123", msg_id="m1"))
+
+        assert _working_values(mock_link) == [True, False]
+        for call in mock_link.report_activity.call_args_list:
+            assert call.args[0] == "room-123"
+
+    @pytest.mark.asyncio
+    async def test_reports_false_even_when_handler_raises(self, mock_link):
+        handler = AsyncMock(side_effect=RuntimeError("boom"))
+        ctx = ExecutionContext("room-123", mock_link, handler, config=_FAST)
+
+        await ctx._process_event(make_message_event(room_id="room-123", msg_id="m1"))
+
+        assert _working_values(mock_link)[-1] is False
+        assert _working_values(mock_link).count(False) == 1
+
+    @pytest.mark.asyncio
+    async def test_participant_event_does_not_report(self, mock_link, mock_handler):
+        ctx = ExecutionContext("room-123", mock_link, mock_handler, config=_FAST)
+
+        await ctx._process_event(
+            make_participant_added_event(room_id="room-123", participant_id="user-2")
+        )
+
+        mock_link.report_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reconnected_event_does_not_report(self, mock_link, mock_handler):
+        ctx = ExecutionContext("room-123", mock_link, mock_handler, config=_FAST)
+
+        await ctx._process_event(ReconnectedEvent(room_id="room-123"))
+
+        mock_link.report_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_hub_room_does_not_report(self, mock_link, mock_handler):
+        ctx = ExecutionContext(
+            "hub-1", mock_link, mock_handler, config=_FAST, hub_room_id="hub-1"
+        )
+
+        await ctx._process_event(make_message_event(room_id="hub-1", msg_id="m1"))
+
+        mock_link.report_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_backlog_message_reports_true_then_false(
+        self, mock_link, mock_handler
+    ):
+        ctx = ExecutionContext("room-123", mock_link, mock_handler, config=_FAST)
+
+        await ctx._process_backlog_message(_backlog_message())
+
+        assert _working_values(mock_link) == [True, False]
+
+    @pytest.mark.asyncio
+    async def test_disabled_config_does_not_report(self, mock_link, mock_handler):
+        ctx = ExecutionContext(
+            "room-123",
+            mock_link,
+            mock_handler,
+            config=SessionConfig(enable_working_state=False),
+        )
+
+        await ctx._process_event(make_message_event(room_id="room-123", msg_id="m1"))
+
+        mock_link.report_activity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rooms_are_isolated(self, mock_handler):
+        link_a = _independent_link()
+        link_b = _independent_link()
+        ctx_a = ExecutionContext("room-a", link_a, mock_handler, config=_FAST)
+        ExecutionContext("room-b", link_b, mock_handler, config=_FAST)
+
+        await ctx_a._process_event(make_message_event(room_id="room-a", msg_id="m1"))
+
+        link_a.report_activity.assert_called()
+        link_b.report_activity.assert_not_called()
+
+
+def _independent_link():
+    link = MagicMock()
+    link.agent_id = "agent-123"
+    link.rest = MagicMock()
+    p = MagicMock(id="user-1", name="User One", type="User")
+    link.rest.agent_api_participants.list_agent_chat_participants = AsyncMock(
+        return_value=MagicMock(data=[p])
+    )
+    link.rest.agent_api_context.get_agent_chat_context = AsyncMock(
+        return_value=MagicMock(data=[])
+    )
+    link.mark_processing = AsyncMock(return_value=True)
+    link.mark_processed = AsyncMock(return_value=True)
+    link.mark_failed = AsyncMock(return_value=True)
+    link.report_activity = AsyncMock(return_value=True)
+    return link
+
+
+@pytest.fixture
+def mock_handler():
+    return AsyncMock()
+
+
+class TestSessionConfigGuards:
+    def test_defaults_are_valid(self):
+        cfg = SessionConfig()
+        assert cfg.enable_working_state is True
+        assert cfg.working_keep_alive_seconds == 3.0
+        assert cfg.working_request_timeout_seconds == 2
+        assert cfg.max_working_state_seconds is None
+
+    def test_cadence_must_be_below_ttl_half(self):
+        with pytest.raises(ValueError):
+            SessionConfig(working_keep_alive_seconds=5.0)  # >= 10/2
+
+    def test_cadence_must_be_positive(self):
+        with pytest.raises(ValueError):
+            SessionConfig(working_keep_alive_seconds=0)
+
+    def test_timeout_must_be_below_cadence(self):
+        with pytest.raises(ValueError):
+            SessionConfig(
+                working_keep_alive_seconds=3.0, working_request_timeout_seconds=3
+            )
+
+    def test_timeout_must_be_positive(self):
+        with pytest.raises(ValueError):
+            SessionConfig(working_request_timeout_seconds=0)
+
+    def test_max_duration_if_set_must_be_positive(self):
+        with pytest.raises(ValueError):
+            SessionConfig(max_working_state_seconds=0)
+
+    def test_disabled_skips_guards(self):
+        # When disabled, odd values must not raise.
+        cfg = SessionConfig(
+            enable_working_state=False, working_keep_alive_seconds=100.0
+        )
+        assert cfg.enable_working_state is False

--- a/tests/runtime/test_working_state.py
+++ b/tests/runtime/test_working_state.py
@@ -1,0 +1,189 @@
+"""Tests for WorkingStateReporter (boolean working-state keep-alive)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from band.runtime.working_state import WorkingStateReporter
+
+
+async def _wait_for(predicate, timeout: float = 2.0) -> None:
+    """Poll until predicate() is truthy or raise on timeout (non-brittle wait)."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError("condition not met within timeout")
+
+
+class Recorder:
+    """Async report callback that records the sequence of working values."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.calls: list[bool] = []
+        self.fail = fail
+
+    async def __call__(self, working: bool) -> bool:
+        self.calls.append(working)
+        if self.fail:
+            raise RuntimeError("report failed")
+        return True
+
+
+class TestStartStop:
+    @pytest.mark.asyncio
+    async def test_start_sends_true_immediately(self):
+        rec = Recorder()
+        reporter = WorkingStateReporter(rec, keep_alive_seconds=10.0)
+
+        await reporter.start()
+
+        assert rec.calls == [True]
+        await reporter.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_sends_false(self):
+        rec = Recorder()
+        reporter = WorkingStateReporter(rec, keep_alive_seconds=10.0)
+
+        await reporter.start()
+        await reporter.stop()
+
+        assert rec.calls[0] is True
+        assert rec.calls[-1] is False
+        assert rec.calls.count(False) == 1
+
+    @pytest.mark.asyncio
+    async def test_stop_without_start_is_noop(self):
+        rec = Recorder()
+        reporter = WorkingStateReporter(rec, keep_alive_seconds=10.0)
+
+        await reporter.stop()
+
+        assert rec.calls == []
+
+    @pytest.mark.asyncio
+    async def test_disabled_reports_nothing(self):
+        rec = Recorder()
+        reporter = WorkingStateReporter(rec, keep_alive_seconds=0.01, enabled=False)
+
+        await reporter.start()
+        await asyncio.sleep(0.05)
+        await reporter.stop()
+
+        assert rec.calls == []
+
+
+class TestKeepAlive:
+    @pytest.mark.asyncio
+    async def test_refreshes_true_on_cadence(self):
+        rec = Recorder()
+        reporter = WorkingStateReporter(rec, keep_alive_seconds=0.02)
+
+        await reporter.start()
+        # initial true + at least two refreshes
+        await _wait_for(lambda: rec.calls.count(True) >= 3)
+        await reporter.stop()
+
+        assert rec.calls.count(True) >= 3
+        assert rec.calls[-1] is False
+
+    @pytest.mark.asyncio
+    async def test_reentrant_start_does_not_duplicate_keepalive(self):
+        rec = Recorder()
+        reporter = WorkingStateReporter(rec, keep_alive_seconds=10.0)
+
+        await reporter.start()
+        await reporter.start()  # already active -> no-op
+
+        assert rec.calls == [True]  # only one initial true, one task
+        await reporter.stop()
+
+
+class TestOrdering:
+    @pytest.mark.asyncio
+    async def test_false_always_after_true_even_on_ultra_short_cycle(self):
+        rec = Recorder()
+        reporter = WorkingStateReporter(rec, keep_alive_seconds=10.0)
+
+        # Ultra-short cycle: start then immediately stop.
+        await reporter.start()
+        await reporter.stop()
+
+        # The lock must guarantee true is sent (and lands) before false.
+        assert rec.calls[0] is True
+        assert rec.calls[-1] is False
+        # No false appears before the first true.
+        first_false = rec.calls.index(False)
+        first_true = rec.calls.index(True)
+        assert first_true < first_false
+
+
+class TestCancellation:
+    @pytest.mark.asyncio
+    async def test_false_sent_even_when_cycle_cancelled(self):
+        rec = Recorder()
+        reporter = WorkingStateReporter(rec, keep_alive_seconds=10.0)
+
+        async def cycle():
+            await reporter.start()
+            try:
+                await asyncio.sleep(100)  # long-running reasoning
+            finally:
+                await reporter.stop()
+
+        task = asyncio.create_task(cycle())
+        await _wait_for(lambda: rec.calls == [True])
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # The shielded false-send must have completed despite the cancel.
+        await _wait_for(lambda: rec.calls and rec.calls[-1] is False)
+        assert rec.calls.count(False) == 1
+
+
+class TestFailureSwallowed:
+    @pytest.mark.asyncio
+    async def test_report_exception_does_not_propagate(self):
+        rec = Recorder(fail=True)
+        reporter = WorkingStateReporter(rec, keep_alive_seconds=0.02)
+
+        # Neither start nor the keep-alive task nor stop may raise.
+        await reporter.start()
+        await asyncio.sleep(0.05)
+        await reporter.stop()
+
+        assert rec.calls  # attempts were made
+
+
+class TestMaxDuration:
+    @pytest.mark.asyncio
+    async def test_keepalive_stops_after_max_but_stop_still_sends_false(self):
+        rec = Recorder()
+        reporter = WorkingStateReporter(
+            rec, keep_alive_seconds=0.02, max_working_state_seconds=0.05
+        )
+
+        await reporter.start()
+        # Let the cap elapse and the keep-alive go quiet.
+        await asyncio.sleep(0.2)
+        count_after_cap = rec.calls.count(True)
+        await asyncio.sleep(0.1)
+        # No further true pings after the cap.
+        assert rec.calls.count(True) == count_after_cap
+
+        # stop() still sends the authoritative false.
+        await reporter.stop()
+        assert rec.calls[-1] is False
+
+
+class TestValidation:
+    def test_non_positive_cadence_rejected(self):
+        with pytest.raises(ValueError):
+            WorkingStateReporter(Recorder(), keep_alive_seconds=0)


### PR DESCRIPTION
## Summary

Implements **INT-831** — every adapter automatically reports a **boolean working/not-working** keep-alive signal to the platform for each remote-agent reasoning cycle (per agent + room), with **no agent-business-logic changes and no per-adapter code**. Wired once in the runtime so all 16 adapters get it for free.

- `working: true` when a reasoning cycle starts
- refreshed on a keep-alive cadence (~3s) while the cycle is active
- `working: false` immediately when the cycle ends (complete / error / interrupt)
- platform TTL (≤10s) is the backstop for abnormal ends (crash / hang / disconnect)

Boolean-only payload — no status enum, tool name, `detail`, or free text.

## Design

`ExecutionContext` brackets the adapter invocation (`_on_execute`) for **message-driven cycles only** via `_execute_message_cycle` (`start()` → try → `finally stop()`):

- **WS path** (`_process_event`): wrapped only for `MessageEvent`; participant add/remove and `ReconnectedEvent` are excluded (housekeeping, not reasoning).
- **Backlog `/next` path** (`_process_backlog_message`): always wrapped.
- **Hub room excluded** via the reporter's `enabled` flag (`room_id == hub_room_id`) — it's an internal contact-triage room with no peer-facing "Reasoning…" surface (so synthetic contact messages, which only occur there, are excluded as a consequence).

Components:
- **`BandLink.report_activity(room_id, working)`** — uses the `band_rest` generated `agent_api_activity.report_agent_chat_activity`; per-POST timeout (2s, `max_retries=0`); all failures swallowed → `False` (never raises into the loop); repeated failures debounced to one warning + a recovery info.
- **`WorkingStateReporter`** (`src/band/runtime/working_state.py`) — per room: immediate `true` + keep-alive refresh; **`asyncio.Lock` serializes all sends** so they can't overlap on the wire; **shielded `false`-send** so it lands even mid-cancellation; optional `max_working_state_seconds` cap pauses pings (TTL clears) without ever cancelling reasoning; never raises.
- **`SessionConfig`** knobs: `enable_working_state` (kill-switch, default `True`), `working_keep_alive_seconds` (3), `working_request_timeout_seconds` (2), `max_working_state_seconds` (None), with a `__post_init__` guard (cadence>0, cadence<TTL/2, timeout<cadence, max>0).

## Dependency note

This branch sits on the **`band-client-rest 0.0.10` (`band_rest`) migration** (merged from `chore/bump-band-client-rest-0.0.10`), which ships the activity endpoint this feature reports against. If that bump lands on `dev` independently, this PR's diff shrinks to just the INT-831 changes.

**Rejected alternative (paper trail):** a standalone `httpx.AsyncClient` in `BandLink` — that was the workaround for the old `thenvoi-client-rest==0.0.7` gap (no activity namespace). Superseded by the generated method; the real-client guard test fails loudly if that namespace ever regresses, at which point the fallback is the documented fix.

## Failure guarantee (honest mapping)

Keep-alive is a **liveness** signal. Normal completion / exception / interrupt → immediate `false` (finally). Loop-block / process-death → TTL clears. A **hung-but-connected live await** is not ≤10s-achievable from the SDK alone (requires framework introspection, out of scope) — mitigated by requiring adapter request timeouts; documented as a limitation for the platform side (PLT-945).

## Tests (TDD; each step reviewed to consensus with an architect)

- `tests/platform/test_link.py::TestReportActivity` — real-client method guard, true/false args, error swallowing (404/401/422/network), failure-log debounce, per-POST timeout.
- `tests/runtime/test_working_state.py` — immediate true, keep-alive cadence, **mid-cycle-cancel asserts false** (non-skippable gate), **true-before-false ordering** (non-skippable gate), failure swallowed, no duplicate keep-alive, cap pause, disabled, validation.
- `tests/runtime/test_execution_working_state.py` — true/false around `MessageEvent`, false on exception, participant/`ReconnectedEvent` excluded, hub-room excluded, backlog path, room isolation, config guards.

Touched-area unit suite: **740 passed**; ruff + pyrefly clean.

## Follow-ups (not in this PR)

- Gated E2E observing the real `agent_executions:{room_id}` broadcast flip (the one test proving the live platform contract).
- Optional tighter UX: drop the indicator at reply-send (and/or a declared per-adapter "reasoning span") so it clears the instant the reply lands rather than after the model's trailing wrap-up turn — discussed, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
