### PR TITLE
feat: Add SDK logging configuration helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ For production JSON logs or Rich console output, install the logging extra:
 uv add "band-sdk[logging]"
 ```
 
-```python
+```python notest
 configure_logging(style="json", stream="stdout")
 configure_logging(style="rich")
 ```
@@ -197,7 +197,7 @@ The examples intentionally show different styles: `examples/langgraph` uses the 
 
 If you need to modify the logging setup before applying it, build a fresh `dictConfig` dictionary:
 
-```python
+```python notest
 import logging.config
 
 from band import build_logging_config

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ configure_logging(style="json", stream="stdout")
 configure_logging(style="rich")
 ```
 
+The examples intentionally show different styles: `examples/langgraph` uses the standard formatter, `examples/parlant` uses Rich, and `examples/codex` emits JSON to stdout.
+
 If you need to modify the logging setup before applying it, build a fresh `dictConfig` dictionary:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -88,16 +88,15 @@ Create `quickstart_agent.py`:
 from __future__ import annotations
 
 import asyncio
-import logging
 import os
-
-logging.basicConfig(level=logging.INFO)
 
 from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import InMemorySaver
 
-from band import Agent
+from band import Agent, configure_logging
 from band.adapters import LangGraphAdapter
+
+configure_logging()
 
 
 async def main() -> None:
@@ -128,9 +127,9 @@ uv run python quickstart_agent.py
 You should see the agent connect:
 
 ```
-INFO:band.adapters.langgraph:LangGraph adapter started for agent: Quickstart Helper
-INFO:band.runtime.runtime:Starting AgentRuntime for agent ########-####-####-####-############
-INFO:band.platform.link:Connected to platform
+2026-06-22 12:00:00 [INFO] band.adapters.langgraph: LangGraph adapter started for agent: Quickstart Helper
+2026-06-22 12:00:00 [INFO] band.runtime.runtime: Starting AgentRuntime for agent ########-####-####-####-############
+2026-06-22 12:00:00 [INFO] band.platform.link: Connected to platform
 ```
 
 Open Band, create a chatroom, and add `Quickstart Helper` on the participants panel (right-hand side). Then send this message:
@@ -172,6 +171,38 @@ adapter = GeminiAdapter(model="gemini-2.5-flash")
 ```
 
 Use [examples/run_agent.py](examples/run_agent.py) when you want one command that can switch between LangGraph, Pydantic AI, Anthropic, Claude SDK, Parlant, CrewAI, Codex, A2A bridge, and A2A gateway. Use the per-framework directories under [examples/](examples/) when you want the adapter-specific setup.
+
+### Logging
+
+The SDK uses standard Python loggers and does not configure process-wide handlers unless your application opts in. For readable Band logs while keeping noisy dependencies quiet:
+
+```python
+from band import configure_logging
+
+configure_logging()
+```
+
+For production JSON logs or Rich console output, install the logging extra:
+
+```bash
+uv add "band-sdk[logging]"
+```
+
+```python
+configure_logging(style="json", stream="stdout")
+configure_logging(style="rich")
+```
+
+If you need to modify the logging setup before applying it, build a fresh `dictConfig` dictionary:
+
+```python
+import logging.config
+
+from band import build_logging_config
+
+config = build_logging_config(style="json", static_fields={"service": "agent"})
+logging.config.dictConfig(config)
+```
 
 ### Slack (`examples/slack/`)
 
@@ -492,13 +523,12 @@ Create a runnable gateway script:
 from __future__ import annotations
 
 import asyncio
-import logging
 import os
 
-from band import Agent
+from band import Agent, configure_logging
 from band.adapters.a2a_gateway import A2AGatewayAdapter
 
-logging.basicConfig(level=logging.INFO)
+configure_logging()
 
 
 async def main() -> None:

--- a/examples/a2a_bridge/setup_logging.py
+++ b/examples/a2a_bridge/setup_logging.py
@@ -1,9 +1,13 @@
 """Shared logging configuration for examples."""
 
+from __future__ import annotations
+
 import logging
 
+from band import configure_logging
 
-def setup_logging(level=logging.INFO, a2a_debug: bool = False):
+
+def setup_logging(level: int = logging.INFO, a2a_debug: bool = False) -> None:
     """Configure logging to show only band logs, hiding noisy dependencies.
 
     Args:
@@ -11,11 +15,5 @@ def setup_logging(level=logging.INFO, a2a_debug: bool = False):
         a2a_debug: If True, enable DEBUG logging for A2A adapter to trace
             context_id and session rehydration
     """
