### PR TITLE
chore: update repo references to band-ai/band-sdk-python

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://github.com/thenvoi/thenvoi-sdk-python#readme
+    url: https://github.com/band-ai/band-sdk-python#readme
     about: Check the README for usage instructions and examples

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -457,7 +457,7 @@ Every example file must include PEP 723 inline script metadata at the top for st
 # dependencies = ["band-sdk[<extra>]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Brief description of what this example does.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Thank you for your interest in contributing to the Band Python SDK! This documen
 2. **Add the upstream remote**
 
    ```bash
-   git remote add upstream https://github.com/thenvoi/thenvoi-sdk-python.git
+   git remote add upstream https://github.com/band-ai/band-sdk-python.git
    ```
 
 3. **Install dependencies**

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Band Python SDK
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/thenvoi/thenvoi-sdk-python/main/assets/band-readme-banner.png" alt="Band" width="100%">
+  <img src="https://raw.githubusercontent.com/band-ai/band-sdk-python/main/assets/band-readme-banner.png" alt="Band" width="100%">
 </p>
 
 <div align="center">
   <a href="https://pypi.org/project/band-sdk/"><img src="https://img.shields.io/pypi/v/band-sdk.svg" alt="PyPI version"></a>
-  <a href="https://github.com/thenvoi/thenvoi-sdk-python/actions"><img src="https://img.shields.io/badge/CI-passing-brightgreen" alt="CI"></a>
+  <a href="https://github.com/band-ai/band-sdk-python/actions"><img src="https://img.shields.io/badge/CI-passing-brightgreen" alt="CI"></a>
   <a href="https://docs.band.ai"><img src="https://img.shields.io/badge/docs-band.ai-blue" alt="Docs"></a>
   <a href="https://discord.gg/gvMYpB9eAY"><img src="https://img.shields.io/badge/Discord-join%20chat-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://pypi.org/project/band-sdk/"><img src="https://img.shields.io/pypi/pyversions/band-sdk.svg" alt="Python 3.11+"></a>

--- a/examples/20-questions-arena/guesser_agent.py
+++ b/examples/20-questions-arena/guesser_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Guesser agent for the 20 Questions Arena game.

--- a/examples/20-questions-arena/start_game.py
+++ b/examples/20-questions-arena/start_game.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """Start a 20 Questions Arena game as a user by creating a room, adding all agents, and sending a message.
 

--- a/examples/20-questions-arena/thinker_agent.py
+++ b/examples/20-questions-arena/thinker_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Thinker agent for the 20 Questions Arena game.

--- a/examples/a2a_bridge/01_basic_agent.py
+++ b/examples/a2a_bridge/01_basic_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[a2a]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic A2A adapter example.

--- a/examples/a2a_bridge/02_with_auth.py
+++ b/examples/a2a_bridge/02_with_auth.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[a2a]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 A2A adapter with authentication example.

--- a/examples/a2a_gateway/01_basic_gateway.py
+++ b/examples/a2a_gateway/01_basic_gateway.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[a2a_gateway]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic A2A Gateway adapter example.

--- a/examples/a2a_gateway/02_with_demo_agent.py
+++ b/examples/a2a_gateway/02_with_demo_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[a2a_gateway_demo]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Run A2A Gateway with Demo Orchestrator Agent.

--- a/examples/acp/01_basic_acp_server.py
+++ b/examples/acp/01_basic_acp_server.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[acp]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic ACP Server example - Band as an ACP agent.

--- a/examples/acp/02_acp_client.py
+++ b/examples/acp/02_acp_client.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[acp]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 ACP Client example - Use a remote ACP agent from Band.

--- a/examples/acp/03_acp_server_with_routing.py
+++ b/examples/acp/03_acp_server_with_routing.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[acp]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 ACP Server with routing - Target specific peers via slash commands or modes.

--- a/examples/acp/04_acp_client_rich_streaming.py
+++ b/examples/acp/04_acp_client_rich_streaming.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[acp]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 ACP Client with rich streaming - Thoughts, tool calls, and plans.

--- a/examples/acp/05_acp_server_push_notifications.py
+++ b/examples/acp/05_acp_server_push_notifications.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[acp]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 ACP Server with push notifications - Real-time activity from Band peers.

--- a/examples/acp/06_cursor_client.py
+++ b/examples/acp/06_cursor_client.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[acp]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Cursor ACP Client - Use Cursor's AI agent from Band.

--- a/examples/acp/07_jetbrains_server.py
+++ b/examples/acp/07_jetbrains_server.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[acp]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 JetBrains ACP Server - Use Band as an ACP agent in JetBrains IDEs.

--- a/examples/acp/08_acp_bridge_architecture.py
+++ b/examples/acp/08_acp_bridge_architecture.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[acp]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 ACP Bridge Architecture example.

--- a/examples/agentcore/agentcore_llm_server.py
+++ b/examples/agentcore/agentcore_llm_server.py
@@ -7,7 +7,7 @@
 # ]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """AgentCore container that runs the Band SDK per invocation.
 

