### PR TITLE
feat: baseline peer helpers — UserOps.lookup_peers + PeerActor (Echo peer)

### DIFF
--- a/tests/e2e/baseline/README.md
+++ b/tests/e2e/baseline/README.md
@@ -201,7 +201,7 @@ These three are why the toolkit is shaped the way it is — keep them when exten
 
 | Path | What it is |
 |------|------------|
-| `toolkit/provisioning.py` | `ResourceManager` (provision/reap agents + rooms, orphan sweep, `track_running` reboot-race guard), `AdapterCell` (build / provision / running / run_as — the per-cell lifecycle object behind `agent`/`cell`), `running_agent` (run an already-provisioned identity — enter twice against one identity for a rejoin), `running_provisioned_agent` (provision + run, composes `running_agent`), `ProvisionedAgent` (`.adapter_id` records the cell/slot it came from) |
+| `toolkit/provisioning.py` | `ResourceManager` (provision/reap agents + rooms, orphan sweep, `track_running` reboot-race guard; `.peer(agent)` mints a `PeerActor`), `AdapterCell` (build / provision / running / run_as — the per-cell lifecycle object behind `agent`/`cell`), `running_agent` (run an already-provisioned identity — enter twice against one identity for a rejoin), `running_provisioned_agent` (provision + run, composes `running_agent`), `ProvisionedAgent` (`.adapter_id` records the cell/slot it came from), `PeerActor` (act as a peer agent — post one message as that agent via its own key; the Agent-API twin of `UserOps`, used for the L0/L4 `Echo` peer) |
 | `toolkit/adapters.py` | registry core: `Adapter` enum (the **one** source of adapter ids), the `@adapter` decorator + registry, `spec_for`, `build_adapter`, `specs`, `adapter_lane`, the discovery guard |
 | `toolkit/builders.py` | the per-framework `@adapter` builder functions (one `_build_*` each); imported by `adapters.py` for the registration side-effect — no public API. Add a new adapter's builder here (see `ADDING_AN_ADAPTER.md`) |
 | `toolkit/ci_lanes.py` | the CI-lane partition + workflow-drift guards: `CILane`, `ci_lanes`, `hosting_lanes` (which lanes' `uv` extra can host a framework), `assert_every_adapter_has_a_ci_home`, `assert_workflow_lane_*` |
@@ -211,7 +211,7 @@ These three are why the toolkit is shaped the way it is — keep them when exten
 | `fixtures/agents.py` | the agent fixtures: `agent` (single running `ProvisionedAgent`), `agents` (the `@with_adapters` group), `cell` (an `AdapterCell` to drive yourself), `adapter_id` (internal `@per_adapter` parametrize target) |
 | `agent_wiring.py` | `assert_agent_fixtures_wired` — the collection-time guard that rejects mis-wired decorator/fixture pairings (see **Wiring fences**) |
 | `smoke/samples/sample_tools.py` | sample custom tools as `ToolSpec`s (`LOOKUP_TOOL`, `WEATHER_TOOL`), prompts, and the `EXECUTION_REPORTING` shape |
-| `toolkit/user_ops.py` | `UserOps`: act as the test user (send message, create/delete room, add/remove/list participants, list messages/events) |
+| `toolkit/user_ops.py` | `UserOps`: act as the test user (send message, create/delete room, add/remove/list participants, list messages/events, `lookup_peers` — the invitable roster) |
 | `toolkit/capture.py` | `ReplyCapture` (subscribe-before-send), `reply_capture` ctx, `wait_for_processed` (delivery-status barrier), `tool_calls()`/`thoughts()`/`errors()`/`tasks()`/`events()`/`memory(agent)`, `CaptureFactory` |
 | `toolkit/requirements.py` | pytest-free requirement facts: `Dep` enum, `DepSpec` predicates, `Lane`/`LANE_EXTRAS`, `dep_lane` (the **one** source of the `Dep`/lane facts the registry references without importing pytest) |
 | `toolkit/judge.py` | `judge()` LLM-as-judge, `Verdict`, `format_transcript` |
@@ -369,6 +369,8 @@ The topology is guarded two ways so a mis-wired test never false-greens:
 | Drive the agent lifecycle myself (build-only / reboot / rehydration) | `@per_adapter()` → `cell` (`cell.build()` / `cell.provision()` / `cell.run_as()` — see **AdapterCell**) |
 | Clean up what I created | nothing: `resource_manager` reaps on teardown (`BAND_E2E_AUTOCLEAN=false` keeps it for debugging) |
 | Drive the platform as a user | the `user_ops` fixture (`UserOps`) |
+| List who the user could invite to a room | `await user_ops.lookup_peers(not_in_room=room_id)` → `list[Peer]` (the invitable roster; `peer_type="Agent"` narrows) |
+| Drive a peer agent (e.g. the `Echo` bounce) | `await resource_manager.peer(peer).send_message(room_id, "ECHO: ...", mention_id=agent.id, mention_name=agent.name)` — posts as that agent, returns the message id to barrier on (needs the peer already in the room) |
 | Observe replies without a race | `async with reply_capture(room_id) as capture:` then send |
 | Know a turn/burst finished (reply captured) | `mid = await user_ops.send_message(...)` then `await capture.wait_for_processed(mid, agent_id)` |
 | Wait for a specific delivery state (e.g. a failure) | `await capture.wait_for_delivery(mid, agent_id, until={DeliveryStatus.FAILED})` |

--- a/tests/e2e/baseline/guards/test_peer_ops.py
+++ b/tests/e2e/baseline/guards/test_peer_ops.py
@@ -1,0 +1,36 @@
+"""Smoke test for PeerActor — driving a provisioned peer agent (the Echo bounce).
+
+Validates the tool, not any L-level contract: provision two peers in a room, have
+one post a message *as itself* mentioning the other, and confirm the message lands
+attributed to the sending peer (not the user).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+from tests.e2e.baseline.toolkit.provisioning import ResourceManager
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_peer_actor_sends_as_agent(
+    resource_manager: ResourceManager, user_ops: UserOps
+) -> None:
+    sender = await resource_manager.provision_agent("peer-sender")
+    target = await resource_manager.provision_agent("peer-target")
+    room_id = await resource_manager.provision_room(
+        title="e2e-peer-ops", participants=[sender.id, target.id]
+    )
+
+    actor = resource_manager.peer(sender)
+    message_id = await actor.send_message(
+        room_id, "ECHO: hello", mention_id=target.id, mention_name=target.name
+    )
+    assert message_id, "send_message should return the new message id"
+
+    messages = await user_ops.list_messages(room_id)
+    assert any(m.id == message_id and m.sender_id == sender.id for m in messages), (
+        "the peer's message should be persisted and attributed to the sending peer"
+    )

--- a/tests/e2e/baseline/guards/test_user_ops.py
+++ b/tests/e2e/baseline/guards/test_user_ops.py
@@ -13,6 +13,23 @@ from band_rest import Peer
 from tests.e2e.baseline.toolkit.provisioning import ResourceManager
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
+_PEER_PAGE_SIZE = 100
+
+
+async def _all_invitable_agents(user_ops: UserOps, room_id: str) -> list[Peer]:
+    """Every Agent peer invitable to ``room_id``, paged so the check never assumes
+    the target lands on page 1 in a workspace that has accumulated agents."""
+    collected: list[Peer] = []
+    page = 1
+    while True:
+        batch = await user_ops.lookup_peers(
+            not_in_room=room_id, peer_type="Agent", page=page, limit=_PEER_PAGE_SIZE
+        )
+        collected.extend(batch)
+        if len(batch) < _PEER_PAGE_SIZE:
+            return collected
+        page += 1
+
 
 @pytest.mark.asyncio(loop_scope="session")
 async def test_user_ops_create_list_delete_room(user_ops: UserOps) -> None:
@@ -40,7 +57,7 @@ async def test_user_ops_lookup_peers_excludes_room_members(
     peer = await resource_manager.provision_agent(label="lookup-peer")
     room_id = await resource_manager.provision_room(title="e2e-userops-peers")
 
-    invitable = await user_ops.lookup_peers(not_in_room=room_id, peer_type="Agent")
+    invitable = await _all_invitable_agents(user_ops, room_id)
     match = next((p for p in invitable if p.id == peer.id), None)
     assert match is not None, (
         "a provisioned agent should be invitable to a room it isn't in"
@@ -53,7 +70,7 @@ async def test_user_ops_lookup_peers_excludes_room_members(
     )
 
     await user_ops.add_participant(room_id, peer.id)
-    after = await user_ops.lookup_peers(not_in_room=room_id)
+    after = await _all_invitable_agents(user_ops, room_id)
     assert all(p.id != peer.id for p in after), (
         "a peer already in the room must drop out of the invitable set"
     )

--- a/tests/e2e/baseline/guards/test_user_ops.py
+++ b/tests/e2e/baseline/guards/test_user_ops.py
@@ -7,8 +7,10 @@ participants, then delete it (the REST-backed delete path).
 from __future__ import annotations
 
 import pytest
+from band_rest import Peer
 
 
+from tests.e2e.baseline.toolkit.provisioning import ResourceManager
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
 
@@ -20,3 +22,38 @@ async def test_user_ops_create_list_delete_room(user_ops: UserOps) -> None:
         assert isinstance(participant_ids, list), "participant_ids should be a list"
     finally:
         await user_ops.delete_room(room_id)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_user_ops_lookup_peers_excludes_room_members(
+    user_ops: UserOps, resource_manager: ResourceManager
+) -> None:
+    """A known owned peer is invitable to a room it's absent from, gone once added.
+
+    Provisions an agent (owned by the test user, so it appears in the user's
+    peer list) but never runs it — no LLM, no provider key. Asserting a *known*
+    id keeps every check non-vacuous: it proves the ``Agent`` type filter is
+    honored and, above all, the ``not_in_room`` exclusion semantics that make
+    this the "who could I invite here" query. Room + agent are reaped by the
+    manager on teardown.
+    """
+    peer = await resource_manager.provision_agent(label="lookup-peer")
+    room_id = await resource_manager.provision_room(title="e2e-userops-peers")
+
+    invitable = await user_ops.lookup_peers(not_in_room=room_id, peer_type="Agent")
+    match = next((p for p in invitable if p.id == peer.id), None)
+    assert match is not None, (
+        "a provisioned agent should be invitable to a room it isn't in"
+    )
+    assert isinstance(match, Peer) and match.name == peer.name, (
+        "the matched peer should carry the fields callers match on"
+    )
+    assert all(p.type == "Agent" for p in invitable), (
+        "the Agent type filter was not honored"
+    )
+
+    await user_ops.add_participant(room_id, peer.id)
+    after = await user_ops.lookup_peers(not_in_room=room_id)
+    assert all(p.id != peer.id for p in after), (
+        "a peer already in the room must drop out of the invitable set"
+    )

--- a/tests/e2e/baseline/smoke/behavior/test_peer_actor.py
+++ b/tests/e2e/baseline/smoke/behavior/test_peer_actor.py
@@ -19,13 +19,13 @@ from tests.e2e.baseline.smoke.samples.sample_agents import (
     unique_marker,
 )
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
-from tests.e2e.baseline.toolkit.provisioning import ResourceManager
+from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceManager
 
 
 @with_adapters(Adapter.ANTHROPIC, prompt=REPLY_PROMPT)
 @pytest.mark.asyncio(loop_scope="session")
 async def test_peer_message_drives_agent_turn(
-    agent,
+    agent: ProvisionedAgent,
     resource_manager: ResourceManager,
     reply_capture: CaptureFactory,
 ) -> None:
@@ -45,7 +45,8 @@ async def test_peer_message_drives_agent_turn(
         )
         await capture.wait_for_processed(mid, agent.id)
 
-    # The agent echoed the marker the *peer* asked for → the peer's message drove
-    # a real turn (delivered, mention-triggered, reached inference), not just a
-    # persisted row.
-    capture.messages.assert_contains_any([marker])
+    # The *agent under test* (not the peer) echoed the marker the peer asked for →
+    # the peer's message drove a real turn (delivered, mention-triggered, reached
+    # inference). Scope to the agent's own replies: the peer is itself an Agent, so
+    # its marker-bearing trigger is captured too and would falsely satisfy this.
+    capture.messages.from_sender(agent.id).assert_contains_any([marker])

--- a/tests/e2e/baseline/smoke/behavior/test_peer_actor.py
+++ b/tests/e2e/baseline/smoke/behavior/test_peer_actor.py
@@ -1,0 +1,51 @@
+"""A peer agent's message drives a real turn on the agent under test.
+
+This is `PeerActor` used in anger (the L0/L4 `Echo` pattern): a *second
+participant* — provisioned but not running any framework adapter — posts a
+message mentioning the agent under test, and the agent processes it and echoes
+the peer's marker. That proves a peer-authored message reaches the agent's
+inference exactly like a user's, which is what the `Echo` bounce relies on, with
+no LLM peer or running adapter needed to produce the message.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.baseline.agents import Adapter, with_adapters
+from tests.e2e.baseline.smoke.samples.sample_agents import (
+    REPLY_PROMPT,
+    liveness_probe,
+    unique_marker,
+)
+from tests.e2e.baseline.toolkit.capture import CaptureFactory
+from tests.e2e.baseline.toolkit.provisioning import ResourceManager
+
+
+@with_adapters(Adapter.ANTHROPIC, prompt=REPLY_PROMPT)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_peer_message_drives_agent_turn(
+    agent,
+    resource_manager: ResourceManager,
+    reply_capture: CaptureFactory,
+) -> None:
+    marker = unique_marker("peer")
+    echo = await resource_manager.provision_agent("echo")
+    room_id = await resource_manager.provision_room(
+        title="e2e-peer-actor", participants=[agent.id, echo.id]
+    )
+
+    async with reply_capture(room_id) as capture:
+        # The peer (not the user) authors the triggering message.
+        mid = await resource_manager.peer(echo).send_message(
+            room_id,
+            liveness_probe(marker),
+            mention_id=agent.id,
+            mention_name=agent.name,
+        )
+        await capture.wait_for_processed(mid, agent.id)
+
+    # The agent echoed the marker the *peer* asked for → the peer's message drove
+    # a real turn (delivered, mention-triggered, reached inference), not just a
+    # persisted row.
+    capture.messages.assert_contains_any([marker])

--- a/tests/e2e/baseline/toolkit/observations/replies.py
+++ b/tests/e2e/baseline/toolkit/observations/replies.py
@@ -69,6 +69,16 @@ class Replies(ContentAssertions, list[MessageCreatedPayload]):
                 f"expected a reply mentioning {participant_id} (by metadata), but none did"
             )
 
