### PR TITLE
feat: add py.typed marker to band package (PEP 561) [INT-885]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ package-dir = {"" = "src"}
 include-package-data = true
 
 [tool.setuptools.package-data]
+"band" = ["py.typed"]
 "band.integrations.slack" = ["templates/*.yaml"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

Mark the `band` package as typed (PEP 561) so downstream consumers' type checkers (mypy, pyright, pyrefly) recognize and use the SDK's inline annotations. Without a `py.typed` marker, `import band` resolves as **untyped** and all our type hints are silently ignored by consumers.

## Changes

- Add empty `src/band/py.typed` marker file
- Add `"band" = ["py.typed"]` to `[tool.setuptools.package-data]` in `pyproject.toml` so the marker is included in the wheel/sdist

## Related Issues

Relates to INT-885

## Testing

- [x] Built the wheel (`uv build`) and confirmed `band/py.typed` is present in the archive
- [x] Unit tests pass (`uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/`)
- [x] Pre-commit checks pass (`uv run pre-commit run --files pyproject.toml src/band/py.typed`)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Code follows project style guidelines

> _Tests added/updated and documentation are N/A: this is a packaging-only marker with no logic and no user-facing API change._