--- a/examples/anthropic/01_basic_agent.py
+++ b/examples/anthropic/01_basic_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[anthropic]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic Anthropic SDK agent example.

--- a/examples/anthropic/02_custom_instructions.py
+++ b/examples/anthropic/02_custom_instructions.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[anthropic]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Agent with custom system prompt instructions.

--- a/examples/anthropic/03_tom_agent.py
+++ b/examples/anthropic/03_tom_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[anthropic]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Tom the cat agent - tries to catch Jerry!

--- a/examples/anthropic/04_jerry_agent.py
+++ b/examples/anthropic/04_jerry_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[anthropic]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Jerry the mouse agent - clever and cheese-loving!

--- a/examples/anthropic/05_contact_management.py
+++ b/examples/anthropic/05_contact_management.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[anthropic]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Contact management example using the Anthropic adapter.

--- a/examples/claude_sdk/01_basic_agent.py
+++ b/examples/claude_sdk/01_basic_agent.py
@@ -4,7 +4,7 @@
 # dependencies = ["band-sdk[claude_sdk]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic Claude SDK Agent Example.

--- a/examples/claude_sdk/02_extended_thinking.py
+++ b/examples/claude_sdk/02_extended_thinking.py
@@ -4,7 +4,7 @@
 # dependencies = ["band-sdk[claude_sdk]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Extended Thinking Claude SDK Agent Example.

--- a/examples/claude_sdk/03_tom_agent.py
+++ b/examples/claude_sdk/03_tom_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[claude_sdk]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Tom the cat agent using Claude SDK.

--- a/examples/claude_sdk/04_jerry_agent.py
+++ b/examples/claude_sdk/04_jerry_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[claude_sdk]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Jerry the mouse agent using Claude SDK.

