### PR TITLE
feat: [2] add tool-call capture and tool_fired assertion INT-913

### DIFF
--- a/tests/e2e/baseline/README.md
+++ b/tests/e2e/baseline/README.md
@@ -13,10 +13,10 @@ quality. They are deterministic by design (no `sleep`, no silence windows).
 |------|------------|
 | `toolkit/provisioning.py` | `ResourceManager` (provision/reap agents + rooms, orphan sweep), `running_provisioned_agent`, `ProvisionedAgent` |
 | `toolkit/user_ops.py` | `UserOps`: act as the test user (send message, create/delete room, add/remove/list participants, list messages/events) |
-| `toolkit/capture.py` | `ReplyCapture` (subscribe-before-send), `reply_capture` ctx, `wait_for_processed` (delivery-status barrier), `tool_calls()` (read the agent's tool calls) |
+| `toolkit/capture.py` | `ReplyCapture` (subscribe-before-send), `reply_capture` ctx, `wait_for_processed` (delivery-status barrier), `tool_calls()`/`thoughts()`/`errors()`/`tasks()`/`events()`/`memory(agent)` |
 | `toolkit/judge.py` | `judge()` LLM-as-judge, `Verdict`, `format_transcript` |
 | `toolkit/assertions.py` | tolerant assertions: `assert_present`, `assert_at_least`, `assert_contains_any`, `assert_mentions` |
-| `toolkit/observations/` | `Replies` (captured replies + assertions) and `ToolCalls`/`ToolCall` (captured tool calls + `assert_fired`) — list subclasses that own their assertions |
+| `toolkit/observations/` | list subclasses that own their assertions: `Replies` (replies), `ToolCalls`/`ToolCall` + `MemoryToolCalls` (tool calls; memory excluded by default), `Events`→`Thoughts`/`Errors`/`Tasks` (emitted events), `Memories`/`MemoryObservation` (stored memory, both layers); shared `tolerant_match` + `ContentAssertions` |
 | `settings.py` | `BaselineSettings`: endpoints, credentials, run policy, LLM creds + models |
 | `requires.py` | `@requires(Dep.X)` decorator + `Dep` enum |
 | `conftest.py` | fixtures (below) + the always-on E2E gate |
@@ -37,12 +37,17 @@ The `toolkit/` modules are pytest-free and reusable anywhere. The package root
 | Wait for a specific delivery state (e.g. observe a failure) | `await capture.wait_for_delivery(mid, agent_id, until={DeliveryStatus.FAILED})` |
 | Inspect the delivery lifecycle that occurred | `capture.delivery_status(mid, agent_id)` / `capture.delivery_history(mid, agent_id)` |
 | Wait on a custom condition | `await capture.wait_until(predicate)` |
-| See which tools an agent fired (with args) | `calls = await capture.tool_calls(sender_id=agent.id)` after the barrier (agent needs `Emit.EXECUTION`) |
+| See which tools an agent fired (with args) | `calls = await capture.tool_calls(sender_id=agent.id)` after the barrier (agent needs `Emit.EXECUTION`; memory tools excluded — pass `include_memory=True` or use `capture.memory(agent)`) |
 | Assert a specific tool fired | `calls.assert_fired("name", with_args={...})` (case-insensitive name, subset args) |
+| See which events an agent emitted | `await capture.thoughts(sender_id=agent.id)` (or `errors()`/`tasks()`/`events(MessageType.X)`; read after the barrier) |
+| Assert an event was emitted | `thoughts.assert_emitted()` / `thoughts.assert_contains_any([marker])` |
+| Observe an agent's memory (both layers) | `mem = await capture.memory(agent, content_query=marker)` after the barrier |
+| Assert a memory operation was called | `mem.calls.assert_store_called(scope=..., system=...)` |
+| Assert a memory actually landed in the store | `mem.stored.assert_stored(content=marker, system=...)` |
 | Assert something happened (cheap) | `assertions.py` helpers, or the methods on `capture.messages` (`Replies`) |
 | Assert a fuzzy/semantic outcome | the `judge` fixture (use sparingly, see below) |
 | Build a cheap agent to run | the `langgraph_adapter` / `anthropic_adapter` fixtures |
-| Gate a test on an optional dependency | `@requires(Dep.OPENAI, ...)` (the E2E + Band-key gate is automatic) |
+| Declare a test's extra requirements | `@requires(Dep.OPENAI, ...)` (a missing one **fails**, see Validation policy; the E2E + Band-key gate is automatic) |
 
 ## Fixtures (from `conftest.py`)
 
@@ -155,6 +160,55 @@ name matches case-insensitively and `with_args` is a subset/substring match, not
 exact args. Pass `sender_id` to scope to one agent, and `since` (a server
 timestamp) to scope to one turn when reusing a capture. See
 `smoke/test_tool_calls.py` and `smoke/test_isolation.py`.
+
+By default `tool_calls()` **excludes memory tools** (mirroring the SDK's own
+`BASE_TOOL_NAMES = ALL_TOOL_NAMES - MEMORY_TOOL_NAMES` split) so generic tool
+assertions aren't polluted by memory operations. Pass `include_memory=True` to
+keep them, or use `capture.memory(agent)` for the dedicated memory view (below).
+
+## Emitted-event inspection
+
+`capture.thoughts()` / `errors()` / `tasks()` (or the generic
+`capture.events(MessageType.X)`) return an `Events` collection of the free-text
+events an agent emitted, on the same read-after-barrier contract as `tool_calls`.
+Drive them with the built-in `band_send_event` tool — the direct LLM-facing way
+to create a `thought`/`error`/`task` message (no `Emit.*` feature needed; the
+tool posts directly). Run such agents **without** `Emit.EXECUTION` when you want
+the room history to contain only the events you drove, not tool-call telemetry.
+`assert_emitted()` and `assert_contains_any([marker])` are the assertions; assert
+the **marker** (not bare presence), since adapters auto-emit a generic `error`
+event on any turn exception. See `smoke/test_events.py`.
+
+## Memory inspection
+
+Memory has two observable layers, and `capture.memory(agent)` reads both in one
+call, returning a `MemoryObservation`:
+
+- **Call layer** — `mem.calls` is a `MemoryToolCalls` (a `ToolCalls` restricted to
+  the memory tools), read from the room's `tool_call` events via the observer
+  client. Operation-named assertions read clearer than raw `assert_fired`:
+  `mem.calls.assert_store_called(scope=..., system=..., type=...)`,
+  `assert_list_called()`, etc. Needs `Emit.EXECUTION`.
+- **Store layer** — `mem.stored` is a `Memories` of records that *actually
+  landed*, read from the memories API. Filter with
+  `mem.stored.where(scope=..., system=...)` and assert with `.assert_stored(...)`
+  / `.assert_present()` / `.assert_none()`.
+
+`memory()` takes the agent handle because the store layer needs the agent's own
+key (the observer client can't see it). The names keep the altitudes distinct:
+`assert_store_called` (invoked) vs `assert_stored` (a record exists). Drive a
+store with `band_store_memory`, read after the barrier; a unique marker keeps the
+read collision-free. Memory tools are an enterprise opt-in, so the store layer
+needs an entitled org. See `smoke/test_memory.py`.
+
+## Validation policy: fail on missing requirements, never skip
+
+A test that needs a key or resource and can't find it **fails** — it does not
+skip. Skipping on missing config hides misconfiguration as a false green. The
+only legitimate skip is `E2E_TESTS_ENABLED` (the on/off switch for the whole live
+suite); `BAND_API_KEY_USER` missing while E2E is enabled **fails** (the always-on
+gate), and any further `@requires(Dep.X)` requirement **fails** when absent, with
+the env-var name as the reason.
 
 ## Not here yet
 

--- a/tests/e2e/baseline/README.md
+++ b/tests/e2e/baseline/README.md
@@ -12,10 +12,11 @@ quality. They are deterministic by design (no `sleep`, no silence windows).
 | Path | What it is |
 |------|------------|
 | `toolkit/provisioning.py` | `ResourceManager` (provision/reap agents + rooms, orphan sweep), `running_provisioned_agent`, `ProvisionedAgent` |
-| `toolkit/user_ops.py` | `UserOps`: act as the test user (send message, create/delete room, add/remove/list participants) |
-| `toolkit/waiting.py` | `ReplyCapture` (subscribe-before-send), `reply_capture` ctx, `wait_for_processed` (delivery-status barrier) |
+| `toolkit/user_ops.py` | `UserOps`: act as the test user (send message, create/delete room, add/remove/list participants, list messages/events) |
+| `toolkit/capture.py` | `ReplyCapture` (subscribe-before-send), `reply_capture` ctx, `wait_for_processed` (delivery-status barrier), `tool_calls()` (read the agent's tool calls) |
 | `toolkit/judge.py` | `judge()` LLM-as-judge, `Verdict`, `format_transcript` |
 | `toolkit/assertions.py` | tolerant assertions: `assert_present`, `assert_at_least`, `assert_contains_any`, `assert_mentions` |
+| `toolkit/observations/` | `Replies` (captured replies + assertions) and `ToolCalls`/`ToolCall` (captured tool calls + `assert_fired`) — list subclasses that own their assertions |
 | `settings.py` | `BaselineSettings`: endpoints, credentials, run policy, LLM creds + models |
 | `requires.py` | `@requires(Dep.X)` decorator + `Dep` enum |
 | `conftest.py` | fixtures (below) + the always-on E2E gate |
@@ -36,7 +37,9 @@ The `toolkit/` modules are pytest-free and reusable anywhere. The package root
 | Wait for a specific delivery state (e.g. observe a failure) | `await capture.wait_for_delivery(mid, agent_id, until={DeliveryStatus.FAILED})` |
 | Inspect the delivery lifecycle that occurred | `capture.delivery_status(mid, agent_id)` / `capture.delivery_history(mid, agent_id)` |
 | Wait on a custom condition | `await capture.wait_until(predicate)` |
-| Assert something happened (cheap) | `assertions.py` helpers |
+| See which tools an agent fired (with args) | `calls = await capture.tool_calls(sender_id=agent.id)` after the barrier (agent needs `Emit.EXECUTION`) |
+| Assert a specific tool fired | `calls.assert_fired("name", with_args={...})` (case-insensitive name, subset args) |
+| Assert something happened (cheap) | `assertions.py` helpers, or the methods on `capture.messages` (`Replies`) |
 | Assert a fuzzy/semantic outcome | the `judge` fixture (use sparingly, see below) |
 | Build a cheap agent to run | the `langgraph_adapter` / `anthropic_adapter` fixtures |
 | Gate a test on an optional dependency | `@requires(Dep.OPENAI, ...)` (the E2E + Band-key gate is automatic) |
@@ -132,10 +135,28 @@ async def test_example(resource_manager, user_ops, reply_capture, anthropic_adap
 
 Run: `E2E_TESTS_ENABLED=true uv run pytest tests/e2e/baseline/ -v -s --no-cov`
 
+## Tool-observation inspection (`tool_calls` + `assert_fired`)
+
+After a turn settles (barrier on the trigger id with `wait_for_processed`), read
+the agent's tool calls and assert what fired:
+
+```python
+mid = await user_ops.send_message(room_id, "...", mention_id=a.id, mention_name=a.name)
+await capture.wait_for_processed(mid, a.id)
+calls = await capture.tool_calls(sender_id=a.id)   # a ToolCalls (list[ToolCall])
+calls.assert_fired("get_weather", with_args={"place": "Zorath"})
+```
+
+This reads the persisted `tool_call` events (so the agent must run with
+`Emit.EXECUTION`), not a live subscription. It is race-free because the platform
+marks the trigger `processed` only after the reply is emitted, by which point the
+turn's tool-call events are already persisted. `assert_fired` is tolerant: the
+name matches case-insensitively and `with_args` is a subset/substring match, not
+exact args. Pass `sender_id` to scope to one agent, and `since` (a server
+timestamp) to scope to one turn when reusing a capture. See
+`smoke/test_tool_calls.py` and `smoke/test_isolation.py`.
+
 ## Not here yet
 
-- Trajectory / tool-observation inspection and the `tool_fired` assertion (assert
-  which tool fired, with which args) are a tracked follow-up. Do not build an ad
-  hoc version here; extend that work when it lands.
 - A full LLM-judge harness (calibration, voting/pass^k, tool-correctness) is
   later work; `judge.py` notes DeepEval as the likely path.

--- a/tests/e2e/baseline/conftest.py
+++ b/tests/e2e/baseline/conftest.py
@@ -196,13 +196,15 @@ def reply_capture(
     """Subscribe-before-send capture with the WS observer + E2E_TIMEOUT pre-bound.
 
     Hides ``baseline_ws`` from tests; use as ``async with reply_capture(room_id)``.
-    The capture's default wait deadline comes from E2E_TIMEOUT. ``user_ops`` is
-    pre-bound so ``capture.tool_calls()`` can read persisted tool-call events.
+    The capture's default wait deadline comes from E2E_TIMEOUT. ``user_ops`` and
+    ``settings`` are pre-bound so ``capture.tool_calls()`` / ``events()`` /
+    ``memory(agent)`` can read persisted events and agent-scoped memory.
     """
     return functools.partial(
         _reply_capture,
         baseline_ws,
         user_ops=user_ops,
+        settings=baseline_settings,
         deadline_s=baseline_settings.e2e_timeout,
     )
 

--- a/tests/e2e/baseline/conftest.py
+++ b/tests/e2e/baseline/conftest.py
@@ -24,8 +24,8 @@ from tests.e2e.baseline.toolkit.judge import Verdict
 from tests.e2e.baseline.toolkit.judge import judge as _judge
 from tests.e2e.baseline.toolkit.provisioning import ResourceManager, new_run_id
 from tests.e2e.baseline.toolkit.user_ops import UserOps
-from tests.e2e.baseline.toolkit.waiting import ReplyCapture
-from tests.e2e.baseline.toolkit.waiting import reply_capture as _reply_capture
+from tests.e2e.baseline.toolkit.capture import ReplyCapture
+from tests.e2e.baseline.toolkit.capture import reply_capture as _reply_capture
 from tests.e2e.helpers import TrackingWebSocketClient
 
 
@@ -191,14 +191,19 @@ def anthropic_adapter(baseline_settings: BaselineSettings) -> SimpleAdapter:
 def reply_capture(
     baseline_ws: TrackingWebSocketClient,
     baseline_settings: BaselineSettings,
+    user_ops: UserOps,
 ) -> Callable[[str], AbstractAsyncContextManager[ReplyCapture]]:
     """Subscribe-before-send capture with the WS observer + E2E_TIMEOUT pre-bound.
 
     Hides ``baseline_ws`` from tests; use as ``async with reply_capture(room_id)``.
-    The capture's default wait deadline comes from E2E_TIMEOUT.
+    The capture's default wait deadline comes from E2E_TIMEOUT. ``user_ops`` is
+    pre-bound so ``capture.tool_calls()`` can read persisted tool-call events.
     """
     return functools.partial(
-        _reply_capture, baseline_ws, deadline_s=baseline_settings.e2e_timeout
+        _reply_capture,
+        baseline_ws,
+        user_ops=user_ops,
+        deadline_s=baseline_settings.e2e_timeout,
     )
 
 

--- a/tests/e2e/baseline/requires.py
+++ b/tests/e2e/baseline/requires.py
@@ -1,12 +1,15 @@
 """Declarative test-dependency requirements.
 
-``@requires(Dep.OPENAI, ...)`` declares the *optional* capabilities a test
-needs; it attaches a marker resolved by a hook in conftest.py. The always-on
-gate (E2E enabled, Band keys present) is applied to every baseline test by that
-hook — it is not a dependency you pass here.
+``@requires(Dep.OPENAI, ...)`` declares the requirements a test needs (provider
+keys, a second user, ...); it attaches a marker resolved by a hook in
+conftest.py. The always-on gate (E2E enabled, BAND_API_KEY_USER present) is
+applied to every baseline test by that hook -- it is not a dependency you pass.
 
-Optional deps skip when absent (the run just can't exercise them). Add one by
-extending ``_CHECKS``.
+Validation policy: a missing requirement **fails** the test, it never skips.
+Skipping a test because a key is absent hides misconfiguration as false-green.
+The only thing that skips is the ``E2E_TESTS_ENABLED`` master switch (the
+deliberate on/off for the whole live suite). Add a requirement by extending
+``_CHECKS``.
 """
 
 from __future__ import annotations
@@ -22,13 +25,13 @@ MARKER = "requires_deps"
 
 
 class Dep(Enum):
-    """An optional capability a test can require (a model-provider key)."""
+    """A requirement a test can declare (a model-provider key)."""
 
     OPENAI = "openai"
     ANTHROPIC = "anthropic"
 
 
-# Dep -> (is-available check, skip reason when absent).
+# Dep -> (is-available check, failure reason when absent).
 _CHECKS: dict[Dep, tuple[Callable[[BaselineSettings], bool], str]] = {
     Dep.OPENAI: (
         lambda s: bool(s.llm_credentials.openai_api_key),
@@ -42,17 +45,19 @@ _CHECKS: dict[Dep, tuple[Callable[[BaselineSettings], bool], str]] = {
 
 
 def require_dep(dep: Dep, settings: BaselineSettings) -> None:
-    """Skip the current test if ``dep``'s capability is unavailable.
+    """Fail the current test if ``dep``'s requirement is unavailable.
 
-    Shared by the gate hook and by fixtures that self-gate on a capability.
+    Missing config that a test needs is a hard failure, never a skip (a skip
+    would hide misconfiguration). Shared by the gate hook and by fixtures that
+    self-gate on a requirement.
     """
     check, reason = _CHECKS[dep]
     if not check(settings):
-        pytest.skip(reason)
+        pytest.fail(reason)
 
 
 def requires(*deps: Dep) -> pytest.MarkDecorator:
-    """Mark a test with the optional capabilities it needs."""
+    """Mark a test with the requirements it needs (each fails if absent)."""
     for dep in deps:
         if not isinstance(dep, Dep):  # guard against stray strings/typos
             raise TypeError(f"requires() takes Dep members, got {dep!r}")

--- a/tests/e2e/baseline/smoke/sample_agents.py
+++ b/tests/e2e/baseline/smoke/sample_agents.py
@@ -1,0 +1,242 @@
+"""Cheap agents and driving instructions for the matrix smokes.
+
+``ADAPTER_BUILDERS`` maps an adapter id to its dependency gate and a builder;
+``adapter_params`` renders it as ``pytest.param``s with the right ``@requires``
+gate, so a matrix test reads ``parametrize("adapter_id", adapter_params())``.
+Only standard tool-loop adapters are here (Anthropic, LangGraph) -- both route
+tool calls through ``execute_tool_call``, so ``band_send_event`` posts a real
+event and ``band_store_memory`` writes a real memory. Adding a framework is a
+single ``ADAPTER_BUILDERS`` entry plus a ``Dep``.
+
+Following ``sample_tools``/``test_tool_calls``, the agent gets a fixed
+role-setting system prompt and the *user message* carries the instruction (with
+the unique marker). Each instruction forces exactly one observable action --
+``band_send_event`` for an event, ``band_store_memory`` for a memory, the only
+way to produce it -- so a precise instruction is the only way to comply.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable, Collection
+
+import pytest
+
+from band.adapters.anthropic import AnthropicAdapter
+from band.core.simple_adapter import SimpleAdapter
+from band.core.types import AdapterFeatures, Capability, Emit, MessageType
+from band.core.memory_types import (
+    MemorySegment,
+    MemoryStoreScope,
+    MemorySystem,
+    WorkingLongTermMemoryType,
+)
+
+from tests.e2e.baseline.requires import Dep, requires
+from tests.e2e.baseline.settings import BaselineSettings
+from tests.e2e.baseline.toolkit.observations import MemoryTool
+
+# Fixed role-setter: the actionable instruction (and marker) travels in the user
+# message, exactly like the opaque-tool smokes.
+TOOL_AGENT_SYSTEM_PROMPT = (
+    "You are under test. When the user messages you, do exactly what they ask: "
+    "make the requested tool call(s) with the given arguments and nothing else. "
+    "Do not send a chat message unless explicitly asked."
+)
+
+AgentBuilder = Callable[..., SimpleAdapter]
+
+
+def build_anthropic_agent(
+    settings: BaselineSettings, *, features: AdapterFeatures | None = None
+) -> AnthropicAdapter:
+    """An Anthropic agent under the shared role-setting system prompt."""
+    return AnthropicAdapter(
+        model=settings.llm_models.anthropic_model,
+        provider_key=settings.llm_credentials.anthropic_api_key,
+        prompt=TOOL_AGENT_SYSTEM_PROMPT,
+        features=features,
+    )
+
+
+def build_langgraph_agent(
+    settings: BaselineSettings, *, features: AdapterFeatures | None = None
+) -> SimpleAdapter:
+    """A LangGraph (OpenAI-backed) agent under the shared role-setting prompt."""
+    from langchain_openai import ChatOpenAI
+    from langgraph.checkpoint.memory import MemorySaver
+
+    from band.adapters.langgraph import LangGraphAdapter
+
+    return LangGraphAdapter(
+        llm=ChatOpenAI(
+            model=settings.llm_models.openai_model,
+            api_key=settings.llm_credentials.openai_api_key,
+        ),
+        checkpointer=MemorySaver(),
+        custom_section=TOOL_AGENT_SYSTEM_PROMPT,
+        features=features,
+    )
+
+
+# TODO: this is temporary until we create generic builders in the next PR
+ADAPTER_BUILDERS: dict[str, tuple[Dep, AgentBuilder]] = {
+    "anthropic": (Dep.ANTHROPIC, build_anthropic_agent),
+    "langgraph": (Dep.OPENAI, build_langgraph_agent),
+}
+
+
+def build_agent(
+    adapter_id: str,
+    settings: BaselineSettings,
+    *,
+    features: AdapterFeatures | None = None,
+) -> SimpleAdapter:
+    """Build the agent registered under ``adapter_id``."""
+    _, builder = ADAPTER_BUILDERS[adapter_id]
+    return builder(settings, features=features)
+
+
+def adapter_params(include: Collection[str] | None = None) -> list[pytest.param]:
+    """One ``pytest.param`` per adapter, each gated by its provider key.
+
+    The ``requires(...)`` mark is resolved per-parameter by the conftest gate
+    hook (a missing key fails the cell). Pass ``include`` to restrict the matrix
+    to specific adapter ids -- e.g. the event matrix runs Anthropic-only because
+    ``gpt-5.4-mini`` is unreliable at driving ``band_send_event`` for
+    thought/error, so LangGraph event cells flake.
+    """
+    return [
+        pytest.param(adapter_id, marks=requires(dep), id=adapter_id)
+        for adapter_id, (dep, _) in ADAPTER_BUILDERS.items()
+        if include is None or adapter_id in include
+    ]
+
+
+def memory_features() -> AdapterFeatures:
+    """Features for the memory smokes: expose the memory tools, and record the
+    tool call as a ``tool_call`` event so the call layer is observable."""
+    return AdapterFeatures(capabilities={Capability.MEMORY}, emit={Emit.EXECUTION})
+
+
+def unique_marker(prefix: str) -> str:
+    """A high-entropy token to assert verbatim in event/memory content."""
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def emit_event_instruction(event_type: MessageType, marker: str) -> str:
+    """User message forcing exactly one ``band_send_event`` of ``event_type``
+    whose content carries ``marker`` verbatim."""
+    return (
+        f"Call the tool band_send_event exactly once with "
+        f"message_type='{event_type.value}' and content that includes the exact "
+        f"token {marker} (verbatim). That tool call is your ONLY action -- do not "
+        "reply with a chat message and do not call any other tool. A plain-text "
+        "reply does not satisfy this; you must call band_send_event."
+    )
+
+
+def emit_thoughts_instruction(markers: list[str]) -> str:
+    """User message forcing one ``band_send_event`` thought per marker (used to
+    demonstrate a count-floor assertion)."""
+    tokens = ", ".join(markers)
+    return (
+        f"Call the tool band_send_event once for each of these tokens: {tokens}. "
+        f"Each call uses message_type='{MessageType.THOUGHT.value}' with content "
+        "containing that exact token verbatim. Those tool calls are your ONLY "
+        "action -- do not reply with a chat message and do not call any other "
+        "tool. A plain-text reply does not satisfy this."
+    )
+
+
+def store_memory_instruction(marker: str) -> str:
+    """User message forcing one organization-scoped ``band_store_memory`` whose
+    content carries ``marker`` verbatim, with an exact valid system/type combo."""
+    return (
+        "Call band_store_memory exactly once with these exact arguments: "
+        f"content = a short sentence that includes the exact token {marker}; "
+        f"system = {MemorySystem.LONG_TERM.value}; "
+        f"type = {WorkingLongTermMemoryType.SEMANTIC.value}; "
+        f"segment = {MemorySegment.USER.value}; "
+        f"scope = {MemoryStoreScope.ORGANIZATION.value}; "
+        "thought = a brief reason. Do not include subject_id. Do not call any "
+        "other tool."
+    )
+
+
+def store_subject_memory_instruction(marker: str, subject_id: str) -> str:
+    """User message forcing one subject-scoped ``band_store_memory`` about
+    ``subject_id`` whose content carries ``marker`` verbatim."""
+    return (
+        "Call band_store_memory exactly once with these exact arguments: "
+        f"content = a short sentence that includes the exact token {marker}; "
+        f"system = {MemorySystem.LONG_TERM.value}; "
+        f"type = {WorkingLongTermMemoryType.SEMANTIC.value}; "
+        f"segment = {MemorySegment.AGENT.value}; "
+        f"scope = {MemoryStoreScope.SUBJECT.value}; "
+        f"subject_id = {subject_id}; "
+        "thought = a brief reason. Do not call any other tool."
+    )
+
+
+def supersede_memory_instruction(marker: str) -> str:
+    """User message forcing a store-then-supersede lifecycle in one turn: store an
+    org-scoped memory carrying ``marker``, then supersede it by the id the store
+    call returns."""
+    return (
+        f"First call {MemoryTool.STORE.value} with content including the exact "
+        f"token {marker}, system={MemorySystem.LONG_TERM.value}, "
+        f"type={WorkingLongTermMemoryType.SEMANTIC.value}, "
+        f"segment={MemorySegment.USER.value}, "
+        f"scope={MemoryStoreScope.ORGANIZATION.value}, and a brief thought. "
+        f"Then call {MemoryTool.SUPERSEDE.value} with memory_id set to the id "
+        "returned by the store call. Do not call any other tool."
+    )
+
+
+def archive_memory_instruction(marker: str) -> str:
+    """User message forcing a store-then-archive lifecycle in one turn: store an
+    org-scoped memory carrying ``marker``, then archive it by the id the store
+    call returns."""
+    return (
+        f"First call {MemoryTool.STORE.value} with content including the exact "
+        f"token {marker}, system={MemorySystem.LONG_TERM.value}, "
+        f"type={WorkingLongTermMemoryType.SEMANTIC.value}, "
+        f"segment={MemorySegment.USER.value}, "
+        f"scope={MemoryStoreScope.ORGANIZATION.value}, and a brief thought. "
+        f"Then call {MemoryTool.ARCHIVE.value} with memory_id set to the id "
+        "returned by the store call. Do not call any other tool."
+    )
+
+
+def recall_memory_instruction(marker: str) -> str:
+    """User message forcing a store-then-recall flow in one turn: store an
+    org-scoped memory carrying ``marker``, then look it back up with the list and
+    get tools (exercises the read-side memory tools)."""
+    return (
+        f"First call {MemoryTool.STORE.value} with content including the exact "
+        f"token {marker}, system={MemorySystem.LONG_TERM.value}, "
+        f"type={WorkingLongTermMemoryType.SEMANTIC.value}, "
+        f"segment={MemorySegment.USER.value}, "
+        f"scope={MemoryStoreScope.ORGANIZATION.value}, and a brief thought. "
+        f"Then call {MemoryTool.LIST.value} with content_query={marker} to find "
+        f"it. Then call {MemoryTool.GET.value} with memory_id set to the id of a "
+        "memory the list returned. Do not call any other tool."
+    )
+
+
+def store_two_memories_instruction(marker: str) -> str:
+    """User message forcing two org-scoped stores that both carry ``marker`` but
+    differ in system/type, so one ``content_query=marker`` read returns both and
+    the store-layer view can be sliced by dimension."""
+    return (
+        f"Call {MemoryTool.STORE.value} twice, both with content including the "
+        f"exact token {marker} and a brief thought, both "
+        f"segment={MemorySegment.USER.value} "
+        f"scope={MemoryStoreScope.ORGANIZATION.value}. First store: "
+        f"system={MemorySystem.LONG_TERM.value}, "
+        f"type={WorkingLongTermMemoryType.SEMANTIC.value}. Second store: "
+        f"system={MemorySystem.WORKING.value}, "
+        f"type={WorkingLongTermMemoryType.EPISODIC.value}. "
+        "Do not call any other tool."
+    )

--- a/tests/e2e/baseline/smoke/sample_tools.py
+++ b/tests/e2e/baseline/smoke/sample_tools.py
@@ -1,0 +1,98 @@
+"""Opaque custom tools for tool-observation smokes.
+
+Defined once and shared across the tool-capture smokes. They are deliberately
+*opaque*: each returns information the model cannot produce on its own (a secret
+access code, a fictional forecast), so to satisfy the request the agent has no
+choice but to call the tool. Tools that merely compute what the model already
+knows (arithmetic, echoing text) get skipped despite any "you must call it"
+instruction, which makes the tool-fired assertion unreliable.
+
+Why opacity rather than just a strong prompt: the adapter never *forces* tool
+use (it passes no ``tool_choice`` to the model), so whether a given tool fires is
+the model's free choice. Making the tool the only way to answer is therefore the
+only way to assert "tool X fired" deterministically without a production change.
+
+``build_tool_agent`` wires any of these into an Anthropic agent with execution
+reporting on, which is what makes the tool calls observable.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from band.adapters.anthropic import AnthropicAdapter
+from band.core.simple_adapter import SimpleAdapter
+from band.core.types import AdapterFeatures, Emit
+from band.runtime.custom_tools import CustomToolDef, get_custom_tool_name
+
+from tests.e2e.baseline.settings import BaselineSettings
+
+# Secret values the model cannot guess; it must call the tool to obtain them.
+ACCESS_CODES = {"alpha": "ZX417", "beta": "QM920", "gamma": "TR365"}
+FORECASTS = {"zorath": "ammonia rain at 400 K", "qyx": "triple sunrise, then calm"}
+
+
+class LookupInput(BaseModel):
+    """Look up the secret access code for a project key (cannot be guessed)."""
+
+    key: str
+    note: str | None = None
+
+
+def _lookup(args: LookupInput) -> str:
+    return ACCESS_CODES.get(args.key.lower(), "NO-SUCH-CODE")
+
+
+class WeatherInput(BaseModel):
+    """Get the (fictional) weather forecast for a place (cannot be guessed)."""
+
+    place: str
+
+
+def _weather(args: WeatherInput) -> str:
+    return FORECASTS.get(args.place.lower(), "clear skies")
+
+
+# Tool names derived from the models so prompts and assertions can't drift.
+LOOKUP = get_custom_tool_name(LookupInput)
+WEATHER = get_custom_tool_name(WeatherInput)
+
+LOOKUP_TOOL: CustomToolDef = (LookupInput, _lookup)
+WEATHER_TOOL: CustomToolDef = (WeatherInput, _weather)
+
+LOOKUP_PROMPT = (
+    f"You have a tool `{LOOKUP}` that returns the secret access code for a key. "
+    f"You do NOT know these codes yourself, so you MUST call `{LOOKUP}` to get "
+    "one. Then report the code in one short sentence using band_send_message."
+)
+WEATHER_PROMPT = (
+    f"You have a tool `{WEATHER}` that returns the forecast for a place. You do "
+    f"NOT know these forecasts, so you MUST call `{WEATHER}`. Then report it in "
+    "one short sentence using band_send_message."
+)
+LOOKUP_AND_WEATHER_PROMPT = (
+    f"You have two tools: `{LOOKUP}` (secret access code for a key) and "
+    f"`{WEATHER}` (forecast for a place). You do not know these values yourself, "
+    "so you MUST call the matching tool for each request, then report both "
+    "results using band_send_message."
+)
+
+
+def build_tool_agent(
+    settings: BaselineSettings,
+    *,
+    tools: list[CustomToolDef],
+    prompt: str,
+) -> SimpleAdapter:
+    """An Anthropic agent exposing ``tools`` with execution reporting enabled.
+
+    ``Emit.EXECUTION`` is what makes each tool call surface as a ``tool_call``
+    event, so the tool calls are observable via ``ReplyCapture.tool_calls``.
+    """
+    return AnthropicAdapter(
+        model=settings.llm_models.anthropic_model,
+        provider_key=settings.llm_credentials.anthropic_api_key,
+        prompt=prompt,
+        additional_tools=tools,
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
+    )

--- a/tests/e2e/baseline/smoke/test_agent_scenarios.py
+++ b/tests/e2e/baseline/smoke/test_agent_scenarios.py
@@ -26,7 +26,7 @@ from tests.e2e.baseline.toolkit.provisioning import (
     running_provisioned_agent,
 )
 from tests.e2e.baseline.toolkit.user_ops import UserOps
-from tests.e2e.baseline.toolkit.waiting import ReplyCapture
+from tests.e2e.baseline.toolkit.capture import ReplyCapture
 
 CaptureFactory = Callable[[str], AbstractAsyncContextManager[ReplyCapture]]
 JudgeFn = Callable[..., Awaitable[Verdict]]

--- a/tests/e2e/baseline/smoke/test_delivery_status.py
+++ b/tests/e2e/baseline/smoke/test_delivery_status.py
@@ -33,7 +33,7 @@ from tests.e2e.baseline.toolkit.provisioning import (
     running_provisioned_agent,
 )
 from tests.e2e.baseline.toolkit.user_ops import UserOps
-from tests.e2e.baseline.toolkit.waiting import ReplyCapture
+from tests.e2e.baseline.toolkit.capture import ReplyCapture
 
 logger = logging.getLogger(__name__)
 

--- a/tests/e2e/baseline/smoke/test_events.py
+++ b/tests/e2e/baseline/smoke/test_events.py
@@ -1,0 +1,217 @@
+"""Emitted-event smokes: drive a deterministic ``band_send_event`` emission and
+assert, from the agent's persisted events, what was emitted and with what content
+(``ReplyCapture.thoughts`` / ``errors`` / ``tasks``).
+
+The matrix runs every event type across every registered adapter (see
+``sample_agents``). Agents run with **no emit features**, so the only events on
+the wire are the ones driven. Assert the injected **marker**, not bare presence:
+adapters auto-emit a generic ``error`` event on any turn exception.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+
+import pytest
+
+from band.core.types import MessageType
+
+from tests.e2e.baseline.requires import Dep, requires
+from tests.e2e.baseline.settings import BaselineSettings
+from tests.e2e.baseline.smoke.sample_agents import (
+    adapter_params,
+    build_agent,
+    emit_event_instruction,
+    emit_thoughts_instruction,
+    unique_marker,
+)
+from tests.e2e.baseline.toolkit.provisioning import (
+    ResourceManager,
+    running_provisioned_agent,
+)
+from tests.e2e.baseline.toolkit.capture import ReplyCapture
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+CaptureFactory = Callable[[str], AbstractAsyncContextManager[ReplyCapture]]
+
+EVENT_TYPES = [MessageType.THOUGHT, MessageType.ERROR, MessageType.TASK]
+
+
+# Anthropic-only: gpt-5.4-mini (LangGraph) is unreliable at *choosing* to call
+# band_send_event (~50% even after a tool-only-channel system prompt + few-shot
+# examples; only tool_choice/strict mode would fix it, which is adapter-level).
+# The observation readers are adapter-agnostic, so one reliable driver suffices.
+@pytest.mark.parametrize("adapter_id", adapter_params(include={"anthropic"}))
+@pytest.mark.parametrize("event_type", EVENT_TYPES, ids=lambda mt: mt.value)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_event_emitted(
+    adapter_id: str,
+    event_type: MessageType,
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Each event type, on each adapter: it is emitted and carries our marker."""
+    marker = unique_marker(event_type.value)
+    adapter = build_agent(adapter_id, baseline_settings)
+    async with running_provisioned_agent(
+        adapter, resource_manager, label=adapter_id
+    ) as (_, agent):
+        room_id = await resource_manager.provision_room(
+            title="e2e-events", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                emit_event_instruction(event_type, marker),
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            # Token-barrier: the FIFO echo proves the emit turn (its event POST
+            # included) was fully processed and persisted before we read it.
+            await capture.wait_for_processed(mid, agent.id)
+            events = await capture.events(event_type, sender_id=agent.id)
+
+    events.assert_emitted()
+    events.assert_contains_any([marker])
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_event_subclasses_one_turn(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """One turn emits all three types; each subclass view reads its own marker.
+
+    Cheapest proof that the shared base read plus the three ``MESSAGE_TYPE``
+    markers all work in a single capture.
+    """
+    thought = unique_marker("thought")
+    task = unique_marker("task")
+    error = unique_marker("error")
+    instruction = (
+        "Call band_send_event three times: "
+        f"(1) message_type='thought' content including {thought}; "
+        f"(2) message_type='task' content including {task}; "
+        f"(3) message_type='error' content including {error}. "
+        "Each token verbatim. Do not call any other tool."
+    )
+    adapter = build_agent("anthropic", baseline_settings)
+    async with running_provisioned_agent(adapter, resource_manager, label="events") as (
+        _,
+        agent,
+    ):
+        room_id = await resource_manager.provision_room(
+            title="e2e-events-all", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id, instruction, mention_id=agent.id, mention_name=agent.name
+            )
+            await capture.wait_for_processed(mid, agent.id)
+            thoughts = await capture.thoughts(sender_id=agent.id)
+            errors = await capture.errors(sender_id=agent.id)
+            tasks = await capture.tasks(sender_id=agent.id)
+
+    thoughts.assert_contains_any([thought])
+    tasks.assert_contains_any([task])
+    errors.assert_contains_any([error])
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_multiple_thoughts_assert_at_least(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Two thoughts in one turn: demonstrates the count-floor assertion."""
+    first = unique_marker("th1")
+    second = unique_marker("th2")
+    adapter = build_agent("anthropic", baseline_settings)
+    async with running_provisioned_agent(
+        adapter, resource_manager, label="thoughts"
+    ) as (_, agent):
+        room_id = await resource_manager.provision_room(
+            title="e2e-events-multi", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                emit_thoughts_instruction([first, second]),
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(mid, agent.id)
+            thoughts = await capture.thoughts(sender_id=agent.id)
+
+    thoughts.assert_at_least(2)
+    thoughts.assert_contains_any([first])
+    thoughts.assert_contains_any([second])
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_event_sender_isolation(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Two agents emit thoughts in one room; thoughts(sender_id=X) returns only
+    X's, demonstrating per-sender scoping of the event readers."""
+    marker_a = unique_marker("th-a")
+    marker_b = unique_marker("th-b")
+    adapter_a = build_agent("anthropic", baseline_settings)
+    adapter_b = build_agent("anthropic", baseline_settings)
+    async with (
+        running_provisioned_agent(adapter_a, resource_manager, label="emit-a") as (
+            _,
+            agent_a,
+        ),
+        running_provisioned_agent(adapter_b, resource_manager, label="emit-b") as (
+            _,
+            agent_b,
+        ),
+    ):
+        room_id = await resource_manager.provision_room(
+            title="e2e-events-isolation", participants=[agent_a.id, agent_b.id]
+        )
+        async with reply_capture(room_id) as capture:
+            m_a = await user_ops.send_message(
+                room_id,
+                emit_event_instruction(MessageType.THOUGHT, marker_a),
+                mention_id=agent_a.id,
+                mention_name=agent_a.name,
+            )
+            m_b = await user_ops.send_message(
+                room_id,
+                emit_event_instruction(MessageType.THOUGHT, marker_b),
+                mention_id=agent_b.id,
+                mention_name=agent_b.name,
+            )
+            # Barrier each emit on its own agent: once both are processed, both
+            # turns' thought events are persisted.
+            await capture.wait_for_processed(m_a, agent_a.id)
+            await capture.wait_for_processed(m_b, agent_b.id)
+            thoughts_a = await capture.thoughts(sender_id=agent_a.id)
+            thoughts_b = await capture.thoughts(sender_id=agent_b.id)
+
+    thoughts_a.assert_contains_any([marker_a])
+    thoughts_b.assert_contains_any([marker_b])
+    assert all(marker_b not in t.content for t in thoughts_a), (
+        "agent A's thought view leaked agent B's event"
+    )
+    assert all(marker_a not in t.content for t in thoughts_b), (
+        "agent B's thought view leaked agent A's event"
+    )

--- a/tests/e2e/baseline/smoke/test_isolation.py
+++ b/tests/e2e/baseline/smoke/test_isolation.py
@@ -1,0 +1,229 @@
+"""Isolation smokes: tool trajectories don't mix across senders or rooms.
+
+The tool-call read is scoped two ways and both are shown here:
+- ``sender_id`` keeps one agent's calls out of another's (same room).
+- reading per room keeps one room's calls out of another's (same agent).
+
+Uses the opaque tools from ``sample_tools`` so each agent must actually call its
+tool (and with a distinguishing arg), which is what makes the cross-checks
+meaningful. Turn completion uses the delivery-status barrier
+(``wait_for_processed``) on the id each ``send_message`` returns: once that id is
+processed, the turn's ``tool_call`` events are persisted and the read is
+race-free.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from datetime import datetime, timezone
+
+import pytest
+
+from tests.e2e.baseline.requires import Dep, requires
+from tests.e2e.baseline.settings import BaselineSettings
+from tests.e2e.baseline.smoke.sample_tools import (
+    LOOKUP,
+    LOOKUP_PROMPT,
+    LOOKUP_TOOL,
+    WEATHER,
+    WEATHER_PROMPT,
+    WEATHER_TOOL,
+    build_tool_agent,
+)
+from tests.e2e.baseline.toolkit.provisioning import (
+    ResourceManager,
+    running_provisioned_agent,
+)
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+from tests.e2e.baseline.toolkit.capture import ReplyCapture
+
+CaptureFactory = Callable[[str], AbstractAsyncContextManager[ReplyCapture]]
+
+
+def _turn_boundary(capture: ReplyCapture) -> datetime:
+    """Server timestamp of the latest captured message — a between-turns boundary.
+
+    Used as ``since`` for the next turn's ``tool_calls`` read. Naive timestamps are
+    treated as UTC (the platform stores UTC), matching the orphan-sweep coercion.
+    """
+    stamp = datetime.fromisoformat(capture.messages[-1].inserted_at)
+    return stamp if stamp.tzinfo else stamp.replace(tzinfo=timezone.utc)
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_tool_calls_isolated_per_sender(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Two agents share a room; each sender sees only its own tool calls."""
+    lookup_agent = build_tool_agent(
+        baseline_settings, tools=[LOOKUP_TOOL], prompt=LOOKUP_PROMPT
+    )
+    weather_agent = build_tool_agent(
+        baseline_settings, tools=[WEATHER_TOOL], prompt=WEATHER_PROMPT
+    )
+    async with contextlib.AsyncExitStack() as stack:
+        _, a = await stack.enter_async_context(
+            running_provisioned_agent(lookup_agent, resource_manager, label="lookup")
+        )
+        _, b = await stack.enter_async_context(
+            running_provisioned_agent(weather_agent, resource_manager, label="weather")
+        )
+        room_id = await resource_manager.provision_room(
+            title="e2e-sender-isolation", participants=[a.id, b.id]
+        )
+        async with reply_capture(room_id) as capture:
+            m_a = await user_ops.send_message(
+                room_id,
+                "look up the access code for key 'alpha'",
+                mention_id=a.id,
+                mention_name=a.name,
+            )
+            await capture.wait_for_processed(m_a, a.id)
+            m_b = await user_ops.send_message(
+                room_id,
+                "get the weather for Zorath",
+                mention_id=b.id,
+                mention_name=b.name,
+            )
+            await capture.wait_for_processed(m_b, b.id)
+            # Sends/barriers stay sequential (one shared capture, one waiter), but
+            # the two reads are independent REST calls, so gather them.
+            a_calls, b_calls = await asyncio.gather(
+                capture.tool_calls(sender_id=a.id),
+                capture.tool_calls(sender_id=b.id),
+            )
+
+    a_calls.assert_fired(LOOKUP, with_args={"key": "alpha"})
+    assert not a_calls.fired(WEATHER), "lookup agent's tool calls leaked a weather call"
+    b_calls.assert_fired(WEATHER, with_args={"place": "Zorath"})
+    assert not b_calls.fired(LOOKUP), "weather agent's tool calls leaked a lookup call"
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_tool_calls_isolated_per_room(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """One agent in two rooms; each room sees only its own tool call."""
+    adapter = build_tool_agent(
+        baseline_settings, tools=[LOOKUP_TOOL], prompt=LOOKUP_PROMPT
+    )
+    async with running_provisioned_agent(adapter, resource_manager, label="lookup") as (
+        _,
+        agent,
+    ):
+        room_one = await resource_manager.provision_room(
+            title="e2e-room-isolation-1", participants=[agent.id]
+        )
+        room_two = await resource_manager.provision_room(
+            title="e2e-room-isolation-2", participants=[agent.id]
+        )
+        # Subscribe to both rooms before sending, so neither turn can be missed.
+        async with (
+            reply_capture(room_one) as cap_one,
+            reply_capture(room_two) as cap_two,
+        ):
+            # The two captures are independent (separate nudges), so both rooms
+            # can run concurrently: send both, settle both, read both.
+            m_one, m_two = await asyncio.gather(
+                user_ops.send_message(
+                    room_one,
+                    "look up the access code for key 'alpha'",
+                    mention_id=agent.id,
+                    mention_name=agent.name,
+                ),
+                user_ops.send_message(
+                    room_two,
+                    "look up the access code for key 'beta'",
+                    mention_id=agent.id,
+                    mention_name=agent.name,
+                ),
+            )
+            await asyncio.gather(
+                cap_one.wait_for_processed(m_one, agent.id),
+                cap_two.wait_for_processed(m_two, agent.id),
+            )
+            calls_one, calls_two = await asyncio.gather(
+                cap_one.tool_calls(sender_id=agent.id),
+                cap_two.tool_calls(sender_id=agent.id),
+            )
+
+    calls_one.assert_fired(LOOKUP, with_args={"key": "alpha"})
+    assert not any(c.args.get("key") == "beta" for c in calls_one), (
+        "room one's tool calls leaked room two's call"
+    )
+    calls_two.assert_fired(LOOKUP, with_args={"key": "beta"})
+    assert not any(c.args.get("key") == "alpha" for c in calls_two), (
+        "room two's tool calls leaked room one's call"
+    )
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_capture_scopes_to_current_turn(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Reusing one capture across turns: the wait and the read scope to the new turn."""
+    adapter = build_tool_agent(
+        baseline_settings, tools=[LOOKUP_TOOL], prompt=LOOKUP_PROMPT
+    )
+    async with running_provisioned_agent(adapter, resource_manager, label="lookup") as (
+        _,
+        agent,
+    ):
+        room_id = await resource_manager.provision_room(
+            title="e2e-turn-scope", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            # Turn 1.
+            m_one = await user_ops.send_message(
+                room_id,
+                "look up the access code for key 'alpha'",
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(m_one, agent.id)
+            # Boundary between turns (server timestamp of turn 1's reply). Turn 1's
+            # call is verified by the unscoped read at the end.
+            boundary = _turn_boundary(capture)
+
+            # Turn 2, same capture reused. Barriering on turn 2's own id scopes the
+            # wait to the new turn — it can't return on turn 1's reply.
+            m_two = await user_ops.send_message(
+                room_id,
+                "now look up the access code for key 'beta'",
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(m_two, agent.id)
+            # Contrast a scoped read against an unscoped one to prove `since`
+            # (not some other effect) is what excludes turn 1.
+            turn_two, all_calls = await asyncio.gather(
+                capture.tool_calls(sender_id=agent.id, since=boundary),
+                capture.tool_calls(sender_id=agent.id),
+            )
+
+    # Unscoped, the room still holds BOTH turns' calls — so turn 1's is present...
+    all_calls.assert_fired(LOOKUP, with_args={"key": "alpha"})
+    all_calls.assert_fired(LOOKUP, with_args={"key": "beta"})
+    # ...but `since` scopes the read to turn 2, so turn 1's call is excluded.
+    turn_two.assert_fired(LOOKUP, with_args={"key": "beta"})
+    assert not any(c.args.get("key") == "alpha" for c in turn_two), (
+        "turn-2 read leaked turn-1's call despite `since`"
+    )

--- a/tests/e2e/baseline/smoke/test_memory.py
+++ b/tests/e2e/baseline/smoke/test_memory.py
@@ -1,0 +1,411 @@
+"""Memory smokes: drive deterministic memory operations and assert at both layers
+from one ``capture.memory(agent)`` read -- the *call* layer
+(``mem.calls.assert_store_called`` etc.) and the *store* layer
+(``mem.stored.assert_stored`` / ``where``).
+
+Memories carry a unique marker so the reads are collision-free; agents run with
+``Emit.EXECUTION`` so the calls surface as ``tool_call`` events.
+
+Precondition: memory tools are an enterprise opt-in -- without the entitlement the
+tools error and the store-layer assertions fail.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+
+import pytest
+
+from band.core.memory_types import (
+    MemoryListScope,
+    MemoryStatus,
+    MemoryStoreScope,
+    MemorySystem,
+    WorkingLongTermMemoryType,
+)
+
+from tests.e2e.baseline.requires import Dep, requires
+from tests.e2e.baseline.settings import BaselineSettings
+from tests.e2e.baseline.smoke.sample_agents import (
+    adapter_params,
+    archive_memory_instruction,
+    build_agent,
+    memory_features,
+    recall_memory_instruction,
+    store_memory_instruction,
+    store_subject_memory_instruction,
+    store_two_memories_instruction,
+    supersede_memory_instruction,
+    unique_marker,
+)
+from tests.e2e.baseline.toolkit.observations import MemoryTool
+from tests.e2e.baseline.toolkit.provisioning import (
+    ResourceManager,
+    running_provisioned_agent,
+)
+from tests.e2e.baseline.toolkit.capture import ReplyCapture
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+CaptureFactory = Callable[[str], AbstractAsyncContextManager[ReplyCapture]]
+
+
+# Anthropic-only: gpt-5.4-mini (LangGraph) intermittently skips band_store_memory
+# (same flakiness as the event matrix; prompt/few-shot didn't fix it). The store
+# reader is adapter-agnostic, so one reliable driver suffices.
+@pytest.mark.parametrize("adapter_id", adapter_params(include={"anthropic"}))
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_memory_stored(
+    adapter_id: str,
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """On each adapter: the store tool fired (call layer) and an org-scoped memory
+    landed in the store (store layer), both carrying our marker."""
+    marker = unique_marker("mem")
+    adapter = build_agent(adapter_id, baseline_settings, features=memory_features())
+    async with running_provisioned_agent(
+        adapter, resource_manager, label=adapter_id
+    ) as (_, agent):
+        room_id = await resource_manager.provision_room(
+            title="e2e-memory", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                store_memory_instruction(marker),
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(mid, agent.id)
+            # One read, both layers (call layer from room events, store layer from
+            # the agent's own memories filtered to our marker).
+            mem = await capture.memory(
+                agent, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            )
+
+    mem.calls.assert_store_called(
+        content=marker,
+        scope=MemoryStoreScope.ORGANIZATION,
+        system=MemorySystem.LONG_TERM,
+        type=WorkingLongTermMemoryType.SEMANTIC,
+    )
+    mem.stored.assert_stored(
+        content=marker,
+        scope=MemoryStoreScope.ORGANIZATION,
+        system=MemorySystem.LONG_TERM,
+        type=WorkingLongTermMemoryType.SEMANTIC,
+    )
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_memory_subject_scope(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """A subject-scoped store about the agent itself, read back by subject_id.
+
+    Exercises ``MemoryStoreScope.SUBJECT`` end to end plus ``where(subject_id=...)``
+    filtering; the agent's own id is the subject, passed in the instruction.
+    """
+    marker = unique_marker("subjmem")
+    adapter = build_agent("anthropic", baseline_settings, features=memory_features())
+    async with running_provisioned_agent(
+        adapter, resource_manager, label="memsubj"
+    ) as (_, agent):
+        room_id = await resource_manager.provision_room(
+            title="e2e-memory-subject", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                store_subject_memory_instruction(marker, subject_id=agent.id),
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(mid, agent.id)
+            mem = await capture.memory(
+                agent,
+                scope=MemoryListScope.SUBJECT,
+                subject_id=agent.id,
+                content_query=marker,
+            )
+
+    mem.calls.assert_store_called(
+        content=marker,
+        scope=MemoryStoreScope.SUBJECT,
+        subject_id=agent.id,
+    )
+    mem.stored.assert_stored(content=marker, scope=MemoryStoreScope.SUBJECT)
+    mem.stored.where(subject_id=agent.id).assert_present()
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_memory_excluded_from_general_tool_view(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Memory tool calls are opted out of the general ``tool_calls()`` view by
+    default, but reachable via ``include_memory=True``, ``named()``, and ``memory()``."""
+    marker = unique_marker("mem")
+    adapter = build_agent("anthropic", baseline_settings, features=memory_features())
+    async with running_provisioned_agent(
+        adapter, resource_manager, label="memfilter"
+    ) as (_, agent):
+        room_id = await resource_manager.provision_room(
+            title="e2e-memory-filter", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                store_memory_instruction(marker),
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(mid, agent.id)
+            general = await capture.tool_calls(sender_id=agent.id)
+            with_memory = await capture.tool_calls(
+                sender_id=agent.id, include_memory=True
+            )
+            mem = await capture.memory(
+                agent, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            )
+
+    # Excluded from the general view by default...
+    assert not general.fired(MemoryTool.STORE), (
+        f"memory tool leaked into the general view: {[c.name for c in general]}"
+    )
+    # ...but present when opted in, via the named() subset, and via memory().
+    with_memory.assert_fired(MemoryTool.STORE)
+    with_memory.named(MemoryTool.STORE).assert_fired(MemoryTool.STORE)
+    mem.calls.assert_store_called(content=marker)
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_memory_lifecycle_supersede(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Store then supersede in one turn: both ops fire and the record ends up
+    superseded, demonstrating the lifecycle tools and the ``status`` dimension."""
+    marker = unique_marker("lifemem")
+    adapter = build_agent("anthropic", baseline_settings, features=memory_features())
+    async with running_provisioned_agent(
+        adapter, resource_manager, label="memlife"
+    ) as (_, agent):
+        room_id = await resource_manager.provision_room(
+            title="e2e-memory-life", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                supersede_memory_instruction(marker),
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(mid, agent.id)
+            # status=ALL so the now-superseded record is still returned.
+            mem = await capture.memory(
+                agent,
+                scope=MemoryListScope.ORGANIZATION,
+                content_query=marker,
+                status=MemoryStatus.ALL,
+            )
+
+    # Call layer: both lifecycle operations fired.
+    mem.calls.assert_store_called(content=marker)
+    mem.calls.assert_supersede_called()
+    # Store layer: the record is now superseded, not active.
+    mem.stored.where(status=MemoryStatus.SUPERSEDED).assert_present()
+    mem.stored.where(status=MemoryStatus.ACTIVE).assert_none()
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_memory_lifecycle_archive(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Store then archive in one turn: the record ends up archived, not active."""
+    marker = unique_marker("arcmem")
+    adapter = build_agent("anthropic", baseline_settings, features=memory_features())
+    async with running_provisioned_agent(adapter, resource_manager, label="memarc") as (
+        _,
+        agent,
+    ):
+        room_id = await resource_manager.provision_room(
+            title="e2e-memory-archive", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                archive_memory_instruction(marker),
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(mid, agent.id)
+            mem = await capture.memory(
+                agent,
+                scope=MemoryListScope.ORGANIZATION,
+                content_query=marker,
+                status=MemoryStatus.ALL,
+            )
+
+    mem.calls.assert_store_called(content=marker)
+    mem.calls.assert_archive_called()
+    mem.stored.where(status=MemoryStatus.ARCHIVED).assert_present()
+    mem.stored.where(status=MemoryStatus.ACTIVE).assert_none()
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_memory_recall(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Store then recall: the read-side list and get tools fire (call layer)."""
+    marker = unique_marker("recall")
+    adapter = build_agent("anthropic", baseline_settings, features=memory_features())
+    async with running_provisioned_agent(
+        adapter, resource_manager, label="memrecall"
+    ) as (_, agent):
+        room_id = await resource_manager.provision_room(
+            title="e2e-memory-recall", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                recall_memory_instruction(marker),
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(mid, agent.id)
+            mem = await capture.memory(
+                agent, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            )
+
+    mem.calls.assert_store_called(content=marker)
+    mem.calls.assert_list_called()
+    mem.calls.assert_get_called()
+    mem.stored.assert_stored(content=marker)
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_memory_store_layer_filtering(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Two memories sharing a marker but differing in system/type: one read,
+    sliced by dimension with where()."""
+    marker = unique_marker("multi")
+    adapter = build_agent("anthropic", baseline_settings, features=memory_features())
+    async with running_provisioned_agent(
+        adapter, resource_manager, label="memfilter2"
+    ) as (_, agent):
+        room_id = await resource_manager.provision_room(
+            title="e2e-memory-filtering", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                store_two_memories_instruction(marker),
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(mid, agent.id)
+            mem = await capture.memory(
+                agent, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            )
+
+    # Both landed; slice the single collection by dimension.
+    mem.stored.assert_at_least(2)
+    mem.stored.where(system=MemorySystem.LONG_TERM).assert_stored(
+        content=marker, type=WorkingLongTermMemoryType.SEMANTIC
+    )
+    mem.stored.where(system=MemorySystem.WORKING).assert_stored(
+        content=marker, type=WorkingLongTermMemoryType.EPISODIC
+    )
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_memory_visible_cross_agent_cross_room(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """An organization-scoped memory stored by one agent in one room is visible to
+    a different agent reading from a different room -- memory is org-scoped, not
+    room-scoped, and org memories are shared across agents in the same org."""
+    marker = unique_marker("xorg")
+    writer = build_agent("anthropic", baseline_settings, features=memory_features())
+    reader = build_agent("anthropic", baseline_settings, features=memory_features())
+    async with (
+        running_provisioned_agent(writer, resource_manager, label="memwriter") as (
+            _,
+            agent_w,
+        ),
+        running_provisioned_agent(reader, resource_manager, label="memreader") as (
+            _,
+            agent_r,
+        ),
+    ):
+        room_w = await resource_manager.provision_room(
+            title="e2e-memory-xroom-writer", participants=[agent_w.id]
+        )
+        async with reply_capture(room_w) as cap_w:
+            mid = await user_ops.send_message(
+                room_w,
+                store_memory_instruction(marker),
+                mention_id=agent_w.id,
+                mention_name=agent_w.name,
+            )
+            await cap_w.wait_for_processed(mid, agent_w.id)
+            mem_w = await cap_w.memory(
+                agent_w, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            )
+
+        # Different agent, different room: read the store through the reader's own
+        # client. No turn is needed -- the writer's store is already durable.
+        room_r = await resource_manager.provision_room(
+            title="e2e-memory-xroom-reader", participants=[agent_r.id]
+        )
+        async with reply_capture(room_r) as cap_r:
+            mem_r = await cap_r.memory(
+                agent_r, scope=MemoryListScope.ORGANIZATION, content_query=marker
+            )
+
+    # Writer stored it (both layers).
+    mem_w.calls.assert_store_called(content=marker)
+    mem_w.stored.assert_stored(content=marker)
+    # Reader, in a different room, sees the same org memory without having written
+    # anything itself.
+    mem_r.stored.assert_stored(content=marker)
+    assert not mem_r.calls, "reader should not have called any memory tool"

--- a/tests/e2e/baseline/smoke/test_processing_barrier.py
+++ b/tests/e2e/baseline/smoke/test_processing_barrier.py
@@ -30,7 +30,7 @@ from tests.e2e.baseline.toolkit.provisioning import (
     running_provisioned_agent,
 )
 from tests.e2e.baseline.toolkit.user_ops import UserOps
-from tests.e2e.baseline.toolkit.waiting import ReplyCapture
+from tests.e2e.baseline.toolkit.capture import ReplyCapture
 
 logger = logging.getLogger(__name__)
 

--- a/tests/e2e/baseline/smoke/test_tool_calls.py
+++ b/tests/e2e/baseline/smoke/test_tool_calls.py
@@ -1,0 +1,185 @@
+"""Tool-observation smokes for the baseline toolkit.
+
+Each drives a deterministic tool use and asserts, by inspecting the agent's tool
+calls, what fired and with which args. This exercises the whole capture path: an
+agent with execution reporting on emits ``tool_call`` events, read back via
+``ReplyCapture.tool_calls`` and checked with ``ToolCalls.assert_fired``.
+
+The tools are opaque (see ``sample_tools``) so the agent must call them rather
+than answer from its own knowledge, which is what makes "did it fire" reliable.
+Dedicated agents are built here (not the shared cheap-agent fixtures) so the
+tools and execution reporting are opt-in exactly where the tool calls matter.
+
+Turn completion uses the delivery-status barrier (``wait_for_processed``), not a
+probe/echo: the platform marks the trigger message ``processed`` only after the
+agent's reply is emitted, by which point the turn's ``tool_call`` events are
+already persisted — so the subsequent ``tool_calls`` read is race-free.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+
+import pytest
+
+from tests.e2e.baseline.requires import Dep, requires
+from tests.e2e.baseline.settings import BaselineSettings
+from tests.e2e.baseline.smoke.sample_tools import (
+    ACCESS_CODES,
+    LOOKUP,
+    LOOKUP_AND_WEATHER_PROMPT,
+    LOOKUP_PROMPT,
+    LOOKUP_TOOL,
+    WEATHER,
+    WEATHER_TOOL,
+    build_tool_agent,
+)
+from tests.e2e.baseline.toolkit.provisioning import (
+    ResourceManager,
+    running_provisioned_agent,
+)
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+from tests.e2e.baseline.toolkit.capture import ReplyCapture
+
+CaptureFactory = Callable[[str], AbstractAsyncContextManager[ReplyCapture]]
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_tool_fired_with_args(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """The proof: a single tool fires and is asserted with the right args."""
+    adapter = build_tool_agent(
+        baseline_settings, tools=[LOOKUP_TOOL], prompt=LOOKUP_PROMPT
+    )
+    async with running_provisioned_agent(adapter, resource_manager, label="lookup") as (
+        _,
+        agent,
+    ):
+        room_id = await resource_manager.provision_room(
+            title="e2e-tool-fired", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                "look up the access code for key 'alpha'",
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            # Delivery-status barrier: once the trigger is processed, the lookup
+            # turn (its tool_call event included) is fully persisted.
+            await capture.wait_for_processed(mid, agent.id)
+            calls = await capture.tool_calls(sender_id=agent.id)
+
+    calls.assert_fired(LOOKUP, with_args={"key": "alpha"})
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_capture_exposes_replies_and_tool_calls(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """One capture, both views: assert the reply (Replies) and the tool (ToolCalls)."""
+    adapter = build_tool_agent(
+        baseline_settings, tools=[LOOKUP_TOOL], prompt=LOOKUP_PROMPT
+    )
+    async with running_provisioned_agent(adapter, resource_manager, label="lookup") as (
+        _,
+        agent,
+    ):
+        room_id = await resource_manager.provision_room(
+            title="e2e-replies-and-tools", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                "look up the access code for key 'beta' and tell me the code",
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(mid, agent.id)
+            calls = await capture.tool_calls(sender_id=agent.id)
+
+    # The reply view: the agent reported the secret code, which it could only know
+    # by calling the tool.
+    capture.messages.assert_present()
+    capture.messages.assert_contains_any([ACCESS_CODES["beta"]])
+    # The tool-call view: the lookup tool fired.
+    calls.assert_fired(LOOKUP, with_args={"key": "beta"})
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.timeout(120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_multiple_tools_in_one_turn(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """A single turn fires two different tools; both are observed in one ToolCalls."""
+    adapter = build_tool_agent(
+        baseline_settings,
+        tools=[LOOKUP_TOOL, WEATHER_TOOL],
+        prompt=LOOKUP_AND_WEATHER_PROMPT,
+    )
+    async with running_provisioned_agent(
+        adapter, resource_manager, label="multitool"
+    ) as (_, agent):
+        room_id = await resource_manager.provision_room(
+            title="e2e-multi-tool", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                "look up the access code for key 'alpha' and get the weather for Zorath",
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(mid, agent.id)
+            calls = await capture.tool_calls(sender_id=agent.id)
+
+    calls.assert_fired(LOOKUP, with_args={"key": "alpha"})
+    calls.assert_fired(WEATHER, with_args={"place": "Zorath"})
+
+
+@requires(Dep.ANTHROPIC)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_with_args_tolerant_match(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """assert_fired with_args is tolerant: case-insensitive substring + arg subset."""
+    adapter = build_tool_agent(
+        baseline_settings, tools=[LOOKUP_TOOL], prompt=LOOKUP_PROMPT
+    )
+    async with running_provisioned_agent(adapter, resource_manager, label="lookup") as (
+        _,
+        agent,
+    ):
+        room_id = await resource_manager.provision_room(
+            title="e2e-tolerant-args", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                "look up the access code for key 'Alpha', note 'urgent'",
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(mid, agent.id)
+            calls = await capture.tool_calls(sender_id=agent.id)
+
+    # Tolerant: 'alph' is a case-insensitive substring of the actual key ('Alpha'),
+    # and we omit `note` entirely (subset match, not exact-args).
+    calls.assert_fired(LOOKUP, with_args={"key": "alph"})

--- a/tests/e2e/baseline/toolkit/capture.py
+++ b/tests/e2e/baseline/toolkit/capture.py
@@ -31,6 +31,7 @@ import logging
 from collections import defaultdict
 from collections.abc import AsyncIterator, Callable, Iterable
 from contextlib import asynccontextmanager
+from datetime import datetime
 from typing import Any
 
 from band.client.streaming import (
@@ -39,6 +40,8 @@ from band.client.streaming import (
     WebSocketClient,
 )
 
+from tests.e2e.baseline.toolkit.observations import Replies, ToolCalls
+from tests.e2e.baseline.toolkit.user_ops import UserOps
 from tests.e2e.helpers import TrackingWebSocketClient
 
 logger = logging.getLogger(__name__)
@@ -66,10 +69,17 @@ class ReplyCapture:
     so call ``wait_until`` sequentially on a capture, not from concurrent tasks.
     """
 
-    def __init__(self, room_id: str, *, deadline_s: float = DEFAULT_DEADLINE_S) -> None:
+    def __init__(
+        self,
+        room_id: str,
+        *,
+        user_ops: UserOps | None = None,
+        deadline_s: float = DEFAULT_DEADLINE_S,
+    ) -> None:
         self.room_id = room_id
         self.deadline_s = deadline_s  # default failure deadline for waits
-        self.messages: list[MessageCreatedPayload] = []
+        self._user_ops = user_ops
+        self.messages: Replies = Replies()
         # message_id -> {recipient_id: delivery-state dict}, fed by
         # ``message_updated`` events. The authoritative "agent finished this
         # message" signal, independent of any LLM reply text.
@@ -218,16 +228,51 @@ class ReplyCapture:
                 f"{self._delivery_error(message_id, recipient_id)}"
             ) from None
 
+    async def tool_calls(
+        self,
+        *,
+        sender_id: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> ToolCalls:
+        """Read this room's tool calls (call after the turn settles).
+
+        Reads the persisted ``tool_call`` events, so the agent must run with
+        execution reporting on, and this should follow a completion barrier such
+        as ``wait_for_processed`` (the platform marks a message ``processed``
+        only after the reply is emitted, by which point the turn's tool-call
+        events are already persisted). Pass ``sender_id`` to keep only one
+        agent's calls.
+
+        Without ``since`` this returns *every* tool call in the room — which is
+        the turn only when the capture spans a single turn. When reusing a
+        capture across turns, pass ``since`` (a server timestamp, e.g. the
+        ``inserted_at`` of the last message before the turn) to exclude earlier
+        turns' calls.
+        """
+        if self._user_ops is None:
+            raise RuntimeError(
+                "ReplyCapture.tool_calls needs user_ops; use the reply_capture fixture"
+            )
+        return await ToolCalls.read(
+            self._user_ops,
+            self.room_id,
+            sender_id=sender_id,
+            since=since,
+            limit=limit,
+        )
+
 
 @asynccontextmanager
 async def reply_capture(
     ws: WebSocketClient | TrackingWebSocketClient,
     room_id: str,
     *,
+    user_ops: UserOps | None = None,
     deadline_s: float = DEFAULT_DEADLINE_S,
 ) -> AsyncIterator[ReplyCapture]:
     """Subscribe to a room before sending, yield a capture, leave on exit."""
-    capture = ReplyCapture(room_id, deadline_s=deadline_s)
+    capture = ReplyCapture(room_id, user_ops=user_ops, deadline_s=deadline_s)
 
     async def handler(payload: MessageCreatedPayload) -> None:
         capture._on_message(payload)

--- a/tests/e2e/baseline/toolkit/capture.py
+++ b/tests/e2e/baseline/toolkit/capture.py
@@ -28,19 +28,38 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from collections import defaultdict
 from collections.abc import AsyncIterator, Callable, Iterable
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any
 
+from band_rest import AsyncRestClient
+
 from band.client.streaming import (
     DeliveryStatus,
     MessageCreatedPayload,
     WebSocketClient,
 )
+from band.core.types import MessageType
 
-from tests.e2e.baseline.toolkit.observations import Replies, ToolCalls
+from tests.e2e.baseline.settings import BaselineSettings
+from tests.e2e.baseline.toolkit.observations import (
+    Errors,
+    Events,
+    Memories,
+    MemoryObservation,
+    MemoryToolCalls,
+    Replies,
+    Tasks,
+    Thoughts,
+    ToolCalls,
+)
+from tests.e2e.baseline.toolkit.provisioning import (
+    ProvisionedAgent,
+    agent_rest_client,
+)
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 from tests.e2e.helpers import TrackingWebSocketClient
 
@@ -74,11 +93,15 @@ class ReplyCapture:
         room_id: str,
         *,
         user_ops: UserOps | None = None,
+        settings: BaselineSettings | None = None,
         deadline_s: float = DEFAULT_DEADLINE_S,
     ) -> None:
         self.room_id = room_id
         self.deadline_s = deadline_s  # default failure deadline for waits
         self._user_ops = user_ops
+        self._settings = settings
+        # One agent-auth REST client per agent id, reused across memory reads.
+        self._agent_clients: dict[str, AsyncRestClient] = {}
         self.messages: Replies = Replies()
         # message_id -> {recipient_id: delivery-state dict}, fed by
         # ``message_updated`` events. The authoritative "agent finished this
@@ -228,12 +251,26 @@ class ReplyCapture:
                 f"{self._delivery_error(message_id, recipient_id)}"
             ) from None
 
+    def _require_user_ops(self) -> UserOps:
+        """Return the bound ``UserOps`` or raise (durable reads need it).
+
+        The calling method's name is read from the stack frame (the single source
+        of truth) so the error names it without each caller passing a literal.
+        """
+        if self._user_ops is None:
+            caller = sys._getframe(1).f_code.co_name
+            raise RuntimeError(
+                f"ReplyCapture.{caller} needs user_ops; use the reply_capture fixture"
+            )
+        return self._user_ops
+
     async def tool_calls(
         self,
         *,
         sender_id: str | None = None,
         since: datetime | None = None,
         limit: int = 100,
+        include_memory: bool = False,
     ) -> ToolCalls:
         """Read this room's tool calls (call after the turn settles).
 
@@ -242,7 +279,9 @@ class ReplyCapture:
         as ``wait_for_processed`` (the platform marks a message ``processed``
         only after the reply is emitted, by which point the turn's tool-call
         events are already persisted). Pass ``sender_id`` to keep only one
-        agent's calls.
+        agent's calls. Memory tools are excluded by default; pass
+        ``include_memory=True`` to keep them, or use ``memory(agent)`` for the
+        dedicated two-layer memory view.
 
         Without ``since`` this returns *every* tool call in the room — which is
         the turn only when the capture spans a single turn. When reusing a
@@ -250,12 +289,134 @@ class ReplyCapture:
         ``inserted_at`` of the last message before the turn) to exclude earlier
         turns' calls.
         """
-        if self._user_ops is None:
-            raise RuntimeError(
-                "ReplyCapture.tool_calls needs user_ops; use the reply_capture fixture"
-            )
         return await ToolCalls.read(
-            self._user_ops,
+            self._require_user_ops(),
+            self.room_id,
+            sender_id=sender_id,
+            since=since,
+            limit=limit,
+            include_memory=include_memory,
+        )
+
+    async def memory(
+        self,
+        agent: ProvisionedAgent,
+        *,
+        since: datetime | None = None,
+        limit: int = 100,
+        subject_id: str | None = None,
+        scope: Any | None = None,
+        system: Any | None = None,
+        type: Any | None = None,
+        segment: Any | None = None,
+        content_query: str | None = None,
+        status: Any | None = None,
+        page_size: int = 50,
+    ) -> MemoryObservation:
+        """Read both layers of ``agent``'s memory for the turn (after the barrier).
+
+        Returns a :class:`MemoryObservation` with ``.calls`` (the *call* layer:
+        which memory tools the agent invoked, from the room's ``tool_call`` events)
+        and ``.stored`` (the *store* layer: which records actually landed, from the
+        memories API via the agent's own key -- hence the ``agent`` arg).
+
+        The ``scope``/``system``/``type``/``segment``/``content_query``/``status``
+        filters narrow the store read. Needs ``user_ops`` and ``settings`` (both
+        bound by the ``reply_capture`` fixture); the agent must run with
+        ``Emit.EXECUTION`` for the call layer to be populated.
+        """
+        user_ops = self._require_user_ops()
+        if self._settings is None:
+            raise RuntimeError(
+                "ReplyCapture.memory needs settings; use the reply_capture fixture"
+            )
+        client = self._agent_clients.get(agent.id)
+        if client is None:
+            client = agent_rest_client(agent, self._settings)
+            self._agent_clients[agent.id] = client
+        # The two layers hit different clients/endpoints (room events via the
+        # observer client, the store via the agent client), so read them
+        # concurrently rather than paying both round-trips in series.
+        calls, stored = await asyncio.gather(
+            MemoryToolCalls.read(
+                user_ops, self.room_id, sender_id=agent.id, since=since, limit=limit
+            ),
+            Memories.read(
+                client,
+                subject_id=subject_id,
+                scope=scope,
+                system=system,
+                type=type,
+                segment=segment,
+                content_query=content_query,
+                status=status,
+                page_size=page_size,
+            ),
+        )
+        return MemoryObservation(calls=calls, stored=stored)
+
+    async def events(
+        self,
+        message_type: MessageType,
+        *,
+        sender_id: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> Events:
+        """Read this room's emitted events of ``message_type`` (call after the turn
+        settles). Same read contract as ``tool_calls``; see ``thoughts``/``errors``/
+        ``tasks`` for the named conveniences."""
+        return await Events.read(
+            self._require_user_ops(),
+            self.room_id,
+            message_type=message_type,
+            sender_id=sender_id,
+            since=since,
+            limit=limit,
+        )
+
+    async def thoughts(
+        self,
+        *,
+        sender_id: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> Thoughts:
+        """Read this room's ``thought`` events (call after the turn settles)."""
+        return await Thoughts.read(
+            self._require_user_ops(),
+            self.room_id,
+            sender_id=sender_id,
+            since=since,
+            limit=limit,
+        )
+
+    async def errors(
+        self,
+        *,
+        sender_id: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> Errors:
+        """Read this room's ``error`` events (call after the turn settles)."""
+        return await Errors.read(
+            self._require_user_ops(),
+            self.room_id,
+            sender_id=sender_id,
+            since=since,
+            limit=limit,
+        )
+
+    async def tasks(
+        self,
+        *,
+        sender_id: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> Tasks:
+        """Read this room's ``task`` events (call after the turn settles)."""
+        return await Tasks.read(
+            self._require_user_ops(),
             self.room_id,
             sender_id=sender_id,
             since=since,
@@ -269,10 +430,13 @@ async def reply_capture(
     room_id: str,
     *,
     user_ops: UserOps | None = None,
+    settings: BaselineSettings | None = None,
     deadline_s: float = DEFAULT_DEADLINE_S,
 ) -> AsyncIterator[ReplyCapture]:
     """Subscribe to a room before sending, yield a capture, leave on exit."""
-    capture = ReplyCapture(room_id, user_ops=user_ops, deadline_s=deadline_s)
+    capture = ReplyCapture(
+        room_id, user_ops=user_ops, settings=settings, deadline_s=deadline_s
+    )
 
     async def handler(payload: MessageCreatedPayload) -> None:
         capture._on_message(payload)

--- a/tests/e2e/baseline/toolkit/observations/__init__.py
+++ b/tests/e2e/baseline/toolkit/observations/__init__.py
@@ -1,0 +1,17 @@
+"""Observation collections: what an agent emitted in a room, with assertions.
+
+Each is a ``list`` subclass of captured items plus fluent, tolerant assertion
+methods, so a check lives with the data it inspects. ``ReplyCapture`` (see
+``capture.py``) surfaces both: ``messages`` (``Replies``) and ``tool_calls()``
+(``ToolCalls``).
+
+- :class:`Replies` — captured agent reply messages.
+- :class:`ToolCalls` / :class:`ToolCall` — the agent's tool calls.
+"""
+
+from __future__ import annotations
+
+from tests.e2e.baseline.toolkit.observations.replies import Replies
+from tests.e2e.baseline.toolkit.observations.tool_calls import ToolCall, ToolCalls
+
+__all__ = ["Replies", "ToolCall", "ToolCalls"]

--- a/tests/e2e/baseline/toolkit/observations/__init__.py
+++ b/tests/e2e/baseline/toolkit/observations/__init__.py
@@ -2,16 +2,51 @@
 
 Each is a ``list`` subclass of captured items plus fluent, tolerant assertion
 methods, so a check lives with the data it inspects. ``ReplyCapture`` (see
-``capture.py``) surfaces both: ``messages`` (``Replies``) and ``tool_calls()``
-(``ToolCalls``).
+``capture.py``) surfaces the room-scoped ones: ``messages`` (``Replies``),
+``tool_calls()`` (``ToolCalls``), ``thoughts()``/``errors()``/``tasks()``
+(``Events``), and ``memory(agent)`` (``MemoryObservation``).
 
-- :class:`Replies` — captured agent reply messages.
-- :class:`ToolCalls` / :class:`ToolCall` — the agent's tool calls.
+- :class:`Replies` -- captured agent reply messages.
+- :class:`ToolCall` / :class:`ToolCalls` -- the agent's tool calls (memory tools
+  excluded by default); :class:`MemoryToolCalls` -- the call-layer memory view;
+  :class:`MemoryTool` -- canonical memory tool names.
+- :class:`Events` / :class:`Thoughts` / :class:`Errors` / :class:`Tasks` -- the
+  free-text emitted events.
+- :class:`Memories` -- the store-layer view: memory records that actually landed
+  (agent-scoped). :class:`MemoryObservation` bundles both memory layers and is
+  what ``ReplyCapture.memory`` returns.
 """
 
 from __future__ import annotations
 
+from tests.e2e.baseline.toolkit.observations.events import (
+    Errors,
+    Events,
+    Tasks,
+    Thoughts,
+)
+from tests.e2e.baseline.toolkit.observations.memories import (
+    Memories,
+    MemoryObservation,
+)
 from tests.e2e.baseline.toolkit.observations.replies import Replies
-from tests.e2e.baseline.toolkit.observations.tool_calls import ToolCall, ToolCalls
+from tests.e2e.baseline.toolkit.observations.tool_calls import (
+    MemoryTool,
+    MemoryToolCalls,
+    ToolCall,
+    ToolCalls,
+)
 
-__all__ = ["Replies", "ToolCall", "ToolCalls"]
+__all__ = [
+    "Errors",
+    "Events",
+    "Memories",
+    "MemoryObservation",
+    "MemoryTool",
+    "MemoryToolCalls",
+    "Replies",
+    "Tasks",
+    "Thoughts",
+    "ToolCall",
+    "ToolCalls",
+]

--- a/tests/e2e/baseline/toolkit/observations/assertions.py
+++ b/tests/e2e/baseline/toolkit/observations/assertions.py
@@ -1,0 +1,64 @@
+"""Shared tolerant assertions for message-list observation collections.
+
+``Replies`` and ``Events`` are both lists of messages exposing a string
+``content``, and both want the same two tolerant checks -- a floor on count and a
+case-insensitive any-of substring over content. Those live here as a mixin so the
+collections stay DRY; failure messages name the message kind from the
+collection's ``MESSAGE_TYPE`` (no separate label constant), and each adds its own
+type-specific assertions on top.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import ClassVar
+
+from band.core.types import MessageType
+
+from tests.e2e.baseline.toolkit.observations.matching import tolerant_match
+
+
+class ContentAssertions:
+    """Mixin: tolerant count/content assertions for a ``list`` of messages with a
+    string ``content`` attribute. Mixed in *before* ``list`` so ``len(self)`` and
+    iteration resolve to the list.
+
+    Failure messages name the message kind from ``MESSAGE_TYPE`` (the same
+    ``MessageType`` the collection already carries), so there is no separate
+    label constant to drift -- ``Events`` subclasses set their type, ``Replies``
+    sets ``MessageType.TEXT``.
+    """
+
+    MESSAGE_TYPE: ClassVar[MessageType | None] = None
+
+    def _noun(self) -> str:
+        return f"{self.MESSAGE_TYPE.value} message" if self.MESSAGE_TYPE else "message"
+
+    def assert_at_least(self, n: int) -> None:
+        """Assert a threshold-of-N items (a floor, never an exact count)."""
+        count = len(self)  # type: ignore[arg-type]
+        if count < n:
+            raise AssertionError(
+                f"expected at least {n} {self._noun()}(s), got {count}"
+            )
+
+    def assert_contains_any(self, options: Iterable[str]) -> None:
+        """Assert some item's content contains any of ``options`` (case-insensitive
+        substring via :func:`tolerant_match`). Any-of, not all-of, so paraphrasing
+        doesn't break it. Routing through ``tolerant_match`` means an empty option
+        matches only empty content (never everything), and an empty collection
+        matches nothing -- so a broken setup fails loudly instead of passing.
+
+        Matching is per message: an option must appear within a single message's
+        content, not span the boundary between two (which a real marker never does).
+        """
+        options = list(options)
+        if not any(
+            tolerant_match(option, item.content)  # type: ignore[attr-defined]
+            for item in self
+            for option in options
+        ):
+            haystack = "\n".join(item.content for item in self)  # type: ignore[attr-defined]
+            raise AssertionError(
+                f"no {self._noun()} contained any of {options}:\n{haystack}"
+            )

--- a/tests/e2e/baseline/toolkit/observations/events.py
+++ b/tests/e2e/baseline/toolkit/observations/events.py
@@ -1,0 +1,116 @@
+"""Emitted-event capture and assertions for live E2E tests.
+
+The non-``tool_call`` event kinds an agent emits in a turn -- the free-text
+``thought`` / ``error`` / ``task`` ``MessageType``s. They read back via the Human
+messages API (``UserOps.list_messages``) on the same durable, race-free
+"read after the barrier" path :class:`ToolCalls` uses (see ``tool_calls.py`` for
+the contract), only filtered to a different ``message_type``.
+
+Unlike ``tool_call`` (JSON ``{name, args}``), this content is **free text**, so
+matching stays substring-based -- no JSON parsing. A shared :class:`Events` base
+carries the read and the tolerant assertions; the thin subclasses
+:class:`Thoughts` / :class:`Errors` / :class:`Tasks` just bind their
+``MessageType`` and can grow bespoke assertions later.
+
+Tests reach this through ``ReplyCapture.thoughts`` / ``errors`` / ``tasks`` (or
+the generic ``ReplyCapture.events``).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import ClassVar
+
+from band_rest import ChatMessage
+
+from band.core.types import MessageType
+
+from tests.e2e.baseline.toolkit.observations.assertions import ContentAssertions
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+logger = logging.getLogger(__name__)
+
+
+class Events(ContentAssertions, list[ChatMessage]):
+    """An agent's emitted events of one ``MessageType`` for a turn: a
+    ``list[ChatMessage]`` with fluent, tolerant assertions.
+
+    Subclasses bind a concrete type via ``MESSAGE_TYPE``; the base reads and
+    asserts generically over the events' free-text ``content``. Being a list, it
+    iterates, indexes, and ``len()``s like one. Read once (see ``Events.read`` /
+    ``ReplyCapture.events``), then assert as many times as needed.
+
+    ``assert_at_least`` and ``assert_contains_any`` come from
+    :class:`ContentAssertions` (shared with ``Replies``).
+    """
+
+    MESSAGE_TYPE: ClassVar[MessageType | None] = None
+
+    @classmethod
+    async def read(
+        cls,
+        user_ops: UserOps,
+        room_id: str,
+        *,
+        message_type: MessageType | None = None,
+        sender_id: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> Events:
+        """Read a room's events of one type, oldest-first.
+
+        ``message_type`` defaults to the subclass's ``MESSAGE_TYPE``; pass it
+        explicitly on the base ``Events`` (a ``ValueError`` is raised if neither
+        is set). Pass ``sender_id`` to keep only one agent's events (rooms can
+        hold several agents). Call after the turn is known complete (e.g. after
+        ``wait_for_processed``); tests usually reach this via ``ReplyCapture``.
+
+        Without ``since`` this returns every event of that type in the room (the
+        turn only when the capture spans a single turn). Pass ``since`` (a server
+        timestamp) to exclude earlier turns when reusing a capture.
+        """
+        mt = message_type or cls.MESSAGE_TYPE
+        if mt is None:
+            raise ValueError(
+                "Events.read needs a message_type, or a subclass that binds one"
+            )
+        messages = await user_ops.list_messages(
+            room_id, message_type=mt, since=since, limit=limit
+        )
+        events = cls()
+        for message in messages:
+            if sender_id is not None and message.sender_id != sender_id:
+                continue
+            events.append(message)
+        return events
+
+    def emitted(self) -> bool:
+        """True if any event of this type was captured."""
+        return len(self) > 0
+
+    def assert_emitted(self, *, what: str | None = None) -> None:
+        """Assert at least one event of this type was emitted."""
+        label = what or (
+            f"a {self.MESSAGE_TYPE.value} event" if self.MESSAGE_TYPE else "an event"
+        )
+        if not self:
+            raise AssertionError(f"expected {label}, but none were emitted")
+
+
+class Thoughts(Events):
+    """Captured ``thought`` events."""
+
+    MESSAGE_TYPE: ClassVar[MessageType | None] = MessageType.THOUGHT
+
+
+class Errors(Events):
+    """Captured ``error`` events."""
+
+    MESSAGE_TYPE: ClassVar[MessageType | None] = MessageType.ERROR
+
+
+class Tasks(Events):
+    """Captured ``task`` events."""
+
+    MESSAGE_TYPE: ClassVar[MessageType | None] = MessageType.TASK

--- a/tests/e2e/baseline/toolkit/observations/matching.py
+++ b/tests/e2e/baseline/toolkit/observations/matching.py
@@ -1,0 +1,40 @@
+"""Tolerant value matching shared by the observation collections.
+
+Both the tool-call arg checks (``ToolCalls``) and the memory dimension checks
+(``Memories``) want the same forgiving comparison: a case-insensitive substring
+for text (so a paraphrased value still matches), and string-coerced equality
+otherwise (so an enum like ``MemorySystem.LONG_TERM`` matches the record's
+``"long_term"`` and an int ``2`` matches a JSON-stringified ``"2"``).
+
+Deliberately substring/equality, not fuzzy (rapidfuzz/difflib) similarity: we
+assert on tokens we injected and exact enum values, so we want a deterministic
+"is it present" check, not a tunable score that risks matching a near-miss
+(e.g. a different marker). Semantic/paraphrase checks belong to the LLM judge.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def tolerant_match(expected: Any, actual: Any) -> bool:
+    """True if ``actual`` tolerantly matches ``expected``.
+
+    ``None`` matches only ``None``. Two strings match when ``expected`` is a
+    case-insensitive substring of ``actual`` (a ``StrEnum`` counts as a string, so
+    ``MemorySystem.LONG_TERM`` matches ``"long_term"``); an empty ``expected``
+    matches only an empty string, never everything. Everything else matches by
+    equality, with a string-coerced fallback (so ``2`` matches ``"2"``).
+    """
+    match (expected, actual):
+        case (None, None):
+            return True
+        case (_, None):
+            return False
+        case ("", _):
+            # An empty pattern must not match every string -- only an empty one.
+            return actual == ""
+        case (str() as want, str() as have):
+            return want.lower() in have.lower()
+        case _:
+            return expected == actual or str(expected) == str(actual)

--- a/tests/e2e/baseline/toolkit/observations/memories.py
+++ b/tests/e2e/baseline/toolkit/observations/memories.py
@@ -1,0 +1,196 @@
+"""Memory store-side capture and assertions for live E2E tests.
+
+The *store* layer of memory observation: whether a memory record actually landed
+in the backend, not merely that ``band_store_memory`` was called (that call-layer
+check is ``observations.tool_calls.MemoryToolCalls``). Hence ``assert_stored``
+here vs ``assert_store_called`` there.
+
+Memories are **agent-scoped, not room-scoped**, so this reads with the agent's
+own credentials (``agent_api_memories.list_agent_memories``) rather than the
+room/user view a ``ReplyCapture`` holds. Tests reach it through
+``ReplyCapture.memory(agent)``, which builds the agent-auth client from the
+``ProvisionedAgent`` and returns a ``MemoryObservation`` -- they never touch a REST
+client directly.
+
+Read after the turn settles (after the ``wait_for_processed`` barrier), so the stored row is durable.
+``read`` takes server-side filters (subject_id, scope, system, type, segment,
+content_query, status); ``where(...)`` adds the same filtering in-memory so a
+single read can be sliced several ways. Matching is tolerant: ``content`` is a
+case-insensitive substring, and enum dimensions match by string value (so the
+core ``band.core.memory_types`` enums and the Fern ``AgentMemory*`` enums compare
+equal).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from band_rest import AgentMemory, AsyncRestClient
+
+from tests.e2e.baseline.toolkit.observations.matching import tolerant_match
+from tests.e2e.baseline.toolkit.observations.tool_calls import MemoryToolCalls
+
+logger = logging.getLogger(__name__)
+
+
+class Memories(list[AgentMemory]):
+    """An agent's stored memory records: a ``list[AgentMemory]`` with fluent,
+    tolerant filtering and assertions.
+
+    Read once (see ``Memories.read`` / ``ReplyCapture.memory``), then ``where(...)``
+    to slice and assert as many times as needed.
+    """
+
+    @classmethod
+    async def read(
+        cls,
+        client: AsyncRestClient,
+        *,
+        subject_id: str | None = None,
+        scope: Any | None = None,
+        system: Any | None = None,
+        type: Any | None = None,
+        segment: Any | None = None,
+        content_query: str | None = None,
+        status: Any | None = None,
+        page_size: int = 50,
+    ) -> Memories:
+        """Read the agent's accessible memories via the agent-auth client.
+
+        All filters are server-side (the ``list_agent_memories`` query). Omits
+        unset filters rather than sending ``null`` (the OMIT-vs-null convention).
+        Enum values are coerced to their string form for the wire. ``subject_id``
+        is required by the API for a subject-scoped query.
+        """
+        kwargs: dict[str, Any] = {"page_size": page_size}
+        for key, value in {
+            "subject_id": subject_id,
+            "scope": scope,
+            "system": system,
+            "type": type,
+            "segment": segment,
+            "content_query": content_query,
+            "status": status,
+        }.items():
+            if value is not None:
+                kwargs[key] = str(value)
+        response = await client.agent_api_memories.list_agent_memories(**kwargs)
+        return cls(response.data or [])
+
+    def where(
+        self,
+        *,
+        content: str | None = None,
+        scope: Any | None = None,
+        system: Any | None = None,
+        type: Any | None = None,
+        segment: Any | None = None,
+        status: Any | None = None,
+        subject_id: str | None = None,
+        source_agent_id: str | None = None,
+    ) -> Memories:
+        """Return a re-wrapped ``Memories`` of records matching every given
+        dimension (in-memory, tolerant). Chains into the assertions below.
+
+        Accepts more dimensions than ``read``'s server-side filters on purpose:
+        ``content`` and ``source_agent_id`` have no ``list_agent_memories`` filter,
+        so they are only matchable here, in memory, after the read.
+        """
+        dims = {
+            "content": content,
+            "scope": scope,
+            "system": system,
+            "type": type,
+            "segment": segment,
+            "status": status,
+            "subject_id": subject_id,
+            "source_agent_id": source_agent_id,
+        }
+        wanted = {key: value for key, value in dims.items() if value is not None}
+        return Memories(
+            memory
+            for memory in self
+            if all(
+                tolerant_match(value, getattr(memory, key, None))
+                for key, value in wanted.items()
+            )
+        )
+
+    def assert_stored(
+        self,
+        *,
+        content: str | None = None,
+        scope: Any | None = None,
+        system: Any | None = None,
+        type: Any | None = None,
+        segment: Any | None = None,
+        status: Any | None = None,
+    ) -> None:
+        """Assert at least one stored memory matches every given dimension."""
+        dims = {
+            "content": content,
+            "scope": scope,
+            "system": system,
+            "type": type,
+            "segment": segment,
+            "status": status,
+        }
+        if not self.where(**dims):
+            wanted = {key: value for key, value in dims.items() if value is not None}
+            observed = [
+                {
+                    "content": m.content,
+                    "scope": str(m.scope),
+                    "system": str(m.system),
+                    "type": str(m.type),
+                    "segment": str(m.segment),
+                    "status": str(m.status),
+                }
+                for m in self
+            ] or ["<none>"]
+            raise AssertionError(
+                f"expected a stored memory matching {wanted}, but none did; "
+                f"observed: {observed}"
+            )
+
+    def assert_present(self, *, what: str = "a stored memory") -> None:
+        """Assert at least one memory was read."""
+        if not self:
+            raise AssertionError(f"expected {what}, but none were read")
+
+    def assert_none(self) -> None:
+        """Assert no memory was read (e.g. after supersede/archive removed it)."""
+        if self:
+            observed = [m.content for m in self]
+            raise AssertionError(
+                f"expected no stored memory, but found {len(self)}: {observed}"
+            )
+
+    def assert_at_least(self, n: int) -> None:
+        """Assert a threshold-of-N stored memories (a floor, never an exact count)."""
+        if len(self) < n:
+            raise AssertionError(
+                f"expected at least {n} stored memory/memories, got {len(self)}"
+            )
+
+
+@dataclass(frozen=True)
+class MemoryObservation:
+    """Both layers of memory observation from a single ``ReplyCapture.memory`` read.
+
+    The layers come from different sources and credentials, so each stays its own
+    collection with its own assertions; this just bundles them under one accessor:
+
+    - ``calls`` (:class:`MemoryToolCalls`) -- the *call* layer: which memory tools
+      the agent invoked, with which params. ``calls.assert_store_called(...)``.
+    - ``stored`` (:class:`Memories`) -- the *store* layer: which memory records
+      actually landed. ``stored.assert_stored(...)`` / ``stored.where(...)``.
+
+    The names keep the altitude explicit: ``assert_store_called`` (invoked) vs
+    ``assert_stored`` (a record exists).
+    """
+
+    calls: MemoryToolCalls
+    stored: Memories

--- a/tests/e2e/baseline/toolkit/observations/replies.py
+++ b/tests/e2e/baseline/toolkit/observations/replies.py
@@ -1,0 +1,58 @@
+"""Captured agent reply messages, with fluent tolerant assertions.
+
+``Replies`` is the buffer a ``ReplyCapture`` fills from the room's
+``message_created`` events (see ``capture.py``); it is a ``list`` of reply
+messages with assertion methods attached, so the check lives with the data it
+inspects.
+
+The assertions are deliberately tolerant — they assert *behaviour held*, not
+exact transcripts. There are no exact-count checks, literal-token recitation,
+mandatory-silence, or strict-ordering assertions; agents are non-deterministic
+and those make suites brittle.
+
+- ``assert_present`` — at least one reply happened.
+- ``assert_at_least`` — threshold-of-N replies (a floor, never an exact count).
+- ``assert_contains_any`` — some reply contains any of the options (substring,
+  case-insensitive); any-of, not all-of, so paraphrasing doesn't break it.
+- ``assert_mentions`` — some reply mentions a participant, checked via message
+  metadata (not by parsing ``@`` text).
+
+A list subclass, so it iterates/indexes/``len``s like one. A derived subset
+(slice or filter) is a plain ``list``, so re-wrap it to keep the methods:
+``Replies(m for m in capture.messages if ...).assert_present()``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from band.client.streaming import MessageCreatedPayload
+
+
+class Replies(list[MessageCreatedPayload]):
+    """A list of captured agent reply messages, with tolerant assertions."""
+
+    def assert_present(self, *, what: str = "an agent reply") -> None:
+        assert self, f"expected {what}, but no agent messages were captured"
+
+    def assert_at_least(self, n: int) -> None:
+        assert len(self) >= n, (
+            f"expected at least {n} agent reply/replies, got {len(self)}"
+        )
+
+    def assert_contains_any(self, options: Iterable[str]) -> None:
+        options = list(options)
+        haystack = "\n".join(m.content for m in self).lower()
+        assert any(option.lower() in haystack for option in options), (
+            f"expected a reply containing any of {options}, but none did:\n{haystack}"
+        )
+
+    def assert_mentions(self, participant_id: str) -> None:
+        for message in self:
+            if message.metadata and any(
+                mention.id == participant_id for mention in message.metadata.mentions
+            ):
+                return
+        raise AssertionError(
+            f"expected a reply mentioning {participant_id} (by metadata), but none did"
+        )

--- a/tests/e2e/baseline/toolkit/observations/replies.py
+++ b/tests/e2e/baseline/toolkit/observations/replies.py
@@ -24,28 +24,27 @@ A list subclass, so it iterates/indexes/``len``s like one. A derived subset
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from typing import ClassVar
 
 from band.client.streaming import MessageCreatedPayload
 
+from band.core.types import MessageType
 
-class Replies(list[MessageCreatedPayload]):
-    """A list of captured agent reply messages, with tolerant assertions."""
+from tests.e2e.baseline.toolkit.observations.assertions import ContentAssertions
+
+
+class Replies(ContentAssertions, list[MessageCreatedPayload]):
+    """A list of captured agent reply messages, with tolerant assertions.
+
+    ``assert_at_least`` and ``assert_contains_any`` come from
+    :class:`ContentAssertions` (shared with ``Events``); the rest are reply-specific.
+    Replies are text messages, so ``MESSAGE_TYPE`` is ``MessageType.TEXT``.
+    """
+
+    MESSAGE_TYPE: ClassVar[MessageType | None] = MessageType.TEXT
 
     def assert_present(self, *, what: str = "an agent reply") -> None:
         assert self, f"expected {what}, but no agent messages were captured"
-
-    def assert_at_least(self, n: int) -> None:
-        assert len(self) >= n, (
-            f"expected at least {n} agent reply/replies, got {len(self)}"
-        )
-
-    def assert_contains_any(self, options: Iterable[str]) -> None:
-        options = list(options)
-        haystack = "\n".join(m.content for m in self).lower()
-        assert any(option.lower() in haystack for option in options), (
-            f"expected a reply containing any of {options}, but none did:\n{haystack}"
-        )
 
     def assert_mentions(self, participant_id: str) -> None:
         for message in self:

--- a/tests/e2e/baseline/toolkit/observations/tool_calls.py
+++ b/tests/e2e/baseline/toolkit/observations/tool_calls.py
@@ -14,10 +14,9 @@ different path (the messages-list API filtered to ``tool_call``): the adapter
 ``await``s each tool-call event POST before it ever emits its reply, and the
 platform only marks a message ``processed`` *after* that reply is emitted — so
 once ``wait_for_processed`` returns, every tool-call event of that turn is
-already persisted and queryable. A real-time path would instead route the
-``event_created`` WebSocket event on the chat-room channel, which the SDK client
-does not currently handle; reading the persisted events is simpler and
-sufficient for asserting what fired.
+already persisted and queryable. A real-time path would instead need to buffer
+the chat-room WebSocket notifications for non-text rows; reading the persisted
+events is simpler and sufficient for asserting what fired.
 
 Tests reach this through ``ReplyCapture.tool_calls`` (see ``capture.py``), which
 returns a :class:`ToolCalls` carrying the calls plus a fluent ``assert_fired``.
@@ -29,15 +28,40 @@ import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from enum import StrEnum
+from typing import Any, ClassVar
 
 from band_rest import ChatMessage
 
 from band.core.types import MessageType
+from band.runtime.tools import MEMORY_TOOL_NAMES
 
+from tests.e2e.baseline.toolkit.observations.matching import tolerant_match
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
 logger = logging.getLogger(__name__)
+
+
+class MemoryTool(StrEnum):
+    """Canonical memory platform-tool names as named members (over raw strings).
+
+    Values are validated against the SDK's ``MEMORY_TOOL_NAMES`` at import (below),
+    so they cannot drift from that source of truth -- if a tool is renamed there,
+    importing this module fails loudly.
+    """
+
+    STORE = "band_store_memory"
+    LIST = "band_list_memories"
+    GET = "band_get_memory"
+    SUPERSEDE = "band_supersede_memory"
+    ARCHIVE = "band_archive_memory"
+
+
+if {tool.value for tool in MemoryTool} != set(MEMORY_TOOL_NAMES):
+    raise ValueError(
+        "MemoryTool drifted from band.runtime.tools.MEMORY_TOOL_NAMES: "
+        f"{set(MEMORY_TOOL_NAMES) ^ {tool.value for tool in MemoryTool}}"
+    )
 
 
 @dataclass(frozen=True)
@@ -84,7 +108,15 @@ class ToolCalls(list[ToolCall]):
     Being a list, it iterates, indexes, and ``len()``s like one. Read it once (see
     ``ToolCalls.read`` / ``ReplyCapture.tool_calls``), then assert as many times as
     needed against the same snapshot.
+
+    The general view **opts memory tools out by default** (``include_memory=False``)
+    so generic tool assertions aren't polluted by memory operations -- mirroring
+    the SDK's own ``BASE_TOOL_NAMES = ALL_TOOL_NAMES - MEMORY_TOOL_NAMES`` split.
+    The ``TOOL_NAMES`` hook lets a subclass restrict the view to a fixed set (see
+    :class:`MemoryToolCalls`); ``None`` means "base, memory excluded".
     """
+
+    TOOL_NAMES: ClassVar[frozenset[str] | None] = None
 
     @classmethod
     async def read(
@@ -95,6 +127,7 @@ class ToolCalls(list[ToolCall]):
         sender_id: str | None = None,
         since: datetime | None = None,
         limit: int = 100,
+        include_memory: bool = False,
     ) -> ToolCalls:
         """Read a room's tool calls, oldest-first.
 
@@ -104,9 +137,12 @@ class ToolCalls(list[ToolCall]):
         ``wait_for_processed``); tests usually reach this via
         ``ReplyCapture.tool_calls``.
 
-        Without ``since`` this returns every tool call in the room (a lower bound
-        on a single turn). Pass ``since`` (a server timestamp) to exclude earlier
-        turns when reusing a capture across turns.
+        When ``TOOL_NAMES`` is set (a subclass), only those tools are kept. On the
+        base view, memory tools are excluded unless ``include_memory=True``.
+
+        Without ``since`` this returns every matching tool call in the room (a
+        lower bound on a single turn). Pass ``since`` (a server timestamp) to
+        exclude earlier turns when reusing a capture across turns.
         """
         messages = await user_ops.list_messages(
             room_id, message_type=MessageType.TOOL_CALL, since=since, limit=limit
@@ -116,9 +152,24 @@ class ToolCalls(list[ToolCall]):
             if sender_id is not None and message.sender_id != sender_id:
                 continue
             call = ToolCall.from_event(message)
-            if call is not None:
+            if call is not None and cls._in_view(call.name, include_memory):
                 calls.append(call)
         return calls
+
+    @classmethod
+    def _in_view(cls, name: str, include_memory: bool) -> bool:
+        """Whether a tool ``name`` belongs to this view (see class docstring)."""
+        if cls.TOOL_NAMES is not None:
+            # A bound view (e.g. MemoryToolCalls) is defined entirely by its
+            # TOOL_NAMES; the base-only include_memory flag does not apply to it.
+            return name in cls.TOOL_NAMES
+        return include_memory or name not in MEMORY_TOOL_NAMES
+
+    def named(self, *names: str) -> ToolCalls:
+        """Return a same-class subset of the calls matching any of ``names``
+        (case-insensitive). Re-wrapped so the assertions stay available."""
+        wanted = {name.lower() for name in names}
+        return type(self)(call for call in self if call.name.lower() in wanted)
 
     def fired(self, name: str) -> bool:
         """True if any call matches ``name`` (case-insensitive)."""
@@ -131,7 +182,7 @@ class ToolCalls(list[ToolCall]):
 
         Tolerant by design: the name matches case-insensitively, and ``with_args``
         is a *subset* check (the call may carry extra args), each value matched via
-        ``_arg_matches``. It is not an exact-args assertion; agents vary phrasing
+        ``tolerant_match``. It is not an exact-args assertion; agents vary phrasing
         and may pass additional fields. With ``with_args`` omitted, a name match
         alone satisfies the assertion.
         """
@@ -151,23 +202,65 @@ class ToolCalls(list[ToolCall]):
             )
 
     @staticmethod
-    def _arg_matches(expected: Any, actual: Any) -> bool:
-        """Tolerant single-arg match: substring for text, value-or-string else.
-
-        Strings match case-insensitively as a substring (so a paraphrased value
-        still matches); everything else matches by equality, with a string-coerced
-        fallback so an int ``2`` matches a JSON-stringified ``"2"``.
-        """
-        if isinstance(expected, str) and isinstance(actual, str):
-            return expected.lower() in actual.lower()
-        if expected == actual:
-            return True
-        return str(expected) == str(actual)
-
-    @staticmethod
     def _args_subset_matches(expected: dict[str, Any], actual: dict[str, Any]) -> bool:
-        """True if every expected key is present in ``actual`` and its value matches."""
+        """True if every expected key is present in ``actual`` and its value
+        ``tolerant_match``es."""
         return all(
-            key in actual and ToolCalls._arg_matches(value, actual[key])
+            key in actual and tolerant_match(value, actual[key])
             for key, value in expected.items()
         )
+
+
+class MemoryToolCalls(ToolCalls):
+    """The call-layer memory view: an agent's memory tool calls for a turn.
+
+    Restricts the view to ``MEMORY_TOOL_NAMES`` and adds operation-named
+    assertions that read clearer than ``assert_fired("band_store_memory", ...)``.
+    This is the *call* layer (the agent invoked a memory tool); the *store*
+    layer (a memory record actually exists) is ``observations.memories.Memories``.
+    Hence ``assert_store_called`` here vs ``assert_stored`` there.
+    """
+
+    TOOL_NAMES: ClassVar[frozenset[str] | None] = MEMORY_TOOL_NAMES
+
+    def assert_store_called(
+        self,
+        *,
+        content: str | None = None,
+        scope: Any | None = None,
+        system: Any | None = None,
+        type: Any | None = None,
+        segment: Any | None = None,
+        subject_id: str | None = None,
+    ) -> None:
+        """Assert ``band_store_memory`` fired, optionally with the given params
+        (a tolerant subset match over the call's args, like ``assert_fired``)."""
+        with_args = {
+            key: value
+            for key, value in {
+                "content": content,
+                "scope": scope,
+                "system": system,
+                "type": type,
+                "segment": segment,
+                "subject_id": subject_id,
+            }.items()
+            if value is not None
+        }
+        self.assert_fired(MemoryTool.STORE, with_args=with_args or None)
+
+    def assert_list_called(self) -> None:
+        """Assert ``band_list_memories`` fired."""
+        self.assert_fired(MemoryTool.LIST)
+
+    def assert_get_called(self) -> None:
+        """Assert ``band_get_memory`` fired."""
+        self.assert_fired(MemoryTool.GET)
+
+    def assert_supersede_called(self) -> None:
+        """Assert ``band_supersede_memory`` fired."""
+        self.assert_fired(MemoryTool.SUPERSEDE)
+
+    def assert_archive_called(self) -> None:
+        """Assert ``band_archive_memory`` fired."""
+        self.assert_fired(MemoryTool.ARCHIVE)

--- a/tests/e2e/baseline/toolkit/observations/tool_calls.py
+++ b/tests/e2e/baseline/toolkit/observations/tool_calls.py
@@ -1,0 +1,173 @@
+"""Tool-observation capture and assertions for live E2E tests.
+
+Captures the agent-under-test's tool calls for a turn: which tools fired, with
+which arguments. When an adapter runs with execution reporting on
+(``Emit.EXECUTION``), each tool invocation is recorded as a ``tool_call`` event
+whose ``content`` is JSON ``{"name", "args", "tool_call_id"}``. Those events are
+persisted and read back via the Human messages API (``UserOps.list_messages``).
+
+This reads the durable record *after* the turn completes (pair it with the
+delivery-status barrier ``wait_for_processed``), so it needs no live event
+subscription. The read is race-free by a specific contract, worth stating
+because the barrier is a *delivery-state* signal while this reads *events* via a
+different path (the messages-list API filtered to ``tool_call``): the adapter
+``await``s each tool-call event POST before it ever emits its reply, and the
+platform only marks a message ``processed`` *after* that reply is emitted — so
+once ``wait_for_processed`` returns, every tool-call event of that turn is
+already persisted and queryable. A real-time path would instead route the
+``event_created`` WebSocket event on the chat-room channel, which the SDK client
+does not currently handle; reading the persisted events is simpler and
+sufficient for asserting what fired.
+
+Tests reach this through ``ReplyCapture.tool_calls`` (see ``capture.py``), which
+returns a :class:`ToolCalls` carrying the calls plus a fluent ``assert_fired``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from band_rest import ChatMessage
+
+from band.core.types import MessageType
+
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """One observed tool invocation: the tool name and the args it fired with."""
+
+    name: str
+    args: dict[str, Any] = field(default_factory=dict)
+    tool_call_id: str | None = None
+    raw: ChatMessage | None = None
+
+    @classmethod
+    def from_event(cls, message: ChatMessage) -> ToolCall | None:
+        """Build a ``ToolCall`` from a ``tool_call`` event's JSON content.
+
+        Tolerant of shape drift: a non-JSON or nameless payload yields ``None``
+        (logged, not raised) so a single odd event never breaks inspection.
+        """
+        try:
+            payload = json.loads(message.content)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(
+                "Skipping tool_call event %s: content is not JSON", message.id
+            )
+            return None
+        if not isinstance(payload, dict) or not payload.get("name"):
+            logger.warning(
+                "Skipping tool_call event %s: no tool name in payload", message.id
+            )
+            return None
+        args = payload.get("args")
+        return cls(
+            name=str(payload["name"]),
+            args=args if isinstance(args, dict) else {},
+            tool_call_id=payload.get("tool_call_id"),
+            raw=message,
+        )
+
+
+class ToolCalls(list[ToolCall]):
+    """An agent's observed tool calls for a turn: a ``list[ToolCall]`` with fluent,
+    tolerant assertions.
+
+    Being a list, it iterates, indexes, and ``len()``s like one. Read it once (see
+    ``ToolCalls.read`` / ``ReplyCapture.tool_calls``), then assert as many times as
+    needed against the same snapshot.
+    """
+
+    @classmethod
+    async def read(
+        cls,
+        user_ops: UserOps,
+        room_id: str,
+        *,
+        sender_id: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> ToolCalls:
+        """Read a room's tool calls, oldest-first.
+
+        Lists the room's ``tool_call`` events and parses each into a ``ToolCall``.
+        Pass ``sender_id`` to keep only one agent's calls (rooms can hold several
+        agents). Call after the turn is known complete (e.g. after
+        ``wait_for_processed``); tests usually reach this via
+        ``ReplyCapture.tool_calls``.
+
+        Without ``since`` this returns every tool call in the room (a lower bound
+        on a single turn). Pass ``since`` (a server timestamp) to exclude earlier
+        turns when reusing a capture across turns.
+        """
+        messages = await user_ops.list_messages(
+            room_id, message_type=MessageType.TOOL_CALL, since=since, limit=limit
+        )
+        calls = cls()
+        for message in messages:
+            if sender_id is not None and message.sender_id != sender_id:
+                continue
+            call = ToolCall.from_event(message)
+            if call is not None:
+                calls.append(call)
+        return calls
+
+    def fired(self, name: str) -> bool:
+        """True if any call matches ``name`` (case-insensitive)."""
+        return any(call.name.lower() == name.lower() for call in self)
+
+    def assert_fired(
+        self, name: str, *, with_args: dict[str, Any] | None = None
+    ) -> None:
+        """Assert a tool named ``name`` fired, optionally with the expected args.
+
+        Tolerant by design: the name matches case-insensitively, and ``with_args``
+        is a *subset* check (the call may carry extra args), each value matched via
+        ``_arg_matches``. It is not an exact-args assertion; agents vary phrasing
+        and may pass additional fields. With ``with_args`` omitted, a name match
+        alone satisfies the assertion.
+        """
+        name_matches = [c for c in self if c.name.lower() == name.lower()]
+        if not name_matches:
+            fired = [c.name for c in self] or ["<none>"]
+            raise AssertionError(
+                f"expected tool {name!r} to have fired, but observed: {fired}"
+            )
+        if with_args is not None and not any(
+            self._args_subset_matches(with_args, call.args) for call in name_matches
+        ):
+            observed = [c.args for c in name_matches]
+            raise AssertionError(
+                f"tool {name!r} fired, but none of its calls matched args "
+                f"{with_args}; observed args: {observed}"
+            )
+
+    @staticmethod
+    def _arg_matches(expected: Any, actual: Any) -> bool:
+        """Tolerant single-arg match: substring for text, value-or-string else.
+
+        Strings match case-insensitively as a substring (so a paraphrased value
+        still matches); everything else matches by equality, with a string-coerced
+        fallback so an int ``2`` matches a JSON-stringified ``"2"``.
+        """
+        if isinstance(expected, str) and isinstance(actual, str):
+            return expected.lower() in actual.lower()
+        if expected == actual:
+            return True
+        return str(expected) == str(actual)
+
+    @staticmethod
+    def _args_subset_matches(expected: dict[str, Any], actual: dict[str, Any]) -> bool:
+        """True if every expected key is present in ``actual`` and its value matches."""
+        return all(
+            key in actual and ToolCalls._arg_matches(value, actual[key])
+            for key, value in expected.items()
+        )

--- a/tests/e2e/baseline/toolkit/provisioning.py
+++ b/tests/e2e/baseline/toolkit/provisioning.py
@@ -47,6 +47,21 @@ class ProvisionedAgent:
     name: str
 
 
+def agent_rest_client(
+    agent: ProvisionedAgent, settings: BaselineSettings
+) -> AsyncRestClient:
+    """An agent-authenticated REST client for reads scoped to the agent itself.
+
+    Memories are agent-scoped, not room-scoped, so reading them back uses the
+    agent's *own* key (not the user/observer client the rest of the toolkit
+    uses). Built like ``conftest.baseline_user_client``: the Fern client wraps an
+    httpx pool with no public close hook, so (like the session user client) it is
+    left to be reclaimed at event-loop teardown rather than closed explicitly.
+    ``ReplyCapture`` reuses one client per agent to bound how many are opened.
+    """
+    return AsyncRestClient(api_key=agent.api_key, base_url=settings.endpoints.rest_url)
+
+
 class ResourceManager:
     """Provisions and reaps platform resources for one test run.
 

--- a/tests/e2e/baseline/toolkit/user_ops.py
+++ b/tests/e2e/baseline/toolkit/user_ops.py
@@ -8,14 +8,19 @@ method yet, so it uses a direct REST call (see ``delete_room``).
 
 from __future__ import annotations
 
+from datetime import datetime
+
 import httpx
 from band_rest import (
     AsyncRestClient,
+    ChatMessage,
     ChatMessageRequest,
     ChatMessageRequestMentionsItem,
     CreateMyChatRoomRequestChat,
     ParticipantRequest,
 )
+
+from band.core.types import MessageType
 
 
 class UserOps:
@@ -68,6 +73,33 @@ class UserOps:
             room_id
         )
         return [participant.id for participant in (response.data or [])]
+
+    async def list_messages(
+        self,
+        room_id: str,
+        *,
+        message_type: MessageType | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> list[ChatMessage]:
+        """List a room's messages/events, optionally filtered by type and time.
+
+        Returns every item the platform records for the room (text plus event
+        types like ``tool_call``/``tool_result``), so it doubles as the read
+        path for an agent's tool calls. Newest-first from the API; reversed
+        here to chronological (oldest-first) so callers read a turn in order.
+        ``None`` ``message_type`` returns all types; ``since`` (a server
+        timestamp) keeps only items after it.
+        """
+        kwargs: dict[str, object] = {"limit": limit}
+        if message_type is not None:
+            kwargs["message_type"] = message_type
+        if since is not None:
+            kwargs["since"] = since
+        response = await self._client.human_api_messages.list_my_chat_messages(
+            room_id, **kwargs
+        )
+        return list(reversed(response.data or []))
 
     async def delete_room(self, room_id: str) -> None:
         """Soft-delete a room.

--- a/tests/websocket/test_reply_capture_delivery.py
+++ b/tests/websocket/test_reply_capture_delivery.py
@@ -15,7 +15,7 @@ import asyncio
 import pytest
 
 from band.client.streaming import DeliveryStatus, MessageCreatedPayload
-from tests.e2e.baseline.toolkit.waiting import ReplyCapture
+from tests.e2e.baseline.toolkit.capture import ReplyCapture
 
 MSG = "msg-1"
 AGENT = "agent-1"


### PR DESCRIPTION
## Summary

Adds tool-call capture for live E2E tests and a tolerant `tool_fired` assertion.

This builds on the E2E toolkit from #395. It reads persisted `tool_call` events after a turn finishes, so tests can check which tools were called and with what arguments.

## What's included

- `RoomCapture.tool_calls()` for reading tool calls from a room.
- `ToolCalls.assert_fired()` for checking tool name and argument matches.
- `Replies` and `ToolCalls` observation helpers.
- Smoke tests for tool calls, multiple tools, tolerant args, and room/sender/turn isolation.
- Small toolkit refactors around reply waiting and drain behavior.

## Testing

- `E2E_TESTS_ENABLED=true uv run pytest tests/e2e/baseline/ -v -s --no-cov`
- `uv run ruff check . && uv run ruff format .`

## Related

- Linear: [INT-913](https://linear.app/thenvoi/issue/INT-913/e2e-baseline-trajectory-tool-observation-inspection-tool-fired)
- Parent: [INT-911](https://linear.app/thenvoi/issue/INT-911/testing-framework-and-l0-4-implementation)
- Builds on: [INT-912](https://linear.app/thenvoi/issue/INT-912/bootstrap-e2e-testing-tools-smoke-tests-pre-l0-l4)
