### PR TITLE
test(tests): add L2 context baseline

### DIFF
--- a/.github/workflows/baseline-l2-live.yml
+++ b/.github/workflows/baseline-l2-live.yml
@@ -1,0 +1,80 @@
+name: Band baseline L2 live
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 9 * * *'
+
+jobs:
+  baseline-l2-live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      E2E_TESTS_ENABLED: "true"
+      E2E_BASELINE_L2_LIVE: "true"
+      E2E_BASELINE_RUN_ID: ${{ github.run_id }}
+      E2E_BASELINE_ARTIFACT_DIR: .claude/reports/e2e-baseline-artifacts
+      THENVOI_BASE_URL: ${{ vars.THENVOI_BASE_URL }}
+      THENVOI_WS_URL: ${{ vars.THENVOI_WS_URL }}
+      TEST_AGENT_ID: ${{ secrets.TEST_AGENT_ID }}
+      THENVOI_API_KEY: ${{ secrets.THENVOI_API_KEY }}
+      THENVOI_API_KEY_USER: ${{ secrets.THENVOI_API_KEY_USER }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      GOOGLE_GENAI_USE_VERTEXAI: ${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}
+      GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+      E2E_BASELINE_INPUT_USD_PER_MILLION_TOKENS: ${{ vars.E2E_BASELINE_INPUT_USD_PER_MILLION_TOKENS }}
+      E2E_BASELINE_OUTPUT_USD_PER_MILLION_TOKENS: ${{ vars.E2E_BASELINE_OUTPUT_USD_PER_MILLION_TOKENS }}
+      E2E_BASELINE_PRICING_SOURCE: ${{ vars.E2E_BASELINE_PRICING_SOURCE }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run live L2 baseline scenario
+        run: uv run pytest tests/e2e/scenarios/test_baseline_l2_context.py -v -s --no-cov
+
+      - name: Require complete live L2 artifact matrix
+        run: |
+          uv run python - <<'PY'
+          import json
+          from pathlib import Path
+
+          expected = {
+              'anthropic', 'claude_sdk', 'codex', 'crewai', 'crewai_flow',
+              'gemini', 'google_adk', 'langgraph', 'letta', 'opencode',
+              'parlant', 'pydantic_ai',
+          }
+          artifact_dir = Path('.claude/reports/e2e-baseline-artifacts')
+          artifacts = [json.loads(path.read_text()) for path in artifact_dir.glob('*.json')]
+          level_artifacts = [artifact for artifact in artifacts if artifact.get('level') == 'L2']
+          adapters = {artifact.get('adapter') for artifact in level_artifacts}
+          missing = expected - adapters
+          if missing:
+              raise SystemExit('Missing live L2 artifact disposition for: ' + ', '.join(sorted(missing)))
+          if not any(artifact.get('status') != 'TIER2_BLOCKED' for artifact in level_artifacts):
+              raise SystemExit('No successful live L2 artifact was produced')
+          PY
+
+      - name: Upload baseline artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: baseline-l2-live-artifacts
+          path: .claude/reports/e2e-baseline-artifacts/*.json
+          if-no-files-found: warn

--- a/tests/e2e/scenarios/test_baseline_l2_context.py
+++ b/tests/e2e/scenarios/test_baseline_l2_context.py
@@ -1,0 +1,208 @@
+"""Gated live L2 context-fidelity scenario.
+
+Run with:
+    E2E_TESTS_ENABLED=true E2E_BASELINE_L2_LIVE=true \
+        uv run pytest tests/e2e/scenarios/test_baseline_l2_context.py -v -s --no-cov
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from thenvoi_rest import AsyncRestClient
+
+from thenvoi.agent import Agent
+
+from tests.e2e.adapters.conftest import (
+    AdapterFactory,
+    BASELINE_DEFAULT_PROVIDER_USAGE_ADAPTER_FACTORIES,
+    BASELINE_DEFAULT_PROVIDER_USAGE_BLOCKED_ADAPTER_NAMES,
+)
+
+from tests.e2e.baseline_artifacts import (
+    baseline_pricing_from_env,
+    provider_usage_from_adapter,
+    start_baseline_tier2_timer,
+    write_baseline_tier2_artifact,
+    write_provider_usage_blocked_artifact_if_needed,
+)
+from tests.e2e.conftest import E2ESettings, requires_e2e
+from tests.e2e.helpers import (
+    assert_content_contains,
+    fetch_chat_messages,
+    message_ids,
+    message_value,
+    send_trigger_message,
+    wait_full_window_for_new_agent_text_messages,
+)
+
+_BURST_TIMEOUT = 400.0
+_STEP_TIMEOUT = 90.0
+_L2_SCENARIO_REFS = [
+    "L2.request.full_history",
+    "L2.request.earliest_turn",
+]
+
+
+def _l2_live_blocked_reason() -> str | None:
+    if os.environ.get("E2E_BASELINE_L2_LIVE") != "true":
+        return "tier2_blocked: E2E_BASELINE_L2_LIVE=true not set for live L2 flow"
+    return None
+
+
+_L2_LIVE_BLOCKED_REASON = _l2_live_blocked_reason()
+pytestmark = pytest.mark.skipif(
+    _L2_LIVE_BLOCKED_REASON is not None,
+    reason=_L2_LIVE_BLOCKED_REASON or "tier2_blocked: unknown L2 live block",
+)
+
+
+@pytest.fixture(
+    params=tuple(BASELINE_DEFAULT_PROVIDER_USAGE_ADAPTER_FACTORIES.items()),
+    ids=lambda item: item[0],
+)
+def l2_provider_usage_adapter_entry(
+    request: pytest.FixtureRequest,
+) -> tuple[str, AdapterFactory]:
+    adapter_name, factory = request.param
+    return str(adapter_name), factory
+
+
+@pytest.mark.parametrize(
+    "adapter_name", BASELINE_DEFAULT_PROVIDER_USAGE_BLOCKED_ADAPTER_NAMES
+)
+def test_l2_live_unsupported_adapter_rows_write_blocked_artifacts_when_configured(
+    adapter_name: str,
+) -> None:
+    blocked_reason = _l2_live_blocked_reason()
+    if blocked_reason:
+        pytest.skip(blocked_reason)
+    blocked_reason = write_provider_usage_blocked_artifact_if_needed(
+        scenario_id="L2.request.full_history",
+        scenario_refs=_L2_SCENARIO_REFS,
+        adapter=adapter_name,
+    )
+    assert blocked_reason is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(650)
+@requires_e2e
+async def test_l2_live_burst_history_recalls_planted_terms_when_configured(
+    e2e_config: E2ESettings,
+    l2_provider_usage_adapter_entry: tuple[str, AdapterFactory],
+    e2e_fresh_room: tuple[str, str, str],
+    e2e_agent_info: tuple[str, str],
+    api_client: AsyncRestClient,
+    e2e_unlimited_user_client: AsyncRestClient,
+) -> None:
+    blocked_reason = _l2_live_blocked_reason()
+    if blocked_reason:
+        pytest.skip(blocked_reason)
+
+    timer = start_baseline_tier2_timer()
+    pricing = baseline_pricing_from_env()
+    chat_id, _user_id, _user_name = e2e_fresh_room
+    agent_id, agent_name = e2e_agent_info
+    adapter_name, adapter_factory = l2_provider_usage_adapter_entry
+
+    adapter = adapter_factory(e2e_config)
+    adapter.clear_provider_usage()
+    agent = Agent.create(
+        adapter=adapter,
+        agent_id=e2e_config.test_agent_id,
+        api_key=e2e_config.thenvoi_api_key,
+        ws_url=e2e_config.thenvoi_ws_url,
+        rest_url=e2e_config.thenvoi_base_url,
+    )
+
+    planted_messages = [
+        "my name is MARCO and I work at ACME",
+        "I have a pet cat named WHISKERS",
+        "my favorite programming language is RUST",
+        "I'm building a project called LIGHTHOUSE",
+        "the deadline for LIGHTHOUSE is the SOLSTICE-SPRINT",
+        "my team has 7 people including SANDRA and KOJI",
+        "we use POSTGRESQL for our database",
+        "our office is in BARCELONA",
+        "I'm learning to play the BANJO on weekends",
+    ]
+
+    async with agent:
+        before_burst = message_ids(await fetch_chat_messages(api_client, chat_id))
+        for message in planted_messages:
+            await send_trigger_message(
+                e2e_unlimited_user_client, chat_id, message, agent_name, agent_id
+            )
+
+        burst_replies = await wait_full_window_for_new_agent_text_messages(
+            api_client,
+            chat_id,
+            agent_id,
+            before_burst,
+            timeout=_BURST_TIMEOUT,
+        )
+        assert len(burst_replies) == 9, [
+            message_value(message, "content") for message in burst_replies
+        ]
+
+        before_recall = message_ids(await fetch_chat_messages(api_client, chat_id))
+        recall_prompt = (
+            "what is my name, what project am I building, and what database do we use?"
+        )
+        await send_trigger_message(
+            api_client,
+            chat_id,
+            recall_prompt,
+            agent_name,
+            agent_id,
+        )
+        recall_replies = await wait_full_window_for_new_agent_text_messages(
+            api_client,
+            chat_id,
+            agent_id,
+            before_recall,
+            timeout=_STEP_TIMEOUT,
+        )
+
+    assert len(recall_replies) == 1, [
+        message_value(message, "content") for message in recall_replies
+    ]
+    for term in ("MARCO", "LIGHTHOUSE", "POSTGRESQL"):
+        assert_content_contains(recall_replies, term)
+    write_baseline_tier2_artifact(
+        scenario_id="L2.request.full_history",
+        scenario_refs=_L2_SCENARIO_REFS,
+        adapter=adapter_name,
+        timer=timer,
+        pricing=pricing,
+        provider_usage=provider_usage_from_adapter(adapter, adapter_name=adapter_name),
+        input_texts=[*planted_messages, recall_prompt],
+        output_texts=[
+            str(message_value(message, "content") or "")
+            for message in [*burst_replies, *recall_replies]
+        ],
+        observed_agent_text_message_count=len(burst_replies) + len(recall_replies),
+        evidence={
+            "L2.request.full_history": {
+                "burst_observation_window_seconds": _BURST_TIMEOUT,
+                "recall_observation_window_seconds": _STEP_TIMEOUT,
+                "burst_reply_count": len(burst_replies),
+                "recall_reply_count": len(recall_replies),
+                "recalled_terms": ["MARCO", "LIGHTHOUSE", "POSTGRESQL"],
+            },
+            "L2.request.earliest_turn": {
+                "earliest_marker_recalled": "MARCO",
+                "recall_observation_window_seconds": _STEP_TIMEOUT,
+            },
+        },
+        platform_observations=[
+            {
+                "kind": "message",
+                "id": str(message_value(recall_replies[0], "id")),
+                "assertion": "single recall reply contains MARCO/LIGHTHOUSE/POSTGRESQL",
+                "scenario_refs": _L2_SCENARIO_REFS,
+            }
+        ],
+    )

--- a/tests/e2e/scenarios/test_baseline_l2_context.py
+++ b/tests/e2e/scenarios/test_baseline_l2_context.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 import os
 
 import pytest
-from thenvoi_rest import AsyncRestClient
+from band_rest import AsyncRestClient
 
-from thenvoi.agent import Agent
+from band.agent import Agent
 
 from tests.e2e.adapters.conftest import (
     AdapterFactory,
@@ -112,9 +112,9 @@ async def test_l2_live_burst_history_recalls_planted_terms_when_configured(
     agent = Agent.create(
         adapter=adapter,
         agent_id=e2e_config.test_agent_id,
-        api_key=e2e_config.thenvoi_api_key,
-        ws_url=e2e_config.thenvoi_ws_url,
-        rest_url=e2e_config.thenvoi_base_url,
+        api_key=e2e_config.band_api_key,
+        ws_url=e2e_config.band_ws_url,
+        rest_url=e2e_config.band_base_url,
     )
 
     planted_messages = [

--- a/tests/framework_conformance/test_baseline_l2_context.py
+++ b/tests/framework_conformance/test_baseline_l2_context.py
@@ -1,0 +1,341 @@
+"""L2 conversation-context fidelity baseline conformance rows."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+import pytest
+
+from tests.framework_conformance.baseline_scenarios import SCENARIOS_BY_ID
+from tests.framework_conformance.platform_fixtures import (
+    AGENT_ID,
+    PEER_AGENT_ID,
+    USER_ID,
+    ConformanceExecutionContext,
+    build_agent_input_through_preprocessor,
+    current_message_event,
+    history_message,
+)
+from tests.framework_conformance.request_capture import (
+    REQUEST_CAPTURE_ADAPTER_IDS,
+    REQUEST_CAPTURE_PROBES,
+    CapturedRequest,
+    assert_token_order,
+    capture_request,
+    visible_text,
+)
+
+_LONG_HISTORY_IDS = [f"msg-l2-history-{index:03d}" for index in range(10)]
+_CURRENT_L2_ID = "msg-l2-current-trigger"
+_CURRENT_L2_SENTINEL = "CURRENT-L2-RECALL"
+_CAPTURE_CACHE: dict[str, CapturedRequest] = {}
+
+
+def _long_history() -> list[dict[str, Any]]:
+    senders = [
+        (USER_ID, "User", "Darvell"),
+        (AGENT_ID, "Agent", "Test Agent"),
+        (PEER_AGENT_ID, "Agent", "Calc"),
+    ]
+    messages = []
+    for index, message_id in enumerate(_LONG_HISTORY_IDS):
+        sender_id, sender_type, sender_name = senders[index % len(senders)]
+        if index == 0:
+            content = "EARLIEST-L2-TURN planted MARCO for recall."
+        elif index == 4:
+            content = "MIDDLE-L2-TURN planted LIGHTHOUSE for recall."
+        elif index == 8:
+            content = "LATEST-L2-TURN planted POSTGRESQL for recall."
+        else:
+            content = f"L2_TURN_{index:02d} context filler."
+        messages.append(
+            history_message(
+                message_id=message_id,
+                content=content,
+                sender_id=sender_id,
+                sender_type=sender_type,
+                sender_name=sender_name,
+                offset_seconds=index + 1,
+            )
+        )
+    return messages
+
+
+def _out_of_order_long_history() -> list[dict[str, Any]]:
+    history = _long_history()
+    return [
+        history[4],
+        history[0],
+        history[9],
+        history[2],
+        history[1],
+        history[8],
+        *history[3:4],
+        *history[5:8],
+    ]
+
+
+async def _capture_l2_request(adapter_id: str) -> CapturedRequest:
+    if adapter_id not in _CAPTURE_CACHE:
+        ctx = ConformanceExecutionContext(history_messages=_out_of_order_long_history())
+        agent_input = await build_agent_input_through_preprocessor(
+            ctx=ctx,
+            event=current_message_event(
+                content=f"@darvell/test-agent please recall {_CURRENT_L2_SENTINEL}.",
+                message_id=_CURRENT_L2_ID,
+            ),
+        )
+        _CAPTURE_CACHE[adapter_id] = await capture_request(adapter_id, agent_input)
+    return _CAPTURE_CACHE[adapter_id]
+
+
+def _expected_l2_source_ids() -> list[str]:
+    return [*_LONG_HISTORY_IDS, _CURRENT_L2_ID]
+
+
+def _assert_l2_source_counts(captured: CapturedRequest) -> None:
+    expected_ids = _expected_l2_source_ids()
+    assert captured.rehydration is not None
+    source_counts = captured.rehydration.source_message_counts
+    assert set(source_counts) == set(expected_ids)
+    for message_id in expected_ids:
+        assert source_counts[message_id] == 1
+
+
+def _assert_l2_recall_oracle(captured: CapturedRequest) -> None:
+    expected_ids = _expected_l2_source_ids()
+    text = visible_text(captured)
+    assert captured.message_ids == expected_ids
+    _assert_l2_source_counts(captured)
+    for token in (
+        "EARLIEST-L2-TURN",
+        "MIDDLE-L2-TURN",
+        "LATEST-L2-TURN",
+        _CURRENT_L2_SENTINEL,
+    ):
+        assert token in text
+    assert_token_order(
+        captured,
+        "EARLIEST-L2-TURN",
+        "MIDDLE-L2-TURN",
+        "LATEST-L2-TURN",
+        _CURRENT_L2_SENTINEL,
+    )
+
+
+def _source_items_by_id(captured: CapturedRequest) -> dict[str, list[Any]]:
+    items_by_id: dict[str, list[Any]] = {}
+    for item in captured.items:
+        if item.source_message_id:
+            items_by_id.setdefault(item.source_message_id, []).append(item)
+    return items_by_id
+
+
+def _expected_l2_roles() -> dict[str, set[str]]:
+    roles: dict[str, set[str]] = {}
+    for message in _long_history():
+        message_id = str(message["id"])
+        if message["sender_id"] == AGENT_ID:
+            roles[message_id] = {"assistant", "ai", "model"}
+        else:
+            roles[message_id] = {"user", "human"}
+    roles[_CURRENT_L2_ID] = {"user", "human"}
+    return roles
+
+
+def _history_label_content_pairs() -> list[tuple[str, str]]:
+    return [
+        (str(message["sender_name"]), str(message["content"]))
+        for message in _long_history()
+    ]
+
+
+def _assert_l2_speaker_attribution_oracle(captured: CapturedRequest) -> None:
+    text = visible_text(captured)
+    if captured.supports_speaker_roles:
+        items_by_id = _source_items_by_id(captured)
+        for message_id, allowed_roles in _expected_l2_roles().items():
+            matching_items = items_by_id.get(message_id, [])
+            assert matching_items, f"{message_id} missing from captured request items"
+            assert {item.role for item in matching_items} <= allowed_roles
+        return
+
+    for sender_name, content in _history_label_content_pairs():
+        if sender_name == "Test Agent":
+            assert content in text
+            continue
+        assert f"[{sender_name}]: {content}" in text
+    for sender_name, content in _history_label_content_pairs():
+        if sender_name == "Test Agent":
+            continue
+        assert f"assistant: [{sender_name}]: {content}" not in text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", REQUEST_CAPTURE_ADAPTER_IDS)
+async def test_l2_full_history_and_earliest_turn_reach_adapter_payloads(
+    adapter_id: str,
+) -> None:
+    captured = await _capture_l2_request(adapter_id)
+
+    _assert_l2_recall_oracle(captured)
+    assert captured.seam_owner.value in {"adapter_payload", "adapter_input"}
+
+
+@pytest.mark.asyncio
+async def test_l2_recall_oracle_rejects_dropped_earliest_turn() -> None:
+    captured = await _capture_l2_request(REQUEST_CAPTURE_ADAPTER_IDS[0])
+    mutated = replace(
+        captured,
+        message_ids=[
+            message_id
+            for message_id in captured.message_ids
+            if message_id != _LONG_HISTORY_IDS[0]
+        ],
+        message_texts=[
+            text.replace("EARLIEST-L2-TURN planted MARCO for recall.", "")
+            for text in captured.message_texts
+        ],
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_l2_recall_oracle(mutated)
+
+
+@pytest.mark.asyncio
+async def test_l2_recall_oracle_rejects_reversed_chronology() -> None:
+    captured = await _capture_l2_request(REQUEST_CAPTURE_ADAPTER_IDS[0])
+    mutated = replace(captured, message_texts=list(reversed(captured.message_texts)))
+
+    with pytest.raises(AssertionError):
+        _assert_l2_recall_oracle(mutated)
+
+
+@pytest.mark.asyncio
+async def test_l2_recall_oracle_rejects_duplicated_source_turn() -> None:
+    captured = await _capture_l2_request(REQUEST_CAPTURE_ADAPTER_IDS[0])
+    assert captured.rehydration is not None
+    source_counts = dict(captured.rehydration.source_message_counts)
+    source_counts[_LONG_HISTORY_IDS[4]] = 2
+    mutated = replace(
+        captured,
+        rehydration=replace(captured.rehydration, source_message_counts=source_counts),
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_l2_recall_oracle(mutated)
+
+
+@pytest.mark.asyncio
+async def test_l2_recall_oracle_rejects_missing_middle_turn() -> None:
+    captured = await _capture_l2_request(REQUEST_CAPTURE_ADAPTER_IDS[0])
+    assert captured.rehydration is not None
+    missing_id = _LONG_HISTORY_IDS[5]
+    source_counts = dict(captured.rehydration.source_message_counts)
+    source_counts.pop(missing_id)
+    mutated = replace(
+        captured,
+        message_ids=[
+            message_id
+            for message_id in captured.message_ids
+            if message_id != missing_id
+        ],
+        rehydration=replace(captured.rehydration, source_message_counts=source_counts),
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_l2_recall_oracle(mutated)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", REQUEST_CAPTURE_ADAPTER_IDS)
+async def test_l2_history_order_is_chronological_with_current_trigger_last(
+    adapter_id: str,
+) -> None:
+    captured = await _capture_l2_request(adapter_id)
+
+    _assert_l2_recall_oracle(captured)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", REQUEST_CAPTURE_ADAPTER_IDS)
+async def test_l2_speaker_attribution_survives_adapter_payload_construction(
+    adapter_id: str,
+) -> None:
+    captured = await _capture_l2_request(adapter_id)
+
+    _assert_l2_speaker_attribution_oracle(captured)
+
+
+@pytest.mark.asyncio
+async def test_l2_speaker_attribution_oracle_rejects_wrong_flattened_speaker() -> None:
+    captured = await _capture_l2_request(REQUEST_CAPTURE_ADAPTER_IDS[0])
+    mutated = replace(
+        captured,
+        supports_speaker_roles=False,
+        message_texts=[
+            text.replace(
+                "[Calc]: LATEST-L2-TURN planted POSTGRESQL for recall.",
+                "[Darvell]: LATEST-L2-TURN planted POSTGRESQL for recall.",
+            )
+            for text in captured.message_texts
+        ],
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_l2_speaker_attribution_oracle(mutated)
+
+
+@pytest.mark.asyncio
+async def test_l2_speaker_attribution_oracle_rejects_peer_as_assistant_channel() -> (
+    None
+):
+    captured = await _capture_l2_request(REQUEST_CAPTURE_ADAPTER_IDS[0])
+    mutated = replace(
+        captured,
+        supports_speaker_roles=False,
+        message_texts=[
+            text.replace(
+                "[Calc]: LATEST-L2-TURN planted POSTGRESQL for recall.",
+                "assistant: [Calc]: LATEST-L2-TURN planted POSTGRESQL for recall.",
+            )
+            for text in captured.message_texts
+        ],
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_l2_speaker_attribution_oracle(mutated)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", REQUEST_CAPTURE_ADAPTER_IDS)
+async def test_l2_speaker_role_opt_out_is_justified_by_capture_shape(
+    adapter_id: str,
+) -> None:
+    """A capture may skip per-message role assertions only when its family has
+    no per-message role channel (history flattened into one prompt/engine
+    input). Discrete-message captures must prove roles; flattened captures
+    must keep attribution via speaker labels instead."""
+    captured = await _capture_l2_request(adapter_id)
+    probe = REQUEST_CAPTURE_PROBES[adapter_id]
+
+    assert captured.history_shape == probe.history_shape
+    assert captured.supports_speaker_roles == (captured.history_shape == "discrete"), (
+        f"{adapter_id}: supports_speaker_roles={captured.supports_speaker_roles} "
+        f"with history_shape={captured.history_shape}; role opt-out is only "
+        "justified for flattened/engine_input captures"
+    )
+
+
+def test_l2_rows_are_registered_as_core_request_capture() -> None:
+    for row_id in {
+        "L2.request.full_history",
+        "L2.request.earliest_turn",
+        "L2.request.chronological_order",
+        "L2.request.speaker_attribution",
+    }:
+        scenario = SCENARIOS_BY_ID[row_id]
+        assert scenario.core_contract is True
+        assert scenario.requires_request_capture is True
+        assert scenario.kind.value == "request_read"


### PR DESCRIPTION
## Summary

- Adds the L2 context-fidelity baseline split: full history, earliest turn retention, chronological ordering, and speaker attribution.
- Adds the gated L2 live workflow and row-specific artifact checks.
- Rebases the L2 slice onto L1 and latest `origin/dev`.

## Verification

- `uv run ruff check .` passed.
- `uv run pyrefly check` passed.
- `uv run pytest tests/framework_conformance/ tests/e2e/test_baseline_artifacts.py tests/e2e/test_e2e_hygiene.py -q -k 'not crewai'` passed: 805 passed, 26 skipped, 98 deselected.
- `BAND_ALLOW_MISSING_FRAMEWORKS=1 uv run pytest tests/adapters/test_crewai_adapter.py tests/adapters/test_crewai_adapter_soak.py tests/adapters/test_crewai_flow_adapter.py tests/adapters/test_crewai_flow_phase3.py tests/adapters/test_crewai_flow_phase4.py tests/adapters/test_crewai_flow_phase5.py tests/adapters/test_crewai_flow_state_source.py tests/converters/test_crewai.py tests/converters/test_crewai_flow.py tests/integrations/test_crewai_tools.py tests/integrations/test_crewai_flow_real_sdk.py tests/framework_conformance/ -q -k crewai` passed: 308 passed, 7 skipped, 704 deselected.

Live provider/platform E2E was not run locally; the L2 live workflow is gated by `E2E_TESTS_ENABLED=true` and `E2E_BASELINE_L2_LIVE=true`.