+    def from_sender(self, sender_id: str) -> "Replies":
+        """The subset of replies authored by ``sender_id``.
+
+        Scope an assertion to one participant's own messages when several agents
+        post into the same captured room — e.g. a peer and the agent under test,
+        where the peer's own message would otherwise satisfy a content assertion.
+        Re-wraps the filter so the tolerant assertion methods survive.
+        """
+        return Replies(message for message in self if message.sender_id == sender_id)
+
     def snapshot(self) -> int:
         """A cursor at the current end of the buffer, for ``since`` after a turn.
 

--- a/tests/e2e/baseline/toolkit/provisioning.py
+++ b/tests/e2e/baseline/toolkit/provisioning.py
@@ -142,6 +142,10 @@ class ResourceManager:
         self._provisioned_agent_ids: list[str] = []
         self._provisioned_room_ids: list[str] = []
         self._running_agent_ids: set[str] = set()
+        # One PeerActor (and its REST client) per agent id, reused across calls so
+        # repeated peer() calls don't open a fresh httpx pool each time (mirrors
+        # ReplyCapture's per-agent client reuse).
+        self._peer_actors: dict[str, PeerActor] = {}
 
     @contextmanager
     def track_running(self, agent_id: str) -> Iterator[None]:
@@ -201,9 +205,14 @@ class ResourceManager:
         """A ``PeerActor`` to drive ``agent`` as a peer (e.g. the ``Echo`` bounce).
 
         The manager already holds the settings and provisioned the identity, so a
