### PR TITLE
fix: stop Pydantic AI duplicate reply on crash recovery…

### DIFF
--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -12,7 +12,7 @@ import asyncio
 import logging
 import warnings
 from contextvars import ContextVar
-from typing import ClassVar, TYPE_CHECKING, Any, Literal
+from typing import ClassVar, TYPE_CHECKING, Any
 
 from band.core.exceptions import BandConfigError
 from band.core.protocols import AgentToolsProtocol
@@ -48,8 +48,6 @@ _current_room_context: ContextVar[tuple[str, AgentToolsProtocol] | None] = Conte
 _reply_tracker_var: ContextVar[ReplyTracker | None] = ContextVar(
     "_crewai_reply_tracker", default=None
 )
-
-MessageType = Literal["thought", "error", "task"]
 
 
 class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -21,8 +21,7 @@ from pydantic_ai import (
 from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
-    TextPart,
-    ToolCallPart,
+    ThinkingPart,
     UserPromptPart,
 )
 
@@ -40,11 +39,23 @@ from band.runtime.tools import get_tool_description
 logger = logging.getLogger(__name__)
 
 
+# A response made up only of these (or with no parts at all) serializes to
+# content:null, which providers reject when it's replayed as history.
+_NON_REPLAYABLE_RESPONSE_PARTS = (ThinkingPart,)
+
+
 def _is_replayable_history_message(message: Any) -> bool:
-    """Drop assistant responses that OpenAI replays as content:null."""
+    """Drop assistant responses that would replay as content:null.
+
+    Keep any response with at least one content-bearing part (text, tool
+    calls, builtin tool calls/returns, files). Drop thinking-only and empty
+    responses, which providers reject when sent back as history.
+    """
     if isinstance(message, ModelResponse):
-        # Only TextPart/ToolCallPart replay safely; ThinkingPart-only etc. become content:null.
-        return any(isinstance(part, (TextPart, ToolCallPart)) for part in message.parts)
+        return any(
+            not isinstance(part, _NON_REPLAYABLE_RESPONSE_PARTS)
+            for part in message.parts
+        )
     return True
 
 

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -479,6 +479,11 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         if is_session_bootstrap:
             if history:
                 self._message_history[room_id] = list(history)
+                logger.debug(
+                    "Room %s: rehydrated %s message(s) from platform history",
+                    room_id,
+                    len(history),
+                )
             else:
                 self._message_history[room_id] = []
         elif room_id not in self._message_history:
@@ -552,11 +557,19 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             elif isinstance(event, AgentRunResultEvent):
                 # Keep native run history, but drop responses that replay as
                 # content:null (e.g. thinking-only) — providers reject them next request.
+                run_messages = list(event.result.all_messages())
                 self._message_history[room_id] = [
                     message
-                    for message in event.result.all_messages()
+                    for message in run_messages
                     if _is_replayable_history_message(message)
                 ]