--- a/examples/claude_sdk/README.md
+++ b/examples/claude_sdk/README.md
@@ -28,7 +28,7 @@ claude --version
 
 ```bash
 # Install with claude_sdk extras
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[claude_sdk]"
+uv add "git+https://github.com/band-ai/band-sdk-python.git[claude_sdk]"
 
 # Or from repository
 uv sync --extra claude_sdk

--- a/examples/claude_sdk_docker/runner.py
+++ b/examples/claude_sdk_docker/runner.py
@@ -4,7 +4,7 @@
 # dependencies = ["band-sdk[claude_sdk]", "pyyaml"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 YAML-based agent runner for Band Claude SDK.

--- a/examples/codex/01_basic_agent.py
+++ b/examples/codex/01_basic_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[codex]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic Codex adapter agent example.

--- a/examples/crewai/01_basic_agent.py
+++ b/examples/crewai/01_basic_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[crewai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic CrewAI agent example.

--- a/examples/crewai/02_role_based_agent.py
+++ b/examples/crewai/02_role_based_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[crewai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 CrewAI agent with role, goal, and backstory.

--- a/examples/crewai/03_coordinator_agent.py
+++ b/examples/crewai/03_coordinator_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[crewai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 CrewAI coordinator agent for multi-agent orchestration.

--- a/examples/crewai/04_research_crew.py
+++ b/examples/crewai/04_research_crew.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[crewai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Complete CrewAI-style crew with multiple specialized agents.

--- a/examples/crewai/05_tom_agent.py
+++ b/examples/crewai/05_tom_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[crewai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Tom the cat agent using CrewAI.

--- a/examples/crewai/06_jerry_agent.py
+++ b/examples/crewai/06_jerry_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[crewai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Jerry the mouse agent using CrewAI.

--- a/examples/crewai/07_contact_and_memory_agent.py
+++ b/examples/crewai/07_contact_and_memory_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[crewai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 CrewAI agent with contact and memory tools enabled.

--- a/examples/crewai/08_flow_router.py
+++ b/examples/crewai/08_flow_router.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[crewai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """CrewAI Flow router example.
 

--- a/examples/crewai/09_flow_custom_tools.py
+++ b/examples/crewai/09_flow_custom_tools.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[crewai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """CrewAI Flow custom tools example.
 

--- a/examples/crewai/10_memory_tool_usage.py
+++ b/examples/crewai/10_memory_tool_usage.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[crewai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 CrewAI agent with memory tools enabled.

--- a/examples/crewai/README.md
+++ b/examples/crewai/README.md
@@ -446,4 +446,4 @@ Those examples depend heavily on model quality and prompt interpretation. They a
 
 - [CrewAI Documentation](https://docs.crewai.com/)
 - [CrewAI GitHub](https://github.com/crewAIInc/crewAI)
-- [Band SDK Documentation](https://github.com/thenvoi/thenvoi-sdk-python)
+- [Band SDK Documentation](https://github.com/band-ai/band-sdk-python)

--- a/examples/gemini/01_basic_agent.py
+++ b/examples/gemini/01_basic_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[gemini]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic Gemini agent example.

--- a/examples/google_adk/01_basic_agent.py
+++ b/examples/google_adk/01_basic_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[google_adk]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic Google ADK agent example.

--- a/examples/google_adk/02_custom_instructions.py
+++ b/examples/google_adk/02_custom_instructions.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[google_adk]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Google ADK agent with custom instructions and model selection.

--- a/examples/google_adk/03_custom_tools.py
+++ b/examples/google_adk/03_custom_tools.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[google_adk]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Google ADK agent with custom tools.

--- a/examples/langgraph/01_simple_agent.py
+++ b/examples/langgraph/01_simple_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Simple LangGraph agent example using the composition API.

--- a/examples/langgraph/02_custom_tools.py
+++ b/examples/langgraph/02_custom_tools.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Example showing how to add custom tools to a Band agent.

--- a/examples/langgraph/03_custom_personality.py
+++ b/examples/langgraph/03_custom_personality.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Example showing how to customize agent personality with custom instructions.

--- a/examples/langgraph/04_calculator_as_tool.py
+++ b/examples/langgraph/04_calculator_as_tool.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Example: Using graph_as_tool to wrap a standalone graph as a tool.

--- a/examples/langgraph/05_rag_as_tool.py
+++ b/examples/langgraph/05_rag_as_tool.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Example: Using the standalone Agentic RAG graph with Band platform.

--- a/examples/langgraph/06_delegate_to_sql_agent.py
+++ b/examples/langgraph/06_delegate_to_sql_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Example: Hierarchical agents with graph_as_tool.

--- a/examples/langgraph/07_tom_agent.py
+++ b/examples/langgraph/07_tom_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Tom the cat agent using LangGraph.

--- a/examples/langgraph/08_jerry_agent.py
+++ b/examples/langgraph/08_jerry_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Jerry the mouse agent using LangGraph.

--- a/examples/langgraph/09_research_ops_orchestrator.py
+++ b/examples/langgraph/09_research_ops_orchestrator.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Custom LangGraph orchestrator with platform tools and subgraph delegation.

--- a/examples/langgraph/10_memory_tool_usage.py
+++ b/examples/langgraph/10_memory_tool_usage.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[langgraph]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 LangGraph agent with memory tools enabled.

--- a/examples/langgraph/README.md
+++ b/examples/langgraph/README.md
@@ -12,7 +12,7 @@ uv sync --extra langgraph
 
 **If using as external library:**
 ```bash
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[langgraph]"
+uv add "git+https://github.com/band-ai/band-sdk-python.git[langgraph]"
 ```
 
 **Configuration:**

--- a/examples/letta/01_basic_agent.py
+++ b/examples/letta/01_basic_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[letta]", "python-dotenv"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic Letta agent example.

--- a/examples/mixed/01_strategy_coordinator.py
+++ b/examples/mixed/01_strategy_coordinator.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[crewai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Mixed-example CrewAI coordinator.

--- a/examples/mixed/02_draft_writer.py
+++ b/examples/mixed/02_draft_writer.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[crewai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Mixed-example CrewAI writer.

--- a/examples/mixed/03_fact_checker_a2a.py
+++ b/examples/mixed/03_fact_checker_a2a.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[a2a]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Remote A2A fact checker for the mixed example.

--- a/examples/mixed/04_risk_reviewer_a2a.py
+++ b/examples/mixed/04_risk_reviewer_a2a.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[a2a]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Remote A2A risk reviewer for the mixed example.

--- a/examples/mixed/05_a2a_bridge.py
+++ b/examples/mixed/05_a2a_bridge.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[a2a]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Mixed-example bridge launcher.

--- a/examples/opencode/01_basic_agent.py
+++ b/examples/opencode/01_basic_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[opencode]", "python-dotenv"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic OpenCode adapter agent example.

--- a/examples/parlant/01_basic_agent.py
+++ b/examples/parlant/01_basic_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[parlant]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic Parlant agent example using the official Parlant SDK.

--- a/examples/parlant/02_with_guidelines.py
+++ b/examples/parlant/02_with_guidelines.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[parlant]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Parlant agent with behavioral guidelines using the official Parlant SDK.

--- a/examples/parlant/03_support_agent.py
+++ b/examples/parlant/03_support_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[parlant]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Customer support agent using Parlant SDK with guidelines.

--- a/examples/parlant/05_jerry_agent.py
+++ b/examples/parlant/05_jerry_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[parlant]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Jerry the mouse agent using Parlant.

--- a/examples/parlant/README.md
+++ b/examples/parlant/README.md
@@ -16,7 +16,7 @@ Parlant provides:
 ### Install with Parlant support
 
 ```bash
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[parlant]"
+uv add "git+https://github.com/band-ai/band-sdk-python.git[parlant]"
 ```
 
 **Or from repository:**

--- a/examples/pydantic_ai/01_basic_agent.py
+++ b/examples/pydantic_ai/01_basic_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[pydantic-ai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic Pydantic AI agent example.

--- a/examples/pydantic_ai/02_custom_instructions.py
+++ b/examples/pydantic_ai/02_custom_instructions.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[pydantic-ai,anthropic]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Agent with custom system prompt instructions.

--- a/examples/pydantic_ai/03_tom_agent.py
+++ b/examples/pydantic_ai/03_tom_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[pydantic-ai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Tom the cat agent using Pydantic AI.

--- a/examples/pydantic_ai/04_jerry_agent.py
+++ b/examples/pydantic_ai/04_jerry_agent.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[pydantic-ai]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Jerry the mouse agent using Pydantic AI.

--- a/examples/pydantic_ai/README.md
+++ b/examples/pydantic_ai/README.md
@@ -6,7 +6,7 @@ Examples showing how to use the Band SDK with Pydantic AI using the composition-
 
 **Install with Pydantic AI support:**
 ```bash
-uv add "git+https://github.com/thenvoi/thenvoi-sdk-python.git[pydantic_ai]"
+uv add "git+https://github.com/band-ai/band-sdk-python.git[pydantic_ai]"
 
 # Plus your model provider:
 pip install "pydantic-ai-slim[openai]"  # or [anthropic], [google], etc.

--- a/examples/run_agent.py
+++ b/examples/run_agent.py
@@ -7,7 +7,7 @@
 # ]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Run Band SDK agents using the composition pattern.

--- a/examples/slack/01_basic_bot.py
+++ b/examples/slack/01_basic_bot.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[slack,anthropic]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Basic Slack bot: wrap an Anthropic brain with the SlackAdapter and

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,7 @@ wheels = [
 
 [[package]]
 name = "band-sdk"
-version = "0.2.11"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "band-client-rest" },


### PR DESCRIPTION
Repo moved GitHub orgs from thenvoi/thenvoi-sdk-python to band-ai/band-sdk-python. Replace all source, config, docs, and example PEP 723 references. CHANGELOG.md history left intact as a historical record; thenvoi/claude-config and thenvoi-sdk-typescript are separate repos and untouched.