-        test needs neither a separate fixture nor to thread ``settings``.
+        test needs neither a separate fixture nor to thread ``settings``. Cached
+        per agent id so repeated calls reuse one REST client.
         """
-        return PeerActor(agent, self._settings)
+        actor = self._peer_actors.get(agent.id)
+        if actor is None:
+            actor = PeerActor(agent, self._settings)
+            self._peer_actors[agent.id] = actor
+        return actor
 
     async def provision_room(
         self, *, title: str | None = None, participants: list[str] | None = None

--- a/tests/e2e/baseline/toolkit/provisioning.py
+++ b/tests/e2e/baseline/toolkit/provisioning.py
@@ -20,7 +20,12 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
-from band_rest import AgentRegisterRequest, AsyncRestClient
+from band_rest import (
+    AgentRegisterRequest,
+    AsyncRestClient,
+    ChatMessageRequest,
+    ChatMessageRequestMentionsItem,
+)
 
 from band.agent import Agent
 from band.core.simple_adapter import SimpleAdapter
@@ -75,6 +80,44 @@ def agent_rest_client(
     ``ReplyCapture`` reuses one client per agent to bound how many are opened.
     """
     return AsyncRestClient(api_key=agent.api_key, base_url=settings.endpoints.rest_url)
+
+
+class PeerActor:
+    """Drive a provisioned peer agent — the agent-side twin of ``UserOps``.
+
+    ``UserOps`` acts as the test *user* (Human API); ``PeerActor`` acts as a peer
+    *agent* (Agent API), so a scenario can have a second participant say something
+    deterministically without running a full framework adapter. The canonical use
+    is the L0/L4 ``Echo`` peer: provision an identity, invite it, then post one
+    ``ECHO: {body}`` bounce. Built from the peer's own key via ``agent_rest_client``.
+
+    The peer must already be a participant of the room (an agent can only post to a
+    room it is in); membership stays with ``ResourceManager``/``UserOps`` or the
+    agent under test, not here.
+    """
+
+    def __init__(self, peer: ProvisionedAgent, settings: BaselineSettings) -> None:
+        self._peer = peer
+        self._client = agent_rest_client(peer, settings)
+
+    async def send_message(
+        self, room_id: str, content: str, *, mention_id: str, mention_name: str
+    ) -> str:
+        """Post one message as this peer; return the message id.
+
+        Mirrors ``UserOps.send_message`` (mention required, returns the id) so a
+        test can barrier on the peer's message with ``wait_for_processed``.
+        """
+        response = await self._client.agent_api_messages.create_agent_chat_message(
+            room_id,
+            message=ChatMessageRequest(
+                content=content,
+                mentions=[
+                    ChatMessageRequestMentionsItem(id=mention_id, name=mention_name)
+                ],
+            ),
+        )
+        return response.data.id
 
 
 class ResourceManager:
