### PR TITLE
ci: use actions/create-github-app-token@v3 directly

### DIFF
--- a/.github/workflows/promote-dev-to-main.yml
+++ b/.github/workflows/promote-dev-to-main.yml
@@ -29,12 +29,12 @@ jobs:
           fetch-depth: 0
           ref: dev
 
-      - name: Generate App Token
-        id: token
-        uses: band-ai/.github/actions/generate-app-token@v1
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
         with:
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          app-client-id: ${{ secrets.APP_CLIENT_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Fetch main
         run: git fetch origin main
@@ -101,7 +101,7 @@ jobs:
       - name: Create Pull Request
         if: steps.check_promotion.outputs.needs_promotion == 'true' && inputs.dry_run == false
         env:
-          GH_TOKEN: ${{ steps.app_token_generator.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr create \
             --base main \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,18 +28,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate App Token
-        id: token
-        uses: band-ai/.github/actions/generate-app-token@v1
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
         with:
-          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          app-client-id: ${{ secrets.APP_CLIENT_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Release Please
         uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ steps.app_token_generator.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main


### PR DESCRIPTION
## Summary
- Replace the cross-org `band-ai/.github/actions/generate-app-token@v1` composite action with a direct call to `actions/create-github-app-token@v3` in both `release.yml` and `promote-dev-to-main.yml`. The composite action lives in a private repo and is not accessible from this public repo.
- Fix the broken `steps.app_token_generator.outputs.token` references (the step id had been renamed to `token` but downstream refs were never updated). New step id is `app-token` and refs use `steps.app-token.outputs.token`.

## Prerequisite
- `secrets.APP_PRIVATE_KEY` must be stored as **raw PEM** (`-----BEGIN PRIVATE KEY-----...`), not base64-encoded. Update the secret value in repo settings before merging.

## Test plan
- [ ] Confirm `APP_CLIENT_ID` and `APP_PRIVATE_KEY` (raw PEM) secrets are set on the repo
- [ ] After merge, trigger `release.yml` and verify the token step succeeds
- [ ] Trigger `promote-dev-to-main` (dry run) and verify the token step succeeds