-    logging.basicConfig(
-        level=logging.WARNING,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    logging.getLogger("band").setLevel(level)
-    if a2a_debug:
-        logging.getLogger("band.integrations.a2a").setLevel(logging.DEBUG)
+    extra_loggers = {"band.integrations.a2a": logging.DEBUG} if a2a_debug else None
+    configure_logging(level, extra_loggers=extra_loggers)

--- a/examples/a2a_gateway/setup_logging.py
+++ b/examples/a2a_gateway/setup_logging.py
@@ -2,16 +2,17 @@
 
 import logging
 
+from band import configure_logging
+
 
 def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging for the example."""
-    logging.basicConfig(
+    configure_logging(
         level=level,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+        root_level=level,
+        extra_loggers={
+            "httpcore": logging.WARNING,
+            "httpx": logging.WARNING,
+            "uvicorn": logging.WARNING,
+        },
     )
-
-    # Reduce noise from libraries
-    logging.getLogger("httpcore").setLevel(logging.WARNING)
-    logging.getLogger("httpx").setLevel(logging.WARNING)
-    logging.getLogger("uvicorn").setLevel(logging.WARNING)

--- a/examples/acp/setup_logging.py
+++ b/examples/acp/setup_logging.py
@@ -4,15 +4,16 @@ from __future__ import annotations
 
 import logging
 
+from band import configure_logging
+
 
 def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging for the example."""
-    logging.basicConfig(
+    configure_logging(
         level=level,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+        root_level=level,
+        extra_loggers={
+            "httpcore": logging.WARNING,
+            "httpx": logging.WARNING,
+        },
     )
-
-    # Reduce noise from libraries
-    logging.getLogger("httpcore").setLevel(logging.WARNING)
-    logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/examples/anthropic/setup_logging.py
+++ b/examples/anthropic/setup_logging.py
@@ -1,15 +1,15 @@
 """Shared logging configuration for examples."""
 
+from __future__ import annotations
+
 import logging
 
+from band import configure_logging
 
-def setup_logging(level=logging.INFO):
+
+def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging to show only band logs, hiding noisy dependencies."""
-    logging.basicConfig(
-        level=logging.WARNING,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+    configure_logging(
+        level,
+        extra_loggers={"band_anthropic_agent": level},
     )
-    logging.getLogger("band").setLevel(level)
-    # Also enable logging for the anthropic adapter module
-    logging.getLogger("band_anthropic_agent").setLevel(level)

--- a/examples/claude_sdk/setup_logging.py
+++ b/examples/claude_sdk/setup_logging.py
@@ -1,16 +1,18 @@
 """Shared logging configuration for Claude SDK examples."""
 
+from __future__ import annotations
+
 import logging
 
+from band import configure_logging
 
-def setup_logging(level=logging.INFO):
+
+def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging to show only band logs, hiding noisy dependencies."""
-    logging.basicConfig(
-        level=logging.WARNING,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+    configure_logging(
+        level,
+        extra_loggers={
+            "band_claude_sdk_agent": level,
+            "session_manager": level,
+        },
     )
-    logging.getLogger("band").setLevel(level)
-    # Also enable logging for the claude_sdk adapter module
-    logging.getLogger("band_claude_sdk_agent").setLevel(level)
-    logging.getLogger("session_manager").setLevel(level)

--- a/examples/codex/01_basic_agent.py
+++ b/examples/codex/01_basic_agent.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["band-sdk[codex]"]
+# dependencies = ["band-sdk[codex,logging]"]
 #
 # [tool.uv.sources]
 # band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }

--- a/examples/codex/setup_logging.py
+++ b/examples/codex/setup_logging.py
@@ -3,16 +3,18 @@
 from __future__ import annotations
 
 import logging
-import sys
+
+from band import configure_logging
 
 
 def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging for examples."""
-    logging.basicConfig(
+    configure_logging(
         level=level,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        stream=sys.stdout,
+        root_level=level,
+        stream="stdout",
+        extra_loggers={
+            "websockets": logging.WARNING,
+            "httpx": logging.WARNING,
+        },
     )
-    # Reduce noise from libraries
-    logging.getLogger("websockets").setLevel(logging.WARNING)
-    logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/examples/codex/setup_logging.py
+++ b/examples/codex/setup_logging.py
@@ -11,6 +11,7 @@ def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging for examples."""
     configure_logging(
         level=level,
+        style="json",
         root_level=level,
         stream="stdout",
         extra_loggers={

--- a/examples/crewai/setup_logging.py
+++ b/examples/crewai/setup_logging.py
@@ -1,15 +1,15 @@
 """Shared logging configuration for examples."""
 
+from __future__ import annotations
+
 import logging
 
+from band import configure_logging
 
-def setup_logging(level=logging.INFO):
+
+def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging to show only band logs, hiding noisy dependencies."""
-    logging.basicConfig(
-        level=logging.WARNING,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+    configure_logging(
+        level,
+        extra_loggers={"band_crewai_agent": level},
     )
-    logging.getLogger("band").setLevel(level)
-    # Also enable logging for the crewai adapter module
-    logging.getLogger("band_crewai_agent").setLevel(level)

--- a/examples/gemini/setup_logging.py
+++ b/examples/gemini/setup_logging.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 import logging
 
+from band import configure_logging
 
-def setup_logging(level=logging.INFO):
+
+def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging to show only band logs, hiding noisy dependencies."""
-    logging.basicConfig(
-        level=logging.WARNING,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    logging.getLogger("band").setLevel(level)
+    configure_logging(level)

--- a/examples/google_adk/setup_logging.py
+++ b/examples/google_adk/setup_logging.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 import logging
 
+from band import configure_logging
 
-def setup_logging(level=logging.INFO):
+
+def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging to show only band logs, hiding noisy dependencies."""
-    logging.basicConfig(
-        level=logging.WARNING,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    logging.getLogger("band").setLevel(level)
+    configure_logging(level)

--- a/examples/langgraph/setup_logging.py
+++ b/examples/langgraph/setup_logging.py
@@ -1,13 +1,12 @@
 """Shared logging configuration for examples."""
 
+from __future__ import annotations
+
 import logging
 
+from band import configure_logging
 
-def setup_logging(level=logging.INFO):
+
+def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging to show only band logs, hiding noisy dependencies."""
-    logging.basicConfig(
-        level=logging.WARNING,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    logging.getLogger("band").setLevel(level)
+    configure_logging(level)

--- a/examples/letta/setup_logging.py
+++ b/examples/letta/setup_logging.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 import logging
 
+from band import configure_logging
+
 
 def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging to show only band logs, hiding noisy dependencies."""
-    logging.basicConfig(
-        level=logging.WARNING,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    logging.getLogger("band").setLevel(level)
+    configure_logging(level)

--- a/examples/mixed/setup_logging.py
+++ b/examples/mixed/setup_logging.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import logging
 
+from band import configure_logging
+
 
 def setup_logging(level: int = logging.INFO) -> None:
     """Configure concise logging for the mixed example suite."""
-    logging.basicConfig(
-        level=logging.WARNING,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+    configure_logging(
+        level,
+        extra_loggers={"band_crewai_agent": level},
     )
-    logging.getLogger("band").setLevel(level)
-    logging.getLogger("band_crewai_agent").setLevel(level)

--- a/examples/opencode/setup_logging.py
+++ b/examples/opencode/setup_logging.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import logging
-import sys
+
+from band import configure_logging
 
 
 def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging for examples."""
-    logging.basicConfig(
+    configure_logging(
         level=level,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        stream=sys.stdout,
+        stream="stdout",
+        root_level=level,
+        extra_loggers={"httpx": logging.WARNING},
     )
-    logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/examples/parlant/01_basic_agent.py
+++ b/examples/parlant/01_basic_agent.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["band-sdk[parlant]"]
+# dependencies = ["band-sdk[parlant,logging]"]
 #
 # [tool.uv.sources]
 # band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }

--- a/examples/parlant/02_with_guidelines.py
+++ b/examples/parlant/02_with_guidelines.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["band-sdk[parlant]"]
+# dependencies = ["band-sdk[parlant,logging]"]
 #
 # [tool.uv.sources]
 # band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }

--- a/examples/parlant/03_support_agent.py
+++ b/examples/parlant/03_support_agent.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["band-sdk[parlant]"]
+# dependencies = ["band-sdk[parlant,logging]"]
 #
 # [tool.uv.sources]
 # band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }

--- a/examples/parlant/04_tom_agent.py
+++ b/examples/parlant/04_tom_agent.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["band-sdk[parlant]"]
+# dependencies = ["band-sdk[parlant,logging]"]
 #
 # [tool.uv.sources]
 # band-sdk = { git = "https://-ai/band-sdk-python.git" }

--- a/examples/parlant/05_jerry_agent.py
+++ b/examples/parlant/05_jerry_agent.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["band-sdk[parlant]"]
+# dependencies = ["band-sdk[parlant,logging]"]
 #
 # [tool.uv.sources]
 # band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }

--- a/examples/parlant/setup_logging.py
+++ b/examples/parlant/setup_logging.py
@@ -15,5 +15,6 @@ def setup_logging(level: int = logging.INFO) -> None:
     """
     configure_logging(
         level,
+        style="rich",
         extra_loggers={"band_parlant_agent": level},
     )

--- a/examples/parlant/setup_logging.py
+++ b/examples/parlant/setup_logging.py
@@ -1,20 +1,19 @@
 """Shared logging configuration for examples."""
 
+from __future__ import annotations
+
 import logging
 
+from band import configure_logging
 
-def setup_logging(level=logging.INFO):
+
+def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging to show only band logs, hiding noisy dependencies.
 
     Args:
         level: Log level for band namespace (default INFO)
     """
-    logging.basicConfig(
-        level=logging.WARNING,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+    configure_logging(
+        level,
+        extra_loggers={"band_parlant_agent": level},
     )
-
-    logging.getLogger("band").setLevel(level)
-    # Also enable logging for the parlant adapter module
-    logging.getLogger("band_parlant_agent").setLevel(level)

--- a/examples/pydantic_ai/setup_logging.py
+++ b/examples/pydantic_ai/setup_logging.py
@@ -1,13 +1,12 @@
 """Shared logging configuration for examples."""
 
+from __future__ import annotations
+
 import logging
 
+from band import configure_logging
 
-def setup_logging(level=logging.INFO):
+
+def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging to show only band logs, hiding noisy dependencies."""
-    logging.basicConfig(
-        level=logging.WARNING,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    logging.getLogger("band").setLevel(level)
+    configure_logging(level)

--- a/examples/slack/setup_logging.py
+++ b/examples/slack/setup_logging.py
@@ -1,15 +1,15 @@
 """Shared logging configuration for Slack examples."""
 
+from __future__ import annotations
+
 import logging
 
+from band import configure_logging
 
-def setup_logging(level=logging.INFO):
+
+def setup_logging(level: int = logging.INFO) -> None:
     """Configure logging to show band + slack-sdk logs, mute noisy deps."""
-    logging.basicConfig(
-        level=logging.WARNING,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+    configure_logging(
+        level,
+        extra_loggers={"slack_sdk": level},
     )
-    logging.getLogger("band").setLevel(level)
-    # Surface Slack SDK retries / Socket Mode connect events.
-    logging.getLogger("slack_sdk").setLevel(level)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+logging = [
+    "python-json-logger>=3.0.0",
+    "rich>=14.0.0",
+]
 codex = [
     "websockets>=13.0",
 ]

--- a/src/band/__init__.py
+++ b/src/band/__init__.py
@@ -155,7 +155,9 @@ __all__ = [
 ]
 
 _band_logger = logging.getLogger("band")
-if not any(isinstance(handler, logging.NullHandler) for handler in _band_logger.handlers):
+if not any(
+    isinstance(handler, logging.NullHandler) for handler in _band_logger.handlers
+):
     _band_logger.addHandler(logging.NullHandler())
 
 try:

--- a/src/band/__init__.py
+++ b/src/band/__init__.py
@@ -54,7 +54,14 @@ from .core.exceptions import (
     BandConnectionError,
     BandToolError,
 )
-from .logging_config import build_logging_config, configure_logging
+from .logging_config import (
+    LogLevel,
+    LoggingConfig,
+    LoggingStyle,
+    LogStream,
+    build_logging_config,
+    configure_logging,
+)
 
 # Platform layer
 from .platform import BandLink, PlatformEvent
@@ -103,6 +110,10 @@ __all__ = [
     "BandConfigError",
     "BandConnectionError",
     "BandToolError",
+    "LogLevel",
+    "LoggingConfig",
+    "LoggingStyle",
+    "LogStream",
     "build_logging_config",
     "configure_logging",
     # Platform

--- a/src/band/__init__.py
+++ b/src/band/__init__.py
@@ -40,6 +40,7 @@ Example (Framework-light pattern):
     await link.run_forever()
 """
 
+import logging
 from importlib.metadata import version as _get_version, PackageNotFoundError
 
 # Composition layer (new pattern)
@@ -53,6 +54,7 @@ from .core.exceptions import (
     BandConnectionError,
     BandToolError,
 )
+from .logging_config import build_logging_config, configure_logging
 
 # Platform layer
 from .platform import BandLink, PlatformEvent
@@ -101,6 +103,8 @@ __all__ = [
     "BandConfigError",
     "BandConnectionError",
     "BandToolError",
+    "build_logging_config",
+    "configure_logging",
     # Platform
     "BandLink",
     "PlatformEvent",
@@ -138,6 +142,10 @@ __all__ = [
     "GracefulShutdown",
     "run_with_graceful_shutdown",
 ]
+
+_band_logger = logging.getLogger("band")
+if not any(isinstance(handler, logging.NullHandler) for handler in _band_logger.handlers):
+    _band_logger.addHandler(logging.NullHandler())
 
 try:
     __version__ = _get_version("band-sdk")

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -1,0 +1,197 @@
+"""Logging configuration helpers for Band SDK applications."""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import logging.config
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+from band.core.exceptions import BandConfigError
+
+LoggingStyle = Literal["standard", "rich", "json"]
+LogLevel = int | str
+LogStream = Literal["stderr", "stdout"]
+
+_STANDARD_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+_JSON_DEFAULT_FIELDS = ("asctime", "levelname", "name", "message")
+_JSON_RENAME_FIELDS = {
+    "asctime": "timestamp",
+    "levelname": "level",
+    "name": "logger",
+}
+
+
+def build_logging_config(
+    level: LogLevel = logging.INFO,
+    *,
+    style: LoggingStyle = "standard",
+    root_level: LogLevel = logging.WARNING,
+    stream: LogStream = "stderr",
+    datefmt: str = "%Y-%m-%d %H:%M:%S",
+    extra_loggers: Mapping[str, LogLevel] | None = None,
+    json_fields: Sequence[str] | None = None,
+    static_fields: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a normalized ``logging.config.dictConfig`` dictionary.
+
+    The default keeps noisy dependencies at WARNING while enabling Band SDK
+    logs at INFO. Applications can inspect, modify, then apply the returned
+    dict themselves, or call :func:`configure_logging`.
+    """
+    normalized_style = _normalize_style(style)
+    normalized_stream = _normalize_stream(stream)
+    band_level = _normalize_level(level, name="level")
+    normalized_root_level = _normalize_level(root_level, name="root_level")
+
+    formatter_name = "console"
+    handler: dict[str, Any] = {
+        "class": "logging.StreamHandler",
+        "formatter": formatter_name,
+        "stream": f"ext://sys.{normalized_stream}",
+    }
+
+    formatters: dict[str, dict[str, Any]]
+    if normalized_style == "standard":
+        formatters = {
+            formatter_name: {
+                "format": _STANDARD_FORMAT,
+                "datefmt": datefmt,
+            }
+        }
+    elif normalized_style == "rich":
+        _require_optional_package("rich", style="rich", extra="logging")
+        handler = {
+            "class": "rich.logging.RichHandler",
+            "formatter": formatter_name,
+            "rich_tracebacks": True,
+            "markup": False,
+            "show_path": False,
+        }
+        formatters = {
+            formatter_name: {
+                "format": "%(message)s",
+                "datefmt": datefmt,
+            }
+        }
+    else:
+        _require_optional_package(
+            "pythonjsonlogger",
+            style="json",
+            extra="logging",
+            package_name="python-json-logger",
+        )
+        fields = tuple(json_fields or _JSON_DEFAULT_FIELDS)
+        _validate_json_fields(fields)
+        json_formatter: dict[str, Any] = {
+            "()": "pythonjsonlogger.json.JsonFormatter",
+            "format": " ".join(f"%({field})s" for field in fields),
+            "datefmt": datefmt,
+            "rename_fields": {
+                field: renamed
+                for field, renamed in _JSON_RENAME_FIELDS.items()
+                if field in fields
+            },
+        }
+        if static_fields:
+            json_formatter["static_fields"] = dict(static_fields)
+        formatters = {formatter_name: json_formatter}
+
+    loggers: dict[str, dict[str, Any]] = {
+        "band": {
+            "level": band_level,
+            "propagate": True,
+        }
+    }
+    if extra_loggers:
+        for logger_name, logger_level in extra_loggers.items():
+            if not logger_name:
+                raise ValueError("extra_loggers keys must be non-empty logger names")
+            loggers[logger_name] = {
+                "level": _normalize_level(
+                    logger_level,
+                    name=f"extra_loggers[{logger_name!r}]",
+                ),
+                "propagate": True,
+            }
+
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": formatters,
+        "handlers": {
+            "console": handler,
+        },
+        "root": {
+            "level": normalized_root_level,
+            "handlers": ["console"],
+        },
+        "loggers": loggers,
+    }
+
+
+def configure_logging(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    """Build and apply Band's logging configuration.
+
+    Returns the applied ``dictConfig`` dictionary so callers can inspect the
+    exact configuration.
+    """
+    config = build_logging_config(*args, **kwargs)
+    logging.config.dictConfig(config)
+    return config
+
+
+def _normalize_style(style: str) -> LoggingStyle:
+    if not isinstance(style, str):
+        raise ValueError("style must be one of: standard, rich, json")
+    normalized = style.lower()
+    if normalized not in {"standard", "rich", "json"}:
+        raise ValueError("style must be one of: standard, rich, json")
+    return normalized  # type: ignore[return-value]
+
+
+def _normalize_stream(stream: str) -> LogStream:
+    if not isinstance(stream, str):
+        raise ValueError("stream must be one of: stderr, stdout")
+    normalized = stream.lower()
+    if normalized not in {"stderr", "stdout"}:
+        raise ValueError("stream must be one of: stderr, stdout")
+    return normalized  # type: ignore[return-value]
+
+
+def _normalize_level(level: LogLevel, *, name: str) -> LogLevel:
+    if isinstance(level, int):
+        if level < 0:
+            raise ValueError(f"{name} must be a non-negative logging level")
+        return level
+    if isinstance(level, str):
+        normalized = level.upper()
+        if normalized in logging.getLevelNamesMapping():
+            return normalized
+        raise ValueError(f"{name} must be a valid logging level")
+    raise ValueError(f"{name} must be an int or logging level name")
+
+
+def _validate_json_fields(fields: Sequence[str]) -> None:
+    if not fields:
+        raise ValueError("json_fields must contain at least one field")
+    for field in fields:
+        if not field or not isinstance(field, str):
+            raise ValueError("json_fields must contain non-empty strings")
+
+
+def _require_optional_package(
+    import_name: str,
+    *,
+    style: str,
+    extra: str,
+    package_name: str | None = None,
+) -> None:
+    if importlib.util.find_spec(import_name) is not None:
+        return
+    dependency = package_name or import_name
+    raise BandConfigError(
+        f"Logging style {style!r} requires optional dependency {dependency!r}. "
+        f"Install it with: pip install 'band-sdk[{extra}]'"
+    )

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -278,6 +278,8 @@ def _normalize_stream(stream: str) -> LogStream:
 
 
 def _normalize_level(level: LogLevel, *, name: str) -> LogLevel:
+    if isinstance(level, bool):
+        raise ValueError(f"{name} must be an int or logging level name")
     if isinstance(level, int):
         if level < 0:
             raise ValueError(f"{name} must be a non-negative logging level")

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -48,26 +48,27 @@ def build_logging_config(
     normalized_root_level = _normalize_level(root_level, name="root_level")
 
     formatter_name = "console"
-    if normalized_style == "standard":
-        handler, formatters = _build_standard_config(
-            formatter_name=formatter_name,
-            stream=normalized_stream,
-            datefmt=datefmt,
-        )
-    elif normalized_style == "rich":
-        handler, formatters = _build_rich_config(
-            formatter_name=formatter_name,
-            stream=normalized_stream,
-            datefmt=datefmt,
-        )
-    else:
-        handler, formatters = _build_json_config(
-            formatter_name=formatter_name,
-            stream=normalized_stream,
-            datefmt=datefmt,
-            json_fields=json_fields,
-            static_fields=static_fields,
-        )
+    match normalized_style:
+        case "standard":
+            handler, formatters = _build_standard_config(
+                formatter_name=formatter_name,
+                stream=normalized_stream,
+                datefmt=datefmt,
+            )
+        case "rich":
+            handler, formatters = _build_rich_config(
+                formatter_name=formatter_name,
+                stream=normalized_stream,
+                datefmt=datefmt,
+            )
+        case "json":
+            handler, formatters = _build_json_config(
+                formatter_name=formatter_name,
+                stream=normalized_stream,
+                datefmt=datefmt,
+                json_fields=json_fields,
+                static_fields=static_fields,
+            )
 
     loggers: dict[str, LoggingConfig] = {
         "band": {

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import logging
 import logging.config
+import sys
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal
 
@@ -63,11 +64,9 @@ def build_logging_config(
     elif normalized_style == "rich":
         _require_optional_package("rich", style="rich", extra="logging")
         handler = {
-            "class": "rich.logging.RichHandler",
+            "()": "band.logging_config._build_rich_handler",
             "formatter": formatter_name,
-            "rich_tracebacks": True,
-            "markup": False,
-            "show_path": False,
+            "stream": normalized_stream,
         }
         formatters = {
             formatter_name: {
@@ -140,6 +139,19 @@ def configure_logging(*args: Any, **kwargs: Any) -> dict[str, Any]:
     config = build_logging_config(*args, **kwargs)
     logging.config.dictConfig(config)
     return config
+
+
+def _build_rich_handler(*, stream: LogStream) -> logging.Handler:
+    from rich.console import Console
+    from rich.logging import RichHandler
+
+    output = sys.stdout if stream == "stdout" else sys.stderr
+    return RichHandler(
+        console=Console(file=output),
+        rich_tracebacks=True,
+        markup=False,
+        show_path=False,
+    )
 
 
 def _normalize_style(style: str) -> LoggingStyle:

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -7,13 +7,14 @@ import logging
 import logging.config
 import sys
 from collections.abc import Mapping, Sequence
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias
 
 from band.core.exceptions import BandConfigError
 
-LoggingStyle = Literal["standard", "rich", "json"]
-LogLevel = int | str
-LogStream = Literal["stderr", "stdout"]
+LoggingStyle: TypeAlias = Literal["standard", "rich", "json"]
+LogLevel: TypeAlias = int | str
+LogStream: TypeAlias = Literal["stderr", "stdout"]
+LoggingConfig: TypeAlias = dict[str, Any]
 
 _STANDARD_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 _JSON_DEFAULT_FIELDS = ("asctime", "levelname", "name", "message")
@@ -34,7 +35,7 @@ def build_logging_config(
     extra_loggers: Mapping[str, LogLevel] | None = None,
     json_fields: Sequence[str] | None = None,
     static_fields: Mapping[str, Any] | None = None,
-) -> dict[str, Any]:
+) -> LoggingConfig:
     """Build a normalized ``logging.config.dictConfig`` dictionary.
 
     The default keeps noisy dependencies at WARNING while enabling Band SDK
@@ -47,13 +48,13 @@ def build_logging_config(
     normalized_root_level = _normalize_level(root_level, name="root_level")
 
     formatter_name = "console"
-    handler: dict[str, Any] = {
+    handler: LoggingConfig = {
         "class": "logging.StreamHandler",
         "formatter": formatter_name,
         "stream": f"ext://sys.{normalized_stream}",
     }
 
-    formatters: dict[str, dict[str, Any]]
+    formatters: dict[str, LoggingConfig]
     if normalized_style == "standard":
         formatters = {
             formatter_name: {
@@ -83,7 +84,7 @@ def build_logging_config(
         )
         fields = tuple(json_fields or _JSON_DEFAULT_FIELDS)
         _validate_json_fields(fields)
-        json_formatter: dict[str, Any] = {
+        json_formatter: LoggingConfig = {
             "()": "pythonjsonlogger.json.JsonFormatter",
             "format": " ".join(f"%({field})s" for field in fields),
             "datefmt": datefmt,
@@ -97,7 +98,7 @@ def build_logging_config(
             json_formatter["static_fields"] = dict(static_fields)
         formatters = {formatter_name: json_formatter}
 
-    loggers: dict[str, dict[str, Any]] = {
+    loggers: dict[str, LoggingConfig] = {
         "band": {
             "level": band_level,
             "propagate": True,
@@ -130,7 +131,7 @@ def build_logging_config(
     }
 
 
-def configure_logging(*args: Any, **kwargs: Any) -> dict[str, Any]:
+def configure_logging(*args: Any, **kwargs: Any) -> LoggingConfig:
     """Build and apply Band's logging configuration.
 
     Returns the applied ``dictConfig`` dictionary so callers can inspect the

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -48,56 +48,26 @@ def build_logging_config(
     normalized_root_level = _normalize_level(root_level, name="root_level")
 
     formatter_name = "console"
-    handler: LoggingConfig = {
-        "class": "logging.StreamHandler",
-        "formatter": formatter_name,
-        "stream": f"ext://sys.{normalized_stream}",
-    }
-
-    formatters: dict[str, LoggingConfig]
     if normalized_style == "standard":
-        formatters = {
-            formatter_name: {
-                "format": _STANDARD_FORMAT,
-                "datefmt": datefmt,
-            }
-        }
-    elif normalized_style == "rich":
-        _require_optional_package("rich", style="rich", extra="logging")
-        handler = {
-            "()": "band.logging_config._build_rich_handler",
-            "formatter": formatter_name,
-            "stream": normalized_stream,
-            "datefmt": datefmt,
-        }
-        formatters = {
-            formatter_name: {
-                "format": "%(message)s",
-                "datefmt": datefmt,
-            }
-        }
-    else:
-        _require_optional_package(
-            "pythonjsonlogger.json",
-            style="json",
-            extra="logging",
-            package_name="python-json-logger>=3.0.0",
+        handler, formatters = _build_standard_config(
+            formatter_name=formatter_name,
+            stream=normalized_stream,
+            datefmt=datefmt,
         )
-        fields = tuple(json_fields or _JSON_DEFAULT_FIELDS)
-        _validate_json_fields(fields)
-        json_formatter: LoggingConfig = {
-            "()": "pythonjsonlogger.json.JsonFormatter",
-            "format": " ".join(f"%({field})s" for field in fields),
-            "datefmt": datefmt,
-            "rename_fields": {
-                field: renamed
-                for field, renamed in _JSON_RENAME_FIELDS.items()
-                if field in fields
-            },
-        }
-        if static_fields:
-            json_formatter["static_fields"] = dict(static_fields)
-        formatters = {formatter_name: json_formatter}
+    elif normalized_style == "rich":
+        handler, formatters = _build_rich_config(
+            formatter_name=formatter_name,
+            stream=normalized_stream,
+            datefmt=datefmt,
+        )
+    else:
+        handler, formatters = _build_json_config(
+            formatter_name=formatter_name,
+            stream=normalized_stream,
+            datefmt=datefmt,
+            json_fields=json_fields,
+            static_fields=static_fields,
+        )
 
     loggers: dict[str, LoggingConfig] = {
         "band": {
@@ -141,6 +111,84 @@ def configure_logging(*args: Any, **kwargs: Any) -> LoggingConfig:
     config = build_logging_config(*args, **kwargs)
     logging.config.dictConfig(config)
     return config
+
+
+def _build_standard_config(
+    *,
+    formatter_name: str,
+    stream: LogStream,
+    datefmt: str,
+) -> tuple[LoggingConfig, dict[str, LoggingConfig]]:
+    handler: LoggingConfig = {
+        "class": "logging.StreamHandler",
+        "formatter": formatter_name,
+        "stream": f"ext://sys.{stream}",
+    }
+    formatters = {
+        formatter_name: {
+            "format": _STANDARD_FORMAT,
+            "datefmt": datefmt,
+        }
+    }
+    return handler, formatters
+
+
+def _build_rich_config(
+    *,
+    formatter_name: str,
+    stream: LogStream,
+    datefmt: str,
+) -> tuple[LoggingConfig, dict[str, LoggingConfig]]:
+    _require_optional_package("rich", style="rich", extra="logging")
+    handler: LoggingConfig = {
+        "()": "band.logging_config._build_rich_handler",
+        "formatter": formatter_name,
+        "stream": stream,
+        "datefmt": datefmt,
+    }
+    formatters = {
+        formatter_name: {
+            "format": "%(message)s",
+            "datefmt": datefmt,
+        }
+    }
+    return handler, formatters
+
+
+def _build_json_config(
+    *,
+    formatter_name: str,
+    stream: LogStream,
+    datefmt: str,
+    json_fields: Sequence[str] | None,
+    static_fields: Mapping[str, Any] | None,
+) -> tuple[LoggingConfig, dict[str, LoggingConfig]]:
+    _require_optional_package(
+        "pythonjsonlogger.json",
+        style="json",
+        extra="logging",
+        package_name="python-json-logger>=3.0.0",
+    )
+    fields = tuple(json_fields or _JSON_DEFAULT_FIELDS)
+    _validate_json_fields(fields)
+    handler: LoggingConfig = {
+        "class": "logging.StreamHandler",
+        "formatter": formatter_name,
+        "stream": f"ext://sys.{stream}",
+    }
+    json_formatter: LoggingConfig = {
+        "()": "pythonjsonlogger.json.JsonFormatter",
+        "format": " ".join(f"%({field})s" for field in fields),
+        "datefmt": datefmt,
+        "rename_fields": {
+            field: renamed
+            for field, renamed in _JSON_RENAME_FIELDS.items()
+            if field in fields
+        },
+    }
+    if static_fields:
+        json_formatter["static_fields"] = dict(static_fields)
+    return handler, {formatter_name: json_formatter}
 
 
 def _build_rich_handler(*, stream: LogStream, datefmt: str) -> logging.Handler:

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -41,6 +41,24 @@ def build_logging_config(
     The default keeps noisy dependencies at WARNING while enabling Band SDK
     logs at INFO. Applications can inspect, modify, then apply the returned
     dict themselves, or call :func:`configure_logging`.
+
+    Args:
+        level: Logging level for the ``band`` logger. Accepts logging constants
+            like ``logging.INFO`` or names like ``"INFO"``.
+        style: Output style: ``"standard"``, ``"rich"``, or ``"json"``.
+            ``"rich"`` and ``"json"`` require ``band-sdk[logging]``.
+        root_level: Root logger level for non-Band loggers.
+        stream: Console stream: ``"stderr"`` or ``"stdout"``.
+        datefmt: Timestamp format used by standard, Rich, and JSON output.
+        extra_loggers: Optional logger-name to level mapping, for example
+            ``{"httpx": "WARNING"}``.
+        json_fields: LogRecord field names to include in JSON output.
+        static_fields: Fixed fields added to every JSON record.
+
+    Examples:
+        ``build_logging_config()``
+        ``build_logging_config(style="json", stream="stdout")``
+        ``build_logging_config(level="DEBUG", extra_loggers={"httpx": "WARNING"})``
     """
     normalized_style = _normalize_style(style)
     normalized_stream = _normalize_stream(stream)
@@ -99,6 +117,14 @@ def configure_logging(*args: Any, **kwargs: Any) -> LoggingConfig:
 
     Returns the applied ``dictConfig`` dictionary so callers can inspect the
     exact configuration.
+
+    Common forms:
+        ``configure_logging()``
+        ``configure_logging(style="rich")``
+        ``configure_logging(style="json", stream="stdout")``
+        ``configure_logging(level="DEBUG", extra_loggers={"httpx": "WARNING"})``
+
+    See :func:`build_logging_config` for all supported options.
     """
     config = build_logging_config(*args, **kwargs)
     logging.config.dictConfig(config)

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -112,7 +112,17 @@ def build_logging_config(
     }
 
 
-def configure_logging(*args: Any, **kwargs: Any) -> LoggingConfig:
+def configure_logging(
+    level: LogLevel = logging.INFO,
+    *,
+    style: LoggingStyle = "standard",
+    root_level: LogLevel = logging.WARNING,
+    stream: LogStream = "stderr",
+    datefmt: str = "%Y-%m-%d %H:%M:%S",
+    extra_loggers: Mapping[str, LogLevel] | None = None,
+    json_fields: Sequence[str] | None = None,
+    static_fields: Mapping[str, Any] | None = None,
+) -> LoggingConfig:
     """Build and apply Band's logging configuration.
 
     Returns the applied ``dictConfig`` dictionary so callers can inspect the
@@ -126,7 +136,16 @@ def configure_logging(*args: Any, **kwargs: Any) -> LoggingConfig:
 
     See :func:`build_logging_config` for all supported options.
     """
-    config = build_logging_config(*args, **kwargs)
+    config = build_logging_config(
+        level,
+        style=style,
+        root_level=root_level,
+        stream=stream,
+        datefmt=datefmt,
+        extra_loggers=extra_loggers,
+        json_fields=json_fields,
+        static_fields=static_fields,
+    )
     logging.config.dictConfig(config)
     return config
 

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -68,6 +68,7 @@ def build_logging_config(
             "()": "band.logging_config._build_rich_handler",
             "formatter": formatter_name,
             "stream": normalized_stream,
+            "datefmt": datefmt,
         }
         formatters = {
             formatter_name: {
@@ -77,10 +78,10 @@ def build_logging_config(
         }
     else:
         _require_optional_package(
-            "pythonjsonlogger",
+            "pythonjsonlogger.json",
             style="json",
             extra="logging",
-            package_name="python-json-logger",
+            package_name="python-json-logger>=3.0.0",
         )
         fields = tuple(json_fields or _JSON_DEFAULT_FIELDS)
         _validate_json_fields(fields)
@@ -142,7 +143,7 @@ def configure_logging(*args: Any, **kwargs: Any) -> LoggingConfig:
     return config
 
 
-def _build_rich_handler(*, stream: LogStream) -> logging.Handler:
+def _build_rich_handler(*, stream: LogStream, datefmt: str) -> logging.Handler:
     from rich.console import Console
     from rich.logging import RichHandler
 
@@ -152,6 +153,7 @@ def _build_rich_handler(*, stream: LogStream) -> logging.Handler:
         rich_tracebacks=True,
         markup=False,
         show_path=False,
+        log_time_format=datefmt,
     )
 
 

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -69,6 +69,8 @@ def build_logging_config(
                 json_fields=json_fields,
                 static_fields=static_fields,
             )
+        case _:
+            raise AssertionError(f"Unexpected logging style: {normalized_style!r}")
 
     loggers: dict[str, LoggingConfig] = {
         "band": {

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -77,6 +77,8 @@ def build_logging_config(
         extra_loggers=extra_loggers,
     )
 
+    # Keep existing application loggers alive; SDK helpers should not silently
+    # disable logging configured by the host process.
     return {
         "version": 1,
         "disable_existing_loggers": False,
@@ -108,6 +110,8 @@ def _build_logger_configs(
     level: LogLevel,
     extra_loggers: Mapping[str, LogLevel] | None,
 ) -> dict[str, LoggingConfig]:
+    # Band logs are opt-in at INFO by default; unrelated dependencies stay at
+    # the root level unless callers explicitly list them in extra_loggers.
     loggers: dict[str, LoggingConfig] = {
         "band": {
             "level": level,
@@ -159,6 +163,8 @@ def _build_rich_config(
     datefmt: str,
 ) -> tuple[LoggingConfig, dict[str, LoggingConfig]]:
     _require_optional_package("rich", style="rich", extra="logging")
+    # Rich needs a factory because stdout/stderr and date formatting are passed
+    # through its Console/RichHandler constructors, not a plain StreamHandler.
     handler: LoggingConfig = {
         "()": "band.logging_config._build_rich_handler",
         "formatter": formatter_name,
@@ -182,6 +188,8 @@ def _build_json_config(
     json_fields: Sequence[str] | None,
     static_fields: Mapping[str, Any] | None,
 ) -> tuple[LoggingConfig, dict[str, LoggingConfig]]:
+    # The formatter path uses the v3 submodule; check that exact import so older
+    # python-json-logger installs fail with our actionable BandConfigError.
     _require_optional_package(
         "pythonjsonlogger.json",
         style="json",
@@ -214,6 +222,7 @@ def _build_rich_handler(*, stream: LogStream, datefmt: str) -> logging.Handler:
     from rich.console import Console
     from rich.logging import RichHandler
 
+    # Do not let Rich default to stderr when callers requested stdout.
     output = sys.stdout if stream == "stdout" else sys.stderr
     return RichHandler(
         console=Console(file=output),

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -72,23 +72,10 @@ def build_logging_config(
         case _:
             raise AssertionError(f"Unexpected logging style: {normalized_style!r}")
 
-    loggers: dict[str, LoggingConfig] = {
-        "band": {
-            "level": band_level,
-            "propagate": True,
-        }
-    }
-    if extra_loggers:
-        for logger_name, logger_level in extra_loggers.items():
-            if not logger_name:
-                raise ValueError("extra_loggers keys must be non-empty logger names")
-            loggers[logger_name] = {
-                "level": _normalize_level(
-                    logger_level,
-                    name=f"extra_loggers[{logger_name!r}]",
-                ),
-                "propagate": True,
-            }
+    loggers = _build_logger_configs(
+        level=band_level,
+        extra_loggers=extra_loggers,
+    )
 
     return {
         "version": 1,
@@ -114,6 +101,35 @@ def configure_logging(*args: Any, **kwargs: Any) -> LoggingConfig:
     config = build_logging_config(*args, **kwargs)
     logging.config.dictConfig(config)
     return config
+
+
+def _build_logger_configs(
+    *,
+    level: LogLevel,
+    extra_loggers: Mapping[str, LogLevel] | None,
+) -> dict[str, LoggingConfig]:
+    loggers: dict[str, LoggingConfig] = {
+        "band": {
+            "level": level,
+            "propagate": True,
+        }
+    }
+
+    if not extra_loggers:
+        return loggers
+
+    for logger_name, logger_level in extra_loggers.items():
+        if not logger_name:
+            raise ValueError("extra_loggers keys must be non-empty logger names")
+        loggers[logger_name] = {
+            "level": _normalize_level(
+                logger_level,
+                name=f"extra_loggers[{logger_name!r}]",
+            ),
+            "propagate": True,
+        }
+
+    return loggers
 
 
 def _build_standard_config(

--- a/src/band/logging_config.py
+++ b/src/band/logging_config.py
@@ -326,7 +326,14 @@ def _require_optional_package(
     extra: str,
     package_name: str | None = None,
 ) -> None:
-    if importlib.util.find_spec(import_name) is not None:
+    # find_spec imports the parent package for a dotted name, so an entirely
+    # missing dependency raises ModuleNotFoundError instead of returning None.
+    # Treat both "missing parent" and "missing submodule" as not installed.
+    try:
+        spec = importlib.util.find_spec(import_name)
+    except ModuleNotFoundError:
+        spec = None
+    if spec is not None:
         return
     dependency = package_name or import_name
     raise BandConfigError(

--- a/tests/test_band_import.py
+++ b/tests/test_band_import.py
@@ -4,10 +4,23 @@ import importlib.util
 
 
 def test_band_import_surface_exposes_agent_and_link() -> None:
-    from band import Agent, BandLink, build_logging_config, configure_logging
+    from band import (
+        Agent,
+        BandLink,
+        LogLevel,
+        LoggingConfig,
+        LoggingStyle,
+        LogStream,
+        build_logging_config,
+        configure_logging,
+    )
 
     assert Agent.__name__ == "Agent"
     assert BandLink.__name__ == "BandLink"
+    assert LogLevel is not None
+    assert LoggingConfig is not None
+    assert LoggingStyle is not None
+    assert LogStream is not None
     assert build_logging_config.__name__ == "build_logging_config"
     assert configure_logging.__name__ == "configure_logging"
 

--- a/tests/test_band_import.py
+++ b/tests/test_band_import.py
@@ -4,10 +4,12 @@ import importlib.util
 
 
 def test_band_import_surface_exposes_agent_and_link() -> None:
-    from band import Agent, BandLink
+    from band import Agent, BandLink, build_logging_config, configure_logging
 
     assert Agent.__name__ == "Agent"
     assert BandLink.__name__ == "BandLink"
+    assert build_logging_config.__name__ == "build_logging_config"
+    assert configure_logging.__name__ == "configure_logging"
 
 
 def test_legacy_root_package_is_not_available() -> None:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -89,13 +89,27 @@ def test_build_logging_config_returns_fresh_normalized_dict(monkeypatch) -> None
 
 def test_json_style_requires_optional_dependency(monkeypatch) -> None:
     def fake_find_spec(name: str):
-        if name == "pythonjsonlogger":
+        if name == "pythonjsonlogger.json":
             return None
         return importlib.util.find_spec(name)
 
     monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
 
     with pytest.raises(BandConfigError, match=r"band-sdk\[logging\]"):
+        build_logging_config(style="json")
+
+
+def test_json_style_requires_v3_json_submodule(monkeypatch) -> None:
+    def fake_find_spec(name: str):
+        if name == "pythonjsonlogger":
+            return object()
+        if name == "pythonjsonlogger.json":
+            return None
+        return importlib.util.find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    with pytest.raises(BandConfigError, match=r"python-json-logger>=3\.0\.0"):
         build_logging_config(style="json")
 
 
@@ -142,3 +156,18 @@ def test_configure_logging_rich_honors_stdout(
     captured = capsys.readouterr()
     assert "rich visible" in captured.out
     assert "rich visible" not in captured.err
+
+
+def test_rich_style_passes_datefmt_to_handler(monkeypatch) -> None:
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str):
+        if name == "rich":
+            return object()
+        return real_find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    config = build_logging_config(style="rich", datefmt="%H:%M:%S")
+
+    assert config["handlers"]["console"]["datefmt"] == "%H:%M:%S"

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -128,3 +128,17 @@ def test_configure_logging_json_outputs_machine_readable_records(
     assert record["logger"] == "band.runtime"
     assert record["message"] == "json visible"
     assert record["service"] == "agent"
+
+
+def test_configure_logging_rich_honors_stdout(
+    capsys,
+    restore_logging,
+) -> None:
+    pytest.importorskip("rich")
+
+    configure_logging(style="rich", stream="stdout")
+    logging.getLogger("band.runtime").info("rich visible")
+
+    captured = capsys.readouterr()
+    assert "rich visible" in captured.out
+    assert "rich visible" not in captured.err

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -12,7 +12,9 @@ from band import BandConfigError, build_logging_config, configure_logging
 
 
 def test_configure_logging_signature_matches_builder() -> None:
-    assert inspect.signature(configure_logging) == inspect.signature(build_logging_config)
+    assert inspect.signature(configure_logging) == inspect.signature(
+        build_logging_config
+    )
 
 
 @pytest.fixture
@@ -57,7 +59,7 @@ def test_build_logging_config_returns_fresh_normalized_dict(monkeypatch) -> None
     real_find_spec = importlib.util.find_spec
 
     def fake_find_spec(name: str):
-        if name == "pythonjsonlogger":
+        if name == "pythonjsonlogger.json":
             return object()
         return real_find_spec(name)
 
@@ -104,6 +106,21 @@ def test_json_style_requires_optional_dependency(monkeypatch) -> None:
         build_logging_config(style="json")
 
 
+def test_json_style_raises_config_error_when_package_absent(monkeypatch) -> None:
+    # When python-json-logger is not installed at all, find_spec imports the
+    # missing parent package and raises ModuleNotFoundError rather than
+    # returning None. The guard must surface the friendly BandConfigError.
+    def fake_find_spec(name: str):
+        if name.startswith("pythonjsonlogger"):
+            raise ModuleNotFoundError(name="pythonjsonlogger")
+        return importlib.util.find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    with pytest.raises(BandConfigError, match=r"band-sdk\[logging\]"):
+        build_logging_config(style="json")
+
+
 def test_json_style_requires_v3_json_submodule(monkeypatch) -> None:
     def fake_find_spec(name: str):
         if name == "pythonjsonlogger":
@@ -122,7 +139,9 @@ def test_bool_levels_are_rejected() -> None:
     with pytest.raises(ValueError, match="level must be an int or logging level name"):
         build_logging_config(level=True)
 
-    with pytest.raises(ValueError, match="root_level must be an int or logging level name"):
+    with pytest.raises(
+        ValueError, match="root_level must be an int or logging level name"
+    ):
         build_logging_config(root_level=False)
 
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import json
 import logging
 from collections.abc import Iterator
@@ -8,6 +9,10 @@ from collections.abc import Iterator
 import pytest
 
 from band import BandConfigError, build_logging_config, configure_logging
+
+
+def test_configure_logging_signature_matches_builder() -> None:
+    assert inspect.signature(configure_logging) == inspect.signature(build_logging_config)
 
 
 @pytest.fixture

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -113,6 +113,14 @@ def test_json_style_requires_v3_json_submodule(monkeypatch) -> None:
         build_logging_config(style="json")
 
 
+def test_bool_levels_are_rejected() -> None:
+    with pytest.raises(ValueError, match="level must be an int or logging level name"):
+        build_logging_config(level=True)
+
+    with pytest.raises(ValueError, match="root_level must be an int or logging level name"):
+        build_logging_config(root_level=False)
+
+
 def test_configure_logging_shows_band_logs_and_suppresses_noisy_info(
     capsys,
     restore_logging,

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from band import BandConfigError, build_logging_config, configure_logging
+
+
+@pytest.fixture
+def restore_logging() -> Iterator[None]:
+    root = logging.getLogger()
+    band_logger = logging.getLogger("band")
+    noisy_logger = logging.getLogger("third_party.noisy")
+
+    root_state = (list(root.handlers), root.level, root.disabled)
+    band_state = (
+        list(band_logger.handlers),
+        band_logger.level,
+        band_logger.propagate,
+        band_logger.disabled,
+    )
+    noisy_state = (
+        list(noisy_logger.handlers),
+        noisy_logger.level,
+        noisy_logger.propagate,
+        noisy_logger.disabled,
+    )
+
+    try:
+        yield
+    finally:
+        root.handlers[:] = root_state[0]
+        root.setLevel(root_state[1])
+        root.disabled = root_state[2]
+
+        band_logger.handlers[:] = band_state[0]
+        band_logger.setLevel(band_state[1])
+        band_logger.propagate = band_state[2]
+        band_logger.disabled = band_state[3]
+
+        noisy_logger.handlers[:] = noisy_state[0]
+        noisy_logger.setLevel(noisy_state[1])
+        noisy_logger.propagate = noisy_state[2]
+        noisy_logger.disabled = noisy_state[3]
+
+
+def test_build_logging_config_returns_fresh_normalized_dict(monkeypatch) -> None:
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str):
+        if name == "pythonjsonlogger":
+            return object()
+        return real_find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    config = build_logging_config(
+        style="json",
+        stream="stdout",
+        extra_loggers={"band_parlant_agent": "DEBUG"},
+        static_fields={"service": "agent"},
+    )
+    second_config = build_logging_config()
+
+    assert config is not second_config
+    assert config["version"] == 1
+    assert config["disable_existing_loggers"] is False
+    assert config["handlers"]["console"]["stream"] == "ext://sys.stdout"
+    assert config["root"] == {"level": logging.WARNING, "handlers": ["console"]}
+    assert config["loggers"]["band"] == {"level": logging.INFO, "propagate": True}
+    assert config["loggers"]["band_parlant_agent"] == {
+        "level": "DEBUG",
+        "propagate": True,
+    }
+
+    formatter = config["formatters"]["console"]
+    assert formatter["()"] == "pythonjsonlogger.json.JsonFormatter"
+    assert formatter["rename_fields"] == {
+        "asctime": "timestamp",
+        "levelname": "level",
+        "name": "logger",
+    }
+    assert formatter["static_fields"] == {"service": "agent"}
+
+
+def test_json_style_requires_optional_dependency(monkeypatch) -> None:
+    def fake_find_spec(name: str):
+        if name == "pythonjsonlogger":
+            return None
+        return importlib.util.find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    with pytest.raises(BandConfigError, match=r"band-sdk\[logging\]"):
+        build_logging_config(style="json")
+
+
+def test_configure_logging_shows_band_logs_and_suppresses_noisy_info(
+    capsys,
+    restore_logging,
+) -> None:
+    configure_logging()
+
+    logging.getLogger("band.runtime").info("band visible")
+    logging.getLogger("third_party.noisy").info("dependency hidden")
+
+    captured = capsys.readouterr()
+    assert "band visible" in captured.err
+    assert "dependency hidden" not in captured.err
+
+
+def test_configure_logging_json_outputs_machine_readable_records(
+    capsys,
+    restore_logging,
+) -> None:
+    pytest.importorskip("pythonjsonlogger")
+
+    configure_logging(style="json", stream="stdout", static_fields={"service": "agent"})
+    logging.getLogger("band.runtime").info("json visible")
+
+    captured = capsys.readouterr()
+    record = json.loads(captured.out)
+    assert record["level"] == "INFO"
+    assert record["logger"] == "band.runtime"
+    assert record["message"] == "json visible"
+    assert record["service"] == "agent"

--- a/tests/test_readme_snippets.py
+++ b/tests/test_readme_snippets.py
@@ -44,9 +44,11 @@ class TestTopLevelImports:
     """README shows `from band import Agent` and similar."""
 
     def test_agent_import(self) -> None:
-        from band import Agent
+        from band import Agent, build_logging_config, configure_logging
 
         assert Agent is not None
+        assert build_logging_config is not None
+        assert configure_logging is not None
 
     def test_adapter_features_and_capability_import(self) -> None:
         from band.core.types import AdapterFeatures, Capability

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,7 @@ wheels = [
 
 [[package]]
 name = "band-sdk"
-version = "0.2.11"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "band-client-rest" },
@@ -615,6 +615,11 @@ langgraph = [
 letta = [
     { name = "letta-client" },
 ]
+logging = [
+    { name = "python-json-logger" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-crewai' or extra == 'extra-8-band-sdk-dev-crewai'" },
+    { name = "rich", version = "15.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai')" },
+]
 opencode = [
     { name = "httpx" },
 ]
@@ -727,8 +732,10 @@ requires-dist = [
     { name = "python-dotenv", marker = "extra == 'bridge'", specifier = ">=1.2.2" },
     { name = "python-dotenv", marker = "extra == 'bridge-agentcore'", specifier = ">=1.2.2" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.2.2" },
+    { name = "python-json-logger", marker = "extra == 'logging'", specifier = ">=3.0.0" },
     { name = "python-multipart", marker = "extra == 'a2a-gateway'", specifier = ">=0.0.22" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rich", marker = "extra == 'logging'", specifier = ">=14.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "ruff", marker = "extra == 'dev-crewai'", specifier = ">=0.8.0" },
     { name = "slack-sdk", marker = "extra == 'dev'", specifier = ">=3.27.0" },
@@ -750,7 +757,7 @@ requires-dist = [
     { name = "werkzeug", marker = "extra == 'dev'", specifier = ">=3.1.6" },
     { name = "werkzeug", marker = "extra == 'parlant'", specifier = ">=3.1.6" },
 ]
-provides-extras = ["codex", "opencode", "letta", "pydantic-ai", "anthropic", "langgraph", "claude-sdk", "parlant", "crewai", "gemini", "a2a", "a2a-gateway", "a2a-gateway-demo", "acp", "slack", "bridge", "bridge-agentcore", "agentcore-runtime", "google-adk", "dev", "dev-crewai"]
+provides-extras = ["logging", "codex", "opencode", "letta", "pydantic-ai", "anthropic", "langgraph", "claude-sdk", "parlant", "crewai", "gemini", "a2a", "a2a-gateway", "a2a-gateway-demo", "acp", "slack", "bridge", "bridge-agentcore", "agentcore-runtime", "google-adk", "dev", "dev-crewai"]
 
 [[package]]
 name = "bcrypt"
@@ -4241,12 +4248,18 @@ resolution-markers = [
     "python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
     "python_full_version == '3.13.*' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
     "python_full_version < '3.13' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
     "python_full_version >= '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
     "python_full_version == '3.13.*' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
     "python_full_version < '3.13' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
 ]
 dependencies = [
-    { name = "mdurl", marker = "extra == 'extra-8-band-sdk-crewai' or extra == 'extra-8-band-sdk-dev-crewai' or (extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-parlant')" },
+    { name = "mdurl", marker = "extra == 'extra-8-band-sdk-crewai' or extra != 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -7311,6 +7324,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
@@ -7778,20 +7800,71 @@ name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version >= '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version == '3.13.*' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
+    "python_full_version < '3.13' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
 ]
 dependencies = [
     { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-parlant')" },
-    { name = "pygments", marker = "extra == 'extra-8-band-sdk-dev' or extra == 'extra-8-band-sdk-parlant' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai')" },
+    { name = "pygments", marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [


### PR DESCRIPTION
## Summary
Adds opt-in SDK logging helpers for standard text, Rich console, and JSON output.

## Why
Band modules use named loggers, and applications should explicitly choose process-wide handlers/formatters. The helper returns a fresh `dictConfig` so callers can inspect or customize it before applying.

## Changes
- Add `build_logging_config(...)` and `configure_logging(...)` at the top-level `band` import surface.
- Add typed aliases for logging style, stream, levels, and config dicts.
- Add optional `band-sdk[logging]` extra for `rich` and `python-json-logger`.
- Update README and shared example `setup_logging.py` helpers.
- Demonstrate standard, Rich, and JSON logging styles in examples.
- Validate inputs (reject bool levels), forward `datefmt` to the Rich handler, and mirror `configure_logging`'s signature to `build_logging_config`.
- Raise a friendly `BandConfigError` (with install hint) when a style's optional dependency is missing, including when the package is absent entirely.

## Related
Linear: INT-882

## Testing
- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/` (full unit suite passes)
- [x] `uv run --extra logging pytest tests/test_logging_config.py tests/test_band_import.py tests/test_readme_snippets.py -q`
- [x] `uv run ruff check src/ tests/ examples/` and `uv run ruff format --check .`
- [x] `uv run pyrefly check`