@@ -153,6 +196,14 @@ class ResourceManager:
         self._provisioned_agent_ids.append(agent.id)
         logger.info("Provisioned agent %s (%s)", agent.id, name)
         return ProvisionedAgent(id=agent.id, api_key=credentials.api_key, name=name)
+
+    def peer(self, agent: ProvisionedAgent) -> PeerActor:
+        """A ``PeerActor`` to drive ``agent`` as a peer (e.g. the ``Echo`` bounce).
+
+        The manager already holds the settings and provisioned the identity, so a
+        test needs neither a separate fixture nor to thread ``settings``.
+        """
+        return PeerActor(agent, self._settings)
 
     async def provision_room(
         self, *, title: str | None = None, participants: list[str] | None = None

--- a/tests/e2e/baseline/toolkit/user_ops.py
+++ b/tests/e2e/baseline/toolkit/user_ops.py
@@ -17,7 +17,9 @@ from band_rest import (
     ChatMessageRequest,
     ChatMessageRequestMentionsItem,
     CreateMyChatRoomRequestChat,
+    ListMyPeersRequestType,
     ParticipantRequest,
+    Peer,
 )
 
 from band.core.types import MessageType
@@ -74,6 +76,31 @@ class UserOps:
         )
         return [participant.id for participant in (response.data or [])]
 
