### PR TITLE
test(tests): add L4 rehydration baseline

### DIFF
--- a/.github/workflows/baseline-l4-live.yml
+++ b/.github/workflows/baseline-l4-live.yml
@@ -1,0 +1,98 @@
+name: Band baseline L4 live
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '41 11 * * *'
+
+jobs:
+  baseline-l4-live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      E2E_TESTS_ENABLED: "true"
+      E2E_BASELINE_L4_LIVE: "true"
+      LANGGRAPH_RESTART_SMOKE: "true"
+      E2E_BASELINE_RUN_ID: ${{ github.run_id }}
+      E2E_BASELINE_ARTIFACT_DIR: .claude/reports/e2e-baseline-artifacts
+      THENVOI_BASE_URL: ${{ vars.THENVOI_BASE_URL }}
+      THENVOI_WS_URL: ${{ vars.THENVOI_WS_URL }}
+      TEST_AGENT_ID: ${{ secrets.TEST_AGENT_ID }}
+      THENVOI_API_KEY: ${{ secrets.THENVOI_API_KEY }}
+      THENVOI_API_KEY_USER: ${{ secrets.THENVOI_API_KEY_USER }}
+      E2E_LANGGRAPH_AGENT_ID: ${{ secrets.E2E_LANGGRAPH_AGENT_ID }}
+      E2E_LANGGRAPH_AGENT_API_KEY: ${{ secrets.E2E_LANGGRAPH_AGENT_API_KEY }}
+      E2E_LANGGRAPH_AGENT_NAME: ${{ vars.E2E_LANGGRAPH_AGENT_NAME }}
+      E2E_ANTHROPIC_AGENT_ID: ${{ secrets.E2E_ANTHROPIC_AGENT_ID }}
+      E2E_ANTHROPIC_AGENT_API_KEY: ${{ secrets.E2E_ANTHROPIC_AGENT_API_KEY }}
+      E2E_ANTHROPIC_AGENT_NAME: ${{ vars.E2E_ANTHROPIC_AGENT_NAME }}
+      E2E_PYDANTIC_AI_AGENT_ID: ${{ secrets.E2E_PYDANTIC_AI_AGENT_ID }}
+      E2E_PYDANTIC_AI_AGENT_API_KEY: ${{ secrets.E2E_PYDANTIC_AI_AGENT_API_KEY }}
+      E2E_PYDANTIC_AI_AGENT_NAME: ${{ vars.E2E_PYDANTIC_AI_AGENT_NAME }}
+      E2E_CLAUDE_SDK_AGENT_ID: ${{ secrets.E2E_CLAUDE_SDK_AGENT_ID }}
+      E2E_CLAUDE_SDK_AGENT_API_KEY: ${{ secrets.E2E_CLAUDE_SDK_AGENT_API_KEY }}
+      E2E_CLAUDE_SDK_AGENT_NAME: ${{ vars.E2E_CLAUDE_SDK_AGENT_NAME }}
+      E2E_GEMINI_AGENT_ID: ${{ secrets.E2E_GEMINI_AGENT_ID }}
+      E2E_GEMINI_AGENT_API_KEY: ${{ secrets.E2E_GEMINI_AGENT_API_KEY }}
+      E2E_GEMINI_AGENT_NAME: ${{ vars.E2E_GEMINI_AGENT_NAME }}
+      E2E_ECHO_AGENT_ID: ${{ secrets.E2E_ECHO_AGENT_ID }}
+      E2E_ECHO_AGENT_NAME: ${{ vars.E2E_ECHO_AGENT_NAME }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      GOOGLE_GENAI_USE_VERTEXAI: ${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}
+      GOOGLE_CLOUD_PROJECT: ${{ vars.GOOGLE_CLOUD_PROJECT }}
+      E2E_BASELINE_INPUT_USD_PER_MILLION_TOKENS: ${{ vars.E2E_BASELINE_INPUT_USD_PER_MILLION_TOKENS }}
+      E2E_BASELINE_OUTPUT_USD_PER_MILLION_TOKENS: ${{ vars.E2E_BASELINE_OUTPUT_USD_PER_MILLION_TOKENS }}
+      E2E_BASELINE_PRICING_SOURCE: ${{ vars.E2E_BASELINE_PRICING_SOURCE }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run live L4 baseline scenario
+        run: uv run pytest tests/e2e/scenarios/test_baseline_l4_rehydration.py -v -s --no-cov
+
+      - name: Require complete live L4 artifact matrix
+        run: |
+          uv run python - <<'PY'
+          import json
+          from pathlib import Path
+
+          expected = {
+              'anthropic', 'claude_sdk', 'codex', 'crewai', 'crewai_flow',
+              'gemini', 'google_adk', 'langgraph', 'letta', 'opencode',
+              'parlant', 'pydantic_ai',
+          }
+          artifact_dir = Path('.claude/reports/e2e-baseline-artifacts')
+          artifacts = [json.loads(path.read_text()) for path in artifact_dir.glob('*.json')]
+          level_artifacts = [artifact for artifact in artifacts if artifact.get('level') == 'L4']
+          adapters = {artifact.get('adapter') for artifact in level_artifacts}
+          missing = expected - adapters
+          if missing:
+              raise SystemExit('Missing live L4 artifact disposition for: ' + ', '.join(sorted(missing)))
+          if not any(artifact.get('status') != 'TIER2_BLOCKED' for artifact in level_artifacts):
+              raise SystemExit('No successful live L4 artifact was produced')
+          PY
+
+      - name: Upload baseline artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: baseline-l4-live-artifacts
+          path: .claude/reports/e2e-baseline-artifacts/*.json
+          if-no-files-found: warn

--- a/tests/e2e/scenarios/test_baseline_l4_rehydration.py
+++ b/tests/e2e/scenarios/test_baseline_l4_rehydration.py
@@ -1,0 +1,667 @@
+"""Gated live L4 cold-restart scenarios.
+
+Run with:
+    E2E_TESTS_ENABLED=true E2E_BASELINE_L4_LIVE=true LANGGRAPH_RESTART_SMOKE=true \
+        uv run pytest tests/e2e/scenarios/test_baseline_l4_rehydration.py -v -s --no-cov
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import multiprocessing
+import os
+import queue
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from thenvoi_rest import AsyncRestClient
+from thenvoi_rest.types import ParticipantRequest
+
+from thenvoi.agent import Agent
+from thenvoi.core.simple_adapter import ProviderUsageSnapshot
+
+from tests.e2e.adapters.conftest import (
+    AdapterFactory,
+    BASELINE_DEFAULT_PROVIDER_USAGE_ADAPTER_FACTORIES,
+    BASELINE_DEFAULT_PROVIDER_USAGE_BLOCKED_ADAPTER_NAMES,
+)
+from tests.e2e.baseline_artifacts import (
+    aggregate_provider_usage,
+    baseline_pricing_from_env,
+    start_baseline_tier2_timer,
+    write_baseline_tier2_artifact,
+    write_baseline_tier2_blocked_artifact,
+    write_provider_usage_blocked_artifact_if_needed,
+)
+from tests.e2e.conftest import E2EAgentCredentials, E2ESettings, requires_e2e
+from tests.e2e.helpers import (
+    assert_content_contains,
+    fetch_chat_messages,
+    mention_ids,
+    message_ids,
+    message_value,
+    participant_ids,
+    send_trigger_message,
+    wait_full_window_for_new_agent_text_messages,
+    wait_until_participant_absent,
+    wait_until_participant_present,
+)
+
+_STEP_TIMEOUT = 90.0
+_L4_SCENARIO_REFS = [
+    "L4.request.cold_start_history",
+    "L4.request.offline_pending_once",
+    "L4.request.handled_message_dedup",
+    "L4.request.completed_tool_no_requeue",
+]
+
+
+def _l4_live_blocked_reason() -> str | None:
+    if os.environ.get("E2E_BASELINE_L4_LIVE") != "true":
+        return "tier2_blocked: E2E_BASELINE_L4_LIVE=true not set for live L4 flow"
+    missing = [
+        name
+        for name in ("E2E_ECHO_AGENT_ID", "E2E_ECHO_AGENT_NAME")
+        if not os.environ.get(name)
+    ]
+    if missing:
+        return f"tier2_blocked: missing live L4 Echo configuration {', '.join(missing)}"
+    return None
+
+
+def _l4_langgraph_live_blocked_reason() -> str | None:
+    blocked_reason = _l4_live_blocked_reason()
+    if blocked_reason:
+        return blocked_reason
+    if os.environ.get("LANGGRAPH_RESTART_SMOKE") != "true":
+        return "tier2_blocked: LANGGRAPH_RESTART_SMOKE=true not set for supported LangGraph cold-restart proof"
+    return None
+
+
+def _marker_count(messages: list[object], marker: str) -> int:
+    return sum(
+        1
+        for message in messages
+        if marker in str(message_value(message, "content") or "")
+    )
+
+
+def _serialize_provider_usage_snapshots(
+    snapshots: list[ProviderUsageSnapshot],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "source": snapshot.source,
+            "input_tokens": snapshot.input_tokens,
+            "output_tokens": snapshot.output_tokens,
+            "total_tokens": snapshot.total_tokens,
+            "api_call_count": snapshot.api_call_count,
+            "cost_usd": snapshot.cost_usd,
+            "raw": snapshot.raw,
+        }
+        for snapshot in snapshots
+    ]
+
+
+def _deserialize_provider_usage_snapshots(
+    snapshots: list[dict[str, Any]],
+) -> list[ProviderUsageSnapshot]:
+    return [
+        ProviderUsageSnapshot(
+            source=str(snapshot["source"]),
+            input_tokens=int(snapshot["input_tokens"]),
+            output_tokens=int(snapshot["output_tokens"]),
+            total_tokens=int(snapshot["total_tokens"]),
+            api_call_count=int(snapshot.get("api_call_count", 1)),
+            cost_usd=snapshot.get("cost_usd"),
+            raw=dict(snapshot.get("raw") or {}),
+        )
+        for snapshot in snapshots
+    ]
+
+
+def _write_l4_usage_snapshots(
+    usage_path: Path,
+    snapshots: list[ProviderUsageSnapshot],
+) -> None:
+    usage_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = usage_path.with_name(f"{usage_path.name}.tmp")
+    tmp_path.write_text(
+        json.dumps(_serialize_provider_usage_snapshots(snapshots), allow_nan=False)
+        + "\n"
+    )
+    tmp_path.replace(usage_path)
+
+
+def _read_l4_usage_snapshots(usage_path: Path) -> list[ProviderUsageSnapshot]:
+    if not usage_path.exists():
+        return []
+    raw = json.loads(usage_path.read_text())
+    if not isinstance(raw, list):
+        return []
+    return _deserialize_provider_usage_snapshots(raw)
+
+
+def _usage_api_call_count(snapshots: list[ProviderUsageSnapshot]) -> int:
+    return sum(snapshot.api_call_count for snapshot in snapshots)
+
+
+def _wait_for_l4_usage_snapshots(
+    usage_path: Path,
+    *,
+    min_api_calls: int,
+    timeout: float,
+) -> list[ProviderUsageSnapshot]:
+    deadline = time.monotonic() + timeout
+    last_snapshots: list[ProviderUsageSnapshot] = []
+    while time.monotonic() < deadline:
+        last_snapshots = _read_l4_usage_snapshots(usage_path)
+        if _usage_api_call_count(last_snapshots) >= min_api_calls:
+            return last_snapshots
+        time.sleep(0.2)
+    raise AssertionError(
+        "tier2_blocked: first agent process did not persist provider usage before kill"
+    )
+
+
+async def _run_l4_first_agent_child_async(
+    *,
+    adapter_name: str,
+    agent_id: str,
+    api_key: str,
+    ws_url: str,
+    rest_url: str,
+    usage_path: Path,
+    ready_queue: multiprocessing.Queue,
+) -> None:
+    settings = E2ESettings()
+    adapter = BASELINE_DEFAULT_PROVIDER_USAGE_ADAPTER_FACTORIES[adapter_name](settings)
+    adapter.clear_provider_usage()
+    agent = Agent.create(
+        adapter=adapter,
+        agent_id=agent_id,
+        api_key=api_key,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    async def write_usage_until_killed() -> None:
+        while True:
+            _write_l4_usage_snapshots(usage_path, adapter.provider_usage_snapshots())
+            await asyncio.sleep(0.25)
+
+    async with agent:
+        usage_task = asyncio.create_task(write_usage_until_killed())
+        ready_queue.put({"status": "ready"})
+        try:
+            await asyncio.Event().wait()
+        finally:
+            usage_task.cancel()
+            _write_l4_usage_snapshots(usage_path, adapter.provider_usage_snapshots())
+
+
+def _run_l4_first_agent_child(
+    adapter_name: str,
+    agent_id: str,
+    api_key: str,
+    ws_url: str,
+    rest_url: str,
+    usage_path: str,
+    ready_queue: multiprocessing.Queue,
+) -> None:
+    try:
+        asyncio.run(
+            _run_l4_first_agent_child_async(
+                adapter_name=adapter_name,
+                agent_id=agent_id,
+                api_key=api_key,
+                ws_url=ws_url,
+                rest_url=rest_url,
+                usage_path=Path(usage_path),
+                ready_queue=ready_queue,
+            )
+        )
+    except BaseException as exc:
+        ready_queue.put({"status": "error", "message": repr(exc)})
+        raise
+
+
+def _wait_for_l4_child_ready(
+    process: multiprocessing.Process,
+    ready_queue: multiprocessing.Queue,
+    *,
+    timeout: float,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not process.is_alive():
+            raise AssertionError(
+                f"tier2_blocked: first agent process exited before readiness: {process.exitcode}"
+            )
+        try:
+            message = ready_queue.get(timeout=0.2)
+        except queue.Empty:
+            continue
+        if message.get("status") == "ready":
+            return
+        raise AssertionError(
+            "tier2_blocked: first agent process failed before readiness: "
+            f"{message.get('message')}"
+        )
+    raise AssertionError("tier2_blocked: first agent process did not become ready")
+
+
+def _terminate_l4_child_process(process: multiprocessing.Process) -> None:
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=5)
+    if process.is_alive():
+        process.kill()
+        process.join(timeout=5)
+    if process.is_alive():
+        raise AssertionError("tier2_blocked: first agent process survived termination")
+
+
+_L4_LIVE_BLOCKED_REASON = _l4_live_blocked_reason()
+pytestmark = pytest.mark.skipif(
+    _L4_LIVE_BLOCKED_REASON is not None,
+    reason=_L4_LIVE_BLOCKED_REASON or "tier2_blocked: unknown L4 live block",
+)
+
+
+@pytest.fixture(
+    params=tuple(BASELINE_DEFAULT_PROVIDER_USAGE_ADAPTER_FACTORIES.items()),
+    ids=lambda item: item[0],
+)
+def adapter_entry(request: pytest.FixtureRequest) -> tuple[str, AdapterFactory]:
+    adapter_name, factory = request.param
+    return str(adapter_name), factory
+
+
+@pytest.mark.parametrize(
+    "adapter_name", BASELINE_DEFAULT_PROVIDER_USAGE_BLOCKED_ADAPTER_NAMES
+)
+def test_l4_live_unsupported_adapter_rows_write_blocked_artifacts_when_configured(
+    adapter_name: str,
+) -> None:
+    blocked_reason = _l4_live_blocked_reason()
+    if blocked_reason:
+        pytest.skip(blocked_reason)
+    blocked_reason = write_provider_usage_blocked_artifact_if_needed(
+        scenario_id="L4.request.cold_start_history",
+        scenario_refs=_L4_SCENARIO_REFS,
+        adapter=adapter_name,
+    )
+    assert blocked_reason is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(700)
+@requires_e2e
+async def test_l4_live_adapter_cold_restart_rehydrates_without_replaying_invite_when_configured(
+    e2e_config: E2ESettings,
+    adapter_entry: tuple[str, AdapterFactory],
+    api_client: AsyncRestClient,
+    e2e_adapter_room: tuple[str, str, str],
+    e2e_adapter_agent_credentials: E2EAgentCredentials,
+    tmp_path: Path,
+) -> None:
+    blocked_reason = _l4_live_blocked_reason()
+    if blocked_reason:
+        pytest.skip(blocked_reason)
+
+    adapter_name, factory = adapter_entry
+    factory(e2e_config)
+    timer = start_baseline_tier2_timer()
+    pricing = baseline_pricing_from_env()
+    input_texts: list[str] = []
+    output_texts: list[str] = []
+    chat_id, _user_id, _user_name = e2e_adapter_room
+    agent_id = e2e_adapter_agent_credentials.agent_id
+    agent_name = e2e_adapter_agent_credentials.name
+    echo_id = os.environ["E2E_ECHO_AGENT_ID"]
+
+    try:
+        await api_client.human_api_participants.add_my_chat_participant(
+            chat_id,
+            participant=ParticipantRequest(participant_id=agent_id, role="member"),
+        )
+    except Exception as exc:
+        if getattr(exc, "status_code", None) != 409:
+            raise
+
+    if echo_id in await participant_ids(api_client, chat_id):
+        await api_client.human_api_participants.remove_my_chat_participant(
+            chat_id,
+            echo_id,
+        )
+        await wait_until_participant_absent(api_client, chat_id, echo_id, _STEP_TIMEOUT)
+
+    usage_path = tmp_path / f"{adapter_name}-first-agent-usage.json"
+    spawn_context = multiprocessing.get_context("spawn")
+    ready_queue = spawn_context.Queue()
+    first_agent_process = spawn_context.Process(
+        target=_run_l4_first_agent_child,
+        args=(
+            adapter_name,
+            agent_id,
+            e2e_adapter_agent_credentials.api_key,
+            e2e_config.thenvoi_ws_url,
+            e2e_config.thenvoi_base_url,
+            str(usage_path),
+            ready_queue,
+        ),
+    )
+    first_agent_process.start()
+    first_agent_exitcode: int | None = None
+    try:
+        _wait_for_l4_child_ready(
+            first_agent_process,
+            ready_queue,
+            timeout=_STEP_TIMEOUT,
+        )
+        before_step_1 = message_ids(await fetch_chat_messages(api_client, chat_id))
+        step_1_prompt = (
+            "for later: the three keywords are ELEPHANT SAXOPHONE MIDNIGHT "
+            "and my favorite color is TURQUOISE — then invite Echo to this room"
+        )
+        input_texts.append(step_1_prompt)
+        step_1_message_id = await send_trigger_message(
+            api_client,
+            chat_id,
+            step_1_prompt,
+            agent_name,
+            agent_id,
+        )
+        step_1_replies = await wait_full_window_for_new_agent_text_messages(
+            api_client,
+            chat_id,
+            agent_id,
+            before_step_1,
+            timeout=_STEP_TIMEOUT,
+        )
+        assert len(step_1_replies) == 1, [
+            message_value(message, "content") for message in step_1_replies
+        ]
+        output_texts.extend(
+            str(message_value(message, "content") or "") for message in step_1_replies
+        )
+        await wait_until_participant_present(
+            api_client, chat_id, echo_id, _STEP_TIMEOUT
+        )
+
+        before_marker = message_ids(await fetch_chat_messages(api_client, chat_id))
+        marker_prompt = "repeat the word UNIQUE_MARKER_789"
+        input_texts.append(marker_prompt)
+        marker_message_id = await send_trigger_message(
+            api_client,
+            chat_id,
+            marker_prompt,
+            agent_name,
+            agent_id,
+        )
+        marker_replies = await wait_full_window_for_new_agent_text_messages(
+            api_client,
+            chat_id,
+            agent_id,
+            before_marker,
+            timeout=_STEP_TIMEOUT,
+        )
+        assert len(marker_replies) == 1, [
+            message_value(message, "content") for message in marker_replies
+        ]
+        output_texts.extend(
+            str(message_value(message, "content") or "") for message in marker_replies
+        )
+        assert_content_contains(marker_replies, "UNIQUE_MARKER_789")
+        try:
+            pre_restart_snapshots = _wait_for_l4_usage_snapshots(
+                usage_path,
+                min_api_calls=2,
+                timeout=10,
+            )
+        except AssertionError as exc:
+            write_baseline_tier2_blocked_artifact(
+                scenario_id="L4.request.cold_start_history",
+                scenario_refs=_L4_SCENARIO_REFS,
+                adapter=adapter_name,
+                reason=str(exc),
+            )
+            raise
+    finally:
+        _terminate_l4_child_process(first_agent_process)
+        first_agent_exitcode = first_agent_process.exitcode
+    assert not first_agent_process.is_alive()
+    assert first_agent_exitcode is not None and first_agent_exitcode != 0
+
+    await api_client.human_api_participants.remove_my_chat_participant(chat_id, echo_id)
+    await wait_until_participant_absent(api_client, chat_id, echo_id, _STEP_TIMEOUT)
+
+    restart_prompt = (
+        "what were the three keywords and favorite color I gave you earlier?"
+    )
+    input_texts.append(restart_prompt)
+    before_restart = message_ids(await fetch_chat_messages(api_client, chat_id))
+    restart_message_id = await send_trigger_message(
+        api_client,
+        chat_id,
+        restart_prompt,
+        agent_name,
+        agent_id,
+    )
+
+    restarted_adapter = factory(e2e_config)
+    restarted_adapter.clear_provider_usage()
+    restarted_agent = Agent.create(
+        adapter=restarted_adapter,
+        agent_id=agent_id,
+        api_key=e2e_adapter_agent_credentials.api_key,
+        ws_url=e2e_config.thenvoi_ws_url,
+        rest_url=e2e_config.thenvoi_base_url,
+    )
+    async with restarted_agent:
+        restart_replies = await wait_full_window_for_new_agent_text_messages(
+            api_client,
+            chat_id,
+            agent_id,
+            before_restart,
+            timeout=_STEP_TIMEOUT,
+        )
+        assert len(restart_replies) == 1, [
+            message_value(message, "content") for message in restart_replies
+        ]
+        output_texts.extend(
+            str(message_value(message, "content") or "") for message in restart_replies
+        )
+        recalled_terms = ["ELEPHANT", "SAXOPHONE", "MIDNIGHT", "TURQUOISE"]
+        for term in recalled_terms:
+            assert_content_contains(restart_replies, term)
+        echo_absent_after_restart = echo_id not in await participant_ids(
+            api_client, chat_id
+        )
+        assert echo_absent_after_restart
+        all_messages_after_restart = await fetch_chat_messages(api_client, chat_id)
+        all_agent_messages_after_restart = [
+            message
+            for message in all_messages_after_restart
+            if message_value(message, "sender_id") == agent_id
+        ]
+        post_restart_agent_messages = [
+            message
+            for message in all_agent_messages_after_restart
+            if str(message_value(message, "id")) not in before_restart
+        ]
+        total_marker_count_after_restart = _marker_count(
+            all_agent_messages_after_restart, "UNIQUE_MARKER_789"
+        )
+        post_restart_marker_count = _marker_count(
+            post_restart_agent_messages, "UNIQUE_MARKER_789"
+        )
+        post_restart_echo_mentions = sum(
+            1
+            for message in post_restart_agent_messages
+            if echo_id in mention_ids(message)
+        )
+        assert total_marker_count_after_restart == 1
+        assert post_restart_marker_count == 0
+        assert post_restart_echo_mentions == 0
+        first_post_restart_usage = aggregate_provider_usage(
+            restarted_adapter.provider_usage_snapshots()
+        )
+        history_to_new_token_ratio = (
+            first_post_restart_usage.input_tokens
+            / first_post_restart_usage.output_tokens
+            if first_post_restart_usage.output_tokens > 0
+            else 0
+        )
+
+        before_are_you_there = message_ids(
+            await fetch_chat_messages(api_client, chat_id)
+        )
+        liveness_prompt = "are you there?"
+        input_texts.append(liveness_prompt)
+        liveness_message_id = await send_trigger_message(
+            api_client,
+            chat_id,
+            liveness_prompt,
+            agent_name,
+            agent_id,
+        )
+        final_replies = await wait_full_window_for_new_agent_text_messages(
+            api_client,
+            chat_id,
+            agent_id,
+            before_are_you_there,
+            timeout=_STEP_TIMEOUT,
+        )
+        assert len(final_replies) == 1, [
+            message_value(message, "content") for message in final_replies
+        ]
+        output_texts.extend(
+            str(message_value(message, "content") or "") for message in final_replies
+        )
+        echo_absent_after_liveness = echo_id not in await participant_ids(
+            api_client, chat_id
+        )
+        assert echo_absent_after_liveness
+        pre_restart_usage = aggregate_provider_usage(pre_restart_snapshots)
+        post_restart_usage = aggregate_provider_usage(
+            restarted_adapter.provider_usage_snapshots()
+        )
+        write_baseline_tier2_artifact(
+            scenario_id="L4.request.cold_start_history",
+            scenario_refs=_L4_SCENARIO_REFS,
+            adapter=adapter_name,
+            timer=timer,
+            pricing=pricing,
+            provider_usage=aggregate_provider_usage(
+                [
+                    *pre_restart_snapshots,
+                    *restarted_adapter.provider_usage_snapshots(),
+                ]
+            ),
+            input_texts=input_texts,
+            output_texts=output_texts,
+            observed_agent_text_message_count=(
+                len(step_1_replies)
+                + len(marker_replies)
+                + len(restart_replies)
+                + len(final_replies)
+            ),
+            evidence={
+                "L4.request.cold_start_history": {
+                    "observation_window_seconds": _STEP_TIMEOUT,
+                    "restart_prompt_message_id": restart_message_id,
+                    "restart_reply_count": len(restart_replies),
+                    "restart_reply_id": str(message_value(restart_replies[0], "id")),
+                    "recalled_terms": recalled_terms,
+                    "first_agent_restart_boundary": "terminated_child_process",
+                    "first_agent_process_exitcode": first_agent_exitcode,
+                    "pre_restart_provider_usage_api_calls": _usage_api_call_count(
+                        pre_restart_snapshots
+                    ),
+                },
+                "L4.request.offline_pending_once": {
+                    "offline_prompt_message_id": restart_message_id,
+                    "restart_reply_count": len(restart_replies),
+                    "restart_reply_id": str(message_value(restart_replies[0], "id")),
+                    "observation_window_seconds": _STEP_TIMEOUT,
+                },
+                "L4.request.handled_message_dedup": {
+                    "marker_prompt_message_id": marker_message_id,
+                    "marker_reply_id": str(message_value(marker_replies[0], "id")),
+                    "agent_marker_count_after_restart": total_marker_count_after_restart,
+                    "post_restart_marker_reply_count": post_restart_marker_count,
+                    "post_restart_agent_message_count": len(
+                        post_restart_agent_messages
+                    ),
+                },
+                "L4.request.completed_tool_no_requeue": {
+                    "invite_prompt_message_id": step_1_message_id,
+                    "echo_absent_after_restart": echo_absent_after_restart,
+                    "echo_absent_after_liveness": echo_absent_after_liveness,
+                    "post_restart_echo_mentions": post_restart_echo_mentions,
+                    "liveness_prompt_message_id": liveness_message_id,
+                    "liveness_reply_count": len(final_replies),
+                    "liveness_reply_id": str(message_value(final_replies[0], "id")),
+                },
+            },
+            platform_observations=[
+                {
+                    "kind": "message",
+                    "id": str(message_value(restart_replies[0], "id")),
+                    "assertion": "exactly one post-restart hydrated recall reply",
+                    "scenario_refs": [
+                        "L4.request.cold_start_history",
+                        "L4.request.offline_pending_once",
+                    ],
+                },
+                {
+                    "kind": "message_count",
+                    "id": chat_id,
+                    "assertion": "UNIQUE_MARKER_789 appears once overall and zero times after restart",
+                    "scenario_ref": "L4.request.handled_message_dedup",
+                },
+                {
+                    "kind": "room_state",
+                    "id": chat_id,
+                    "assertion": "Echo absent after restart and no post-restart Echo mention",
+                    "scenario_ref": "L4.request.completed_tool_no_requeue",
+                },
+                {
+                    "kind": "message",
+                    "id": str(message_value(final_replies[0], "id")),
+                    "assertion": "exactly one liveness reply after restart",
+                    "scenario_ref": "L4.request.completed_tool_no_requeue",
+                },
+            ],
+            l4_provider_token_split={
+                "history_replay_tokens": first_post_restart_usage.input_tokens,
+                "new_inference_tokens": first_post_restart_usage.output_tokens,
+                "history_to_new_token_ratio": history_to_new_token_ratio,
+                "source": "provider_reported_first_post_restart_call_proxy",
+                "pre_restart_input_tokens": pre_restart_usage.input_tokens,
+                "pre_restart_output_tokens": pre_restart_usage.output_tokens,
+                "post_restart_input_tokens": post_restart_usage.input_tokens,
+                "post_restart_output_tokens": post_restart_usage.output_tokens,
+            },
+        )
+
+
+@pytest.mark.asyncio
+@requires_e2e
+async def test_l4_live_langgraph_cold_restart_no_duplicate_response_when_configured() -> (
+    None
+):
+    blocked_reason = _l4_langgraph_live_blocked_reason()
+    if blocked_reason:
+        pytest.skip(blocked_reason)
+
+    from tests.e2e.scenarios.test_langgraph_restart_rehydration import (
+        run_langgraph_answers_down_message_once_after_restart,
+    )
+
+    await run_langgraph_answers_down_message_once_after_restart()

--- a/tests/e2e/scenarios/test_baseline_l4_rehydration.py
+++ b/tests/e2e/scenarios/test_baseline_l4_rehydration.py
@@ -17,11 +17,11 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from thenvoi_rest import AsyncRestClient
-from thenvoi_rest.types import ParticipantRequest
+from band_rest import AsyncRestClient
+from band_rest.types import ParticipantRequest
 
-from thenvoi.agent import Agent
-from thenvoi.core.simple_adapter import ProviderUsageSnapshot
+from band.agent import Agent
+from band.core.simple_adapter import ProviderUsageSnapshot
 
 from tests.e2e.adapters.conftest import (
     AdapterFactory,
@@ -349,8 +349,8 @@ async def test_l4_live_adapter_cold_restart_rehydrates_without_replaying_invite_
             adapter_name,
             agent_id,
             e2e_adapter_agent_credentials.api_key,
-            e2e_config.thenvoi_ws_url,
-            e2e_config.thenvoi_base_url,
+            e2e_config.band_ws_url,
+            e2e_config.band_base_url,
             str(usage_path),
             ready_queue,
         ),
@@ -459,8 +459,8 @@ async def test_l4_live_adapter_cold_restart_rehydrates_without_replaying_invite_
         adapter=restarted_adapter,
         agent_id=agent_id,
         api_key=e2e_adapter_agent_credentials.api_key,
-        ws_url=e2e_config.thenvoi_ws_url,
-        rest_url=e2e_config.thenvoi_base_url,
+        ws_url=e2e_config.band_ws_url,
+        rest_url=e2e_config.band_base_url,
     )
     async with restarted_agent:
         restart_replies = await wait_full_window_for_new_agent_text_messages(

--- a/tests/e2e/test_e2e_hygiene.py
+++ b/tests/e2e/test_e2e_hygiene.py
@@ -363,15 +363,14 @@ def test_tool_observations_require_call_and_result_after_turn_boundary() -> None
             "event-1",
             "tool_call",
             content=(
-                '{"name":"thenvoi_get_participants","tool_call_id":"call-1","args":{}}'
+                '{"name":"band_get_participants","tool_call_id":"call-1","args":{}}'
             ),
         ),
         _fake_message(
             "event-2",
             "tool_result",
             content=(
-                '{"name":"thenvoi_get_participants",'
-                '"tool_call_id":"call-1","output":[]}'
+                '{"name":"band_get_participants","tool_call_id":"call-1","output":[]}'
             ),
         ),
     ]
@@ -389,7 +388,7 @@ def test_tool_observations_require_call_and_result_after_turn_boundary() -> None
     ]
     assert_required_tool_observations(
         observations,
-        required_tool_names={"thenvoi_get_participants"},
+        required_tool_names={"band_get_participants"},
     )
 
 
@@ -410,12 +409,12 @@ def test_tool_observations_ignore_correct_text_without_read_tool_events() -> Non
         after_message_id="trigger-1",
     )
 
-    with pytest.raises(AssertionError, match="thenvoi_get_participants"):
+    with pytest.raises(AssertionError, match="band_get_participants"):
         assert_required_tool_observations(
             observations,
             required_tool_names={
-                "thenvoi_get_participants",
-                "thenvoi_lookup_peers",
+                "band_get_participants",
+                "band_lookup_peers",
             },
         )
 
@@ -425,7 +424,7 @@ def test_tool_observations_do_not_cross_turn_boundary() -> None:
         _fake_message(
             "event-before",
             "tool_call",
-            content=('{"name":"thenvoi_remove_participant","tool_call_id":"old-call"}'),
+            content=('{"name":"band_remove_participant","tool_call_id":"old-call"}'),
         ),
         _fake_message("trigger-1", "text", sender_id="user-1"),
     ]
@@ -438,10 +437,10 @@ def test_tool_observations_do_not_cross_turn_boundary() -> None:
     )
 
     assert observations == []
-    with pytest.raises(AssertionError, match="thenvoi_remove_participant"):
+    with pytest.raises(AssertionError, match="band_remove_participant"):
         assert_required_tool_observations(
             observations,
-            required_tool_names={"thenvoi_remove_participant"},
+            required_tool_names={"band_remove_participant"},
         )
 
 
@@ -452,7 +451,7 @@ def test_successful_tool_execution_correlates_unnamed_result_by_call_id() -> Non
             "event-1",
             "tool_call",
             content=(
-                '{"name":"thenvoi_send_message",'
+                '{"name":"band_send_message",'
                 '"tool_call_id":"call-1","args":{"content":"hello"}}'
             ),
         ),
@@ -471,7 +470,7 @@ def test_successful_tool_execution_correlates_unnamed_result_by_call_id() -> Non
     )
     execution = require_successful_tool_execution(
         observations,
-        tool_name="thenvoi_send_message",
+        tool_name="band_send_message",
     )
 
     assert execution.tool_call_id == "call-1"
@@ -486,7 +485,7 @@ def test_successful_tool_execution_rejects_error_result() -> None:
             "event-1",
             "tool_call",
             content=(
-                '{"name":"thenvoi_send_message",'
+                '{"name":"band_send_message",'
                 '"tool_call_id":"call-1","args":{"content":"hello"}}'
             ),
         ),
@@ -494,8 +493,8 @@ def test_successful_tool_execution_rejects_error_result() -> None:
             "event-2",
             "tool_result",
             content=(
-                '{"name":"thenvoi_send_message",'
-                '"tool_call_id":"call-1","output":"Error executing thenvoi_send_message"}'
+                '{"name":"band_send_message",'
+                '"tool_call_id":"call-1","output":"Error executing band_send_message"}'
             ),
         ),
     ]
@@ -510,5 +509,5 @@ def test_successful_tool_execution_rejects_error_result() -> None:
     with pytest.raises(AssertionError, match="reported an error"):
         require_successful_tool_execution(
             observations,
-            tool_name="thenvoi_send_message",
+            tool_name="band_send_message",
         )

--- a/tests/e2e/test_e2e_hygiene.py
+++ b/tests/e2e/test_e2e_hygiene.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+import importlib
+import os
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+from tests.e2e.conftest import (
+    DEFAULT_E2E_ADAPTERS,
+    E2ESettings,
+    _PROVIDER_BASE_URL_ENV_VARS,
+    _RateLimitedObjectProxy,
+    _assert_room_creation_budget_available,
+    _cleared_provider_base_url_env_vars,
+    _created_room_budget_from_env,
+    _track_created_room,
+)
+from tests.e2e.helpers import (
+    TrackingWebSocketClient,
+    assert_required_tool_observations,
+    listening_for_agent_responses,
+    require_successful_tool_execution,
+    tool_observations_after_boundary,
+)
+
+
+def test_e2e_settings_reject_placeholder_openai_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("E2E_LLM_MODEL", "gpt-X.X-mini")
+
+    with pytest.raises(ValidationError, match="concrete model name"):
+        E2ESettings()
+
+
+def test_e2e_settings_reject_placeholder_anthropic_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("E2E_ANTHROPIC_MODEL", "claude-placeholder")
+
+    with pytest.raises(ValidationError, match="concrete model name"):
+        E2ESettings()
+
+
+def test_default_anthropic_model_is_haiku_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("E2E_ANTHROPIC_MODEL", raising=False)
+
+    assert "haiku" in E2ESettings().e2e_anthropic_model.lower()
+
+
+def test_default_e2e_adapter_matrix_excludes_crewai_lane() -> None:
+    assert "crewai" not in DEFAULT_E2E_ADAPTERS
+    assert "pydantic_ai" in DEFAULT_E2E_ADAPTERS
+    assert "codex" in DEFAULT_E2E_ADAPTERS
+
+
+def test_baseline_l0_adapter_matrix_covers_every_non_bridge_adapter() -> None:
+    from tests.e2e.adapters.conftest import (
+        BASELINE_L0_ADAPTER_FACTORIES,
+        BASELINE_L0_BLOCKED_ADAPTER_NAMES,
+    )
+
+    expected_non_bridge = {
+        "anthropic",
+        "claude_sdk",
+        "codex",
+        "crewai",
+        "crewai_flow",
+        "gemini",
+        "google_adk",
+        "langgraph",
+        "letta",
+        "opencode",
+        "parlant",
+        "pydantic_ai",
+    }
+    runnable = set(BASELINE_L0_ADAPTER_FACTORIES)
+    blocked = set(BASELINE_L0_BLOCKED_ADAPTER_NAMES)
+
+    assert runnable | blocked == expected_non_bridge
+    assert not (runnable & blocked)
+
+
+def test_provider_usage_baseline_matrix_covers_every_non_bridge_adapter() -> None:
+    from tests.e2e.adapters.conftest import (
+        BASELINE_DEFAULT_PROVIDER_USAGE_ADAPTER_FACTORIES,
+        BASELINE_DEFAULT_PROVIDER_USAGE_BLOCKED_ADAPTER_NAMES,
+    )
+
+    expected_non_bridge = {
+        "anthropic",
+        "claude_sdk",
+        "codex",
+        "crewai",
+        "crewai_flow",
+        "gemini",
+        "google_adk",
+        "langgraph",
+        "letta",
+        "opencode",
+        "parlant",
+        "pydantic_ai",
+    }
+    runnable = set(BASELINE_DEFAULT_PROVIDER_USAGE_ADAPTER_FACTORIES)
+    blocked = set(BASELINE_DEFAULT_PROVIDER_USAGE_BLOCKED_ADAPTER_NAMES)
+
+    assert runnable | blocked == expected_non_bridge
+    assert not (runnable & blocked)
+
+
+def test_provider_base_url_overrides_are_scoped_for_live_e2e(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in _PROVIDER_BASE_URL_ENV_VARS:
+        monkeypatch.setenv(name, "http://localhost:9999")
+
+    with _cleared_provider_base_url_env_vars():
+        for name in _PROVIDER_BASE_URL_ENV_VARS:
+            assert name not in os.environ
+
+    for name in _PROVIDER_BASE_URL_ENV_VARS:
+        assert os.environ[name] == "http://localhost:9999"
+
+
+async def test_rate_limited_rest_proxy_waits_before_nested_api_calls() -> None:
+    endpoint = SimpleNamespace(fetch=AsyncMock(return_value="ok"))
+    limiter = SimpleNamespace(wait=AsyncMock())
+    proxy = _RateLimitedObjectProxy(SimpleNamespace(endpoint=endpoint), limiter)
+
+    result = await proxy.endpoint.fetch("room-1")
+
+    assert result == "ok"
+    limiter.wait.assert_awaited_once_with()
+    endpoint.fetch.assert_awaited_once_with("room-1")
+
+
+def test_crewai_factory_skips_without_crewai_lane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests.e2e.adapters import conftest as adapter_conftest
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(adapter_conftest, "_is_conflicting_crewai_lane", lambda: True)
+
+    with pytest.raises(pytest.skip.Exception, match="dev-crewai lane"):
+        adapter_conftest.create_crewai_adapter(E2ESettings())
+
+
+def test_parlant_module_import_does_not_mutate_agent_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("THENVOI_API_KEY", "thnv_u_test_user_key")
+    monkeypatch.delenv("TEST_AGENT_ID", raising=False)
+    monkeypatch.delenv("THENVOI_AGENT_ID", raising=False)
+    monkeypatch.delenv("THENVOI_API_KEY_USER", raising=False)
+
+    module = importlib.import_module("tests.e2e.adapters.test_parlant")
+    importlib.reload(module)
+
+    assert "TEST_AGENT_ID" not in os.environ
+    assert "THENVOI_AGENT_ID" not in os.environ
+    assert "THENVOI_API_KEY_USER" not in os.environ
+    assert os.environ["THENVOI_API_KEY"] == "thnv_u_test_user_key"
+
+
+def test_room_creation_budget_rejects_before_create() -> None:
+    with pytest.raises(pytest.fail.Exception, match="budget exhausted"):
+        _assert_room_creation_budget_available(
+            created_room_ids=["room-1"],
+            budget=1,
+            label="adapter:fresh",
+        )
+
+
+async def test_l3_room_creation_rejects_before_create_when_budget_exhausted() -> None:
+    from tests.e2e.scenarios.test_baseline_l3_multiparty import (
+        _LiveAgentSpec,
+        _create_l3_room,
+    )
+
+    client = SimpleNamespace(
+        agent_api_chats=SimpleNamespace(create_agent_chat=AsyncMock()),
+        agent_api_participants=SimpleNamespace(add_agent_chat_participant=AsyncMock()),
+    )
+    spec = _LiveAgentSpec(
+        role="test",
+        agent_id="agent-1",
+        api_key="thnv_a_test",
+        name="Agent One",
+        handle="owner/agent-one",
+        description="Agent one description",
+    )
+
+    with pytest.raises(pytest.fail.Exception, match="budget exhausted"):
+        await _create_l3_room(
+            client,
+            spec,
+            spec,
+            spec,
+            created_room_ids=["room-1"],
+            room_creation_budget=1,
+            user_peer=SimpleNamespace(id="user-1"),
+        )
+
+    client.agent_api_chats.create_agent_chat.assert_not_awaited()
+    client.agent_api_participants.add_agent_chat_participant.assert_not_awaited()
+
+
+def test_created_room_tracking_appends_only_with_budget() -> None:
+    created_room_ids: list[str] = []
+
+    _track_created_room(
+        created_room_ids=created_room_ids,
+        budget=1,
+        room_id="room-1",
+        label="adapter:fresh",
+    )
+
+    assert created_room_ids == ["room-1"]
+    with pytest.raises(pytest.fail.Exception, match="budget exhausted"):
+        _track_created_room(
+            created_room_ids=created_room_ids,
+            budget=1,
+            room_id="room-2",
+            label="adapter:fresh-2",
+        )
+    assert created_room_ids == ["room-1"]
+
+
+def test_room_creation_budget_env_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("E2E_CREATED_ROOM_BUDGET", "2")
+    assert _created_room_budget_from_env() == 2
+
+    monkeypatch.setenv("E2E_CREATED_ROOM_BUDGET", "-1")
+    with pytest.raises(ValueError, match=">= 0"):
+        _created_room_budget_from_env()
+
+
+def test_codex_e2e_requires_explicit_disposable_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from tests.e2e.adapters import conftest as adapter_conftest
+
+    monkeypatch.delenv("CODEX_CWD", raising=False)
+    with pytest.raises(pytest.skip.Exception, match="CODEX_CWD"):
+        adapter_conftest._require_codex_disposable_cwd()
+
+    monkeypatch.setenv("CODEX_CWD", str(tmp_path))
+    monkeypatch.delenv("E2E_CODEX_CWD_IS_DISPOSABLE", raising=False)
+    with pytest.raises(pytest.skip.Exception, match="E2E_CODEX_CWD_IS_DISPOSABLE"):
+        adapter_conftest._require_codex_disposable_cwd()
+
+    monkeypatch.setenv("E2E_CODEX_CWD_IS_DISPOSABLE", "true")
+    assert adapter_conftest._require_codex_disposable_cwd() == str(tmp_path.resolve())
+
+
+def test_write_capable_auto_approval_requires_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests.e2e.adapters import conftest as adapter_conftest
+
+    monkeypatch.setenv("CODEX_APPROVAL_MODE", "auto_accept")
+    monkeypatch.delenv("E2E_ALLOW_WRITE_CAPABLE_AUTO_APPROVAL", raising=False)
+    with pytest.raises(pytest.skip.Exception, match="auto_accept requires"):
+        adapter_conftest._safe_approval_mode(
+            adapter_name="Codex",
+            env_var="CODEX_APPROVAL_MODE",
+            default="manual",
+        )
+
+    monkeypatch.setenv("E2E_ALLOW_WRITE_CAPABLE_AUTO_APPROVAL", "true")
+    assert (
+        adapter_conftest._safe_approval_mode(
+            adapter_name="Codex",
+            env_var="CODEX_APPROVAL_MODE",
+            default="manual",
+        )
+        == "auto_accept"
+    )
+
+    monkeypatch.delenv("CODEX_APPROVAL_MODE", raising=False)
+    assert (
+        adapter_conftest._safe_approval_mode(
+            adapter_name="Codex",
+            env_var="CODEX_APPROVAL_MODE",
+            default="manual",
+        )
+        == "manual"
+    )
+
+
+class _FailingLeaveWebSocket:
+    async def join_chat_room_channel(
+        self,
+        chat_room_id: str,
+        on_message_created: Callable[[Any], Awaitable[None]],
+    ) -> None:
+        self.chat_room_id = chat_room_id
+        self.on_message_created = on_message_created
+
+    async def leave_chat_room_channel(self, chat_room_id: str) -> None:
+        raise RuntimeError(f"cannot leave {chat_room_id}")
+
+
+async def test_tracking_websocket_cleanup_failures_are_visible() -> None:
+    ws = TrackingWebSocketClient(_FailingLeaveWebSocket())
+    await ws.join_chat_room_channel("room-1", AsyncMock())
+
+    with pytest.raises(AssertionError, match="Failed to leave E2E WebSocket"):
+        await ws.cleanup_channels()
+
+
+async def test_listener_cleanup_failure_fails_when_body_succeeds() -> None:
+    ws = _FailingLeaveWebSocket()
+
+    with pytest.raises(AssertionError, match="Failed to leave E2E WebSocket"):
+        async with listening_for_agent_responses(ws, "room-1"):
+            pass
+
+
+async def test_listener_cleanup_failure_preserves_primary_failure() -> None:
+    ws = _FailingLeaveWebSocket()
+
+    with pytest.raises(ValueError, match="primary") as exc_info:
+        async with listening_for_agent_responses(ws, "room-1"):
+            raise ValueError("primary")
+
+    notes = getattr(exc_info.value, "__notes__", [])
+    assert any("Cleanup error" in note for note in notes)
+
+
+def _fake_message(
+    message_id: str,
+    message_type: str,
+    *,
+    sender_id: str = "agent-1",
+    content: str = "",
+    room_id: str = "room-1",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=message_id,
+        message_type=message_type,
+        sender_id=sender_id,
+        chat_room_id=room_id,
+        content=content,
+        metadata={},
+    )
+
+
+def test_tool_observations_require_call_and_result_after_turn_boundary() -> None:
+    messages = [
+        _fake_message("trigger-1", "text", sender_id="user-1"),
+        _fake_message(
+            "event-1",
+            "tool_call",
+            content=(
+                '{"name":"thenvoi_get_participants","tool_call_id":"call-1","args":{}}'
+            ),
+        ),
+        _fake_message(
+            "event-2",
+            "tool_result",
+            content=(
+                '{"name":"thenvoi_get_participants",'
+                '"tool_call_id":"call-1","output":[]}'
+            ),
+        ),
+    ]
+
+    observations = tool_observations_after_boundary(
+        messages,
+        room_id="room-1",
+        agent_id="agent-1",
+        after_message_id="trigger-1",
+    )
+
+    assert [observation.message_type for observation in observations] == [
+        "tool_call",
+        "tool_result",
+    ]
+    assert_required_tool_observations(
+        observations,
+        required_tool_names={"thenvoi_get_participants"},
+    )
+
+
+def test_tool_observations_ignore_correct_text_without_read_tool_events() -> None:
+    messages = [
+        _fake_message("trigger-1", "text", sender_id="user-1"),
+        _fake_message(
+            "reply-1",
+            "text",
+            content="CURRENT_ROOM: User, Agent\nINVITABLE_PEERS: Echo",
+        ),
+    ]
+
+    observations = tool_observations_after_boundary(
+        messages,
+        room_id="room-1",
+        agent_id="agent-1",
+        after_message_id="trigger-1",
+    )
+
+    with pytest.raises(AssertionError, match="thenvoi_get_participants"):
+        assert_required_tool_observations(
+            observations,
+            required_tool_names={
+                "thenvoi_get_participants",
+                "thenvoi_lookup_peers",
+            },
+        )
+
+
+def test_tool_observations_do_not_cross_turn_boundary() -> None:
+    messages = [
+        _fake_message(
+            "event-before",
+            "tool_call",
+            content=('{"name":"thenvoi_remove_participant","tool_call_id":"old-call"}'),
+        ),
+        _fake_message("trigger-1", "text", sender_id="user-1"),
+    ]
+
+    observations = tool_observations_after_boundary(
+        messages,
+        room_id="room-1",
+        agent_id="agent-1",
+        after_message_id="trigger-1",
+    )
+
+    assert observations == []
+    with pytest.raises(AssertionError, match="thenvoi_remove_participant"):
+        assert_required_tool_observations(
+            observations,
+            required_tool_names={"thenvoi_remove_participant"},
+        )
+
+
+def test_successful_tool_execution_correlates_unnamed_result_by_call_id() -> None:
+    messages = [
+        _fake_message("trigger-1", "text", sender_id="user-1"),
+        _fake_message(
+            "event-1",
+            "tool_call",
+            content=(
+                '{"name":"thenvoi_send_message",'
+                '"tool_call_id":"call-1","args":{"content":"hello"}}'
+            ),
+        ),
+        _fake_message(
+            "event-2",
+            "tool_result",
+            content='{"tool_call_id":"call-1","output":{"id":"msg-1"}}',
+        ),
+    ]
+
+    observations = tool_observations_after_boundary(
+        messages,
+        room_id="room-1",
+        agent_id="agent-1",
+        after_message_id="trigger-1",
+    )
+    execution = require_successful_tool_execution(
+        observations,
+        tool_name="thenvoi_send_message",
+    )
+
+    assert execution.tool_call_id == "call-1"
+    assert execution.call.event_id == "event-1"
+    assert execution.result.event_id == "event-2"
+
+
+def test_successful_tool_execution_rejects_error_result() -> None:
+    messages = [
+        _fake_message("trigger-1", "text", sender_id="user-1"),
+        _fake_message(
+            "event-1",
+            "tool_call",
+            content=(
+                '{"name":"thenvoi_send_message",'
+                '"tool_call_id":"call-1","args":{"content":"hello"}}'
+            ),
+        ),
+        _fake_message(
+            "event-2",
+            "tool_result",
+            content=(
+                '{"name":"thenvoi_send_message",'
+                '"tool_call_id":"call-1","output":"Error executing thenvoi_send_message"}'
+            ),
+        ),
+    ]
+
+    observations = tool_observations_after_boundary(
+        messages,
+        room_id="room-1",
+        agent_id="agent-1",
+        after_message_id="trigger-1",
+    )
+
+    with pytest.raises(AssertionError, match="reported an error"):
+        require_successful_tool_execution(
+            observations,
+            tool_name="thenvoi_send_message",
+        )

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -483,7 +483,11 @@ def _build_crewai_flow_config() -> AdapterConfig:
 
 
 def _build_claude_sdk_config() -> AdapterConfig | None:
-    from band.adapters.claude_sdk import _CLAUDE_SDK_AVAILABLE, ClaudeSDKAdapter
+    from band.adapters.claude_sdk import (
+        _CLAUDE_SDK_AVAILABLE,
+        _DEFAULT_MODEL,
+        ClaudeSDKAdapter,
+    )
 
     if not _CLAUDE_SDK_AVAILABLE:
         return None  # optional dep not installed; skip in CI
@@ -493,7 +497,7 @@ def _build_claude_sdk_config() -> AdapterConfig | None:
         display_name="ClaudeSDK",
         adapter_factory=_claude_sdk_factory,
         expected_initial_values={
-            "model": _default_from_init(ClaudeSDKAdapter, "model"),
+            "model": _DEFAULT_MODEL,
             "fallback_model": _default_from_init(ClaudeSDKAdapter, "fallback_model"),
             "custom_section": _default_from_init(ClaudeSDKAdapter, "custom_section"),
             "max_thinking_tokens": _default_from_init(

--- a/tests/framework_conformance/test_baseline_l4_rehydration.py
+++ b/tests/framework_conformance/test_baseline_l4_rehydration.py
@@ -1,0 +1,450 @@
+"""L4 rehydration baseline conformance rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from anthropic.types import TextBlock
+from pydantic import BaseModel
+
+from thenvoi.adapters.anthropic import AnthropicAdapter
+from thenvoi.core.types import AgentInput
+from thenvoi.runtime.execution import ExecutionContext
+from thenvoi.runtime.types import SessionConfig
+
+from tests.framework_conformance.baseline_applicability import (
+    ApplicabilityStatus,
+    build_applicability_matrix,
+)
+from tests.framework_conformance.baseline_scenarios import SCENARIOS_BY_ID
+from tests.framework_conformance.baseline_status import BaselineContract
+from tests.framework_conformance.platform_fixtures import (
+    AGENT_ID,
+    ROOM_ID,
+    USER_ID,
+    ConformanceExecutionContext,
+    build_agent_input_through_preprocessor,
+    canonical_history,
+    canonical_participants,
+    completed_tool_history,
+    current_message_event,
+    history_message,
+)
+from tests.framework_conformance.request_capture import (
+    REQUEST_CAPTURE_ADAPTER_IDS,
+    ConformanceSchemaRecorder,
+    CapturedRequest,
+    CapturedRequestItem,
+    RehydrationRequestState,
+    RequestItemPurpose,
+    capture_request,
+    visible_text,
+)
+
+_PENDING_L4_ID = "msg-l4-offline-pending"
+_CURRENT_L4_ID = "msg-l4-current-trigger"
+
+
+class _L4ReplayGuardInput(BaseModel):
+    """A custom side-effect tool that must not be replayed from history."""
+
+    code: str
+
+
+@dataclass(frozen=True)
+class _ScriptedResponse:
+    stop_reason: str
+    content: list[Any]
+
+
+class _NoReplayAnthropicAdapter(AnthropicAdapter):
+    def __init__(self, *, calls: list[_L4ReplayGuardInput]) -> None:
+        async def l4_replay_guard(args: _L4ReplayGuardInput) -> dict[str, str]:
+            calls.append(args)
+            return {"replayed": args.code}
+
+        super().__init__(
+            provider_key="test-provider-key",
+            additional_tools=[(_L4ReplayGuardInput, l4_replay_guard)],
+        )
+        self._responses = [
+            _ScriptedResponse(
+                stop_reason="end_turn",
+                content=[TextBlock(text="done", type="text")],
+            )
+        ]
+
+    async def _call_anthropic(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[Any],
+    ) -> Any:
+        del messages, tools
+        return self._responses.pop(0)
+
+
+def _rehydration_state(captured: CapturedRequest) -> RehydrationRequestState:
+    assert captured.supports_rehydration_state
+    assert captured.rehydration is not None
+    return captured.rehydration
+
+
+def _assert_no_current_tool_replay(captured: CapturedRequest) -> None:
+    state = _rehydration_state(captured)
+    assert state.completed_tool_call_ids == ("tool-call-001",)
+    assert state.pending_tool_call_ids == ()
+    assert all(
+        item.tool_call_id != "tool-call-001"
+        for item in captured.items
+        if item.purpose is RequestItemPurpose.CURRENT_WORK
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", REQUEST_CAPTURE_ADAPTER_IDS)
+async def test_l4_cold_start_rebuilds_persisted_history_in_canonical_order(
+    adapter_id: str,
+) -> None:
+    history = [*canonical_history(), *completed_tool_history()]
+    ctx = ConformanceExecutionContext(history_messages=history)
+    agent_input = await build_agent_input_through_preprocessor(
+        ctx=ctx,
+        event=current_message_event(
+            content="@darvell/test-agent continue from cold start.",
+            message_id=_CURRENT_L4_ID,
+        ),
+    )
+
+    captured = await capture_request(adapter_id, agent_input)
+    expected_history_ids = (
+        "msg-history-001",
+        "msg-history-002",
+        "msg-history-003",
+        "msg-tool-call-001",
+        "msg-tool-result-001",
+    )
+    state = _rehydration_state(captured)
+
+    assert state.history_message_ids == expected_history_ids
+    assert state.current_work_message_ids == (_CURRENT_L4_ID,)
+    assert captured.message_ids == [*expected_history_ids, _CURRENT_L4_ID]
+    text = visible_text(captured)
+    assert "MARCO" in text
+    assert "LIGHTHOUSE" in text
+    assert "POSTGRESQL" in text
+    assert "thenvoi_send_message" in text
+    assert "tool-call-001" in text
+    assert "msg-sent" in text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", REQUEST_CAPTURE_ADAPTER_IDS)
+async def test_l4_offline_pending_message_is_current_work_not_inert_history(
+    adapter_id: str,
+) -> None:
+    pending_context_message = history_message(
+        message_id=_PENDING_L4_ID,
+        content="OFFLINE-L4-PENDING should execute once as current work.",
+        sender_id="22222222-2222-4222-8222-222222222222",
+        sender_type="User",
+        sender_name="Darvell",
+        offset_seconds=4,
+        metadata={"mentions": [], "source_message_id": _PENDING_L4_ID},
+    )
+    ctx = ConformanceExecutionContext(
+        history_messages=[*canonical_history(), pending_context_message]
+    )
+    agent_input = await build_agent_input_through_preprocessor(
+        ctx=ctx,
+        event=current_message_event(
+            content="OFFLINE-L4-PENDING should execute once as current work.",
+            message_id=_PENDING_L4_ID,
+        ),
+    )
+
+    captured = await capture_request(adapter_id, agent_input)
+    state = _rehydration_state(captured)
+
+    assert state.current_work_message_ids == (_PENDING_L4_ID,)
+    assert _PENDING_L4_ID not in state.history_message_ids
+    assert state.source_message_counts[_PENDING_L4_ID] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", REQUEST_CAPTURE_ADAPTER_IDS)
+async def test_l4_handled_message_is_history_not_current_work(adapter_id: str) -> None:
+    handled_id = "msg-l4-handled-user"
+    pending_id = "msg-l4-unhandled-pending"
+    handled_message = history_message(
+        message_id=handled_id,
+        content="HANDLED-L4 should remain historical only.",
+        sender_id=USER_ID,
+        sender_type="User",
+        sender_name="Darvell",
+        offset_seconds=4,
+        metadata={"mentions": [], "source_message_id": handled_id},
+    )
+    handled_reply = history_message(
+        message_id="msg-l4-handled-reply",
+        content="HANDLED-L4 already answered.",
+        sender_id=AGENT_ID,
+        sender_type="Agent",
+        sender_name="Test Agent",
+        offset_seconds=5,
+        metadata={"mentions": [], "source_message_id": handled_id},
+    )
+    ctx = ConformanceExecutionContext(
+        history_messages=[*canonical_history(), handled_message, handled_reply]
+    )
+    agent_input = await build_agent_input_through_preprocessor(
+        ctx=ctx,
+        event=current_message_event(
+            content="UNHANDLED-L4 should be the only current work.",
+            message_id=pending_id,
+        ),
+    )
+
+    captured = await capture_request(adapter_id, agent_input)
+    state = _rehydration_state(captured)
+
+    assert state.current_work_message_ids == (pending_id,)
+    assert handled_id in state.history_message_ids
+    assert handled_id not in state.current_work_message_ids
+    assert state.source_message_counts[handled_id] == 2
+    assert "HANDLED-L4 should remain historical only." in visible_text(captured)
+    assert "HANDLED-L4 already answered." in visible_text(captured)
+
+
+@pytest.mark.asyncio
+async def test_l4_processed_replay_message_does_not_reach_adapter_handler() -> None:
+    handled_id = "msg-l4-processed-replay"
+    handled_context_message = history_message(
+        message_id=handled_id,
+        content="@darvell/test-agent PROCESSED-L4 must not reopen.",
+        sender_id=USER_ID,
+        sender_type="User",
+        sender_name="Darvell",
+        offset_seconds=4,
+        metadata={
+            "mentions": [],
+            "source_message_id": handled_id,
+            "delivery_status": {AGENT_ID: {"status": "processed"}},
+        },
+    )
+    handled_reply = history_message(
+        message_id="msg-l4-processed-reply",
+        content="PROCESSED-L4 was already answered.",
+        sender_id=AGENT_ID,
+        sender_type="Agent",
+        sender_name="Test Agent",
+        offset_seconds=5,
+        metadata={"mentions": [], "source_message_id": handled_id},
+    )
+    context_items = []
+    for message in (handled_context_message, handled_reply):
+        item = MagicMock()
+        item.id = message["id"]
+        item.content = message["content"]
+        item.sender_id = message["sender_id"]
+        item.sender_type = message["sender_type"]
+        item.sender_name = message["sender_name"]
+        item.message_type = message["message_type"]
+        item.metadata = message["metadata"]
+        item.inserted_at = message["inserted_at"]
+        context_items.append(item)
+
+    handler = AsyncMock()
+    link = MagicMock()
+    link.mark_processing = AsyncMock(return_value=True)
+    link.mark_processed = AsyncMock(return_value=True)
+    link.mark_failed = AsyncMock(return_value=True)
+    link.rest.agent_api_participants.list_agent_chat_participants = AsyncMock(
+        return_value=MagicMock(data=[])
+    )
+    link.rest.agent_api_context.get_agent_chat_context = AsyncMock(
+        return_value=MagicMock(data=context_items)
+    )
+    ctx = ExecutionContext(
+        room_id=ROOM_ID,
+        link=link,
+        on_execute=handler,
+        config=SessionConfig(enable_context_hydration=True),
+        agent_id=AGENT_ID,
+    )
+    replay_event = current_message_event(
+        content="@darvell/test-agent PROCESSED-L4 must not reopen.",
+        message_id=handled_id,
+    )
+
+    processed = await ctx._process_event(replay_event)
+
+    assert processed is True
+    handler.assert_not_called()
+    link.mark_processing.assert_not_called()
+    link.mark_processed.assert_not_called()
+    link.mark_failed.assert_not_called()
+    assert handled_id in ctx._processed_ids
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("adapter_id", REQUEST_CAPTURE_ADAPTER_IDS)
+async def test_l4_completed_tool_history_is_inert_for_request_capture_adapters(
+    adapter_id: str,
+) -> None:
+    tools = ConformanceSchemaRecorder(
+        participants=canonical_participants(),
+        room_id=ROOM_ID,
+    )
+    ctx = ConformanceExecutionContext(
+        history_messages=[*canonical_history(), *completed_tool_history()]
+    )
+    agent_input = await build_agent_input_through_preprocessor(ctx=ctx)
+    agent_input = AgentInput(
+        msg=agent_input.msg,
+        tools=tools,
+        history=agent_input.history,
+        participants_msg=agent_input.participants_msg,
+        contacts_msg=agent_input.contacts_msg,
+        is_session_bootstrap=agent_input.is_session_bootstrap,
+        room_id=agent_input.room_id,
+    )
+
+    captured = await capture_request(adapter_id, agent_input)
+    text = visible_text(captured)
+
+    state = _rehydration_state(captured)
+
+    assert "msg-tool-call-001" in state.history_message_ids
+    assert "msg-tool-result-001" in state.history_message_ids
+    _assert_no_current_tool_replay(captured)
+    assert "tool-call-001" in text
+    assert "msg-sent" in text
+    assert tools.tool_calls == []
+    assert tools.messages_sent == []
+
+
+@pytest.mark.asyncio
+async def test_l4_tool_replay_oracle_rejects_completed_tool_as_current_work() -> None:
+    captured = await capture_request(
+        REQUEST_CAPTURE_ADAPTER_IDS[0],
+        await build_agent_input_through_preprocessor(
+            ctx=ConformanceExecutionContext(
+                history_messages=[*canonical_history(), *completed_tool_history()]
+            )
+        ),
+    )
+    replay_item = CapturedRequestItem(
+        surface="test",
+        index=999,
+        role="assistant",
+        text="replayed completed tool call",
+        purpose=RequestItemPurpose.CURRENT_WORK,
+        tool_call_id="tool-call-001",
+    )
+    mutated = replace(captured, items=(*captured.items, replay_item))
+
+    with pytest.raises(AssertionError):
+        _assert_no_current_tool_replay(mutated)
+
+
+@pytest.mark.asyncio
+async def test_l4_tool_replay_oracle_rejects_pending_completed_tool_split() -> None:
+    captured = await capture_request(
+        REQUEST_CAPTURE_ADAPTER_IDS[0],
+        await build_agent_input_through_preprocessor(
+            ctx=ConformanceExecutionContext(
+                history_messages=[*canonical_history(), *completed_tool_history()]
+            )
+        ),
+    )
+    state = _rehydration_state(captured)
+    mutated_state = replace(state, pending_tool_call_ids=("tool-call-001",))
+    mutated = replace(captured, rehydration=mutated_state)
+
+    with pytest.raises(AssertionError):
+        _assert_no_current_tool_replay(mutated)
+
+
+@pytest.mark.asyncio
+async def test_l4_completed_tool_history_does_not_replay_side_effects() -> None:
+    calls: list[_L4ReplayGuardInput] = []
+    tools = ConformanceSchemaRecorder(
+        participants=canonical_participants(),
+        room_id=ROOM_ID,
+    )
+    ctx = ConformanceExecutionContext(
+        history_messages=[*canonical_history(), *completed_tool_history()]
+    )
+    agent_input = await build_agent_input_through_preprocessor(ctx=ctx)
+    agent_input = AgentInput(
+        msg=agent_input.msg,
+        tools=tools,
+        history=agent_input.history,
+        participants_msg=agent_input.participants_msg,
+        contacts_msg=agent_input.contacts_msg,
+        is_session_bootstrap=agent_input.is_session_bootstrap,
+        room_id=agent_input.room_id,
+    )
+    adapter = _NoReplayAnthropicAdapter(calls=calls)
+
+    await adapter.on_started("Test Agent", "A conformance test agent")
+    await adapter.on_event(agent_input)
+
+    assert calls == []
+    assert tools.tool_calls == []
+
+
+def test_l4_rehydration_rows_are_request_visible_except_cleanup_hardening() -> None:
+    request_rows = {
+        "L4.request.offline_pending_once",
+        "L4.request.handled_message_dedup",
+        "L4.request.completed_tool_no_requeue",
+    }
+    for row_id in request_rows:
+        scenario = SCENARIOS_BY_ID[row_id]
+        assert scenario.core_contract is True
+        assert scenario.domain_contract is BaselineContract.L4_REHYDRATION
+        assert scenario.requires_request_capture is True
+
+    cleanup = SCENARIOS_BY_ID["L4.runtime.cleanup_not_required_for_crash_correctness"]
+    assert cleanup.core_contract is False
+
+    cells = [
+        cell
+        for cell in build_applicability_matrix()
+        if cell.scenario_id in {*request_rows, cleanup.id}
+    ]
+    assert cells
+    covered = [
+        cell for cell in cells if cell.status is ApplicabilityStatus.COVERED_BY_EXISTING
+    ]
+    excluded = [
+        cell for cell in cells if cell.status is ApplicabilityStatus.EXCLUDED_BRIDGE
+    ]
+    blocked = [
+        cell for cell in cells if cell.status is ApplicabilityStatus.TIER2_BLOCKED
+    ]
+    applicable = [
+        cell for cell in cells if cell.status is ApplicabilityStatus.APPLICABLE
+    ]
+    assert covered
+    assert excluded
+    assert blocked
+    assert len(covered) + len(excluded) + len(blocked) + len(applicable) == len(cells)
+    assert all(cell.covered_by_existing is not None for cell in covered)
+    assert all(cell.coverage_evidence for cell in covered)
+
+    request_cells = [cell for cell in cells if cell.scenario_id in request_rows]
+    assert {
+        cell.adapter_id
+        for cell in request_cells
+        if cell.status is not ApplicabilityStatus.APPLICABLE
+    } == {
+        "crewai_flow",
+        "a2a",
+        "a2a_gateway",
+        "acp",
+    }

--- a/tests/framework_conformance/test_baseline_l4_rehydration.py
+++ b/tests/framework_conformance/test_baseline_l4_rehydration.py
@@ -10,10 +10,10 @@ import pytest
 from anthropic.types import TextBlock
 from pydantic import BaseModel
 
-from thenvoi.adapters.anthropic import AnthropicAdapter
-from thenvoi.core.types import AgentInput
-from thenvoi.runtime.execution import ExecutionContext
-from thenvoi.runtime.types import SessionConfig
+from band.adapters.anthropic import AnthropicAdapter
+from band.core.types import AgentInput
+from band.runtime.execution import ExecutionContext
+from band.runtime.types import SessionConfig
 
 from tests.framework_conformance.baseline_applicability import (
     ApplicabilityStatus,
@@ -135,7 +135,7 @@ async def test_l4_cold_start_rebuilds_persisted_history_in_canonical_order(
     assert "MARCO" in text
     assert "LIGHTHOUSE" in text
     assert "POSTGRESQL" in text
-    assert "thenvoi_send_message" in text
+    assert "band_send_message" in text
     assert "tool-call-001" in text
     assert "msg-sent" in text
 
@@ -447,4 +447,5 @@ def test_l4_rehydration_rows_are_request_visible_except_cleanup_hardening() -> N
         "a2a",
         "a2a_gateway",
         "acp",
+        "slack",
     }

--- a/tests/framework_conformance/test_baseline_l4_rehydration.py
+++ b/tests/framework_conformance/test_baseline_l4_rehydration.py
@@ -7,10 +7,8 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from anthropic.types import TextBlock
 from pydantic import BaseModel
 
-from band.adapters.anthropic import AnthropicAdapter
 from band.core.types import AgentInput
 from band.runtime.execution import ExecutionContext
 from band.runtime.types import SessionConfig
@@ -58,32 +56,6 @@ class _L4ReplayGuardInput(BaseModel):
 class _ScriptedResponse:
     stop_reason: str
     content: list[Any]
-
-
-class _NoReplayAnthropicAdapter(AnthropicAdapter):
-    def __init__(self, *, calls: list[_L4ReplayGuardInput]) -> None:
-        async def l4_replay_guard(args: _L4ReplayGuardInput) -> dict[str, str]:
-            calls.append(args)
-            return {"replayed": args.code}
-
-        super().__init__(
-            provider_key="test-provider-key",
-            additional_tools=[(_L4ReplayGuardInput, l4_replay_guard)],
-        )
-        self._responses = [
-            _ScriptedResponse(
-                stop_reason="end_turn",
-                content=[TextBlock(text="done", type="text")],
-            )
-        ]
-
-    async def _call_anthropic(
-        self,
-        messages: list[dict[str, Any]],
-        tools: list[Any],
-    ) -> Any:
-        del messages, tools
-        return self._responses.pop(0)
 
 
 def _rehydration_state(captured: CapturedRequest) -> RehydrationRequestState:
@@ -370,6 +342,35 @@ async def test_l4_tool_replay_oracle_rejects_pending_completed_tool_split() -> N
 
 @pytest.mark.asyncio
 async def test_l4_completed_tool_history_does_not_replay_side_effects() -> None:
+    from anthropic.types import TextBlock
+
+    from band.adapters.anthropic import AnthropicAdapter
+
+    class _NoReplayAnthropicAdapter(AnthropicAdapter):
+        def __init__(self, *, calls: list[_L4ReplayGuardInput]) -> None:
+            async def l4_replay_guard(args: _L4ReplayGuardInput) -> dict[str, str]:
+                calls.append(args)
+                return {"replayed": args.code}
+
+            super().__init__(
+                provider_key="test-provider-key",
+                additional_tools=[(_L4ReplayGuardInput, l4_replay_guard)],
+            )
+            self._responses = [
+                _ScriptedResponse(
+                    stop_reason="end_turn",
+                    content=[TextBlock(text="done", type="text")],
+                )
+            ]
+
+        async def _call_anthropic(
+            self,
+            messages: list[dict[str, Any]],
+            tools: list[Any],
+        ) -> Any:
+            del messages, tools
+            return self._responses.pop(0)
+
     calls: list[_L4ReplayGuardInput] = []
     tools = ConformanceSchemaRecorder(
         participants=canonical_participants(),


### PR DESCRIPTION
## Summary

- Adds the L4 rehydration baseline split: cold-start history rebuild, offline pending pickup, handled-message dedupe, and completed-tool no-requeue behavior.
- Adds the gated L4 live workflow and the cross-level E2E hygiene gate for live artifact/workflow integrity.
- Keeps Anthropic-only replay-guard coverage lazy so the CrewAI CI lane can collect with missing optional frameworks, and rebases the L4 slice onto L3/latest `origin/dev`.

## Verification

- `uv run ruff check .` passed.
- `uv run pyrefly check` passed.
- `uv run pytest tests/framework_conformance/ tests/e2e/test_baseline_artifacts.py tests/e2e/test_e2e_hygiene.py -q -k 'not crewai'` passed: 805 passed, 26 skipped, 98 deselected.
- `BAND_ALLOW_MISSING_FRAMEWORKS=1 uv run pytest tests/adapters/test_crewai_adapter.py tests/adapters/test_crewai_adapter_soak.py tests/adapters/test_crewai_flow_adapter.py tests/adapters/test_crewai_flow_phase3.py tests/adapters/test_crewai_flow_phase4.py tests/adapters/test_crewai_flow_phase5.py tests/adapters/test_crewai_flow_state_source.py tests/converters/test_crewai.py tests/converters/test_crewai_flow.py tests/integrations/test_crewai_tools.py tests/integrations/test_crewai_flow_real_sdk.py tests/framework_conformance/ -q -k crewai` passed: 308 passed, 7 skipped, 704 deselected.

Live provider/platform E2E was not run locally; the L4 live workflow is gated by `E2E_TESTS_ENABLED=true` and `E2E_BASELINE_L4_LIVE=true`.