### PR TITLE
fix: refresh participant cache and retry on mention miss in send_message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "python-dotenv>=1.2.2",
     "pyyaml>=6.0",
     "cryptography>=46.0.5",
+    "tenacity>=9.0",
 ]
 
 [project.optional-dependencies]

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -13,6 +13,14 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import AliasChoices, BaseModel, Field, ValidationError, model_validator
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_chain,
+    wait_exponential,
+    wait_fixed,
+)
 
 from band.client.rest import ChatRoomRequest, DEFAULT_REQUEST_OPTIONS
 from band.core.exceptions import BandToolError
@@ -38,6 +46,20 @@ if TYPE_CHECKING:
     from .execution import ExecutionContext
 
 logger = logging.getLogger(__name__)
+
+# Mention-resolution retry: refresh participants on a miss, then retry. First
+# retry is immediate; later ones back off for a lagging participants endpoint.
+_MENTION_REFRESH_ATTEMPTS = 2
+_MENTION_REFRESH_WAIT = wait_chain(
+    wait_fixed(0),
+    wait_exponential(multiplier=0.2, max=1.0),
+)
+
+
+async def _refresh_participants_after(retry_state: Any) -> None:
+    """tenacity ``after`` hook: refresh participants after a failed resolve."""
+    tools = retry_state.args[0]
+    await tools.get_participants()
 
 
 def _normalize_handle(value: str) -> str:
@@ -1295,7 +1317,8 @@ class AgentTools(AgentToolsProtocol):
                 stacklevel=2,
             )
 
-        resolved_mentions = self._resolve_mentions(mentions or [])
+        # Resolve mentions; refreshes participants and retries on a miss.
+        resolved_mentions = await self._resolve_mentions_with_refresh(mentions or [])
 
         # Validate mentions are not empty — API requires ≥1 mention.
         # Return a helpful error so the LLM can retry with proper mentions.
@@ -1978,6 +2001,24 @@ class AgentTools(AgentToolsProtocol):
         return response.data
 
     # --- Mention resolution ---