+    async def lookup_peers(
+        self,
+        *,
+        not_in_room: str | None = None,
+        peer_type: ListMyPeersRequestType | None = None,
+        limit: int = 100,
+    ) -> list[Peer]:
+        """List peers the user can interact with — the invitable roster.
+
+        The driver-side mirror of the agent's own ``band_lookup_peers``: it asks
+        the Human API which entities (users and agents) the test user could bring
+        into a room. Pass ``not_in_room=<room_id>`` to exclude peers already in
+        that room, so the result is exactly the set still invitable there;
+        ``peer_type`` (``"User"``/``"Agent"``) narrows by kind. Returns the ``Peer``
+        models so callers match on ``.name``/``.id``/``.handle``/``.type``.
+
+        ``not_in_room``/``peer_type`` are query params: left ``None`` they are
+        omitted (not sent as ``null``), matching how the SDK itself calls this
+        endpoint, so no conditional kwargs bag is needed.
+        """
+        response = await self._client.human_api_peers.list_my_peers(
+            not_in_chat=not_in_room, type=peer_type, page_size=limit
+        )
+        return list(response.data or [])
+
     async def list_messages(
         self,
         room_id: str,
@@ -89,15 +116,11 @@ class UserOps:
         path for an agent's tool calls. Newest-first from the API; reversed
         here to chronological (oldest-first) so callers read a turn in order.
         ``None`` ``message_type`` returns all types; ``since`` (a server
-        timestamp) keeps only items after it.
+        timestamp) keeps only items after it. Both are query params: left
+        ``None`` they are omitted (not sent as ``null``), so they pass directly.
         """
-        kwargs: dict[str, object] = {"limit": limit}
-        if message_type is not None:
-            kwargs["message_type"] = message_type
-        if since is not None:
-            kwargs["since"] = since
         response = await self._client.human_api_messages.list_my_chat_messages(
-            room_id, **kwargs
+            room_id, message_type=message_type, since=since, limit=limit
         )
         return list(reversed(response.data or []))
 

--- a/tests/e2e/baseline/toolkit/user_ops.py
+++ b/tests/e2e/baseline/toolkit/user_ops.py
@@ -81,9 +81,10 @@ class UserOps:
         *,
         not_in_room: str | None = None,
         peer_type: ListMyPeersRequestType | None = None,
+        page: int = 1,
         limit: int = 100,
     ) -> list[Peer]:
-        """List peers the user can interact with — the invitable roster.
+        """List one page of peers the user can interact with — the invitable roster.
 
         The driver-side mirror of the agent's own ``band_lookup_peers``: it asks
         the Human API which entities (users and agents) the test user could bring
@@ -92,12 +93,15 @@ class UserOps:
         ``peer_type`` (``"User"``/``"Agent"``) narrows by kind. Returns the ``Peer``
         models so callers match on ``.name``/``.id``/``.handle``/``.type``.
 
+        Returns a single page (``limit`` items from ``page``); a caller that must
+        see the whole roster in a populated workspace pages until a short page.
+
         ``not_in_room``/``peer_type`` are query params: left ``None`` they are
         omitted (not sent as ``null``), matching how the SDK itself calls this
         endpoint, so no conditional kwargs bag is needed.
         """
         response = await self._client.human_api_peers.list_my_peers(
-            not_in_chat=not_in_room, type=peer_type, page_size=limit
+            not_in_chat=not_in_room, type=peer_type, page=page, page_size=limit
         )
         return list(response.data or [])
 


