### PR TITLE
test(tests): add L0 platform baseline

### DIFF
--- a/.github/workflows/baseline-l0-live.yml
+++ b/.github/workflows/baseline-l0-live.yml
@@ -1,0 +1,105 @@
+name: Band baseline L0 live
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '7 8 * * *'
+
+jobs:
+  baseline-l0-live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      E2E_TESTS_ENABLED: "true"
+      E2E_BASELINE_L0_LIVE: "true"
+      E2E_BASELINE_RUN_ID: ${{ github.run_id }}
+      E2E_BASELINE_ARTIFACT_DIR: .claude/reports/e2e-baseline-artifacts
+      THENVOI_BASE_URL: ${{ vars.THENVOI_BASE_URL }}
+      THENVOI_WS_URL: ${{ vars.THENVOI_WS_URL }}
+      TEST_AGENT_ID: ${{ secrets.TEST_AGENT_ID }}
+      THENVOI_API_KEY: ${{ secrets.THENVOI_API_KEY }}
+      THENVOI_API_KEY_USER: ${{ secrets.THENVOI_API_KEY_USER }}
+      E2E_ECHO_AGENT_ID: ${{ secrets.E2E_ECHO_AGENT_ID }}
+      E2E_ECHO_AGENT_API_KEY: ${{ secrets.E2E_ECHO_AGENT_API_KEY }}
+      E2E_ECHO_AGENT_NAME: ${{ vars.E2E_ECHO_AGENT_NAME }}
+      E2E_ECHO_AGENT_HANDLE: ${{ vars.E2E_ECHO_AGENT_HANDLE }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      GOOGLE_GENAI_USE_VERTEXAI: ${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}
+      GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+      E2E_GEMINI_MODEL: ${{ vars.E2E_GEMINI_MODEL }}
+      CODEX_CWD: ${{ vars.CODEX_CWD }}
+      E2E_CODEX_CWD_IS_DISPOSABLE: ${{ vars.E2E_CODEX_CWD_IS_DISPOSABLE }}
+      CODEX_TRANSPORT: ${{ vars.CODEX_TRANSPORT }}
+      CODEX_COMMAND: ${{ vars.CODEX_COMMAND }}
+      CODEX_WS_URL: ${{ vars.CODEX_WS_URL }}
+      CODEX_MODEL: ${{ vars.CODEX_MODEL }}
+      CODEX_APPROVAL_POLICY: ${{ vars.CODEX_APPROVAL_POLICY }}
+      CODEX_APPROVAL_MODE: ${{ vars.CODEX_APPROVAL_MODE }}
+      E2E_ALLOW_WRITE_CAPABLE_AUTO_APPROVAL: ${{ vars.E2E_ALLOW_WRITE_CAPABLE_AUTO_APPROVAL }}
+      OPENCODE_BASE_URL: ${{ vars.OPENCODE_BASE_URL }}
+      OPENCODE_PROVIDER_ID: ${{ vars.OPENCODE_PROVIDER_ID }}
+      OPENCODE_MODEL_ID: ${{ vars.OPENCODE_MODEL_ID }}
+      OPENCODE_AGENT: ${{ vars.OPENCODE_AGENT }}
+      OPENCODE_APPROVAL_MODE: ${{ vars.OPENCODE_APPROVAL_MODE }}
+      OPENCODE_QUESTION_MODE: ${{ vars.OPENCODE_QUESTION_MODE }}
+      LETTA_BASE_URL: ${{ vars.LETTA_BASE_URL }}
+      LETTA_API_KEY: ${{ secrets.LETTA_API_KEY }}
+      LETTA_PROJECT: ${{ vars.LETTA_PROJECT }}
+      LETTA_MODEL: ${{ vars.LETTA_MODEL }}
+      MCP_SERVER_URL: ${{ vars.MCP_SERVER_URL }}
+      E2E_BASELINE_INPUT_USD_PER_MILLION_TOKENS: ${{ vars.E2E_BASELINE_INPUT_USD_PER_MILLION_TOKENS }}
+      E2E_BASELINE_OUTPUT_USD_PER_MILLION_TOKENS: ${{ vars.E2E_BASELINE_OUTPUT_USD_PER_MILLION_TOKENS }}
+      E2E_BASELINE_PRICING_SOURCE: ${{ vars.E2E_BASELINE_PRICING_SOURCE }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run live L0 baseline scenario
+        run: uv run pytest tests/e2e/scenarios/test_baseline_l0_platform.py -v -s --no-cov
+
+      - name: Require complete live L0 artifact matrix
+        run: |
+          uv run python - <<'PY'
+          import json
+          from pathlib import Path
+
+          expected = {
+              'anthropic', 'claude_sdk', 'codex', 'crewai', 'crewai_flow',
+              'gemini', 'google_adk', 'langgraph', 'letta', 'opencode',
+              'parlant', 'pydantic_ai',
+          }
+          artifact_dir = Path('.claude/reports/e2e-baseline-artifacts')
+          artifacts = [json.loads(path.read_text()) for path in artifact_dir.glob('*.json')]
+          level_artifacts = [artifact for artifact in artifacts if artifact.get('level') == 'L0']
+          adapters = {artifact.get('adapter') for artifact in level_artifacts}
+          missing = expected - adapters
+          if missing:
+              raise SystemExit('Missing live L0 artifact disposition for: ' + ', '.join(sorted(missing)))
+          if not any(artifact.get('status') != 'TIER2_BLOCKED' for artifact in level_artifacts):
+              raise SystemExit('No successful live L0 artifact was produced')
+          PY
+
+      - name: Upload baseline artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: baseline-l0-live-artifacts
+          path: .claude/reports/e2e-baseline-artifacts/*.json
+          if-no-files-found: warn

--- a/tests/e2e/scenarios/test_baseline_l0_platform.py
+++ b/tests/e2e/scenarios/test_baseline_l0_platform.py
@@ -1,0 +1,696 @@
+"""Gated live L0 platform-adaptation scenario.
+
+Run with:
+    E2E_TESTS_ENABLED=true E2E_BASELINE_L0_LIVE=true \
+        E2E_ECHO_AGENT_ID=<uuid> E2E_ECHO_AGENT_NAME=<name> E2E_ECHO_AGENT_HANDLE=<handle> \
+        uv run pytest tests/e2e/scenarios/test_baseline_l0_platform.py -v -s --no-cov
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from contextlib import AsyncExitStack
+from typing import Any
+
+import pytest
+from thenvoi_rest import AsyncRestClient
+from thenvoi_rest.types import ParticipantRequest
+
+from thenvoi.agent import Agent
+from thenvoi.core.protocols import AgentToolsProtocol
+from thenvoi.core.simple_adapter import SimpleAdapter
+from thenvoi.core.types import AdapterFeatures, Emit, PlatformMessage
+from thenvoi.runtime.types import AgentConfig
+
+from tests.e2e.adapters.conftest import (
+    AdapterFactory,
+    BASELINE_L0_ADAPTER_FACTORIES,
+    BASELINE_L0_BLOCKED_ADAPTER_NAMES,
+)
+from tests.e2e.baseline_artifacts import (
+    baseline_pricing_from_env,
+    l0_usage_from_live_observation,
+    start_baseline_tier2_timer,
+    write_baseline_tier2_artifact,
+    write_baseline_tier2_blocked_artifact,
+)
+from tests.e2e.conftest import E2EAgentCredentials, E2ESettings, requires_e2e
+from tests.e2e.helpers import (
+    ToolObservationUnavailableError,
+    agent_text_messages,
+    assert_content_contains,
+    fetch_chat_messages,
+    mention_ids,
+    message_ids,
+    message_value,
+    participant_ids,
+    send_trigger_message,
+    wait_for_chat_messages,
+    wait_for_new_agent_text_messages,
+    wait_for_required_tool_observations,
+    wait_until_participant_absent,
+    wait_until_participant_present,
+)
+
+_STEP_TIMEOUT = 90.0
+_LOOP_SUPPRESSION_WINDOW = 90.0
+_L0_SCENARIO_REFS = [
+    "L0.request.platform_context",
+    "L0.request.history",
+    "L0.request.participants",
+    "L0.dispatch.send_message",
+    "L0.dispatch.add_participant",
+    "L0.dispatch.remove_participant",
+    "L0.dispatch.get_participants",
+    "L0.dispatch.lookup_peers",
+]
+
+
+def _l0_live_blocked_reason() -> str | None:
+    if os.environ.get("E2E_BASELINE_L0_LIVE") != "true":
+        return "tier2_blocked: E2E_BASELINE_L0_LIVE=true not set for live Echo flow"
+    missing = [
+        name
+        for name in (
+            "E2E_ECHO_AGENT_ID",
+            "E2E_ECHO_AGENT_API_KEY",
+            "E2E_ECHO_AGENT_NAME",
+            "E2E_ECHO_AGENT_HANDLE",
+        )
+        if not os.environ.get(name)
+    ]
+    if missing:
+        return f"tier2_blocked: missing live Echo configuration {', '.join(missing)}"
+    return None
+
+
+_L0_LIVE_BLOCKED_REASON = _l0_live_blocked_reason()
+pytestmark = pytest.mark.skipif(
+    _L0_LIVE_BLOCKED_REASON is not None,
+    reason=_L0_LIVE_BLOCKED_REASON or "tier2_blocked: unknown L0 live block",
+)
+
+
+@pytest.fixture(
+    params=tuple(BASELINE_L0_ADAPTER_FACTORIES.items()),
+    ids=lambda item: item[0],
+)
+def adapter_entry(request: pytest.FixtureRequest) -> tuple[str, AdapterFactory]:
+    adapter_name, factory = request.param
+    return str(adapter_name), factory
+
+
+@pytest.mark.parametrize("adapter_name", BASELINE_L0_BLOCKED_ADAPTER_NAMES)
+def test_l0_live_unsupported_adapter_rows_write_blocked_artifacts_when_configured(
+    adapter_name: str,
+) -> None:
+    blocked_reason = _l0_live_blocked_reason()
+    if blocked_reason:
+        pytest.skip(blocked_reason)
+    reason = (
+        "tier2_blocked: adapter does not have a baseline L0 full-flow live factory "
+        f"in this dependency lane: {adapter_name}"
+    )
+    write_baseline_tier2_blocked_artifact(
+        scenario_id="L0.request.platform_context",
+        scenario_refs=_L0_SCENARIO_REFS,
+        adapter=adapter_name,
+        reason=reason,
+    )
+
+
+class _DeterministicEchoAdapter(SimpleAdapter[Any]):
+    async def on_message(
+        self,
+        msg: PlatformMessage,
+        tools: AgentToolsProtocol,
+        history: Any,
+        participants_msg: str | None,
+        contacts_msg: str | None,
+        *,
+        is_session_bootstrap: bool,
+        room_id: str,
+    ) -> None:
+        del history, participants_msg, contacts_msg, is_session_bootstrap, room_id
+        participants = await tools.get_participants()
+        sender_handle = next(
+            (
+                participant.handle
+                for participant in participants
+                if participant.id == msg.sender_id and participant.handle
+            ),
+            None,
+        )
+        if sender_handle is None:
+            raise AssertionError(
+                f"No participant handle found for sender {msg.sender_id}"
+            )
+        content = "ECHO: HELLO_ECHO" if "HELLO_ECHO" in msg.content else msg.content
+        await tools.send_message(
+            content=content,
+            mentions=[f"@{sender_handle.lstrip('@')}"],
+        )
+
+
+def _labeled_line(content: str, label: str) -> str:
+    prefix = f"{label}:"
+    for line in content.splitlines():
+        if line.strip().lower().startswith(prefix.lower()):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError(f"Missing {label}: line in reply: {content}")
+
+
+async def _wait_for_required_tool_observations_or_block(
+    client: AsyncRestClient,
+    *,
+    room_id: str,
+    agent_id: str,
+    after_message_id: str,
+    required_tool_names: set[str],
+    timeout: float,
+    adapter_name: str,
+) -> list[Any]:
+    try:
+        return await wait_for_required_tool_observations(
+            client,
+            room_id=room_id,
+            agent_id=agent_id,
+            after_message_id=after_message_id,
+            required_tool_names=required_tool_names,
+            timeout=timeout,
+        )
+    except ToolObservationUnavailableError as exc:
+        reason = str(exc)
+        write_baseline_tier2_blocked_artifact(
+            scenario_id="L0.request.platform_context",
+            scenario_refs=_L0_SCENARIO_REFS,
+            adapter=adapter_name,
+            reason=reason,
+        )
+        pytest.skip(reason)
+
+
+def _tool_observation_records(
+    observations: list[Any], assertion: str
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "kind": "tool_execution_event",
+            "id": observation.event_id,
+            "tool_name": observation.tool_name,
+            "message_type": observation.message_type,
+            "tool_call_id": observation.tool_call_id,
+            "assertion": assertion,
+        }
+        for observation in observations
+    ]
+
+
+def _enable_execution_reporting_or_block(
+    adapter: SimpleAdapter[Any],
+    *,
+    adapter_name: str,
+) -> str | None:
+    if Emit.EXECUTION not in adapter.SUPPORTED_EMIT:
+        return (
+            "tier2_blocked: adapter does not expose live tool execution events "
+            f"for baseline L0 proof: {adapter_name}"
+        )
+    existing = adapter.features
+    adapter.features = AdapterFeatures(
+        capabilities=existing.capabilities,
+        emit={*existing.emit, Emit.EXECUTION},
+        include_tools=existing.include_tools,
+        exclude_tools=existing.exclude_tools,
+        include_categories=existing.include_categories,
+    )
+    return None
+
+
+async def _agent_messages_after(
+    client: AsyncRestClient,
+    chat_id: str,
+    agent_id: str,
+    *,
+    after_message: Any,
+    duration: float,
+) -> list[Any]:
+    after_id = str(message_value(after_message, "id"))
+    deadline = asyncio.get_running_loop().time() + duration
+    current: list[Any] = []
+    while asyncio.get_running_loop().time() < deadline:
+        messages = await fetch_chat_messages(client, chat_id)
+        boundary_index = next(
+            (
+                index
+                for index, message in enumerate(messages)
+                if str(message_value(message, "id")) == after_id
+            ),
+            None,
+        )
+        if boundary_index is not None:
+            current = agent_text_messages(messages[:boundary_index], agent_id)
+        await asyncio.sleep(0.5)
+    return current
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(500)
+@requires_e2e
+async def test_l0_live_identity_context_echo_loop_and_remove_when_configured(
+    e2e_config: E2ESettings,
+    adapter_entry: tuple[str, AdapterFactory],
+    e2e_fresh_adapter_room: tuple[str, str, str],
+    api_client: AsyncRestClient,
+    e2e_adapter_agent_credentials: E2EAgentCredentials,
+) -> None:
+    blocked_reason = _l0_live_blocked_reason()
+    if blocked_reason:
+        pytest.skip(blocked_reason)
+
+    adapter_name, factory = adapter_entry
+    timer = start_baseline_tier2_timer()
+    pricing = baseline_pricing_from_env()
+    input_texts: list[str] = []
+    output_texts: list[str] = []
+    observed_agent_text_message_count = 0
+    chat_id, _user_id, user_name = e2e_fresh_adapter_room
+    agent_id = e2e_adapter_agent_credentials.agent_id
+    agent_name = e2e_adapter_agent_credentials.name
+    echo_id = os.environ["E2E_ECHO_AGENT_ID"]
+    echo_api_key = os.environ["E2E_ECHO_AGENT_API_KEY"]
+    echo_name = os.environ["E2E_ECHO_AGENT_NAME"]
+    echo_handle = os.environ["E2E_ECHO_AGENT_HANDLE"].lstrip("@")
+
+    try:
+        await api_client.human_api_participants.add_my_chat_participant(
+            chat_id,
+            participant=ParticipantRequest(participant_id=agent_id, role="member"),
+        )
+    except Exception as exc:
+        if getattr(exc, "status_code", None) != 409:
+            raise
+
+    if echo_id in await participant_ids(api_client, chat_id):
+        await api_client.human_api_participants.remove_my_chat_participant(
+            chat_id,
+            echo_id,
+        )
+        await wait_until_participant_absent(api_client, chat_id, echo_id, _STEP_TIMEOUT)
+
+    adapter = factory(e2e_config)
+    execution_blocked_reason = _enable_execution_reporting_or_block(
+        adapter,
+        adapter_name=adapter_name,
+    )
+    if execution_blocked_reason is not None:
+        write_baseline_tier2_blocked_artifact(
+            scenario_id="L0.request.platform_context",
+            scenario_refs=_L0_SCENARIO_REFS,
+            adapter=adapter_name,
+            reason=execution_blocked_reason,
+        )
+        pytest.skip(execution_blocked_reason)
+    adapter.clear_provider_usage()
+    agent_observation_client = AsyncRestClient(
+        api_key=e2e_adapter_agent_credentials.api_key,
+        base_url=e2e_config.thenvoi_base_url,
+    )
+    agent = Agent.create(
+        adapter=adapter,
+        agent_id=agent_id,
+        api_key=e2e_adapter_agent_credentials.api_key,
+        ws_url=e2e_config.thenvoi_ws_url,
+        rest_url=e2e_config.thenvoi_base_url,
+    )
+    echo_agent = Agent.create(
+        adapter=_DeterministicEchoAdapter(),
+        agent_id=echo_id,
+        api_key=echo_api_key,
+        ws_url=e2e_config.thenvoi_ws_url,
+        rest_url=e2e_config.thenvoi_base_url,
+        config=AgentConfig(auto_subscribe_existing_rooms=False),
+    )
+
+    async with AsyncExitStack() as stack:
+        await stack.enter_async_context(echo_agent)
+        await stack.enter_async_context(agent)
+
+        before_step_1 = message_ids(await fetch_chat_messages(api_client, chat_id))
+        assert before_step_1 == [], (
+            "fresh adapter-owned L0 room already contains durable messages: "
+            f"{before_step_1}"
+        )
+        step_1_prompt = (
+            "tell me your name and which chat we are in. Then reply with exactly "
+            "two labeled lines: CURRENT_ROOM: the people currently in this room; "
+            "INVITABLE_PEERS: the people you could invite but who are not currently "
+            "in this room."
+        )
+        input_texts.append(step_1_prompt)
+        step_1_trigger_id = await send_trigger_message(
+            api_client,
+            chat_id,
+            step_1_prompt,
+            agent_name,
+            agent_id,
+        )
+        identity_replies = await wait_for_new_agent_text_messages(
+            api_client,
+            chat_id,
+            agent_id,
+            before_step_1,
+            min_count=1,
+            timeout=_STEP_TIMEOUT,
+            quiet_after=3.0,
+        )
+        assert len(identity_replies) == 1, [
+            message_value(message, "content") for message in identity_replies
+        ]
+        observed_agent_text_message_count += len(identity_replies)
+        output_texts.extend(
+            str(message_value(message, "content") or "") for message in identity_replies
+        )
+        identity_reply = identity_replies[0]
+        assert_content_contains([identity_reply], agent_name)
+        assert_content_contains([identity_reply], chat_id)
+        assert_content_contains([identity_reply], user_name)
+        echo_absent_before_invite = echo_id not in await participant_ids(
+            api_client, chat_id
+        )
+        assert echo_absent_before_invite
+        identity_content = str(message_value(identity_reply, "content") or "")
+        current_room_line = _labeled_line(identity_content, "CURRENT_ROOM")
+        invitable_peers_line = _labeled_line(identity_content, "INVITABLE_PEERS")
+        assert user_name.lower() in current_room_line.lower(), identity_content
+        assert agent_name.lower() in current_room_line.lower(), identity_content
+        assert all(
+            not value or value.lower() not in current_room_line.lower()
+            for value in (echo_name, echo_handle)
+        ), identity_content
+        assert any(
+            value and value.lower() in invitable_peers_line.lower()
+            for value in (echo_name, echo_handle)
+        ), identity_content
+        assert user_name.lower() not in invitable_peers_line.lower(), identity_content
+        assert agent_name.lower() not in invitable_peers_line.lower(), identity_content
+        step_1_tool_observations = await _wait_for_required_tool_observations_or_block(
+            agent_observation_client,
+            room_id=chat_id,
+            agent_id=agent_id,
+            after_message_id=step_1_trigger_id,
+            required_tool_names={
+                "thenvoi_get_participants",
+                "thenvoi_lookup_peers",
+            },
+            timeout=_STEP_TIMEOUT,
+            adapter_name=adapter_name,
+        )
+
+        before_step_2 = message_ids(await fetch_chat_messages(api_client, chat_id))
+        step_2_prompt = (
+            "invite Echo to this chat and send them the exact message HELLO_ECHO"
+        )
+        input_texts.append(step_2_prompt)
+        step_2_trigger_id = await send_trigger_message(
+            api_client,
+            chat_id,
+            step_2_prompt,
+            agent_name,
+            agent_id,
+        )
+        step_2_messages = await wait_for_chat_messages(
+            api_client,
+            chat_id,
+            lambda messages: any(
+                str(message_value(message, "content") or "").strip() == "HELLO_ECHO"
+                and mention_ids(message) == {echo_id}
+                for message in agent_text_messages(messages, agent_id, before_step_2)
+            ),
+            _STEP_TIMEOUT,
+        )
+        await wait_until_participant_present(
+            api_client, chat_id, echo_id, _STEP_TIMEOUT
+        )
+        agent_hello_messages = [
+            message
+            for message in agent_text_messages(step_2_messages, agent_id, before_step_2)
+            if str(message_value(message, "content") or "").strip() == "HELLO_ECHO"
+            and mention_ids(message) == {echo_id}
+        ]
+        assert len(agent_hello_messages) == 1, [
+            message_value(message, "content")
+            for message in agent_text_messages(step_2_messages, agent_id, before_step_2)
+        ]
+        observed_agent_text_message_count += len(agent_hello_messages)
+        output_texts.extend(
+            str(message_value(message, "content") or "")
+            for message in agent_hello_messages
+        )
+        hello_message = agent_hello_messages[0]
+        step_2_tool_observations = await _wait_for_required_tool_observations_or_block(
+            agent_observation_client,
+            room_id=chat_id,
+            agent_id=agent_id,
+            after_message_id=step_2_trigger_id,
+            required_tool_names={
+                "thenvoi_add_participant",
+                "thenvoi_send_message",
+            },
+            timeout=_STEP_TIMEOUT,
+            adapter_name=adapter_name,
+        )
+
+        echo_received = await wait_for_chat_messages(
+            api_client,
+            chat_id,
+            lambda messages: any(
+                message_value(message, "sender_id") == echo_id
+                and message_value(message, "message_type") == "text"
+                and str(message_value(message, "id")) not in before_step_2
+                and "ECHO: HELLO_ECHO" in str(message_value(message, "content") or "")
+                for message in messages
+            ),
+            _STEP_TIMEOUT,
+        )
+        echo_message = next(
+            message
+            for message in echo_received
+            if message_value(message, "sender_id") == echo_id
+            and message_value(message, "message_type") == "text"
+            and str(message_value(message, "id")) not in before_step_2
+            and "ECHO: HELLO_ECHO" in str(message_value(message, "content") or "")
+        )
+        post_echo_agent_messages = await _agent_messages_after(
+            api_client,
+            chat_id,
+            agent_id,
+            after_message=echo_message,
+            duration=_LOOP_SUPPRESSION_WINDOW,
+        )
+        assert len(post_echo_agent_messages) <= 1, [
+            message_value(message, "content") for message in post_echo_agent_messages
+        ]
+        if post_echo_agent_messages:
+            post_echo = post_echo_agent_messages[0]
+            post_echo_content = str(message_value(post_echo, "content") or "").strip()
+            assert post_echo_content
+            assert (
+                post_echo_content
+                != str(message_value(hello_message, "content") or "").strip()
+            )
+            assert post_echo_content != "ECHO: HELLO_ECHO"
+            assert "HELLO_ECHO" not in post_echo_content
+            assert echo_id not in mention_ids(post_echo)
+
+        step_3_prompt = "remove Echo from this chat"
+        input_texts.append(step_3_prompt)
+        step_3_trigger_id = await send_trigger_message(
+            api_client,
+            chat_id,
+            step_3_prompt,
+            agent_name,
+            agent_id,
+        )
+        await wait_until_participant_absent(
+            api_client,
+            chat_id,
+            echo_id,
+            _STEP_TIMEOUT,
+        )
+        step_3_tool_observations = await _wait_for_required_tool_observations_or_block(
+            agent_observation_client,
+            room_id=chat_id,
+            agent_id=agent_id,
+            after_message_id=step_3_trigger_id,
+            required_tool_names={"thenvoi_remove_participant"},
+            timeout=_STEP_TIMEOUT,
+            adapter_name=adapter_name,
+        )
+        echo_removed = echo_id not in await participant_ids(api_client, chat_id)
+        all_tool_observations = [
+            *step_1_tool_observations,
+            *step_2_tool_observations,
+            *step_3_tool_observations,
+        ]
+        write_baseline_tier2_artifact(
+            scenario_id="L0.request.platform_context",
+            scenario_refs=_L0_SCENARIO_REFS,
+            adapter=adapter_name,
+            timer=timer,
+            pricing=pricing,
+            provider_usage=l0_usage_from_live_observation(
+                adapter=adapter,
+                adapter_name=adapter_name,
+                input_texts=input_texts,
+                output_texts=output_texts,
+                observed_agent_text_message_count=observed_agent_text_message_count,
+            ),
+            input_texts=input_texts,
+            output_texts=output_texts,
+            observed_agent_text_message_count=observed_agent_text_message_count,
+            evidence={
+                "L0.request.platform_context": {
+                    "identity_reply_count": len(identity_replies),
+                    "identity_reply_message_id": str(
+                        message_value(identity_reply, "id")
+                    ),
+                    "agent_name_observed": agent_name,
+                    "room_id_observed": chat_id,
+                    "user_name_observed": user_name,
+                },
+                "L0.request.history": {
+                    "input_turn_count": len(input_texts),
+                    "output_turn_count": len(output_texts),
+                    "step_1_trigger_id": step_1_trigger_id,
+                    "step_2_trigger_id": step_2_trigger_id,
+                    "step_3_trigger_id": step_3_trigger_id,
+                },
+                "L0.request.participants": {
+                    "current_room_excludes_echo": echo_absent_before_invite,
+                    "current_room_line_checked": True,
+                    "invitable_peers_line_checked": True,
+                },
+                "L0.dispatch.lookup_peers": {
+                    "echo_invitable_in_identity_reply": True,
+                    "echo_name": echo_name,
+                    "echo_handle": echo_handle,
+                    "observed_tool_events": [
+                        {
+                            "id": observation.event_id,
+                            "message_type": observation.message_type,
+                            "tool_call_id": observation.tool_call_id,
+                        }
+                        for observation in step_1_tool_observations
+                        if observation.tool_name == "thenvoi_lookup_peers"
+                    ],
+                },
+                "L0.dispatch.add_participant": {
+                    "echo_present_after_invite": True,
+                    "echo_id": echo_id,
+                    "observed_tool_events": [
+                        {
+                            "id": observation.event_id,
+                            "message_type": observation.message_type,
+                            "tool_call_id": observation.tool_call_id,
+                        }
+                        for observation in step_2_tool_observations
+                        if observation.tool_name == "thenvoi_add_participant"
+                    ],
+                },
+                "L0.dispatch.send_message": {
+                    "hello_message_count": len(agent_hello_messages),
+                    "hello_message_id": str(message_value(hello_message, "id")),
+                    "hello_mention_ids": sorted(mention_ids(hello_message)),
+                    "observed_tool_events": [
+                        {
+                            "id": observation.event_id,
+                            "message_type": observation.message_type,
+                            "tool_call_id": observation.tool_call_id,
+                        }
+                        for observation in step_2_tool_observations
+                        if observation.tool_name == "thenvoi_send_message"
+                    ],
+                },
+                "L0.dispatch.get_participants": {
+                    "identity_roster_reply_count": len(identity_replies),
+                    "echo_roster_lookup_replied": str(
+                        message_value(echo_message, "id")
+                    ),
+                    "observed_tool_events": [
+                        {
+                            "id": observation.event_id,
+                            "message_type": observation.message_type,
+                            "tool_call_id": observation.tool_call_id,
+                        }
+                        for observation in step_1_tool_observations
+                        if observation.tool_name == "thenvoi_get_participants"
+                    ],
+                },
+                "L0.dispatch.remove_participant": {
+                    "echo_removed": echo_removed,
+                    "post_echo_agent_message_count": len(post_echo_agent_messages),
+                    "observed_tool_events": [
+                        {
+                            "id": observation.event_id,
+                            "message_type": observation.message_type,
+                            "tool_call_id": observation.tool_call_id,
+                        }
+                        for observation in step_3_tool_observations
+                    ],
+                },
+                "observed_tool_events": [
+                    {
+                        "id": observation.event_id,
+                        "tool_name": observation.tool_name,
+                        "message_type": observation.message_type,
+                        "tool_call_id": observation.tool_call_id,
+                    }
+                    for observation in all_tool_observations
+                ],
+            },
+            platform_observations=[
+                {
+                    "kind": "message",
+                    "id": str(message_value(identity_reply, "id")),
+                    "assertion": "identity/context answer observed",
+                    "scenario_refs": [
+                        "L0.request.platform_context",
+                        "L0.request.participants",
+                        "L0.dispatch.get_participants",
+                        "L0.dispatch.lookup_peers",
+                    ],
+                },
+                {
+                    "kind": "participant",
+                    "id": echo_id,
+                    "assertion": "Echo participant present after invite request",
+                    "scenario_ref": "L0.dispatch.add_participant",
+                },
+                {
+                    "kind": "message",
+                    "id": str(message_value(hello_message, "id")),
+                    "assertion": "HELLO_ECHO sent with exact Echo mention metadata",
+                    "scenario_ref": "L0.dispatch.send_message",
+                },
+                {
+                    "kind": "room_state",
+                    "id": chat_id,
+                    "assertion": "Echo participant removed after remove request",
+                    "scenario_ref": "L0.dispatch.remove_participant",
+                },
+                *_tool_observation_records(
+                    step_1_tool_observations,
+                    "Step 1 used live read tools for participants and peers",
+                ),
+                *_tool_observation_records(
+                    step_2_tool_observations,
+                    "Step 2 used live add-participant and send-message tools",
+                ),
+                *_tool_observation_records(
+                    step_3_tool_observations,
+                    "Step 4 used live remove-participant tool",
+                ),
+            ],
+        )

--- a/tests/e2e/scenarios/test_baseline_l0_platform.py
+++ b/tests/e2e/scenarios/test_baseline_l0_platform.py
@@ -14,14 +14,14 @@ from contextlib import AsyncExitStack
 from typing import Any
 
 import pytest
-from thenvoi_rest import AsyncRestClient
-from thenvoi_rest.types import ParticipantRequest
+from band_rest import AsyncRestClient
+from band_rest.types import ParticipantRequest
 
-from thenvoi.agent import Agent
-from thenvoi.core.protocols import AgentToolsProtocol
-from thenvoi.core.simple_adapter import SimpleAdapter
-from thenvoi.core.types import AdapterFeatures, Emit, PlatformMessage
-from thenvoi.runtime.types import AgentConfig
+from band.agent import Agent
+from band.core.protocols import AgentToolsProtocol
+from band.core.simple_adapter import SimpleAdapter
+from band.core.types import AdapterFeatures, Emit, PlatformMessage
+from band.runtime.types import AgentConfig
 
 from tests.e2e.adapters.conftest import (
     AdapterFactory,
@@ -315,21 +315,21 @@ async def test_l0_live_identity_context_echo_loop_and_remove_when_configured(
     adapter.clear_provider_usage()
     agent_observation_client = AsyncRestClient(
         api_key=e2e_adapter_agent_credentials.api_key,
-        base_url=e2e_config.thenvoi_base_url,
+        base_url=e2e_config.band_base_url,
     )
     agent = Agent.create(
         adapter=adapter,
         agent_id=agent_id,
         api_key=e2e_adapter_agent_credentials.api_key,
-        ws_url=e2e_config.thenvoi_ws_url,
-        rest_url=e2e_config.thenvoi_base_url,
+        ws_url=e2e_config.band_ws_url,
+        rest_url=e2e_config.band_base_url,
     )
     echo_agent = Agent.create(
         adapter=_DeterministicEchoAdapter(),
         agent_id=echo_id,
         api_key=echo_api_key,
-        ws_url=e2e_config.thenvoi_ws_url,
-        rest_url=e2e_config.thenvoi_base_url,
+        ws_url=e2e_config.band_ws_url,
+        rest_url=e2e_config.band_base_url,
         config=AgentConfig(auto_subscribe_existing_rooms=False),
     )
 
@@ -401,8 +401,8 @@ async def test_l0_live_identity_context_echo_loop_and_remove_when_configured(
             agent_id=agent_id,
             after_message_id=step_1_trigger_id,
             required_tool_names={
-                "thenvoi_get_participants",
-                "thenvoi_lookup_peers",
+                "band_get_participants",
+                "band_lookup_peers",
             },
             timeout=_STEP_TIMEOUT,
             adapter_name=adapter_name,
@@ -455,8 +455,8 @@ async def test_l0_live_identity_context_echo_loop_and_remove_when_configured(
             agent_id=agent_id,
             after_message_id=step_2_trigger_id,
             required_tool_names={
-                "thenvoi_add_participant",
-                "thenvoi_send_message",
+                "band_add_participant",
+                "band_send_message",
             },
             timeout=_STEP_TIMEOUT,
             adapter_name=adapter_name,
@@ -524,7 +524,7 @@ async def test_l0_live_identity_context_echo_loop_and_remove_when_configured(
             room_id=chat_id,
             agent_id=agent_id,
             after_message_id=step_3_trigger_id,
-            required_tool_names={"thenvoi_remove_participant"},
+            required_tool_names={"band_remove_participant"},
             timeout=_STEP_TIMEOUT,
             adapter_name=adapter_name,
         )
@@ -583,7 +583,7 @@ async def test_l0_live_identity_context_echo_loop_and_remove_when_configured(
                             "tool_call_id": observation.tool_call_id,
                         }
                         for observation in step_1_tool_observations
-                        if observation.tool_name == "thenvoi_lookup_peers"
+                        if observation.tool_name == "band_lookup_peers"
                     ],
                 },
                 "L0.dispatch.add_participant": {
@@ -596,7 +596,7 @@ async def test_l0_live_identity_context_echo_loop_and_remove_when_configured(
                             "tool_call_id": observation.tool_call_id,
                         }
                         for observation in step_2_tool_observations
-                        if observation.tool_name == "thenvoi_add_participant"
+                        if observation.tool_name == "band_add_participant"
                     ],
                 },
                 "L0.dispatch.send_message": {
@@ -610,7 +610,7 @@ async def test_l0_live_identity_context_echo_loop_and_remove_when_configured(
                             "tool_call_id": observation.tool_call_id,
                         }
                         for observation in step_2_tool_observations
-                        if observation.tool_name == "thenvoi_send_message"
+                        if observation.tool_name == "band_send_message"
                     ],
                 },
                 "L0.dispatch.get_participants": {
@@ -625,7 +625,7 @@ async def test_l0_live_identity_context_echo_loop_and_remove_when_configured(
                             "tool_call_id": observation.tool_call_id,
                         }
                         for observation in step_1_tool_observations
-                        if observation.tool_name == "thenvoi_get_participants"
+                        if observation.tool_name == "band_get_participants"
                     ],
                 },
                 "L0.dispatch.remove_participant": {

--- a/tests/framework_conformance/test_baseline_l0_platform.py
+++ b/tests/framework_conformance/test_baseline_l0_platform.py
@@ -48,14 +48,14 @@ _L0_REQUEST_ROWS = {
 }
 
 _CHAT_TOOL_ARGS: dict[str, dict[str, Any]] = {
-    "thenvoi_send_message": {
+    "band_send_message": {
         "content": "L0 dispatch sentinel",
         "mentions": ["@darvell"],
     },
-    "thenvoi_add_participant": {"identifier": "darvell/greeter", "role": "member"},
-    "thenvoi_remove_participant": {"identifier": "darvell/greeter"},
-    "thenvoi_get_participants": {},
-    "thenvoi_lookup_peers": {"page": 1, "page_size": 10},
+    "band_add_participant": {"identifier": "darvell/greeter", "role": "member"},
+    "band_remove_participant": {"identifier": "darvell/greeter"},
+    "band_get_participants": {},
+    "band_lookup_peers": {"page": 1, "page_size": 10},
 }
 
 
@@ -208,7 +208,7 @@ async def test_l0_chat_tool_dispatch_reaches_real_adapter_path(
 def test_l0_dispatch_oracle_rejects_corrupted_tool_arguments() -> None:
     result = DispatchResult(
         adapter_id="anthropic",
-        tool_name="thenvoi_send_message",
+        tool_name="band_send_message",
         arguments={"content": "expected", "mentions": ["@darvell"]},
         tool_calls=[],
         messages_sent=[

--- a/tests/framework_conformance/test_baseline_l0_platform.py
+++ b/tests/framework_conformance/test_baseline_l0_platform.py
@@ -1,0 +1,260 @@
+"""L0 platform-adaptation baseline conformance rows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.framework_conformance.baseline_applicability import (
+    ApplicabilityStatus,
+    build_applicability_matrix,
+)
+from tests.framework_conformance.baseline_scenarios import SCENARIOS_BY_ID
+from tests.framework_conformance.baseline_status import ScenarioKind
+from tests.framework_conformance.dispatch_capture import (
+    HONEST_DISPATCH_ADAPTER_IDS,
+    DispatchResult,
+    assert_dispatch_result,
+    dispatch_tool,
+)
+from tests.framework_conformance.platform_fixtures import (
+    AGENT_ID,
+    PEER_AGENT_ID,
+    PEER_AGENT_HANDLE,
+    ROOM_ID,
+    SECOND_PEER_AGENT_HANDLE,
+    ConformanceExecutionContext,
+    apply_participant_event,
+    build_agent_input_through_preprocessor,
+    canonical_history,
+    canonical_participants,
+    canonical_peers,
+    current_message_event,
+    participant_added_event,
+    participant_removed_event,
+)
+from tests.framework_conformance.request_capture import (
+    REQUEST_CAPTURE_ADAPTER_IDS,
+    ConformanceSchemaRecorder,
+    capture_request,
+    visible_text as captured_visible_text,
+)
+
+_L0_REQUEST_ROWS = {
+    "L0.request.platform_context",
+    "L0.request.history",
+    "L0.request.participants",
+}
+
+_CHAT_TOOL_ARGS: dict[str, dict[str, Any]] = {
+    "thenvoi_send_message": {
+        "content": "L0 dispatch sentinel",
+        "mentions": ["@darvell"],
+    },
+    "thenvoi_add_participant": {"identifier": "darvell/greeter", "role": "member"},
+    "thenvoi_remove_participant": {"identifier": "darvell/greeter"},
+    "thenvoi_get_participants": {},
+    "thenvoi_lookup_peers": {"page": 1, "page_size": 10},
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", REQUEST_CAPTURE_ADAPTER_IDS)
+async def test_l0_platform_context_reaches_model_visible_surface(
+    adapter_id: str,
+) -> None:
+    agent_input = await build_agent_input_through_preprocessor()
+
+    captured = await capture_request(adapter_id, agent_input)
+    visible_text = captured_visible_text(captured)
+
+    assert captured.system_text is not None
+    assert "Test Agent" in captured.system_text
+    assert "conformance test agent" in captured.system_text
+    assert (
+        "Treat messages from other participants as user input" in visible_text
+        or "Plain text responses will NOT be delivered" in visible_text
+    )
+    assert captured.base_instruction_surface is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", REQUEST_CAPTURE_ADAPTER_IDS)
+async def test_l0_history_and_current_trigger_are_present_without_duplication(
+    adapter_id: str,
+) -> None:
+    agent_input = await build_agent_input_through_preprocessor()
+    captured = await capture_request(adapter_id, agent_input)
+
+    assert captured.message_ids == [
+        "msg-history-001",
+        "msg-history-002",
+        "msg-history-003",
+        "msg-current-trigger",
+    ]
+    assert captured.message_ids.count("msg-current-trigger") == 1
+    visible_text = captured_visible_text(captured)
+    assert visible_text.count("MARCO") == 1
+    assert visible_text.count("LIGHTHOUSE") == 1
+    assert visible_text.count("POSTGRESQL") == 1
+    assert visible_text.count("@darvell/test-agent please recall the room facts") == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", REQUEST_CAPTURE_ADAPTER_IDS)
+async def test_l0_participant_add_update_roster_reaches_adapter_surface(
+    adapter_id: str,
+) -> None:
+    ctx = ConformanceExecutionContext(history_messages=canonical_history())
+    ctx.mark_participants_sent()
+    assert canonical_peers()[0]["handle"] == SECOND_PEER_AGENT_HANDLE
+    assert all(
+        participant.get("handle") != SECOND_PEER_AGENT_HANDLE
+        for participant in ctx.participants
+    )
+
+    apply_participant_event(ctx, participant_added_event())
+    agent_input = await build_agent_input_through_preprocessor(
+        ctx=ctx,
+        event=current_message_event(message_id="msg-participant-added"),
+        agent_id=AGENT_ID,
+    )
+
+    captured = await capture_request(adapter_id, agent_input)
+    visible_text = captured_visible_text(captured)
+
+    assert "## Current Participants" in visible_text
+    assert "@darvell" in visible_text
+    assert "@darvell/test-agent" in visible_text
+    assert "@darvell/calc" in visible_text
+    assert "@darvell/greeter" in visible_text
+    assert "(User)" in visible_text
+    assert "(Agent)" in visible_text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", REQUEST_CAPTURE_ADAPTER_IDS)
+async def test_l0_participant_remove_update_roster_reaches_adapter_surface(
+    adapter_id: str,
+) -> None:
+    ctx = ConformanceExecutionContext(history_messages=canonical_history())
+    ctx.mark_participants_sent()
+    assert any(
+        participant.get("id") == PEER_AGENT_ID for participant in ctx.participants
+    )
+
+    apply_participant_event(
+        ctx, participant_removed_event(participant_id=PEER_AGENT_ID)
+    )
+    agent_input = await build_agent_input_through_preprocessor(
+        ctx=ctx,
+        event=current_message_event(message_id="msg-participant-removed"),
+        agent_id=AGENT_ID,
+    )
+
+    captured = await capture_request(adapter_id, agent_input)
+    visible_text = captured_visible_text(captured)
+
+    assert "## Current Participants" in visible_text
+    assert "@darvell" in visible_text
+    assert "@darvell/test-agent" in visible_text
+    assert f"@{PEER_AGENT_HANDLE}" not in visible_text
+
+
+@pytest.mark.asyncio
+async def test_l0_participant_change_steady_state_suppression() -> None:
+    ctx = ConformanceExecutionContext(history_messages=canonical_history())
+
+    first = await build_agent_input_through_preprocessor(
+        ctx=ctx,
+        event=current_message_event(message_id="msg-participant-first"),
+        agent_id=AGENT_ID,
+    )
+    second = await build_agent_input_through_preprocessor(
+        ctx=ctx,
+        event=current_message_event(message_id="msg-participant-second"),
+        agent_id=AGENT_ID,
+    )
+
+    assert first.participants_msg is not None
+    assert second.participants_msg is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", HONEST_DISPATCH_ADAPTER_IDS)
+@pytest.mark.parametrize("tool_name,arguments", _CHAT_TOOL_ARGS.items())
+async def test_l0_chat_tool_dispatch_reaches_real_adapter_path(
+    adapter_id: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> None:
+    tools = ConformanceSchemaRecorder(
+        participants=canonical_participants(),
+        peers=canonical_peers(),
+        room_id=ROOM_ID,
+    )
+
+    result = await dispatch_tool(
+        adapter_id,
+        tool_name=tool_name,
+        arguments=arguments,
+        tools=tools,
+    )
+
+    assert_dispatch_result(result)
+
+
+def test_l0_dispatch_oracle_rejects_corrupted_tool_arguments() -> None:
+    result = DispatchResult(
+        adapter_id="anthropic",
+        tool_name="thenvoi_send_message",
+        arguments={"content": "expected", "mentions": ["@darvell"]},
+        tool_calls=[],
+        messages_sent=[
+            {"id": "msg-0", "content": "corrupted", "mentions": ["@darvell"]}
+        ],
+        participants_added=[],
+        participants_removed=[],
+        context_calls=[],
+    )
+
+    with pytest.raises(AssertionError):
+        assert_dispatch_result(result)
+
+
+def test_l0_scorecard_has_reviewed_request_and_dispatch_cells() -> None:
+    l0_ids = {
+        scenario.id
+        for scenario in SCENARIOS_BY_ID.values()
+        if scenario.level.value == "l0"
+    }
+    l0_cells = [
+        cell for cell in build_applicability_matrix() if cell.scenario_id in l0_ids
+    ]
+
+    assert l0_cells
+    assert all(
+        cell.status is not ApplicabilityStatus.UNKNOWN_FAIL_CLOSED for cell in l0_cells
+    )
+    dispatch_cells = [
+        cell
+        for cell in l0_cells
+        if SCENARIOS_BY_ID[cell.scenario_id].kind is ScenarioKind.DISPATCH
+    ]
+    runtime_owned_dispatch = [
+        cell
+        for cell in dispatch_cells
+        if cell.status is ApplicabilityStatus.TIER2_BLOCKED
+    ]
+    assert runtime_owned_dispatch
+    assert all(
+        cell.reason and not cell.tier2_pointer for cell in runtime_owned_dispatch
+    )
+
+
+def test_l0_request_rows_are_registered_as_core_contract() -> None:
+    for row_id in _L0_REQUEST_ROWS:
+        scenario = SCENARIOS_BY_ID[row_id]
+        assert scenario.core_contract is True
+        assert scenario.requires_request_capture is True


### PR DESCRIPTION
## Summary

- Adds the L0 platform-adaptation baseline split: model-visible platform context, history/participant request capture, and dispatch rows for the Band chat tools.
- Adds the gated L0 live workflow and artifact expectations for successful versus blocked Tier-2 compensation.
- Rebases the L0 slice onto the shared substrate branch and latest `origin/dev`.

## Verification

- `uv run ruff check .` passed.
- `uv run pyrefly check` passed.
- `uv run pytest tests/framework_conformance/ tests/e2e/test_baseline_artifacts.py tests/e2e/test_e2e_hygiene.py -q -k 'not crewai'` passed: 805 passed, 26 skipped, 98 deselected.
- `BAND_ALLOW_MISSING_FRAMEWORKS=1 uv run pytest tests/adapters/test_crewai_adapter.py tests/adapters/test_crewai_adapter_soak.py tests/adapters/test_crewai_flow_adapter.py tests/adapters/test_crewai_flow_phase3.py tests/adapters/test_crewai_flow_phase4.py tests/adapters/test_crewai_flow_phase5.py tests/adapters/test_crewai_flow_state_source.py tests/converters/test_crewai.py tests/converters/test_crewai_flow.py tests/integrations/test_crewai_tools.py tests/integrations/test_crewai_flow_real_sdk.py tests/framework_conformance/ -q -k crewai` passed: 308 passed, 7 skipped, 704 deselected.

Live provider/platform E2E was not run locally; the L0 live workflow is gated by `E2E_TESTS_ENABLED=true` and `E2E_BASELINE_L0_LIVE=true`.