+                dropped = len(run_messages) - len(self._message_history[room_id])
+                if dropped:
+                    logger.debug(
+                        "Room %s: dropped %s content:null response(s) from history",
+                        room_id,
+                        dropped,
+                    )
 
         logger.debug(
             "Room %s: Pydantic AI agent completed (history now has %s messages)",

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -20,6 +20,9 @@ from pydantic_ai import (
 )
 from pydantic_ai.messages import (
     ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
     UserPromptPart,
 )
 
@@ -35,6 +38,14 @@ from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import get_tool_description
 
 logger = logging.getLogger(__name__)
+
+
+def _is_replayable_history_message(message: Any) -> bool:
+    """Drop assistant responses that OpenAI replays as content:null."""
+    if isinstance(message, ModelResponse):
+        # Only TextPart/ToolCallPart replay safely; ThinkingPart-only etc. become content:null.
+        return any(isinstance(part, (TextPart, ToolCallPart)) for part in message.parts)
+    return True
 
 
 class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
@@ -468,9 +479,6 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         if is_session_bootstrap:
             if history:
                 self._message_history[room_id] = list(history)
-                logger.debug(
-                    "Room %s: Loaded %s Pydantic AI messages", room_id, len(history)
-                )
             else:
                 self._message_history[room_id] = []
         elif room_id not in self._message_history:
@@ -542,8 +550,12 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                     except Exception as e:
                         logger.warning("Failed to send tool_result event: %s", e)
             elif isinstance(event, AgentRunResultEvent):
-                # Update stored history with all messages from this run
-                self._message_history[room_id] = list(event.result.all_messages())
+                # Keep native run history; drop poison ModelResponses (e.g. thinking-only).
+                self._message_history[room_id] = [
+                    message
+                    for message in event.result.all_messages()
+                    if _is_replayable_history_message(message)
+                ]
 
         logger.debug(
             "Room %s: Pydantic AI agent completed (history now has %s messages)",

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -550,7 +550,8 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                     except Exception as e:
                         logger.warning("Failed to send tool_result event: %s", e)
             elif isinstance(event, AgentRunResultEvent):
-                # Keep native run history; drop poison ModelResponses (e.g. thinking-only).
+                # Keep native run history, but drop responses that replay as
+                # content:null (e.g. thinking-only) — providers reject them next request.
                 self._message_history[room_id] = [
                     message
                     for message in event.result.all_messages()

--- a/src/band/converters/pydantic_ai.py
+++ b/src/band/converters/pydantic_ai.py
@@ -9,6 +9,7 @@ try:
         ModelRequest,
         ModelResponse,
         RetryPromptPart,
+        TextPart,
         ToolCallPart,
         ToolReturnPart,
         UserPromptPart,
@@ -61,7 +62,7 @@ class PydanticAIHistoryConverter(HistoryConverter[PydanticAIMessages]):
     - other agents' messages → ModelRequest with UserPromptPart (with [name] prefix)
     - tool_call → ModelResponse with ToolCallPart
     - tool_result → ModelRequest with ToolReturnPart (or RetryPromptPart if is_error=True)
-    - this agent's text messages → skipped (redundant with tool results)
+    - this agent's text messages → ModelResponse with TextPart
 
     Tool events are stored in platform as JSON:
     - tool_call: {"name": "...", "args": {...}, "tool_call_id": "..."}
@@ -73,15 +74,15 @@ class PydanticAIHistoryConverter(HistoryConverter[PydanticAIMessages]):
         Initialize converter.
 
         Args:
-            agent_name: Name of this agent. Messages from this agent are skipped
-                       (they're redundant with tool results). Messages from other
-                       agents are included as ModelRequest.
+            agent_name: Name of this agent. Messages from this agent are preserved
+                       as ModelResponse. Messages from other agents are included
+                       as ModelRequest.
         """
         self._agent_name = agent_name
 
     def set_agent_name(self, name: str) -> None:
         """
-        Set agent name so converter knows which messages to skip.
+        Set agent name so the converter can recognize this agent's own messages.
 
         Args:
             name: Name of this agent
@@ -148,9 +149,13 @@ class PydanticAIHistoryConverter(HistoryConverter[PydanticAIMessages]):
                 role = hist.get("role", "user")
                 sender_name = hist.get("sender_name", "")
 
-                if role == "assistant" and sender_name == self._agent_name:
-                    # Skip THIS agent's text (redundant with tool results)
-                    continue
+                if (
+                    role == "assistant"
+                    and self._agent_name
+                    and sender_name == self._agent_name
+                ):
+                    # Preserve own text so restart rehydration knows the agent already replied.
+                    messages.append(ModelResponse(parts=[TextPart(content=content)]))
                 else:
                     # User messages AND other agents' messages
                     formatted_content = (

--- a/src/band/converters/pydantic_ai.py
+++ b/src/band/converters/pydantic_ai.py
@@ -63,6 +63,8 @@ class PydanticAIHistoryConverter(HistoryConverter[PydanticAIMessages]):
     - tool_call → ModelResponse with ToolCallPart
     - tool_result → ModelRequest with ToolReturnPart (or RetryPromptPart if is_error=True)
     - this agent's text messages → ModelResponse with TextPart
+      (dropped when emitted mid tool call, where it would split the
+      ToolCallPart from its ToolReturnPart)
 
     Tool events are stored in platform as JSON:
     - tool_call: {"name": "...", "args": {...}, "tool_call_id": "..."}
@@ -142,18 +144,25 @@ class PydanticAIHistoryConverter(HistoryConverter[PydanticAIMessages]):
                     pending_tool_results.append(tool_result_part)
 
             elif message_type == "text":
+                role = hist.get("role", "user")
+                sender_name = hist.get("sender_name", "")
+                is_own = (
+                    role == "assistant"
+                    and self._agent_name
+                    and sender_name == self._agent_name
+                )
+
+                # Own platform text while a tool call is unresolved is usually the side
+                # effect of band_send_message. Replaying it here would split the
+                # ToolCallPart from its ToolReturnPart, which providers reject.
+                if is_own and pending_tool_calls:
+                    continue
+
                 # Flush pending tool calls and results first
                 _flush_pending_tool_calls(messages, pending_tool_calls)
                 _flush_pending_tool_results(messages, pending_tool_results)
 
-                role = hist.get("role", "user")
-                sender_name = hist.get("sender_name", "")
-
-                if (
-                    role == "assistant"
-                    and self._agent_name
-                    and sender_name == self._agent_name
-                ):
+                if is_own:
                     # Preserve own text so restart rehydration knows the agent already replied.
                     messages.append(ModelResponse(parts=[TextPart(content=content)]))
                 else:

--- a/src/band/converters/pydantic_ai.py
+++ b/src/band/converters/pydantic_ai.py
@@ -104,78 +104,114 @@ class PydanticAIHistoryConverter(HistoryConverter[PydanticAIMessages]):
             message_type = hist.get("message_type", "text")
             content = hist.get("content", "")
 
-            if message_type == "tool_call":
-                # Flush pending tool results before starting new tool calls
-                _flush_pending_tool_results(messages, pending_tool_results)
-
-                # Parse tool call JSON and collect for batching
-                parsed = parse_tool_call(content)
-                if parsed:
-                    tool_call_part = ToolCallPart(
-                        tool_name=parsed.name,
-                        args=parsed.args,
-                        tool_call_id=parsed.tool_call_id,
+            match message_type:
+                case "tool_call":
+                    self._handle_tool_call(
+                        content, messages, pending_tool_calls, pending_tool_results
                     )
-                    pending_tool_calls.append(tool_call_part)
-
-            elif message_type == "tool_result":
-                # Flush pending tool calls first (tool results follow tool calls)
-                _flush_pending_tool_calls(messages, pending_tool_calls)
-
-                # Parse tool result JSON and collect for batching
-                parsed = parse_tool_result(content)
-                if parsed:
-                    if parsed.is_error:
-                        # Use RetryPromptPart for error results
-                        tool_result_part: ToolReturnPart | RetryPromptPart = (
-                            RetryPromptPart(
-                                content=parsed.output,
-                                tool_name=parsed.name,
-                                tool_call_id=parsed.tool_call_id,
-                            )
-                        )
-                    else:
-                        # Use ToolReturnPart for successful results
-                        tool_result_part = ToolReturnPart(
-                            tool_name=parsed.name,
-                            content=parsed.output,
-                            tool_call_id=parsed.tool_call_id,
-                        )
-                    pending_tool_results.append(tool_result_part)
-
-            elif message_type == "text":
-                role = hist.get("role", "user")
-                sender_name = hist.get("sender_name", "")
-                is_own = (
-                    role == "assistant"
-                    and self._agent_name
-                    and sender_name == self._agent_name
-                )
-
-                # Own platform text while a tool call is unresolved is usually the side
-                # effect of band_send_message. Replaying it here would split the
-                # ToolCallPart from its ToolReturnPart, which providers reject.
-                if is_own and pending_tool_calls:
-                    continue
-
-                # Flush pending tool calls and results first
-                _flush_pending_tool_calls(messages, pending_tool_calls)
-                _flush_pending_tool_results(messages, pending_tool_results)
-
-                if is_own:
-                    # Preserve own text so restart rehydration knows the agent already replied.
-                    messages.append(ModelResponse(parts=[TextPart(content=content)]))
-                else:
-                    # User messages AND other agents' messages
-                    formatted_content = (
-                        f"[{sender_name}]: {content}" if sender_name else content
+                case "tool_result":
+                    self._handle_tool_result(
+                        content, messages, pending_tool_calls, pending_tool_results
                     )
-                    messages.append(
-                        ModelRequest(parts=[UserPromptPart(content=formatted_content)])
+                case "text":
+                    self._handle_text(
+                        hist,
+                        content,
+                        messages,
+                        pending_tool_calls,
+                        pending_tool_results,
                     )
+                # Other types (e.g. "thought") are intentionally ignored.
 
         # Flush any remaining pending tool calls and results
         _flush_pending_tool_calls(messages, pending_tool_calls)
         _flush_pending_tool_results(messages, pending_tool_results)
 
         return messages
+
+    def _handle_tool_call(
+        self,
+        content: str,
+        messages: PydanticAIMessages,
+        pending_tool_calls: list[ToolCallPart],
+        pending_tool_results: list[ToolReturnPart | RetryPromptPart],
+    ) -> None:
+        """Collect a tool call for batching, flushing any pending results first."""
+        _flush_pending_tool_results(messages, pending_tool_results)
+
+        parsed = parse_tool_call(content)
+        if parsed:
+            pending_tool_calls.append(
+                ToolCallPart(
+                    tool_name=parsed.name,
+                    args=parsed.args,
+                    tool_call_id=parsed.tool_call_id,
+                )
+            )
+
+    def _handle_tool_result(
+        self,
+        content: str,
+        messages: PydanticAIMessages,
+        pending_tool_calls: list[ToolCallPart],
+        pending_tool_results: list[ToolReturnPart | RetryPromptPart],
+    ) -> None:
+        """Collect a tool result for batching, flushing the calls it answers first."""
+        _flush_pending_tool_calls(messages, pending_tool_calls)
+
+        parsed = parse_tool_result(content)
+        if not parsed:
+            return
+
+        if parsed.is_error:
+            # Use RetryPromptPart for error results
+            tool_result_part: ToolReturnPart | RetryPromptPart = RetryPromptPart(
+                content=parsed.output,
+                tool_name=parsed.name,
+                tool_call_id=parsed.tool_call_id,
+            )
+        else:
+            # Use ToolReturnPart for successful results
+            tool_result_part = ToolReturnPart(
+                tool_name=parsed.name,
+                content=parsed.output,
+                tool_call_id=parsed.tool_call_id,
+            )
+        pending_tool_results.append(tool_result_part)
+
+    def _handle_text(
+        self,
+        hist: dict[str, Any],
+        content: str,
+        messages: PydanticAIMessages,
+        pending_tool_calls: list[ToolCallPart],
+        pending_tool_results: list[ToolReturnPart | RetryPromptPart],
+    ) -> None:
+        """Append a text turn: own text as ModelResponse, others as ModelRequest."""
+        role = hist.get("role", "user")
+        sender_name = hist.get("sender_name", "")
+        is_own = (
+            role == "assistant" and self._agent_name and sender_name == self._agent_name
+        )
+
+        # Own platform text while a tool call is unresolved is usually the side
+        # effect of band_send_message. Replaying it here would split the
+        # ToolCallPart from its ToolReturnPart, which providers reject.
+        if is_own and pending_tool_calls:
+            return
+
+        # Flush pending tool calls and results first
+        _flush_pending_tool_calls(messages, pending_tool_calls)
+        _flush_pending_tool_results(messages, pending_tool_results)
+
+        if is_own:
+            # Preserve own text so restart rehydration knows the agent already replied.
+            messages.append(ModelResponse(parts=[TextPart(content=content)]))
+        else:
+            # User messages AND other agents' messages
+            formatted_content = (
+                f"[{sender_name}]: {content}" if sender_name else content
+            )
+            messages.append(
+                ModelRequest(parts=[UserPromptPart(content=formatted_content)])
+            )

--- a/src/band/converters/pydantic_ai.py
+++ b/src/band/converters/pydantic_ai.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 try:
@@ -23,6 +24,8 @@ except ImportError as e:
 from band.core.protocols import HistoryConverter
 
 from ._tool_parsing import parse_tool_call, parse_tool_result
+
+logger = logging.getLogger(__name__)
 
 # Type alias for Pydantic AI messages (can be requests or responses)
 PydanticAIMessages = list[ModelRequest | ModelResponse]
@@ -121,7 +124,10 @@ class PydanticAIHistoryConverter(HistoryConverter[PydanticAIMessages]):
                         pending_tool_calls,
                         pending_tool_results,
                     )
-                # Other types (e.g. "thought") are intentionally ignored.
+                case "thought" | "error" | "task":
+                    pass # Known platform-internal types intentionally excluded from LLM history.
+                case _:
+                    logger.warning("Unknown message_type in history: %s", message_type)
 
         # Flush any remaining pending tool calls and results
         _flush_pending_tool_calls(messages, pending_tool_calls)

--- a/src/band/converters/pydantic_ai.py
+++ b/src/band/converters/pydantic_ai.py
@@ -22,6 +22,7 @@ except ImportError as e:
     ) from e
 
 from band.core.protocols import HistoryConverter
+from band.core.types import MessageType
 
 from ._tool_parsing import parse_tool_call, parse_tool_result
 
@@ -108,15 +109,15 @@ class PydanticAIHistoryConverter(HistoryConverter[PydanticAIMessages]):
             content = hist.get("content", "")
 
             match message_type:
-                case "tool_call":
+                case MessageType.TOOL_CALL:
                     self._handle_tool_call(
                         content, messages, pending_tool_calls, pending_tool_results
                     )
-                case "tool_result":
+                case MessageType.TOOL_RESULT:
                     self._handle_tool_result(
                         content, messages, pending_tool_calls, pending_tool_results
                     )
-                case "text":
+                case MessageType.TEXT:
                     self._handle_text(
                         hist,
                         content,
@@ -124,8 +125,10 @@ class PydanticAIHistoryConverter(HistoryConverter[PydanticAIMessages]):
                         pending_tool_calls,
                         pending_tool_results,
                     )
-                case "thought" | "error" | "task":
-                    pass # Known platform-internal types intentionally excluded from LLM history.
+                case MessageType.THOUGHT | MessageType.ERROR | MessageType.TASK:
+                    # Known platform-internal types intentionally excluded from
+                    # LLM history.
+                    pass
                 case _:
                     logger.warning("Unknown message_type in history: %s", message_type)
 

--- a/src/band/core/types.py
+++ b/src/band/core/types.py
@@ -5,13 +5,29 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
-from typing import TYPE_CHECKING, Any, TypeVar
+from enum import Enum, StrEnum
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 if TYPE_CHECKING:
     from band.core.protocols import AgentToolsProtocol, HistoryConverter
 
 T = TypeVar("T")
+
+
+class MessageType(StrEnum):
+    """Canonical ``message_type`` values used across platform history and events."""
+
+    TEXT = "text"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    THOUGHT = "thought"
+    ERROR = "error"
+    TASK = "task"
+
+
+# Subset of message types accepted by ``band_send_event`` — the non-history
+# event kinds. Derived from MessageType so the taxonomy stays single-sourced.
+EventMessageType = Literal[MessageType.THOUGHT, MessageType.ERROR, MessageType.TASK]
 
 
 class Capability(str, Enum):

--- a/src/band/integrations/crewai/tools.py
+++ b/src/band/integrations/crewai/tools.py
@@ -51,7 +51,13 @@ from band.core.memory_types import (
 )
 from band.core.protocols import AgentToolsProtocol
 from band.core.tool_filter import filter_tool_schemas
-from band.core.types import AdapterFeatures, Capability, Emit
+from band.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    EventMessageType,
+    MessageType,
+)
 from band.integrations.crewai.runtime import run_async
 from band.runtime.custom_tools import (
     CustomToolDef,
@@ -297,8 +303,8 @@ class _SendMessageInput(BaseModel):
 
 class _SendEventInput(BaseModel):
     content: str = Field(..., description="Human-readable event content")
-    message_type: Literal["thought", "error", "task"] = Field(
-        default="thought",
+    message_type: EventMessageType = Field(
+        default=MessageType.THOUGHT,
         description="Type of event: 'thought', 'error', or 'task'",
     )
     metadata: dict[str, Any] | None = Field(

--- a/src/band/runtime/prompts.py
+++ b/src/band/runtime/prompts.py
@@ -93,8 +93,11 @@ _MEMORY_COMMON_PATTERNS = f"""Common patterns:
 - How to perform a task: `system="{MemorySystem.LONG_TERM.value}"`, `type="{WorkingLongTermMemoryType.PROCEDURAL.value}"`, `segment="{MemorySegment.TOOL.value}"`"""
 
 
-_MEMORY_SCOPE_GUIDANCE = f"""When storing with `scope="{MemoryStoreScope.SUBJECT.value}"`, you must pass a real `subject_id` UUID
-(e.g. from `band_lookup_peers` or the participant list). 
+_MEMORY_SCOPE_GUIDANCE = f"""Prefer `scope="{MemoryStoreScope.SUBJECT.value}"` whenever the memory is about a specific person or agent, so it
+stays attached to that subject rather than leaking org-wide. Storing with `scope="{MemoryStoreScope.SUBJECT.value}"` requires a
+real `subject_id` UUID, so resolve it first via `band_lookup_peers` or the participant list.
+Reserve `scope="{MemoryStoreScope.ORGANIZATION.value}"` for knowledge that is genuinely shared across the whole organization and
+is not about any one subject.
 """
 
 

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -28,6 +28,7 @@ from band.core.memory_types import (
     validate_subject_scope,
 )
 from band.core.protocols import AgentToolsProtocol
+from band.core.types import EventMessageType
 
 if TYPE_CHECKING:
     from anthropic.types import ToolParam
@@ -120,9 +121,7 @@ class SendEventInput(BaseModel):
     """
 
     content: str = Field(..., description="Human-readable event content")
-    message_type: Literal["thought", "error", "task"] = Field(
-        ..., description="Type of event"
-    )
+    message_type: EventMessageType = Field(..., description="Type of event")
     metadata: dict[str, Any] | None = Field(
         None, description="Optional structured data for the event"
     )

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -403,7 +403,7 @@ class TestHistoryManagement:
         assert adapter._message_history["room-123"] == new_messages
 
     @pytest.mark.asyncio
-    async def test_keeps_native_history_and_drops_poison_responses(
+    async def test_keeps_native_history_and_drops_content_null_responses(
         self, sample_message, mock_tools, mock_pydantic_agent
     ):
         """Should keep native tool history but drop responses that replay as null."""
@@ -431,13 +431,13 @@ class TestHistoryManagement:
                 )
             ]
         )
-        poison_response = ModelResponse(parts=[])
+        content_null_response = ModelResponse(parts=[])
         text_response = ModelResponse(parts=[TextPart(content="A1")])
         result_messages = [
             user_request,
             tool_call_response,
             tool_return_request,
-            poison_response,
+            content_null_response,
             text_response,
         ]
         adapter._agent.run_stream_events = MagicMock(
@@ -461,7 +461,7 @@ class TestHistoryManagement:
             tool_return_request,
             text_response,
         ]
-        assert poison_response not in stored_history
+        assert content_null_response not in stored_history
 
     @pytest.mark.asyncio
     async def test_ensures_history_exists_for_non_bootstrap(

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -17,7 +17,14 @@ from pydantic_ai import (
     FunctionToolCallEvent,
     FunctionToolResultEvent,
 )
-from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
 
 from band.adapters.pydantic_ai import PydanticAIAdapter
 from band.core.types import AdapterFeatures, Capability, PlatformMessage
@@ -394,6 +401,67 @@ class TestHistoryManagement:
         )
 
         assert adapter._message_history["room-123"] == new_messages
+
+    @pytest.mark.asyncio
+    async def test_keeps_native_history_and_drops_poison_responses(
+        self, sample_message, mock_tools, mock_pydantic_agent
+    ):
+        """Should keep native tool history but drop responses that replay as null."""
+        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
+
+        with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
+            await adapter.on_started("TestBot", "Test bot")
+
+        user_request = ModelRequest(parts=[UserPromptPart(content="Q1")])
+        tool_call_response = ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="band_send_message",
+                    args={"content": "A1", "mentions": ["Alice"]},
+                    tool_call_id="call_1",
+                )
+            ]
+        )
+        tool_return_request = ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="band_send_message",
+                    content={"id": "msg_1"},
+                    tool_call_id="call_1",
+                )
+            ]
+        )
+        poison_response = ModelResponse(parts=[])
+        text_response = ModelResponse(parts=[TextPart(content="A1")])
+        result_messages = [
+            user_request,
+            tool_call_response,
+            tool_return_request,
+            poison_response,
+            text_response,
+        ]
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_stream_events(result_messages=result_messages)
+        )
+
+        await adapter.on_message(
+            msg=sample_message,
+            tools=mock_tools,
+            history=[],
+            participants_msg=None,
+            contacts_msg=None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        stored_history = adapter._message_history["room-123"]
+        assert stored_history == [
+            user_request,
+            tool_call_response,
+            tool_return_request,
+            text_response,
+        ]
+        assert poison_response not in stored_history
 
     @pytest.mark.asyncio
     async def test_ensures_history_exists_for_non_bootstrap(

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -18,6 +18,7 @@ from pydantic_ai import (
     FunctionToolResultEvent,
 )
 from pydantic_ai.messages import (
+    BuiltinToolCallPart,
     ModelRequest,
     ModelResponse,
     TextPart,
@@ -26,7 +27,10 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 
-from band.adapters.pydantic_ai import PydanticAIAdapter
+from band.adapters.pydantic_ai import (
+    PydanticAIAdapter,
+    _is_replayable_history_message,
+)
 from band.core.types import AdapterFeatures, Capability, PlatformMessage
 
 
@@ -462,6 +466,20 @@ class TestHistoryManagement:
             text_response,
         ]
         assert content_null_response not in stored_history
+
+    def test_keeps_response_with_only_builtin_tool_part(self):
+        """Builtin tool calls carry content the provider expects — keep them."""
+        response = ModelResponse(
+            parts=[
+                BuiltinToolCallPart(
+                    tool_name="web_search",
+                    args={"query": "weather"},
+                    tool_call_id="call_1",
+                )
+            ]
+        )
+
+        assert _is_replayable_history_message(response) is True
 
     @pytest.mark.asyncio
     async def test_ensures_history_exists_for_non_bootstrap(

--- a/tests/converters/test_pydantic_ai.py
+++ b/tests/converters/test_pydantic_ai.py
@@ -347,6 +347,43 @@ class TestToolEventConversion:
         assert result[0].parts[0].tool_name == "tool1"
         assert result[0].parts[1].tool_name == "tool2"
 
+    def test_drops_own_text_between_tool_call_and_result(self):
+        """Own text emitted mid tool call is dropped so the call/result pair stays intact.
+
+        band_send_message posts the agent's text between the tool_call and
+        tool_result events. Keeping that text would split the ToolCallPart from
+        its ToolReturnPart, which providers reject.
+        """
+        converter = PydanticAIHistoryConverter(agent_name="Bot")
+        raw = [
+            {
+                "role": "assistant",
+                "content": '{"name": "band_send_message", "args": {"content": "hi"}, "tool_call_id": "call_1"}',
+                "sender_name": "Bot",
+                "message_type": "tool_call",
+            },
+            {
+                "role": "assistant",
+                "content": "hi",
+                "sender_name": "Bot",
+                "message_type": "text",
+            },
+            {
+                "role": "assistant",
+                "content": '{"name": "band_send_message", "output": {"id": "msg_1"}, "tool_call_id": "call_1"}',
+                "sender_name": "Bot",
+                "message_type": "tool_result",
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert len(result) == 2
+        assert isinstance(result[0], ModelResponse)
+        assert isinstance(result[0].parts[0], ToolCallPart)
+        assert isinstance(result[1], ModelRequest)
+        assert isinstance(result[1].parts[0], ToolReturnPart)
+
     def test_uses_retry_prompt_part_for_error_results(self):
         """tool_result with is_error=True uses RetryPromptPart instead of ToolReturnPart."""
         converter = PydanticAIHistoryConverter()

--- a/tests/converters/test_pydantic_ai.py
+++ b/tests/converters/test_pydantic_ai.py
@@ -11,6 +11,7 @@ from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
+    TextPart,
     ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
@@ -467,7 +468,7 @@ class TestMixedHistory:
                 "content": '{"name": "get_weather", "output": "sunny", "tool_call_id": "call_123"}',
                 "message_type": "tool_result",
             },
-            # Agent responds with text (skipped - own message)
+            # Agent responds with text (preserved for crash recovery)
             {
                 "role": "assistant",
                 "content": "It's sunny today!",
@@ -485,9 +486,8 @@ class TestMixedHistory:
 
         result = converter.convert(raw)
 
-        # Should have: user message, tool_call, tool_result, user follow-up
-        # (agent's own text is skipped)
-        assert len(result) == 4
+        # Should have: user message, tool_call, tool_result, agent text, user follow-up
+        assert len(result) == 5
 
         # User question
         assert isinstance(result[0], ModelRequest)
@@ -504,10 +504,15 @@ class TestMixedHistory:
         assert isinstance(result[2].parts[0], ToolReturnPart)
         assert result[2].parts[0].content == "sunny"
 
+        # Agent text (ModelResponse with TextPart)
+        assert isinstance(result[3], ModelResponse)
+        assert isinstance(result[3].parts[0], TextPart)
+        assert result[3].parts[0].content == "It's sunny today!"
+
         # User follow-up
-        assert isinstance(result[3], ModelRequest)
-        assert isinstance(result[3].parts[0], UserPromptPart)
-        assert result[3].parts[0].content == "[Alice]: Thanks!"
+        assert isinstance(result[4], ModelRequest)
+        assert isinstance(result[4].parts[0], UserPromptPart)
+        assert result[4].parts[0].content == "[Alice]: Thanks!"
 
     def test_multi_user_conversation(self):
         """Handles multiple users in conversation."""
@@ -535,10 +540,13 @@ class TestMixedHistory:
 
         result = converter.convert(raw)
 
-        # Agent's own message is skipped
-        assert len(result) == 2
+        # Agent's own message is preserved as assistant context
+        assert len(result) == 3
         assert result[0].parts[0].content == "[Alice]: Hi team!"
         assert result[1].parts[0].content == "[Bob]: Hello everyone!"
+        assert isinstance(result[2], ModelResponse)
+        assert isinstance(result[2].parts[0], TextPart)
+        assert result[2].parts[0].content == "Hello Alice and Bob!"
 
     def test_multi_agent_conversation_flow(self):
         """Should include other agents' messages in multi-agent conversations."""
@@ -551,7 +559,7 @@ class TestMixedHistory:
                 "sender_name": "Alice",
                 "message_type": "text",
             },
-            # Main Agent asks Weather Agent (skipped - own message)
+            # Main Agent asks Weather Agent (preserved as assistant context)
             {
                 "role": "assistant",
                 "content": "Let me check with the weather agent.",
@@ -565,7 +573,7 @@ class TestMixedHistory:
                 "sender_name": "Weather Agent",
                 "message_type": "text",
             },
-            # Main Agent relays the response (skipped - own message)
+            # Main Agent relays the response (preserved as assistant context)
             {
                 "role": "assistant",
                 "content": "The weather in Tokyo is 15°C and cloudy.",
@@ -576,14 +584,21 @@ class TestMixedHistory:
 
         result = converter.convert(raw)
 
-        # Should have: Alice's message + Weather Agent's message
-        # (Main Agent's own messages are skipped)
-        assert len(result) == 2
+        # Should have all text turns; own Main Agent text is assistant context
+        assert len(result) == 4
 
         assert isinstance(result[0], ModelRequest)
         assert result[0].parts[0].content == "[Alice]: What's the weather in Tokyo?"
 
-        assert isinstance(result[1], ModelRequest)
+        assert isinstance(result[1], ModelResponse)
+        assert isinstance(result[1].parts[0], TextPart)
+        assert result[1].parts[0].content == "Let me check with the weather agent."
+
+        assert isinstance(result[2], ModelRequest)
         assert (
-            result[1].parts[0].content == "[Weather Agent]: Tokyo is 15°C and cloudy."
+            result[2].parts[0].content == "[Weather Agent]: Tokyo is 15°C and cloudy."
         )
+
+        assert isinstance(result[3], ModelResponse)
+        assert isinstance(result[3].parts[0], TextPart)
+        assert result[3].parts[0].content == "The weather in Tokyo is 15°C and cloudy."

--- a/tests/framework_configs/converters.py
+++ b/tests/framework_configs/converters.py
@@ -207,6 +207,7 @@ def _build_pydantic_ai_config() -> ConverterConfig:
         empty_result=[],
         empty_sender_behavior=SenderBehavior.CONTENT_AS_IS,
         missing_sender_behavior=SenderBehavior.CONTENT_AS_IS,
+        includes_own_text_without_tool_events=True,
         output_adapter=PydanticAIOutputAdapter(),
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "band-sdk"
-version = "0.2.9"
+version = "0.2.11"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
… [INT-847]

Preserve the agent's own text turns when rehydrating room history so a restarted agent sees it already replied, instead of re-answering the redelivered message. Also drop content-less ModelResponses (e.g. thinking-only) from stored run history, which OpenAI otherwise replays as content:null on the next turn.

## PR Title Format

> **Required:** PR titles must follow Conventional Commits format:
> `type(scope): description`
>
> **Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
>
> **Examples:**
> - `feat(agent): add event streaming support`
> - `fix(api): resolve timeout handling`
> - `docs: update integration examples`

---

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the main changes in this PR -->
-

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Testing

<!-- Describe how you tested these changes -->
- [x] Unit tests pass (`uv run pytest tests/ --ignore=tests/integration/`)
- [x] Pre-commit checks pass (`uv run pre-commit run --all-files`)
- [x] Integration tests pass (if applicable)

## Checklist

- [ ] PR title follows Conventional Commits format
- [ ] Code follows project style guidelines
- [ ] Tests added/updated as needed
- [ ] Documentation updated as needed