+
+    @retry(
+        retry=retry_if_exception_type(ValueError),
+        stop=stop_after_attempt(_MENTION_REFRESH_ATTEMPTS),
+        wait=_MENTION_REFRESH_WAIT,
+        after=_refresh_participants_after,
+        reraise=True,
+    )
+    async def _resolve_mentions_with_refresh(
+        self, mentions: list[str] | list[dict[str, str]]
+    ) -> list[dict[str, str]]:
+        """Resolve mentions against the cache; refresh and retry on a miss.
+
+        Handles a cold/stale cache (e.g. a freshly added agent whose
+        participants endpoint hasn't caught up). An unknown mention exhausts the
+        retries and the final ``ValueError`` propagates.
+        """
+        return self._resolve_mentions(mentions)
 
     def _resolve_mentions(
         self, mentions: list[str] | list[dict[str, str]]

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -18,10 +18,25 @@ from band.runtime.tools import (
     LookupPeersInput,
     GetParticipantsInput,
     CreateChatroomInput,
+    _MENTION_REFRESH_ATTEMPTS,
     _matches_identifier,
     append_mention_handles_hint,
     available_mention_handles,
 )
+
+
+@pytest.fixture
+def fast_mention_retry(monkeypatch):
+    """Strip the backoff from the mention-refresh retry so tests don't sleep.
+
+    The @retry decorator captures its wait at import time, so patch the
+    decorated function's retry instance rather than the module constant.
+    """
+    from tenacity import wait_none
+
+    monkeypatch.setattr(
+        AgentTools._resolve_mentions_with_refresh.retry, "wait", wait_none()
+    )
 
 
 @pytest.fixture
@@ -493,6 +508,67 @@ class TestAgentToolsSendMessage:
 
         with pytest.raises(ValueError, match="Unknown participant 'Unknown'"):
             await tools.send_message("Hello!", mentions=["Unknown"])
+
+    async def test_send_message_cache_hit_skips_refresh(
+        self, mock_rest_client, participants
+    ):
+        """A mention already in the cache resolves without an API refresh."""
+        tools = AgentTools("room-123", mock_rest_client, participants)
+
+        await tools.send_message("Hello!", mentions=["User One"])
+
+        mock_rest_client.agent_api_participants.list_agent_chat_participants.assert_not_called()
+
+    async def test_send_message_refreshes_cold_cache_and_retries(
+        self, mock_rest_client
+    ):
+        """A miss on a cold cache refreshes participants once, then resolves."""
+        # Empty cache — the mock REST client knows about user-1.
+        tools = AgentTools("room-123", mock_rest_client)
+        assert tools._participants == []
+
+        await tools.send_message("Hello!", mentions=["user-1"])
+
+        # Refreshed once from the API, then sent successfully.
+        mock_rest_client.agent_api_participants.list_agent_chat_participants.assert_called_once()
+        call_args = (
+            mock_rest_client.agent_api_messages.create_agent_chat_message.call_args
+        )
+        message = call_args.kwargs["message"]
+        assert message.mentions[0].id == "user-1"
+
+    async def test_send_message_unknown_mention_raises_after_refresh(
+        self, mock_rest_client, fast_mention_retry
+    ):
+        """An unknown mention surfaces the error once retries are exhausted."""
+        tools = AgentTools("room-123", mock_rest_client)
+
+        with pytest.raises(ValueError, match="Unknown participant 'Unknown'"):
+            await tools.send_message("Hello!", mentions=["Unknown"])
+
+        # One refresh per attempt (the after hook fires on each failed attempt).
+        assert (
+            mock_rest_client.agent_api_participants.list_agent_chat_participants.call_count
+            == _MENTION_REFRESH_ATTEMPTS
+        )
+
+    async def test_send_message_empty_refresh_still_raises(
+        self, mock_rest_client, fast_mention_retry
+    ):
+        """If refresh keeps returning nothing, the error surfaces after retries
+        rather than looping forever."""
+        mock_rest_client.agent_api_participants.list_agent_chat_participants.return_value = MagicMock(
+            data=None
+        )
+        tools = AgentTools("room-123", mock_rest_client)
+
+        with pytest.raises(ValueError, match="Unknown participant"):
+            await tools.send_message("Hello!", mentions=["user-1"])
+
+        assert (
+            mock_rest_client.agent_api_participants.list_agent_chat_participants.call_count
+            == _MENTION_REFRESH_ATTEMPTS
+        )
 
     async def test_send_message_no_response_raises(
         self, mock_rest_client, participants

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,7 @@ wheels = [
 
 [[package]]
 name = "band-sdk"
-version = "0.2.11"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "band-client-rest" },
@@ -478,6 +478,7 @@ dependencies = [
     { name = "phoenix-channels-python-client" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "tenacity" },
 ]
 
 [package.optional-dependencies]
@@ -738,6 +739,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'acp'", specifier = ">=0.40.0" },
     { name = "starlette", marker = "extra == 'dev'", specifier = ">=0.40.0" },
     { name = "starlette", marker = "extra == 'slack'", specifier = ">=0.40.0" },
+    { name = "tenacity", specifier = ">=9.0" },
     { name = "thenvoi-testing-python", marker = "extra == 'dev'", specifier = "==0.1.4" },
     { name = "thenvoi-testing-python", marker = "extra == 'dev-crewai'", specifier = "==0.1.4" },
     { name = "uvicorn", marker = "extra == 'a2a-gateway'", specifier = ">=0.32.0" },


### PR DESCRIPTION
## Problem

`send_message` raised `Unknown participant '<uuid>'. Available handles: []` when `@mentioning` a valid participant — the tools instance's participant cache was empty. A freshly added agent can reply before the participants endpoint reflects room membership (eventual consistency), so the cache resolves empty.

## Fix

Resolve mentions against the cache; on a miss, refresh participants (tenacity `after` hook) and retry with a short backoff. A cache hit never refreshes; an unknown mention surfaces the error after retries exhaust.

## Tests

- cache hit → no refresh
- cold cache → refresh once, then resolves
- unknown mention → errors after bounded retries
- refresh keeps returning nothing → errors, no infinite loop

## Dependency

Adds `tenacity` (Apache 2.0, compatible with this SDK's MIT license).
