### PR TITLE
feat: raise a visible UserWarning for unsupported adapter feature flags

### DIFF
--- a/src/band/core/simple_adapter.py
+++ b/src/band/core/simple_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Generic, TypeVar, cast
 
@@ -21,6 +22,21 @@ logger = logging.getLogger(__name__)
 H = TypeVar("H")
 
 
+def _warn_unsupported(
+    adapter_name: str,
+    kind: str,
+    unsupported: frozenset[Emit] | frozenset[Capability],
+) -> None:
+    """Log and emit a UserWarning naming feature flags an adapter ignores."""
+    message = (
+        f"{adapter_name} does not support {kind} values: "
+        f"{', '.join(sorted(v.value for v in unsupported))} "
+        "(they will have no effect)"
+    )
+    logger.warning(message)
+    warnings.warn(message, UserWarning, stacklevel=3)
+
+
 class SimpleAdapter(Generic[H], ABC):
     """
     Simple base class for framework adapters.
@@ -30,7 +46,7 @@ class SimpleAdapter(Generic[H], ABC):
 
     Subclasses should declare SUPPORTED_EMIT and SUPPORTED_CAPABILITIES
     as class-level sets to document what they actually implement.
-    on_started() will warn if features request unsupported values.
+    on_started() logs and emits a UserWarning for unsupported values.
 
     Example:
         class MyAdapter(SimpleAdapter[list[ChatMessage]]):
@@ -112,21 +128,12 @@ class SimpleAdapter(Generic[H], ABC):
         self.agent_name = agent_name
         self.agent_description = agent_description
 
-        # Warn on unsupported feature values
-        unsupported_emit = self.features.emit - self.SUPPORTED_EMIT
-        if unsupported_emit:
-            logger.warning(
-                "%s does not support emit values: %s (they will have no effect)",
-                type(self).__name__,
-                ", ".join(sorted(e.value for e in unsupported_emit)),
-            )
-        unsupported_caps = self.features.capabilities - self.SUPPORTED_CAPABILITIES
-        if unsupported_caps:
-            logger.warning(
-                "%s does not support capability values: %s (they will have no effect)",
-                type(self).__name__,
-                ", ".join(sorted(c.value for c in unsupported_caps)),
-            )
+        # Warn on unsupported feature values.
+        name = type(self).__name__
+        if unsupported_emit := self.features.emit - self.SUPPORTED_EMIT:
+            _warn_unsupported(name, "emit", unsupported_emit)
+        if unsupported_caps := self.features.capabilities - self.SUPPORTED_CAPABILITIES:
+            _warn_unsupported(name, "capability", unsupported_caps)
 
         # Propagate agent name to converter if it supports it
         if self.history_converter and hasattr(self.history_converter, "set_agent_name"):

--- a/tests/core/test_simple_adapter_features.py
+++ b/tests/core/test_simple_adapter_features.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import Any
 
 import pytest
@@ -88,7 +89,8 @@ class TestSimpleAdapterFeatures:
             features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
         )
         with caplog.at_level(logging.WARNING):
-            await adapter.on_started("test-agent", "A test agent")
+            with pytest.warns(UserWarning, match="does not support emit values"):
+                await adapter.on_started("test-agent", "A test agent")
         assert "does not support emit values" in caplog.text
         assert "THOUGHTS" in caplog.text or "thoughts" in caplog.text
 
@@ -102,7 +104,8 @@ class TestSimpleAdapterFeatures:
             ),
         )
         with caplog.at_level(logging.WARNING):
-            await adapter.on_started("test-agent", "A test agent")
+            with pytest.warns(UserWarning, match="does not support capability values"):
+                await adapter.on_started("test-agent", "A test agent")
         assert "does not support capability values" in caplog.text
         assert "CONTACTS" in caplog.text or "contacts" in caplog.text
 
@@ -116,7 +119,9 @@ class TestSimpleAdapterFeatures:
             ),
         )
         with caplog.at_level(logging.WARNING):
-            await adapter.on_started("test-agent", "A test agent")
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", UserWarning)
+                await adapter.on_started("test-agent", "A test agent")
         assert "does not support" not in caplog.text
 
     @pytest.mark.asyncio
@@ -125,7 +130,9 @@ class TestSimpleAdapterFeatures:
     ) -> None:
         adapter = _TestAdapter()
         with caplog.at_level(logging.WARNING):
-            await adapter.on_started("test-agent", "A test agent")
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", UserWarning)
+                await adapter.on_started("test-agent", "A test agent")
         assert "does not support" not in caplog.text
 
     @pytest.mark.asyncio
@@ -137,6 +144,7 @@ class TestSimpleAdapterFeatures:
             features=AdapterFeatures(emit={Emit.EXECUTION}),
         )
         with caplog.at_level(logging.WARNING):
-            await adapter.on_started("test-agent", "A test agent")
+            with pytest.warns(UserWarning, match="does not support emit values"):
+                await adapter.on_started("test-agent", "A test agent")
         # _BareAdapter has empty SUPPORTED_EMIT, so EXECUTION is unsupported
         assert "does not support emit values" in caplog.text

--- a/tests/integrations/slack/test_wrapping.py
+++ b/tests/integrations/slack/test_wrapping.py
@@ -21,6 +21,7 @@ import hashlib
 import hmac
 import json
 import time
+import warnings
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
@@ -295,7 +296,11 @@ async def test_on_started_mirrors_inner_support_no_spurious_warning(caplog):
     adapter, _, _, _ = _make_adapter(inner=inner)
 
     with caplog.at_level("WARNING"):
-        await adapter.on_started("MyBot", "")
+        with warnings.catch_warnings():
+            # A spurious UserWarning here would mean the wrapper failed to
+            # mirror the inner's support before the base check ran.
+            warnings.simplefilter("error", UserWarning)
+            await adapter.on_started("MyBot", "")
 
     # Wrapper now reflects the inner's declared support.
     assert adapter.SUPPORTED_EMIT == frozenset({Emit.EXECUTION})


### PR DESCRIPTION
## Summary

`SimpleAdapter.on_started` previously only logged a `logger.warning` when an adapter received `AdapterFeatures` flags it doesn't implement (e.g. `emit` values on `ParlantAdapter`). That line is easy to miss — in libraries the logger is often unconfigured or set above `WARNING`, so the misconfiguration silently has no effect.

This now **also** emits a non-fatal `UserWarning` via `warnings.warn` for unsupported `emit`/`capability` values, while keeping the existing log line.

### Why both?

- **`logger.warning`** — durable operator trail: goes to the configured log sink with timestamps/context, survives in prod history. But easily missed when logging is unconfigured or above `WARNING`.
- **`warnings.warn(UserWarning)`** — dev/CI signal: fires regardless of logging config, surfaces in dev/test output and IDEs, and can be promoted to an error (`-W error` / `filterwarnings`) to fail CI on misconfiguration. But deduped per call-site and often silenced in prod.

Each covers the other's blind spot, so the misconfiguration is hard to miss at dev time **and** recorded at runtime.

## Changes

- Refactored the warning logic into a `_warn_unsupported(adapter_name, kind, unsupported)` helper that both logs and emits the `UserWarning`.
- Check stays in `on_started` so `SlackAdapter`'s inner-support mirroring still runs first (no spurious warning).

## Testing

- `tests/core/test_simple_adapter_features.py` — asserts `UserWarning` is raised for unsupported emit/capability, and that supported configs raise no warning.
- `tests/integrations/slack/test_wrapping.py` — verifies the wrapper mirrors inner support before the base check (no spurious `UserWarning`).
- Tests + ruff + pyrefly pass.

Closes INT-880

🤖 Generated with [Claude Code](https://claude.com/claude-code)