### PR DESCRIPTION
## Summary

Baseline E2E toolkit additions that unblock the L0/L4 scenarios, plus docs. **Test tooling only — no SDK/product changes.** Stacked on the adapter-discovery branch (#402).

Two capabilities: read the *invitable roster* as the user, and *act as a peer agent* (the L0/L4 `Echo` peer). The Echo peer is deliberately **not** a running "bouncer adapter" — a provisioned identity + a single scripted send is more deterministic (an LLM bouncer could race or double-send).

## Changes

- **`UserOps.lookup_peers`** — driver-side mirror of the agent's `band_lookup_peers`; returns `list[Peer]`, `not_in_room=<room_id>` yields the still-invitable set, `page`/`limit` for pagination. Also cleaned `list_messages` to the same direct-typed-call form, dropping the `dict[str, object]` kwargs bag (the module is now pyrefly-clean).
- **`PeerActor` + `ResourceManager.peer(agent)`** (`toolkit/provisioning.py`) — the Agent-API twin of `UserOps`: post one message as a provisioned peer via its own key. So the Echo peer is just `provision_agent("echo")` + `resource_manager.peer(echo).send_message(...)`. Cached per agent id so repeated calls reuse one REST client.
- **`Replies.from_sender(sender_id)`** (`toolkit/observations/replies.py`) — scope a content assertion to one participant's own messages (needed when a peer and the agent under test both post into the same captured room).
- **Tests**
  - `guards/test_user_ops.py` — `lookup_peers` proven with a known owned agent: invitable to a room it's absent from, gone once added (pages the full roster so it's non-vacuous and not page-1-dependent; no LLM).
  - `guards/test_peer_ops.py` — keyless tool smoke: a peer posts as itself; the message lands attributed to the sending peer (not the user).
  - `smoke/behavior/test_peer_actor.py` — meaningful usage: a peer's message triggers and drives a real turn on a live agent, which echoes the peer's marker — asserted on the *agent's own* replies (`from_sender`), so the peer's trigger can't falsely satisfy it.
- **Docs** (`baseline/README.md`) — layout rows for `PeerActor` / `ResourceManager.peer` / `lookup_peers`, plus two "I want to…" entries.

## Related Issues

Relates to INT-930 (L0–L4 Tier-2 implementation) and parent INT-911. `lookup_peers` and the Echo peer are the two toolkit pieces those scenarios needed.

## Testing

- `uv run ruff check .` / `ruff format --check` — clean on all changed files.
- `uv run pyrefly check` — no net-new errors (the only ones on the touched modules are the pre-existing repo-wide `tests.*` import-root warnings).
- Ran a high-effort self code-review; the three findings (false-green behavior test, page-1 flake, per-call client leak) are fixed in this PR.
- New tests are **E2E-gated** (live `core` lane; need `BAND_API_KEY_USER` + `ANTHROPIC_API_KEY`). Verified they collect and pass every static gate; they execute in the live lane, not PR CI.
- [x] Unit tests unaffected (changes are under `tests/e2e/**`, skipped unless `E2E_TESTS_ENABLED`).
- [x] Lint / format / typecheck pass on changed files.
