### PR TITLE
docs(examples): prefer EMIT over deprecated execution-reporting flags

### DIFF
--- a/examples/anthropic/README.md
+++ b/examples/anthropic/README.md
@@ -99,9 +99,11 @@ adapter = AnthropicAdapter(
 Enable visibility into tool calls:
 
 ```python
+from band.core.types import AdapterFeatures, Emit
+
 adapter = AnthropicAdapter(
     model="claude-sonnet-4-5-20250929",
-    enable_execution_reporting=True,  # Shows tool calls in chat
+    features=AdapterFeatures(emit={Emit.EXECUTION}),  # Shows tool calls in chat
 )
 ```
 

--- a/examples/claude_sdk/README.md
+++ b/examples/claude_sdk/README.md
@@ -101,11 +101,13 @@ Features:
 Enable extended thinking for complex reasoning tasks:
 
 ```python
+from band.core.types import AdapterFeatures, Emit
+
 adapter = ClaudeSDKAdapter(
     model="opus",
     fallback_model="sonnet",
     max_thinking_tokens=10000,  # Enable extended thinking
-    enable_execution_reporting=True,
+    features=AdapterFeatures(emit={Emit.EXECUTION}),
 )
 ```
 

--- a/examples/codex/01_basic_agent.py
+++ b/examples/codex/01_basic_agent.py
@@ -45,6 +45,7 @@ from dotenv import load_dotenv
 from setup_logging import setup_logging
 from band import Agent
 from band.adapters.codex import CodexAdapter, CodexAdapterConfig
+from band.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -125,10 +126,10 @@ async def main() -> None:
             personality="pragmatic",
             custom_section=custom_section,
             include_base_instructions=True,
-            enable_task_events=True,
             emit_turn_task_markers=_env_bool("CODEX_TURN_TASK_MARKERS", False),
             fallback_send_agent_text=True,
-        )
+        ),
+        features=AdapterFeatures(emit={Emit.TASK_EVENTS}),
     )
 
     agent = Agent.from_config(

--- a/examples/codex/02_tom_agent.py
+++ b/examples/codex/02_tom_agent.py
@@ -39,6 +39,7 @@ from prompts.characters import generate_tom_prompt
 from setup_logging import setup_logging
 from band import Agent
 from band.adapters.codex import CodexAdapter, CodexAdapterConfig
+from band.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -91,9 +92,9 @@ async def main() -> None:
             personality="none",
             custom_section=generate_tom_prompt("Tom"),
             include_base_instructions=True,
-            enable_task_events=True,
             fallback_send_agent_text=True,
-        )
+        ),
+        features=AdapterFeatures(emit={Emit.TASK_EVENTS}),
     )
 
     agent = Agent.from_config(

--- a/examples/codex/03_jerry_agent.py
+++ b/examples/codex/03_jerry_agent.py
@@ -39,6 +39,7 @@ from prompts.characters import generate_jerry_prompt
 from setup_logging import setup_logging
 from band import Agent
 from band.adapters.codex import CodexAdapter, CodexAdapterConfig
+from band.core.types import AdapterFeatures, Emit
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -91,9 +92,9 @@ async def main() -> None:
             personality="none",
             custom_section=generate_jerry_prompt("Jerry"),
             include_base_instructions=True,
-            enable_task_events=True,
             fallback_send_agent_text=True,
-        )
+        ),
+        features=AdapterFeatures(emit={Emit.TASK_EVENTS}),
     )
 
     agent = Agent.from_config(

--- a/examples/crewai/README.md
+++ b/examples/crewai/README.md
@@ -357,7 +357,6 @@ adapter = CrewAIAdapter(
     goal="Help users find and analyze information",
     backstory="Expert researcher with deep domain knowledge",
     custom_section="Extra instructions",
-    enable_execution_reporting=False,
     verbose=False,
 )
 ```

--- a/examples/run_agent.py
+++ b/examples/run_agent.py
@@ -502,13 +502,11 @@ async def run_codex_agent(
             codex_ws_url=codex_ws_url,
             custom_section=custom_section,
             include_base_instructions=True,
-            enable_task_events=True,
             emit_turn_task_markers=codex_turn_task_markers,
-            enable_execution_reporting=False,
-            emit_thought_events=False,
             fallback_send_agent_text=True,
             experimental_api=True,
-        )
+        ),
+        features=AdapterFeatures(emit={Emit.TASK_EVENTS}),
     )
 
     agent = Agent.create(


### PR DESCRIPTION
## What

Migrate every example off the deprecated boolean reporting flags to the preferred `features=AdapterFeatures(emit={...})` API.

## Why

The `enable_execution_reporting` / `emit_thought_events` booleans are deprecated (they emit `DeprecationWarning`s), and `enable_task_events` is a legacy boolean the adapters convert to `Emit.TASK_EVENTS` internally. Examples are user-facing docs, so they should demonstrate the current idiom.

## Changes

| File | Before | After |
|---|---|---|
| `examples/anthropic/README.md` | `enable_execution_reporting=True` | `features=AdapterFeatures(emit={Emit.EXECUTION})` + import |
| `examples/claude_sdk/README.md` | `enable_execution_reporting=True` | `features=AdapterFeatures(emit={Emit.EXECUTION})` + import |
| `examples/crewai/README.md` | `enable_execution_reporting=False` | removed (reporting off → no `features` needed) |
| `examples/codex/01_basic_agent.py` | `enable_task_events=True` | `features=AdapterFeatures(emit={Emit.TASK_EVENTS})` + import |
| `examples/codex/02_tom_agent.py` | `enable_task_events=True` | `features=AdapterFeatures(emit={Emit.TASK_EVENTS})` + import |
| `examples/codex/03_jerry_agent.py` | `enable_task_events=True` | `features=AdapterFeatures(emit={Emit.TASK_EVENTS})` + import |
| `examples/run_agent.py` | `enable_task_events=True`, stale `enable_execution_reporting=False`/`emit_thought_events=False` | `features=AdapterFeatures(emit={Emit.TASK_EVENTS})` |

## Notes

- **Behavior-preserving**: the adapters already mapped these booleans to the same `Emit` values, so runtime behavior is unchanged.
- Audited all ~22 example framework directories (parallel review); the ~28 examples that already report were on the `AdapterFeatures(emit=...)` API and are untouched.
- Edited Python files compile and pass `ruff check`.

Resolves INT-932

✌️
