### PR TITLE
feat: Emit.USAGE seam — per-turn token usage capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ celerybeat-schedule
 .env
 .env.test
 .venv/
+.venv-crewai/
 env/
 venv/
 ENV/

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -329,6 +329,15 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
         ``metrics`` (a ``RunMetrics``, aggregated across the run's model calls)
         is optional and its token field names line up 1:1 with TurnUsage's, so
         this is a straight ``from_object`` (missing metrics → empty usage).
+
+        Agno exposes a separate ``reasoning_tokens``, but unlike the single-provider
+        adapters it is a multi-provider aggregator whose ``output_tokens`` already
+        *includes* reasoning for some backends (OpenAI's completion tokens) and
+        *excludes* it for others (Gemini's candidates), so no static fold is
+        correct for every backend — folding would double-count OpenAI-backed runs.
+        Leaving reasoning out (rather than statically folding) mirrors the RAW
+        cache convention: don't apply a provider-specific normalization that this
+        aggregator can't guarantee. So reasoning is deliberately not folded here.
         """
         return TurnUsage.from_object(
             getattr(response, "metrics", None),

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -18,6 +18,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    TurnUsage,
 )
 from band.converters.agno import AgnoHistoryConverter, AgnoMessages
 from band.runtime.prompts import render_system_prompt
@@ -108,7 +109,7 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
     """
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset(
-        {Emit.EXECUTION, Emit.THOUGHTS}
+        {Emit.EXECUTION, Emit.THOUGHTS, Emit.USAGE}
     )
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
         {Capability.MEMORY, Capability.CONTACTS}
@@ -301,6 +302,9 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
         if Emit.THOUGHTS in self.features.emit:
             await self._report_thoughts(response, tools, room_id=room_id, msg_id=msg.id)
 
+        # RunOutput.metrics is aggregated across the run's model calls.
+        await self.emit_usage(tools, self._usage_from_response(response))
+
         self._persist_turn(room_id, response)
 
         if not any(
@@ -317,6 +321,29 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
     async def on_cleanup(self, room_id: str) -> None:
         """Drop the room's accumulated transcript when the agent leaves."""
         self._message_history.pop(room_id, None)
+
+    @staticmethod
+    def _usage_from_response(response: RunOutput) -> TurnUsage:
+        """Map an Agno ``RunOutput.metrics`` onto TurnUsage.
+
+        ``metrics`` (a ``RunMetrics``) is aggregated across the run's model
+        calls; its token field names line up with TurnUsage's. It is optional,
+        so a missing metrics object yields empty usage.
+        """
+        metrics = getattr(response, "metrics", None)
+        if metrics is None:
+            return TurnUsage()
+
+        def _int(name: str) -> int:
+            value = getattr(metrics, name, 0)
+            return value if isinstance(value, int) else 0
+
+        return TurnUsage(
+            input_tokens=_int("input_tokens"),
+            output_tokens=_int("output_tokens"),
+            cache_read_tokens=_int("cache_read_tokens"),
+            cache_write_tokens=_int("cache_write_tokens"),
+        )
 
     def _prior_transcript(
         self,

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -326,23 +326,16 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
     def _usage_from_response(response: RunOutput) -> TurnUsage:
         """Map an Agno ``RunOutput.metrics`` onto TurnUsage.
 
-        ``metrics`` (a ``RunMetrics``) is aggregated across the run's model
-        calls; its token field names line up with TurnUsage's. It is optional,
-        so a missing metrics object yields empty usage.
+        ``metrics`` (a ``RunMetrics``, aggregated across the run's model calls)
+        is optional and its token field names line up 1:1 with TurnUsage's, so
+        this is a straight ``from_object`` (missing metrics → empty usage).
         """
-        metrics = getattr(response, "metrics", None)
-        if metrics is None:
-            return TurnUsage()
-
-        def _int(name: str) -> int:
-            value = getattr(metrics, name, 0)
-            return value if isinstance(value, int) else 0
-
-        return TurnUsage(
-            input_tokens=_int("input_tokens"),
-            output_tokens=_int("output_tokens"),
-            cache_read_tokens=_int("cache_read_tokens"),
-            cache_write_tokens=_int("cache_write_tokens"),
+        return TurnUsage.from_object(
+            getattr(response, "metrics", None),
+            input="input_tokens",
+            output="output_tokens",
+            cache_read="cache_read_tokens",
+            cache_write="cache_write_tokens",
         )
 
     def _prior_transcript(

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -271,61 +271,62 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
 
         # Tool loop - let LLM decide when to stop. Anthropic reports usage
         # per API call, so sum it across every iteration of the loop into one
-        # per-turn TurnUsage (emitted once, after the loop).
+        # per-turn TurnUsage, emitted on every exit via the finally.
         turn_usage = TurnUsage()
-        while True:
-            try:
-                response = await self._call_anthropic(
-                    messages=self._message_history[room_id],
-                    tools=tool_schemas,
-                )
-            except Exception as e:
-                logger.error("Error calling Anthropic: %s", e, exc_info=True)
-                await self._report_error(tools, str(e))
-                raise  # Re-raise so message is marked as failed
-
-            turn_usage = turn_usage + self._usage_from_response(response)
-
-            # Check for tool use
-            if response.stop_reason != "tool_use":
-                # No more tool calls - extract text content if any
-                text_content = self._extract_text_content(response.content)
-                if text_content:
-                    self._message_history[room_id].append(
-                        {
-                            "role": "assistant",
-                            "content": text_content,
-                        }
+        try:
+            while True:
+                try:
+                    response = await self._call_anthropic(
+                        messages=self._message_history[room_id],
+                        tools=tool_schemas,
                     )
-                logger.debug(
-                    "Room %s: Completed with stop_reason=%s",
-                    room_id,
-                    response.stop_reason,
+                except Exception as e:
+                    logger.error("Error calling Anthropic: %s", e, exc_info=True)
+                    await self._report_error(tools, str(e))
+                    raise  # Re-raise so message is marked as failed
+
+                turn_usage = turn_usage + self._usage_from_response(response)
+
+                # Check for tool use
+                if response.stop_reason != "tool_use":
+                    # No more tool calls - extract text content if any
+                    text_content = self._extract_text_content(response.content)
+                    if text_content:
+                        self._message_history[room_id].append(
+                            {
+                                "role": "assistant",
+                                "content": text_content,
+                            }
+                        )
+                    logger.debug(
+                        "Room %s: Completed with stop_reason=%s",
+                        room_id,
+                        response.stop_reason,
+                    )
+                    break
+
+                # Add assistant response with tool_use blocks to history
+                serialized_content = self._serialize_content_blocks(response.content)
+                self._message_history[room_id].append(
+                    {
+                        "role": "assistant",
+                        "content": serialized_content,
+                    }
                 )
-                break
 
-            # Add assistant response with tool_use blocks to history
-            serialized_content = self._serialize_content_blocks(response.content)
-            self._message_history[room_id].append(
-                {
-                    "role": "assistant",
-                    "content": serialized_content,
-                }
-            )
+                # Process tool calls
+                tool_results = await self._process_tool_calls(response, tools)
 
-            # Process tool calls
-            tool_results = await self._process_tool_calls(response, tools)
-
-            # Add tool results to history
-            self._message_history[room_id].append(
-                {
-                    "role": "user",
-                    "content": tool_results,
-                }
-            )
-
-        # Emit the turn's aggregated token usage (no-op unless Emit.USAGE is on).
-        await self.emit_usage(tools, turn_usage)
+                # Add tool results to history
+                self._message_history[room_id].append(
+                    {
+                        "role": "user",
+                        "content": tool_results,
+                    }
+                )
+        finally:
+            # No-op unless Emit.USAGE is on; best-effort, never raises.
+            await self.emit_usage(tools, turn_usage)
 
         logger.debug(
             "Message %s processed successfully (history now has %s messages)",

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -22,6 +22,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    TurnUsage,
 )
 from band.converters.anthropic import AnthropicHistoryConverter, AnthropicMessages
 from band.runtime.custom_tools import (
@@ -55,7 +56,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
         await agent.run()
     """
 
-    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
         {Capability.MEMORY, Capability.CONTACTS}
     )
@@ -268,7 +269,10 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
             custom_schemas = custom_tools_to_schemas(self._custom_tools, "anthropic")
             tool_schemas.extend(cast(list[ToolParam], custom_schemas))
 
-        # Tool loop - let LLM decide when to stop
+        # Tool loop - let LLM decide when to stop. Anthropic reports usage
+        # per API call, so sum it across every iteration of the loop into one
+        # per-turn TurnUsage (emitted once, after the loop).
+        turn_usage = TurnUsage()
         while True:
             try:
                 response = await self._call_anthropic(
@@ -279,6 +283,8 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                 logger.error("Error calling Anthropic: %s", e, exc_info=True)
                 await self._report_error(tools, str(e))
                 raise  # Re-raise so message is marked as failed
+
+            turn_usage = turn_usage + self._usage_from_response(response)
 
             # Check for tool use
             if response.stop_reason != "tool_use":
@@ -318,6 +324,9 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                 }
             )
 
+        # Emit the turn's aggregated token usage (no-op unless Emit.USAGE is on).
+        await self.emit_usage(tools, turn_usage)
+
         logger.debug(
             "Message %s processed successfully (history now has %s messages)",
             msg.id,
@@ -353,6 +362,21 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
             system=self._system_prompt,
             messages=cast(list[MessageParam], messages),
             tools=tools,
+        )
+
+    @staticmethod
+    def _usage_from_response(response: Message) -> TurnUsage:
+        """Map an Anthropic ``Message.usage`` onto the framework-agnostic TurnUsage.
+
+        Cache fields are optional on the SDK model (absent/None when prompt
+        caching is off), so they are read defensively and default to 0.
+        """
+        usage = response.usage
+        return TurnUsage(
+            input_tokens=usage.input_tokens or 0,
+            output_tokens=usage.output_tokens or 0,
+            cache_read_tokens=getattr(usage, "cache_read_input_tokens", 0) or 0,
+            cache_write_tokens=getattr(usage, "cache_creation_input_tokens", 0) or 0,
         )
 
     # --- Copied from BandAnthropicAgent._extract_text_content ---

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -369,14 +369,14 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
         """Map an Anthropic ``Message.usage`` onto the framework-agnostic TurnUsage.
 
         Cache fields are optional on the SDK model (absent/None when prompt
-        caching is off), so they are read defensively and default to 0.
+        caching is off); ``from_object`` reads them defensively (missing → 0).
         """
-        usage = response.usage
-        return TurnUsage(
-            input_tokens=usage.input_tokens or 0,
-            output_tokens=usage.output_tokens or 0,
-            cache_read_tokens=getattr(usage, "cache_read_input_tokens", 0) or 0,
-            cache_write_tokens=getattr(usage, "cache_creation_input_tokens", 0) or 0,
+        return TurnUsage.from_object(
+            response.usage,
+            input="input_tokens",
+            output="output_tokens",
+            cache_read="cache_read_input_tokens",
+            cache_write="cache_creation_input_tokens",
         )
 
     # --- Copied from BandAnthropicAgent._extract_text_content ---

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -370,6 +370,9 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
 
         Cache fields are optional on the SDK model (absent/None when prompt
         caching is off); ``from_object`` reads them defensively (missing → 0).
+        Anthropic's ``input_tokens`` EXCLUDES cached tokens, so ``cache_in_input``
+        is False — cache is folded into the total input per the TurnUsage
+        convention.
         """
         return TurnUsage.from_object(
             response.usage,
@@ -377,6 +380,7 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
             output="output_tokens",
             cache_read="cache_read_input_tokens",
             cache_write="cache_creation_input_tokens",
+            cache_in_input=False,
         )
 
     # --- Copied from BandAnthropicAgent._extract_text_content ---

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -368,11 +368,10 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
     def _usage_from_response(response: Message) -> TurnUsage:
         """Map an Anthropic ``Message.usage`` onto the framework-agnostic TurnUsage.
 
-        Cache fields are optional on the SDK model (absent/None when prompt
-        caching is off); ``from_object`` reads them defensively (missing → 0).
-        Anthropic's ``input_tokens`` EXCLUDES cached tokens, so ``cache_in_input``
-        is False — cache is folded into the total input per the TurnUsage
-        convention.
+        Raw per the TurnUsage convention: Anthropic's ``input_tokens`` excludes
+        cached tokens (reported separately in the cache fields). Cache fields are
+        optional on the SDK model (absent/None when caching is off); ``from_object``
+        reads them defensively (missing → 0).
         """
         return TurnUsage.from_object(
             response.usage,
@@ -380,7 +379,6 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
             output="output_tokens",
             cache_read="cache_read_input_tokens",
             cache_write="cache_creation_input_tokens",
-            cache_in_input=False,
         )
 
     # --- Copied from BandAnthropicAgent._extract_text_content ---

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -50,7 +50,13 @@ except ImportError:
 from band.core.exceptions import BandConfigError
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
-from band.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
+from band.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+    TurnUsage,
+)
 from band.converters.claude_sdk import (
     ClaudeSDKHistoryConverter,
     ClaudeSDKSessionState,
@@ -178,7 +184,7 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
     PermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions"]
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset(
-        {Emit.EXECUTION, Emit.THOUGHTS}
+        {Emit.EXECUTION, Emit.THOUGHTS, Emit.USAGE}
     )
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
         {Capability.MEMORY, Capability.CONTACTS}
@@ -770,7 +776,33 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                                 room_id,
                                 e,
                             )
+                # The ResultMessage carries the turn's total usage (the SDK runs
+                # its own tool loop internally, so this is already aggregated).
+                await self.emit_usage(tools, self._usage_from_result(sdk_message))
                 break
+
+    @staticmethod
+    def _usage_from_result(sdk_message: ResultMessage) -> TurnUsage:
+        """Map a Claude SDK ``ResultMessage.usage`` onto TurnUsage.
+
+        ``usage`` is the raw API usage dict (``input_tokens``, ``output_tokens``,
+        ``cache_read_input_tokens``, ``cache_creation_input_tokens``); it may be
+        absent, so read defensively and default each dimension to 0.
+        """
+        usage = getattr(sdk_message, "usage", None)
+        if not isinstance(usage, dict):
+            return TurnUsage()
+
+        def _int(key: str) -> int:
+            value = usage.get(key, 0)
+            return value if isinstance(value, int) else 0
+
+        return TurnUsage(
+            input_tokens=_int("input_tokens"),
+            output_tokens=_int("output_tokens"),
+            cache_read_tokens=_int("cache_read_input_tokens"),
+            cache_write_tokens=_int("cache_creation_input_tokens"),
+        )
 
     # --- Copied from BandClaudeSDKAgent._cleanup_session ---
     async def on_cleanup(self, room_id: str) -> None:

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -785,7 +785,10 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
     def _usage_from_result(sdk_message: ResultMessage) -> TurnUsage:
         """Map a Claude SDK ``ResultMessage.usage`` (raw API dict) onto TurnUsage.
 
-        ``usage`` may be absent; ``from_mapping`` yields empty usage then.
+        ``usage`` may be absent; ``from_mapping`` yields empty usage then. The
+        Claude API's ``input_tokens`` EXCLUDES cached tokens, so ``cache_in_input``
+        is False — cache is folded into the total input per the TurnUsage
+        convention.
         """
         return TurnUsage.from_mapping(
             getattr(sdk_message, "usage", None),
@@ -793,6 +796,7 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
             output="output_tokens",
             cache_read="cache_read_input_tokens",
             cache_write="cache_creation_input_tokens",
+            cache_in_input=False,
         )
 
     # --- Copied from BandClaudeSDKAgent._cleanup_session ---

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -785,10 +785,9 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
     def _usage_from_result(sdk_message: ResultMessage) -> TurnUsage:
         """Map a Claude SDK ``ResultMessage.usage`` (raw API dict) onto TurnUsage.
 
-        ``usage`` may be absent; ``from_mapping`` yields empty usage then. The
-        Claude API's ``input_tokens`` EXCLUDES cached tokens, so ``cache_in_input``
-        is False — cache is folded into the total input per the TurnUsage
-        convention.
+        Raw per the TurnUsage convention: the Claude API's ``input_tokens``
+        excludes cached tokens (reported separately in the cache fields).
+        ``usage`` may be absent; ``from_mapping`` yields empty usage then.
         """
         return TurnUsage.from_mapping(
             getattr(sdk_message, "usage", None),
@@ -796,7 +795,6 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
             output="output_tokens",
             cache_read="cache_read_input_tokens",
             cache_write="cache_creation_input_tokens",
-            cache_in_input=False,
         )
 
     # --- Copied from BandClaudeSDKAgent._cleanup_session ---

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -783,25 +783,16 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
 
     @staticmethod
     def _usage_from_result(sdk_message: ResultMessage) -> TurnUsage:
-        """Map a Claude SDK ``ResultMessage.usage`` onto TurnUsage.
+        """Map a Claude SDK ``ResultMessage.usage`` (raw API dict) onto TurnUsage.
 
-        ``usage`` is the raw API usage dict (``input_tokens``, ``output_tokens``,
-        ``cache_read_input_tokens``, ``cache_creation_input_tokens``); it may be
-        absent, so read defensively and default each dimension to 0.
+        ``usage`` may be absent; ``from_mapping`` yields empty usage then.
         """
-        usage = getattr(sdk_message, "usage", None)
-        if not isinstance(usage, dict):
-            return TurnUsage()
-
-        def _int(key: str) -> int:
-            value = usage.get(key, 0)
-            return value if isinstance(value, int) else 0
-
-        return TurnUsage(
-            input_tokens=_int("input_tokens"),
-            output_tokens=_int("output_tokens"),
-            cache_read_tokens=_int("cache_read_input_tokens"),
-            cache_write_tokens=_int("cache_creation_input_tokens"),
+        return TurnUsage.from_mapping(
+            getattr(sdk_message, "usage", None),
+            input="input_tokens",
+            output="output_tokens",
+            cache_read="cache_read_input_tokens",
+            cache_write="cache_creation_input_tokens",
         )
 
     # --- Copied from BandClaudeSDKAgent._cleanup_session ---

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -1546,9 +1546,17 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         thread cumulatives, so each emitted record is this turn's usage —
         matching what the in-process adapters emit. Codex reports no cache
         dimension, so those stay 0; a ``None`` usage yields empty (no emit).
+
+        Codex reports reasoning tokens *disjointly* from output (its own total is
+        ``input + output + reasoning``), so fold reasoning into ``output_tokens``
+        — otherwise reasoning-heavy turns undercount, and this stays consistent
+        with providers that already count reasoning inside output.
         """
         return TurnUsage.from_object(
-            usage, input="turn_input_tokens", output="turn_output_tokens"
+            usage,
+            input="turn_input_tokens",
+            output="turn_output_tokens",
+            reasoning="turn_reasoning_tokens",
         )
 
     async def _emit_turn_outcome(

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -24,6 +24,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    TurnUsage,
 )
 from band.integrations.codex import (
     CodexJsonRpcError,
@@ -297,7 +298,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
     """
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset(
-        {Emit.EXECUTION, Emit.THOUGHTS, Emit.TASK_EVENTS}
+        {Emit.EXECUTION, Emit.THOUGHTS, Emit.TASK_EVENTS, Emit.USAGE}
     )
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
         {Capability.MEMORY, Capability.CONTACTS}
@@ -1537,6 +1538,19 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     exc_info=True,
                 )
 
+    @staticmethod
+    def _turn_usage(usage: CodexTokenUsage | None) -> TurnUsage:
+        """Map codex's per-turn token deltas onto the framework-agnostic TurnUsage.
+
+        Uses the per-turn deltas (rise from the turn-start anchor), not the
+        thread cumulatives, so each emitted record is this turn's usage —
+        matching what the in-process adapters emit. Codex reports no cache
+        dimension, so those stay 0; a ``None`` usage yields empty (no emit).
+        """
+        return TurnUsage.from_object(
+            usage, input="turn_input_tokens", output="turn_output_tokens"
+        )
+
     async def _emit_turn_outcome(
         self,
         *,
@@ -1554,6 +1568,13 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
         # Look up token usage once for both marker and lifecycle events.
         usage = self._token_usage.get(thread_id)
         has_usage = usage is not None and usage.total_tokens > 0
+
+        # Emit this turn's usage through the unified Emit.USAGE seam so the
+        # toolkit's capture.usage() reads codex like every other adapter. This
+        # is independent of the codex-specific emit_token_usage_events path
+        # (which embeds codex_*_tokens on the marker/lifecycle task events);
+        # emit_usage no-ops unless Emit.USAGE is enabled and usage is non-empty.
+        await self.emit_usage(tools, self._turn_usage(usage))
 
         if (
             Emit.TASK_EVENTS in self.features.emit

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -17,12 +17,7 @@ from typing import ClassVar, TYPE_CHECKING, Any
 from band.core.exceptions import BandConfigError
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
-from band.core.types import (
-    AdapterFeatures,
-    Capability,
-    Emit,
-    PlatformMessage,
-)
+from band.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
 from band.converters.crewai import CrewAIHistoryConverter, CrewAIMessages
 from band.integrations.crewai import (
     CrewAIToolContext,

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -17,7 +17,13 @@ from typing import ClassVar, TYPE_CHECKING, Any
 from band.core.exceptions import BandConfigError
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
-from band.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
+from band.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+    TurnUsage,
+)
 from band.converters.crewai import CrewAIHistoryConverter, CrewAIMessages
 from band.integrations.crewai import (
     CrewAIToolContext,
@@ -101,7 +107,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         the CrewAI LLM class (e.g., OPENAI_API_KEY, ANTHROPIC_API_KEY).
     """
 
-    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
         {Capability.MEMORY, Capability.CONTACTS}
     )
@@ -442,6 +448,9 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
                     "band_send_message tool.",
                 )
 
+            # usage_metrics is the run's cumulative total, so emit once here.
+            await self.emit_usage(tools, self._usage_from_result(result))
+
             logger.info(
                 "Room %s: CrewAI agent completed (output_length=%s)",
                 room_id,
@@ -480,6 +489,23 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             "Message %s processed successfully (history now has %s messages)",
             msg.id,
             len(self._message_history[room_id]),
+        )
+
+    @staticmethod
+    def _usage_from_result(result: Any) -> TurnUsage:
+        """Map a CrewAI ``LiteAgentOutput.usage_metrics`` onto TurnUsage.
+
+        ``usage_metrics`` is a dict (``UsageMetrics.model_dump()``) or ``None``,
+        and is the run's cumulative total across model calls — read once, no
+        loop-summing. ``cache_creation_tokens`` is CrewAI's cache-write field
+        (Anthropic cache writes); ``cached_prompt_tokens`` is the cache read.
+        """
+        return TurnUsage.from_mapping(
+            getattr(result, "usage_metrics", None),
+            input="prompt_tokens",
+            output="completion_tokens",
+            cache_read="cached_prompt_tokens",
+            cache_write="cache_creation_tokens",
         )
 
     async def on_cleanup(self, room_id: str) -> None:

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -55,6 +55,45 @@ _reply_tracker_var: ContextVar[ReplyTracker | None] = ContextVar(
     "_crewai_reply_tracker", default=None
 )
 
+# Per-turn token-usage accumulator for the fallback path (see the usage-capture
+# comment in _process_message). Keyed by contextvar so concurrent rooms sharing
+# CrewAI's process-global event bus never cross-contaminate: CrewAI copy_context()s
+# at emit time (crewai/events/event_bus.py), so a list set here before kickoff is
+# carried into the (thread-pool) handler and scoped to THIS turn's task. list.append
+# is atomic under the GIL, so no lock is needed.
+_current_usage_var: ContextVar[list[TurnUsage] | None] = ContextVar(
+    "_crewai_turn_usage", default=None
+)
+
+# One persistent LLMCallCompletedEvent handler is registered on CrewAI's singleton
+# bus (idempotent), not one per turn — a per-turn registration on a global bus is
+# what caused cross-room contamination. The handler just routes each call's usage
+# into the current turn's contextvar accumulator.
+_usage_handler_registered = False
+
+
+def _ensure_usage_handler_registered() -> None:
+    """Register the singleton usage-routing handler on CrewAI's event bus once.
+
+    Imported locally so the crewai-mocked unit tests (which stub
+    ``sys.modules["crewai"]``) don't need these submodules at import time.
+    """
+    global _usage_handler_registered
+    if _usage_handler_registered:
+        return
+    from crewai.events import crewai_event_bus
+    from crewai.events.types.llm_events import LLMCallCompletedEvent
+
+    @crewai_event_bus.on(LLMCallCompletedEvent)
+    def _route_usage(_source: Any, event: LLMCallCompletedEvent) -> None:
+        # CrewAI invokes handlers as handler(source, event). Append this call's
+        # usage to the current turn's accumulator (None when no turn is active).
+        acc = _current_usage_var.get()
+        if acc is not None:
+            acc.append(CrewAIAdapter._usage_from_event(event))
+
+    _usage_handler_registered = True
+
 
 def _silence_lite_agent_error_panel() -> None:
     """Deregister CrewAI's benign red "LiteAgent Failed" console panel.
@@ -423,25 +462,16 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             is_session_bootstrap,
         )
 
-        # Capture token usage from CrewAI's per-call telemetry rather than the
-        # run result: on the benign empty-final-answer path below, kickoff raises
-        # and no LiteAgentOutput (hence no usage_metrics) is returned — but the
-        # LLM calls that did the work already fired LLMCallCompletedEvent with
-        # usage. Accumulating those (and emitting in ``finally``) records usage on
-        # every path, mirroring the stream-capture approach the langgraph/opencode
-        # adapters use. Imported locally so the crewai-mocked unit tests (which
-        # stub sys.modules["crewai"]) don't need these submodules.
-        from crewai.events import crewai_event_bus
-        from crewai.events.types.llm_events import LLMCallCompletedEvent
-
+        # Token usage: prefer the kickoff's own result.usage_metrics (authoritative,
+        # per-kickoff -> concurrency-safe, includes cache). On the benign
+        # empty-final-answer path below, kickoff raises and no result is returned,
+        # so fall back to usage accumulated from CrewAI's LLMCallCompletedEvents
+        # into a contextvar (scoped to this turn -> safe under concurrent rooms on
+        # the process-global bus; see _current_usage_var). Emit once in finally.
+        _ensure_usage_handler_registered()
+        usage_records: list[TurnUsage] = []
+        usage_token = _current_usage_var.set(usage_records)
         turn_usage = TurnUsage()
-
-        def _accumulate_usage(_source: Any, event: LLMCallCompletedEvent) -> None:
-            # CrewAI's bus invokes handlers as handler(source, event).
-            nonlocal turn_usage
-            turn_usage = turn_usage + self._usage_from_event(event)
-
-        crewai_event_bus.on(LLMCallCompletedEvent)(_accumulate_usage)
         try:
             # Type ignore explanation: CrewAI's kickoff_async is typed to accept
             # only a string prompt, but the implementation also accepts a list of
@@ -449,6 +479,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             # context. This is documented behavior but the type stubs haven't been
             # updated. See: https://docs.crewai.com/concepts/agents
             result = await self._crewai_agent.kickoff_async(messages)  # type: ignore[arg-type]
+            turn_usage = self._usage_from_result(result)
 
             if result and result.raw:
                 self._message_history[room_id].append(
@@ -501,11 +532,14 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             await self._report_error(tools, str(e))
             raise
         finally:
-            # Deregister the per-turn handler and emit the accumulated usage on
-            # every exit path — success, the benign empty-answer return above, or
-            # a genuine error (tokens were still spent). No-op unless Emit.USAGE
-            # is on and usage is non-empty.
-            crewai_event_bus.off(LLMCallCompletedEvent, _accumulate_usage)
+            _current_usage_var.reset(usage_token)
+            # Emit on every exit path (success, benign empty-answer return, genuine
+            # error — tokens were still spent). Prefer the authoritative result
+            # usage set on success; fall back to the event-accumulated usage when
+            # the run raised before returning a result. No-op unless Emit.USAGE is
+            # on and usage is non-empty.
+            if turn_usage.is_empty:
+                turn_usage = sum(usage_records, TurnUsage())
             await self.emit_usage(tools, turn_usage)
 
         logger.debug(
@@ -515,19 +549,43 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         )
 
     @staticmethod
+    def _usage_from_result(result: Any) -> TurnUsage:
+        """Map a CrewAI ``LiteAgentOutput.usage_metrics`` onto TurnUsage.
+
+        The authoritative per-kickoff total (a dict, ``UsageMetrics.model_dump()``,
+        or ``None``); ``prompt_tokens`` already includes cached tokens (LiteLLM),
+        so the default ``cache_in_input=True`` holds. Used on the success path
+        (race-free, includes cache); ``None`` yields empty usage.
+        """
+        return TurnUsage.from_mapping(
+            getattr(result, "usage_metrics", None),
+            input="prompt_tokens",
+            output="completion_tokens",
+            cache_read="cached_prompt_tokens",
+            cache_write="cache_creation_tokens",
+        )
+
+    @staticmethod
     def _usage_from_event(event: Any) -> TurnUsage:
         """Map a CrewAI ``LLMCallCompletedEvent.usage`` dict onto TurnUsage.
 
-        Captured per LLM call and summed across the turn, so usage is recorded
-        even on the benign empty-final-answer path (where kickoff raises and no
-        result/usage_metrics is returned). The event's ``usage`` is the raw
-        LiteLLM usage dict (``prompt_tokens`` / ``completion_tokens``); cache
-        tokens are nested/uncertain there, so they're left 0.
+        The fallback source (accumulated per LLM call into the turn's contextvar)
+        for the benign empty-answer path, where kickoff raises and no result is
+        returned. The event's ``usage`` is the raw LiteLLM dict; cache lives
+        nested under ``prompt_tokens_details.cached_tokens``, flattened here so it
+        maps like the others. ``prompt_tokens`` already includes cached.
         """
+        usage = getattr(event, "usage", None)
+        if not isinstance(usage, dict):
+            return TurnUsage()
+        details = usage.get("prompt_tokens_details")
+        details = details if isinstance(details, dict) else {}
+        flat = {**usage, "cached_tokens": details.get("cached_tokens")}
         return TurnUsage.from_mapping(
-            getattr(event, "usage", None),
+            flat,
             input="prompt_tokens",
             output="completion_tokens",
+            cache_read="cached_tokens",
         )
 
     async def on_cleanup(self, room_id: str) -> None:

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -22,7 +22,6 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
-    TurnUsage,
 )
 from band.converters.crewai import CrewAIHistoryConverter, CrewAIMessages
 from band.integrations.crewai import (
@@ -54,45 +53,6 @@ _current_room_context: ContextVar[tuple[str, AgentToolsProtocol] | None] = Conte
 _reply_tracker_var: ContextVar[ReplyTracker | None] = ContextVar(
     "_crewai_reply_tracker", default=None
 )
-
-# Per-turn token-usage accumulator for the fallback path (see the usage-capture
-# comment in _process_message). Keyed by contextvar so concurrent rooms sharing
-# CrewAI's process-global event bus never cross-contaminate: CrewAI copy_context()s
-# at emit time (crewai/events/event_bus.py), so a list set here before kickoff is
-# carried into the (thread-pool) handler and scoped to THIS turn's task. list.append
-# is atomic under the GIL, so no lock is needed.
-_current_usage_var: ContextVar[list[TurnUsage] | None] = ContextVar(
-    "_crewai_turn_usage", default=None
-)
-
-# One persistent LLMCallCompletedEvent handler is registered on CrewAI's singleton
-# bus (idempotent), not one per turn — a per-turn registration on a global bus is
-# what caused cross-room contamination. The handler just routes each call's usage
-# into the current turn's contextvar accumulator.
-_usage_handler_registered = False
-
-
-def _ensure_usage_handler_registered() -> None:
-    """Register the singleton usage-routing handler on CrewAI's event bus once.
-
-    Imported locally so the crewai-mocked unit tests (which stub
-    ``sys.modules["crewai"]``) don't need these submodules at import time.
-    """
-    global _usage_handler_registered
-    if _usage_handler_registered:
-        return
-    from crewai.events import crewai_event_bus
-    from crewai.events.types.llm_events import LLMCallCompletedEvent
-
-    @crewai_event_bus.on(LLMCallCompletedEvent)
-    def _route_usage(_source: Any, event: LLMCallCompletedEvent) -> None:
-        # CrewAI invokes handlers as handler(source, event). Append this call's
-        # usage to the current turn's accumulator (None when no turn is active).
-        acc = _current_usage_var.get()
-        if acc is not None:
-            acc.append(CrewAIAdapter._usage_from_event(event))
-
-    _usage_handler_registered = True
 
 
 def _silence_lite_agent_error_panel() -> None:
@@ -146,7 +106,7 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         the CrewAI LLM class (e.g., OPENAI_API_KEY, ANTHROPIC_API_KEY).
     """
 
-    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION, Emit.USAGE})
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
         {Capability.MEMORY, Capability.CONTACTS}
     )
@@ -462,16 +422,13 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             is_session_bootstrap,
         )
 
-        # Token usage: prefer the kickoff's own result.usage_metrics (authoritative,
-        # per-kickoff -> concurrency-safe, includes cache). On the benign
-        # empty-final-answer path below, kickoff raises and no result is returned,
-        # so fall back to usage accumulated from CrewAI's LLMCallCompletedEvents
-        # into a contextvar (scoped to this turn -> safe under concurrent rooms on
-        # the process-global bus; see _current_usage_var). Emit once in finally.
-        _ensure_usage_handler_registered()
-        usage_records: list[TurnUsage] = []
-        usage_token = _current_usage_var.set(usage_records)
-        turn_usage = TurnUsage()
+        # NOTE: CrewAI usage capture is intentionally NOT implemented (Emit.USAGE
+        # is not in SUPPORTED_EMIT). CrewAI's result.usage_metrics is a cumulative
+        # lifetime counter on the once-created agent (not per-turn, and shared
+        # across concurrent rooms), and its per-call event usage comes in two
+        # incompatible provider shapes (LiteLLM vs native Anthropic) — so neither
+        # source yields correct per-turn usage without significant extra work.
+        # Deferred until that's addressed.
         try:
             # Type ignore explanation: CrewAI's kickoff_async is typed to accept
             # only a string prompt, but the implementation also accepts a list of
@@ -479,7 +436,6 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             # context. This is documented behavior but the type stubs haven't been
             # updated. See: https://docs.crewai.com/concepts/agents
             result = await self._crewai_agent.kickoff_async(messages)  # type: ignore[arg-type]
-            turn_usage = self._usage_from_result(result)
 
             if result and result.raw:
                 self._message_history[room_id].append(
@@ -531,61 +487,11 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             logger.error("Error processing message: %s", e, exc_info=True)
             await self._report_error(tools, str(e))
             raise
-        finally:
-            _current_usage_var.reset(usage_token)
-            # Emit on every exit path (success, benign empty-answer return, genuine
-            # error — tokens were still spent). Prefer the authoritative result
-            # usage set on success; fall back to the event-accumulated usage when
-            # the run raised before returning a result. No-op unless Emit.USAGE is
-            # on and usage is non-empty.
-            if turn_usage.is_empty:
-                turn_usage = sum(usage_records, TurnUsage())
-            await self.emit_usage(tools, turn_usage)
 
         logger.debug(
             "Message %s processed successfully (history now has %s messages)",
             msg.id,
             len(self._message_history[room_id]),
-        )
-
-    @staticmethod
-    def _usage_from_result(result: Any) -> TurnUsage:
-        """Map a CrewAI ``LiteAgentOutput.usage_metrics`` onto TurnUsage.
-
-        The authoritative per-kickoff total (a dict, ``UsageMetrics.model_dump()``,
-        or ``None``); ``prompt_tokens`` already includes cached tokens (LiteLLM),
-        so the default ``cache_in_input=True`` holds. Used on the success path
-        (race-free, includes cache); ``None`` yields empty usage.
-        """
-        return TurnUsage.from_mapping(
-            getattr(result, "usage_metrics", None),
-            input="prompt_tokens",
-            output="completion_tokens",
-            cache_read="cached_prompt_tokens",
-            cache_write="cache_creation_tokens",
-        )
-
-    @staticmethod
-    def _usage_from_event(event: Any) -> TurnUsage:
-        """Map a CrewAI ``LLMCallCompletedEvent.usage`` dict onto TurnUsage.
-
-        The fallback source (accumulated per LLM call into the turn's contextvar)
-        for the benign empty-answer path, where kickoff raises and no result is
-        returned. The event's ``usage`` is the raw LiteLLM dict; cache lives
-        nested under ``prompt_tokens_details.cached_tokens``, flattened here so it
-        maps like the others. ``prompt_tokens`` already includes cached.
-        """
-        usage = getattr(event, "usage", None)
-        if not isinstance(usage, dict):
-            return TurnUsage()
-        details = usage.get("prompt_tokens_details")
-        details = details if isinstance(details, dict) else {}
-        flat = {**usage, "cached_tokens": details.get("cached_tokens")}
-        return TurnUsage.from_mapping(
-            flat,
-            input="prompt_tokens",
-            output="completion_tokens",
-            cache_read="cached_tokens",
         )
 
     async def on_cleanup(self, room_id: str) -> None:

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -423,6 +423,25 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             is_session_bootstrap,
         )
 
+        # Capture token usage from CrewAI's per-call telemetry rather than the
+        # run result: on the benign empty-final-answer path below, kickoff raises
+        # and no LiteAgentOutput (hence no usage_metrics) is returned — but the
+        # LLM calls that did the work already fired LLMCallCompletedEvent with
+        # usage. Accumulating those (and emitting in ``finally``) records usage on
+        # every path, mirroring the stream-capture approach the langgraph/opencode
+        # adapters use. Imported locally so the crewai-mocked unit tests (which
+        # stub sys.modules["crewai"]) don't need these submodules.
+        from crewai.events import crewai_event_bus
+        from crewai.events.types.llm_events import LLMCallCompletedEvent
+
+        turn_usage = TurnUsage()
+
+        def _accumulate_usage(_source: Any, event: LLMCallCompletedEvent) -> None:
+            # CrewAI's bus invokes handlers as handler(source, event).
+            nonlocal turn_usage
+            turn_usage = turn_usage + self._usage_from_event(event)
+
+        crewai_event_bus.on(LLMCallCompletedEvent)(_accumulate_usage)
         try:
             # Type ignore explanation: CrewAI's kickoff_async is typed to accept
             # only a string prompt, but the implementation also accepts a list of
@@ -447,9 +466,6 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
                     "or the agent returned a final answer instead of using the "
                     "band_send_message tool.",
                 )
-
-            # usage_metrics is the run's cumulative total, so emit once here.
-            await self.emit_usage(tools, self._usage_from_result(result))
 
             logger.info(
                 "Room %s: CrewAI agent completed (output_length=%s)",
@@ -484,6 +500,13 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             logger.error("Error processing message: %s", e, exc_info=True)
             await self._report_error(tools, str(e))
             raise
+        finally:
+            # Deregister the per-turn handler and emit the accumulated usage on
+            # every exit path — success, the benign empty-answer return above, or
+            # a genuine error (tokens were still spent). No-op unless Emit.USAGE
+            # is on and usage is non-empty.
+            crewai_event_bus.off(LLMCallCompletedEvent, _accumulate_usage)
+            await self.emit_usage(tools, turn_usage)
 
         logger.debug(
             "Message %s processed successfully (history now has %s messages)",
@@ -492,20 +515,19 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
         )
 
     @staticmethod
-    def _usage_from_result(result: Any) -> TurnUsage:
-        """Map a CrewAI ``LiteAgentOutput.usage_metrics`` onto TurnUsage.
+    def _usage_from_event(event: Any) -> TurnUsage:
+        """Map a CrewAI ``LLMCallCompletedEvent.usage`` dict onto TurnUsage.
 
-        ``usage_metrics`` is a dict (``UsageMetrics.model_dump()``) or ``None``,
-        and is the run's cumulative total across model calls — read once, no
-        loop-summing. ``cache_creation_tokens`` is CrewAI's cache-write field
-        (Anthropic cache writes); ``cached_prompt_tokens`` is the cache read.
+        Captured per LLM call and summed across the turn, so usage is recorded
+        even on the benign empty-final-answer path (where kickoff raises and no
+        result/usage_metrics is returned). The event's ``usage`` is the raw
+        LiteLLM usage dict (``prompt_tokens`` / ``completion_tokens``); cache
+        tokens are nested/uncertain there, so they're left 0.
         """
         return TurnUsage.from_mapping(
-            getattr(result, "usage_metrics", None),
+            getattr(event, "usage", None),
             input="prompt_tokens",
             output="completion_tokens",
-            cache_read="cached_prompt_tokens",
-            cache_write="cache_creation_tokens",
         )
 
     async def on_cleanup(self, room_id: str) -> None:

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -417,13 +417,9 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             is_session_bootstrap,
         )
 
-        # NOTE: CrewAI usage capture is intentionally NOT implemented (Emit.USAGE
-        # is not in SUPPORTED_EMIT). CrewAI's result.usage_metrics is a cumulative
-        # lifetime counter on the once-created agent (not per-turn, and shared
-        # across concurrent rooms), and its per-call event usage comes in two
-        # incompatible provider shapes (LiteLLM vs native Anthropic) — so neither
-        # source yields correct per-turn usage without significant extra work.
-        # Deferred until that's addressed.
+        # CrewAI usage is intentionally not emitted (Emit.USAGE absent from
+        # SUPPORTED_EMIT): result.usage_metrics is cumulative-lifetime, not
+        # per-turn. Proper per-turn capture is deferred — don't add emit_usage here.
         try:
             # Type ignore explanation: CrewAI's kickoff_async is typed to accept
             # only a string prompt, but the implementation also accepts a list of

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -234,45 +234,49 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
 
         gemini_tools = self._build_gemini_tools(tools)
         tool_rounds = 0
-        # Gemini reports usage per call; sum across the loop into one TurnUsage.
+        # Gemini reports usage per call; sum across the loop into one
+        # TurnUsage, emitted on every exit via the finally.
         turn_usage = TurnUsage()
-        while True:
-            if tool_rounds >= self.max_tool_rounds:
-                raise RuntimeError(
-                    f"Exceeded max tool rounds ({self.max_tool_rounds}) in room {room_id}"
+        try:
+            while True:
+                if tool_rounds >= self.max_tool_rounds:
+                    raise RuntimeError(
+                        f"Exceeded max tool rounds ({self.max_tool_rounds}) "
+                        f"in room {room_id}"
+                    )
+
+                try:
+                    response = await self._call_gemini(
+                        contents=self._message_history[room_id], tools=gemini_tools
+                    )
+                except Exception as e:
+                    logger.exception("Error calling Gemini: %s", e)
+                    await self._report_error(tools, str(e))
+                    raise
+
+                turn_usage = turn_usage + self._usage_from_response(response)
+
+                candidate_content = self._extract_candidate_content(response)
+                if candidate_content is not None:
+                    self._message_history[room_id].append(candidate_content)
+
+                function_calls = list(response.function_calls or [])
+                if not function_calls:
+                    break
+
+                tool_response_parts = await self._process_function_calls(
+                    function_calls=function_calls,
+                    tools=tools,
                 )
+                if tool_response_parts:
+                    self._message_history[room_id].append(
+                        types.Content(role="user", parts=tool_response_parts)
+                    )
 
-            try:
-                response = await self._call_gemini(
-                    contents=self._message_history[room_id], tools=gemini_tools
-                )
-            except Exception as e:
-                logger.exception("Error calling Gemini: %s", e)
-                await self._report_error(tools, str(e))
-                raise
-
-            turn_usage = turn_usage + self._usage_from_response(response)
-
-            candidate_content = self._extract_candidate_content(response)
-            if candidate_content is not None:
-                self._message_history[room_id].append(candidate_content)
-
-            function_calls = list(response.function_calls or [])
-            if not function_calls:
-                break
-
-            tool_response_parts = await self._process_function_calls(
-                function_calls=function_calls,
-                tools=tools,
-            )
-            if tool_response_parts:
-                self._message_history[room_id].append(
-                    types.Content(role="user", parts=tool_response_parts)
-                )
-
-            tool_rounds += 1
-
-        await self.emit_usage(tools, turn_usage)
+                tool_rounds += 1
+        finally:
+            # No-op unless Emit.USAGE is on; best-effort, never raises.
+            await self.emit_usage(tools, turn_usage)
 
         # Trim after the tool loop so the LLM always sees full context for the
         # current turn; trimming only affects the next turn's window.

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -31,6 +31,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    TurnUsage,
 )
 from band.converters.gemini import GeminiHistoryConverter, GeminiMessages
 from band.runtime.custom_tools import (
@@ -63,7 +64,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
         await agent.run()
     """
 
-    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
         {Capability.MEMORY, Capability.CONTACTS}
     )
@@ -233,6 +234,8 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
 
         gemini_tools = self._build_gemini_tools(tools)
         tool_rounds = 0
+        # Gemini reports usage per call; sum across the loop into one TurnUsage.
+        turn_usage = TurnUsage()
         while True:
             if tool_rounds >= self.max_tool_rounds:
                 raise RuntimeError(
@@ -247,6 +250,8 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                 logger.exception("Error calling Gemini: %s", e)
                 await self._report_error(tools, str(e))
                 raise
+
+            turn_usage = turn_usage + self._usage_from_response(response)
 
             candidate_content = self._extract_candidate_content(response)
             if candidate_content is not None:
@@ -267,6 +272,8 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
 
             tool_rounds += 1
 
+        await self.emit_usage(tools, turn_usage)
+
         # Trim after the tool loop so the LLM always sees full context for the
         # current turn; trimming only affects the next turn's window.
         self._trim_history(room_id)
@@ -275,6 +282,20 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
         """Clean up message history when the agent leaves a room."""
         self._message_history.pop(room_id, None)
         logger.debug("Room %s: Cleaned up Gemini history", room_id)
+
+    @staticmethod
+    def _usage_from_response(response: Any) -> TurnUsage:
+        """Map a Gemini ``GenerateContentResponse.usage_metadata`` onto TurnUsage.
+
+        A response without usage yields empty usage. Gemini has no cache-write
+        dimension (left 0); ``cached_content_token_count`` is the cache read.
+        """
+        return TurnUsage.from_object(
+            getattr(response, "usage_metadata", None),
+            input="prompt_token_count",
+            output="candidates_token_count",
+            cache_read="cached_content_token_count",
+        )
 
     def _trim_history(self, room_id: str) -> None:
         """Trim message history to stay within ``max_history_messages``.

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -289,11 +289,19 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
 
         A response without usage yields empty usage. Gemini has no cache-write
         dimension (left 0); ``cached_content_token_count`` is the cache read.
+
+        Gemini reports thinking tokens *disjointly* from output (its own
+        ``total_token_count`` is ``prompt + candidates + thoughts``, so
+        ``candidates_token_count`` excludes thoughts), so fold
+        ``thoughts_token_count`` into ``output_tokens`` — otherwise thinking-model
+        turns undercount, and this stays consistent with providers that already
+        count reasoning inside output.
         """
         return TurnUsage.from_object(
             getattr(response, "usage_metadata", None),
             input="prompt_token_count",
             output="candidates_token_count",
+            reasoning="thoughts_token_count",
             cache_read="cached_content_token_count",
         )
 

--- a/src/band/adapters/google_adk.py
+++ b/src/band/adapters/google_adk.py
@@ -475,6 +475,9 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
         # accumulates session history internally and tool schemas may change
         # between calls.  History is injected as a text transcript instead.
         runner = self._create_runner(tools)
+        # Per-turn usage, summed across the event stream below. Initialized
+        # outside the try so the finally can emit whatever accumulated.
+        turn_usage = TurnUsage()
         try:
             # Always create a new session ID — each runner is fresh, so there
             # is no in-memory state to resume.  The ID is stored for cleanup
@@ -545,10 +548,9 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
             )
 
             # Run the ADK agent - it handles the full tool loop. Usage is
-            # reported per model response on the event stream, so sum across the
-            # loop into one per-turn TurnUsage (emitted after a clean run).
+            # reported per model response on the event stream, so sum across
+            # the loop into one per-turn TurnUsage.
             final_response_text = ""
-            turn_usage = TurnUsage()
             async for event in runner.run_async(
                 user_id=room_id,
                 session_id=session_id,
@@ -575,11 +577,10 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
             await self._report_error(tools, str(e))
             raise
         finally:
+            # Emit before close so a close() failure can't drop the usage.
+            # No-op unless Emit.USAGE is on; best-effort, never raises.
+            await self.emit_usage(tools, turn_usage)
             await runner.close()
-
-        # Emit the turn's aggregated usage (reached only on a clean run — the
-        # except above re-raises). No-op unless Emit.USAGE is on.
-        await self.emit_usage(tools, turn_usage)
 
         # Accumulate message history for future transcript injection
         self._room_history[room_id].append(

--- a/src/band/adapters/google_adk.py
+++ b/src/band/adapters/google_adk.py
@@ -22,7 +22,13 @@ from band.core.exceptions import BandConfigError
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
 from band.core.tool_filter import sanitize_tool_schema
-from band.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
+from band.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+    TurnUsage,
+)
 from band.converters.google_adk import GoogleADKHistoryConverter, GoogleADKMessages
 from band.runtime.custom_tools import (
     CustomToolDef,
@@ -280,7 +286,7 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
         await agent.run()
     """
 
-    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
         {Capability.MEMORY, Capability.CONTACTS}
     )
@@ -538,13 +544,18 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
                 len(room_history),
             )
 
-            # Run the ADK agent - it handles the full tool loop
+            # Run the ADK agent - it handles the full tool loop. Usage is
+            # reported per model response on the event stream, so sum across the
+            # loop into one per-turn TurnUsage (emitted after a clean run).
             final_response_text = ""
+            turn_usage = TurnUsage()
             async for event in runner.run_async(
                 user_id=room_id,
                 session_id=session_id,
                 new_message=user_content,
             ):
+                turn_usage = turn_usage + self._usage_from_event(event)
+
                 # Report tool calls/results if enabled
                 if Emit.EXECUTION in self.features.emit:
                     try:
@@ -566,6 +577,10 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
         finally:
             await runner.close()
 
+        # Emit the turn's aggregated usage (reached only on a clean run — the
+        # except above re-raises). No-op unless Emit.USAGE is on.
+        await self.emit_usage(tools, turn_usage)
+
         # Accumulate message history for future transcript injection
         self._room_history[room_id].append(
             {"role": "user", "content": msg.format_for_llm()}
@@ -585,6 +600,29 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
             ]
 
         logger.debug("Message %s processed successfully", msg.id)
+
+    @staticmethod
+    def _usage_from_event(event: Any) -> TurnUsage:
+        """Map an ADK event's ``usage_metadata`` onto TurnUsage.
+
+        Usage rides model-response events (``prompt_token_count`` /
+        ``candidates_token_count`` / ``cached_content_token_count``); events
+        without it (tool calls, etc.) contribute empty usage. Gemini has no
+        cache-write dimension, so it stays 0.
+        """
+        usage_metadata = getattr(event, "usage_metadata", None)
+        if usage_metadata is None:
+            return TurnUsage()
+
+        def _int(name: str) -> int:
+            value = getattr(usage_metadata, name, 0)
+            return value if isinstance(value, int) else 0
+
+        return TurnUsage(
+            input_tokens=_int("prompt_token_count"),
+            output_tokens=_int("candidates_token_count"),
+            cache_read_tokens=_int("cached_content_token_count"),
+        )
 
     async def on_cleanup(self, room_id: str) -> None:
         """Clean up session and history when agent leaves a room."""

--- a/src/band/adapters/google_adk.py
+++ b/src/band/adapters/google_adk.py
@@ -605,23 +605,14 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
     def _usage_from_event(event: Any) -> TurnUsage:
         """Map an ADK event's ``usage_metadata`` onto TurnUsage.
 
-        Usage rides model-response events (``prompt_token_count`` /
-        ``candidates_token_count`` / ``cached_content_token_count``); events
-        without it (tool calls, etc.) contribute empty usage. Gemini has no
-        cache-write dimension, so it stays 0.
+        Usage rides model-response events; events without it (tool calls, etc.)
+        contribute empty usage. Gemini has no cache-write dimension (left 0).
         """
-        usage_metadata = getattr(event, "usage_metadata", None)
-        if usage_metadata is None:
-            return TurnUsage()
-
-        def _int(name: str) -> int:
-            value = getattr(usage_metadata, name, 0)
-            return value if isinstance(value, int) else 0
-
-        return TurnUsage(
-            input_tokens=_int("prompt_token_count"),
-            output_tokens=_int("candidates_token_count"),
-            cache_read_tokens=_int("cached_content_token_count"),
+        return TurnUsage.from_object(
+            getattr(event, "usage_metadata", None),
+            input="prompt_token_count",
+            output="candidates_token_count",
+            cache_read="cached_content_token_count",
         )
 
     async def on_cleanup(self, room_id: str) -> None:

--- a/src/band/adapters/google_adk.py
+++ b/src/band/adapters/google_adk.py
@@ -607,11 +607,19 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
 
         Usage rides model-response events; events without it (tool calls, etc.)
         contribute empty usage. Gemini has no cache-write dimension (left 0).
+
+        Gemini reports thinking tokens *disjointly* from output (its own
+        ``total_token_count`` is ``prompt + candidates + thoughts``, so
+        ``candidates_token_count`` excludes thoughts), so fold
+        ``thoughts_token_count`` into ``output_tokens`` — otherwise thinking-model
+        turns undercount, and this stays consistent with providers that already
+        count reasoning inside output.
         """
         return TurnUsage.from_object(
             getattr(event, "usage_metadata", None),
             input="prompt_token_count",
             output="candidates_token_count",
+            reasoning="thoughts_token_count",
             cache_read="cached_content_token_count",
         )
 

--- a/src/band/adapters/google_adk.py
+++ b/src/band/adapters/google_adk.py
@@ -556,7 +556,8 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
                 session_id=session_id,
                 new_message=user_content,
             ):
-                turn_usage = turn_usage + self._usage_from_event(event)
+                if Emit.USAGE in self.features.emit:
+                    turn_usage = turn_usage + self._usage_from_event(event)
 
                 # Report tool calls/results if enabled
                 if Emit.EXECUTION in self.features.emit:
@@ -577,10 +578,13 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
             await self._report_error(tools, str(e))
             raise
         finally:
-            # Emit before close so a close() failure can't drop the usage.
-            # No-op unless Emit.USAGE is on; best-effort, never raises.
-            await self.emit_usage(tools, turn_usage)
-            await runner.close()
+            # Emit before close so a close() failure can't drop the usage, but
+            # nested so close() runs even if a cancellation interrupts the emit.
+            try:
+                # No-op unless Emit.USAGE is on; best-effort, never raises.
+                await self.emit_usage(tools, turn_usage)
+            finally:
+                await runner.close()
 
         # Accumulate message history for future transcript injection
         self._room_history[room_id].append(

--- a/src/band/adapters/langgraph.py
+++ b/src/band/adapters/langgraph.py
@@ -14,7 +14,13 @@ from langgraph.pregel import Pregel
 from band.core.exceptions import BandConfigError
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
-from band.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
+from band.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+    TurnUsage,
+)
 from band.converters.langchain import LangChainHistoryConverter, LangChainMessages
 from band.runtime.prompts import render_system_prompt
 
@@ -72,7 +78,7 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
         await agent.run()
     """
 
-    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
         {Capability.MEMORY, Capability.CONTACTS}
     )
@@ -328,6 +334,9 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
 
         graph_input = {"messages": messages}
 
+        # Usage is reported per model call on the stream; a turn may make several
+        # (a tool loop), so sum across every on_chat_model_end into one TurnUsage.
+        turn_usage = TurnUsage()
         try:
             async for event in graph.astream_events(
                 graph_input,
@@ -340,6 +349,9 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
                 version="v2",
             ):
                 await self._handle_stream_event(event, room_id, tools)
+                turn_usage = turn_usage + self._usage_from_stream_event(event)
+
+            await self.emit_usage(tools, turn_usage)
 
             if should_mark_bootstrapped:
                 self._bootstrapped_rooms[room_id] = None
@@ -422,6 +434,37 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
                 )
             except Exception as e:
                 logger.warning("Failed to send tool_result event: %s", e)
+
+    @staticmethod
+    def _usage_from_stream_event(event: Any) -> TurnUsage:
+        """Map a LangChain ``on_chat_model_end`` stream event onto TurnUsage.
+
+        Any other event (or a shape without ``usage_metadata``) contributes an
+        empty ``TurnUsage``. LangChain reports cache tokens under
+        ``input_token_details`` (``cache_read`` / ``cache_creation``).
+        """
+        if not isinstance(event, dict) or event.get("event") != "on_chat_model_end":
+            return TurnUsage()
+        data = event.get("data")
+        output = data.get("output") if isinstance(data, dict) else None
+        usage_metadata = getattr(output, "usage_metadata", None)
+        if usage_metadata is None and isinstance(output, dict):
+            usage_metadata = output.get("usage_metadata")
+        if not isinstance(usage_metadata, dict):
+            return TurnUsage()
+
+        details = usage_metadata.get("input_token_details")
+        details = details if isinstance(details, dict) else {}
+
+        def _int(value: Any) -> int:
+            return value if isinstance(value, int) else 0
+
+        return TurnUsage(
+            input_tokens=_int(usage_metadata.get("input_tokens")),
+            output_tokens=_int(usage_metadata.get("output_tokens")),
+            cache_read_tokens=_int(details.get("cache_read")),
+            cache_write_tokens=_int(details.get("cache_creation")),
+        )
 
     async def on_cleanup(self, room_id: str) -> None:
         """Clean up process-local LangGraph bookkeeping for a room."""

--- a/src/band/adapters/langgraph.py
+++ b/src/band/adapters/langgraph.py
@@ -335,7 +335,8 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
         graph_input = {"messages": messages}
 
         # Usage is reported per model call on the stream; a turn may make several
-        # (a tool loop), so sum across every on_chat_model_end into one TurnUsage.
+        # (a tool loop), so sum across every on_chat_model_end into one TurnUsage,
+        # emitted on every exit via the finally.
         turn_usage = TurnUsage()
         try:
             async for event in graph.astream_events(
@@ -350,8 +351,6 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
             ):
                 await self._handle_stream_event(event, room_id, tools)
                 turn_usage = turn_usage + self._usage_from_stream_event(event)
-
-            await self.emit_usage(tools, turn_usage)
 
             if should_mark_bootstrapped:
                 self._bootstrapped_rooms[room_id] = None
@@ -379,6 +378,9 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
             except Exception:
                 logger.exception("Failed to report error event for message %s", msg.id)
             raise
+        finally:
+            # No-op unless Emit.USAGE is on; best-effort, never raises.
+            await self.emit_usage(tools, turn_usage)
 
     async def _handle_stream_event(
         self,

--- a/src/band/adapters/langgraph.py
+++ b/src/band/adapters/langgraph.py
@@ -453,17 +453,21 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
         if not isinstance(usage_metadata, dict):
             return TurnUsage()
 
+        # Cache tokens live one level down under input_token_details; flatten
+        # them alongside the top-level counts so it's a single from_mapping.
         details = usage_metadata.get("input_token_details")
         details = details if isinstance(details, dict) else {}
-
-        def _int(value: Any) -> int:
-            return value if isinstance(value, int) else 0
-
-        return TurnUsage(
-            input_tokens=_int(usage_metadata.get("input_tokens")),
-            output_tokens=_int(usage_metadata.get("output_tokens")),
-            cache_read_tokens=_int(details.get("cache_read")),
-            cache_write_tokens=_int(details.get("cache_creation")),
+        flat = {
+            **usage_metadata,
+            "cache_read": details.get("cache_read"),
+            "cache_creation": details.get("cache_creation"),
+        }
+        return TurnUsage.from_mapping(
+            flat,
+            input="input_tokens",
+            output="output_tokens",
+            cache_read="cache_read",
+            cache_write="cache_creation",
         )
 
     async def on_cleanup(self, room_id: str) -> None:

--- a/src/band/adapters/langgraph.py
+++ b/src/band/adapters/langgraph.py
@@ -336,7 +336,10 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
 
         # Usage is reported per model call on the stream; a turn may make several
         # (a tool loop), so sum across every on_chat_model_end into one TurnUsage,
-        # emitted on every exit via the finally.
+        # emitted on every exit via the finally. Gated outside the loop: the
+        # stream yields per-token events, so accumulation there is pure churn
+        # when usage emission is off.
+        track_usage = Emit.USAGE in self.features.emit
         turn_usage = TurnUsage()
         try:
             async for event in graph.astream_events(
@@ -350,7 +353,8 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
                 version="v2",
             ):
                 await self._handle_stream_event(event, room_id, tools)
-                turn_usage = turn_usage + self._usage_from_stream_event(event)
+                if track_usage:
+                    turn_usage = turn_usage + self._usage_from_stream_event(event)
 
             if should_mark_bootstrapped:
                 self._bootstrapped_rooms[room_id] = None

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -481,30 +481,53 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         Returns the list of assistant text parts collected during the turn.
         """
         messages = [{"role": "user", "content": content}]
-        final_text_parts: list[str] = []
-        used_send_message = False  # tracks if agent called band_send_message
         # Per-turn token usage. Reachable only on the per_room path, where the
         # non-streamed LettaResponse carries an aggregate .usage; the shared-mode
         # Conversations stream exposes no such aggregate, so it stays empty (N-A).
+        # Emitted on every exit via the finally.
         turn_usage = TurnUsage()
 
         room_ctx = self._rooms.get(room_id)
 
-        # Use Conversations API in shared mode, direct agent API in per_room mode
-        if self.config.mode == "shared" and room_ctx and room_ctx.conversation_id:
-            conversation_stream = await self._client.conversations.messages.create(
-                conversation_id=room_ctx.conversation_id,
-                messages=messages,
-            )
-            response_messages = [resp_msg async for resp_msg in conversation_stream]
-        else:
-            response = await self._client.agents.messages.create(
-                agent_id=agent_id,
-                messages=messages,
-            )
-            response_messages = list(response.messages)
-            turn_usage = self._usage_from_response(response)
+        try:
+            # Use Conversations API in shared mode, direct agent API in per_room mode
+            if self.config.mode == "shared" and room_ctx and room_ctx.conversation_id:
+                conversation_stream = await self._client.conversations.messages.create(
+                    conversation_id=room_ctx.conversation_id,
+                    messages=messages,
+                )
+                response_messages = [resp_msg async for resp_msg in conversation_stream]
+            else:
+                response = await self._client.agents.messages.create(
+                    agent_id=agent_id,
+                    messages=messages,
+                )
+                response_messages = list(response.messages)
+                turn_usage = self._usage_from_response(response)
 
+            return await self._process_response_messages(
+                response_messages,
+                tools,
+                room_id,
+                reply_to_sender_id,
+            )
+        finally:
+            # No-op unless Emit.USAGE is on; best-effort, never raises.
+            await self.emit_usage(tools, turn_usage)
+
+    async def _process_response_messages(
+        self,
+        response_messages: list[Any],
+        tools: AgentToolsProtocol,
+        room_id: str,
+        reply_to_sender_id: str,
+    ) -> list[str]:
+        """Observe Letta response messages: report tool events, auto-relay text.
+
+        Returns the list of assistant text parts collected during the turn.
+        """
+        final_text_parts: list[str] = []
+        used_send_message = False  # tracks if agent called band_send_message
         for resp_msg in response_messages:
             msg_type = getattr(resp_msg, "message_type", None)
             logger.debug("Room %s: Letta response message type=%s", room_id, msg_type)
@@ -576,10 +599,6 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
             await tools.send_message(final_text, mentions=mentions)
         else:
             logger.debug("Room %s: Letta turn complete, no output", room_id)
-
-        # Emit the turn's token usage (no-op unless Emit.USAGE is on; empty on
-        # the shared-mode stream path, so nothing is emitted there).
-        await self.emit_usage(tools, turn_usage)
 
         return final_text_parts
 

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -14,7 +14,13 @@ from band.converters.letta import LettaHistoryConverter, LettaSessionState
 from band.core.exceptions import BandConfigError
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
-from band.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
+from band.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+    TurnUsage,
+)
 from band.runtime.prompts import render_system_prompt
 
 logger = logging.getLogger(__name__)
@@ -156,7 +162,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
     """
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset(
-        {Emit.EXECUTION, Emit.TASK_EVENTS}
+        {Emit.EXECUTION, Emit.TASK_EVENTS, Emit.USAGE}
     )
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
         {Capability.MEMORY, Capability.CONTACTS}
@@ -477,6 +483,10 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
         messages = [{"role": "user", "content": content}]
         final_text_parts: list[str] = []
         used_send_message = False  # tracks if agent called band_send_message
+        # Per-turn token usage. Reachable only on the per_room path, where the
+        # non-streamed LettaResponse carries an aggregate .usage; the shared-mode
+        # Conversations stream exposes no such aggregate, so it stays empty (N-A).
+        turn_usage = TurnUsage()
 
         room_ctx = self._rooms.get(room_id)
 
@@ -493,6 +503,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                 messages=messages,
             )
             response_messages = list(response.messages)
+            turn_usage = self._usage_from_response(response)
 
         for resp_msg in response_messages:
             msg_type = getattr(resp_msg, "message_type", None)
@@ -565,6 +576,10 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
             await tools.send_message(final_text, mentions=mentions)
         else:
             logger.debug("Room %s: Letta turn complete, no output", room_id)
+
+        # Emit the turn's token usage (no-op unless Emit.USAGE is on; empty on
+        # the shared-mode stream path, so nothing is emitted there).
+        await self.emit_usage(tools, turn_usage)
 
         return final_text_parts
 
@@ -878,6 +893,22 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
             )
         except Exception as e:
             logger.warning("Room %s: Memory consolidation failed: %s", room_id, e)
+
+    @staticmethod
+    def _usage_from_response(response: Any) -> TurnUsage:
+        """Map a Letta ``LettaResponse.usage`` (a ``Usage``) onto TurnUsage.
+
+        Field names verified against letta-client: ``prompt_tokens`` /
+        ``completion_tokens`` / ``cached_input_tokens`` / ``cache_write_tokens``.
+        A missing ``usage`` yields empty usage.
+        """
+        return TurnUsage.from_object(
+            getattr(response, "usage", None),
+            input="prompt_tokens",
+            output="completion_tokens",
+            cache_read="cached_input_tokens",
+            cache_write="cache_write_tokens",
+        )
 
     @staticmethod
     def _format_time_ago(dt: datetime) -> str:

--- a/src/band/adapters/opencode.py
+++ b/src/band/adapters/opencode.py
@@ -286,6 +286,14 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
                 )
 
             self._begin_turn(room_state, sender_id=msg.sender_id)
+            # Snapshot THIS turn's state before the prompt await: prompt_async
+            # can span the whole turn (session.idle may arrive mid-POST), and a
+            # message racing in during that window would _begin_turn again;
+            # reading room_state afterwards would wire this turn's watch task
+            # to the wrong turn's future and usage dict.
+            release_future = room_state.turn_release_future
+            turn_future = room_state.turn_future
+            usage_by_message = room_state.usage_by_message
             try:
                 await client.prompt_async(
                     session_id,
@@ -305,20 +313,22 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
                     variant=self.config.variant,
                 )
             except Exception:
-                self._clear_turn_state(room_state)
+                self._clear_turn_state(room_state, expected_future=turn_future)
                 raise
 
-            release_future = room_state.turn_release_future
-            turn_future = room_state.turn_future
             turn_task = asyncio.create_task(
                 self._watch_turn_completion(
                     room_state,
                     room_id,
                     turn_future,
-                    room_state.usage_by_message,
+                    usage_by_message,
                 )
             )
-            room_state.turn_task = turn_task
+            # Register the watcher only while this turn is still current; a
+            # superseded turn's task must not clobber (or be cancelled through)
+            # the next turn's ambient pointer.
+            if room_state.turn_future is turn_future:
+                room_state.turn_task = turn_task
 
             if release_future is not None:
                 await release_future
@@ -1055,9 +1065,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         """
         if room_state.tools is None:
             return
-        total = TurnUsage()
-        for usage in usage_by_message.values():
-            total = total + usage
+        total = sum(usage_by_message.values(), TurnUsage())
         await self.emit_usage(room_state.tools, total)
 
     @staticmethod

--- a/src/band/adapters/opencode.py
+++ b/src/band/adapters/opencode.py
@@ -319,24 +319,10 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
                 await release_future
             if turn_future is not None and turn_future.done():
                 await turn_task
-        except asyncio.TimeoutError:
-            logger.warning(
-                "OpenCode turn timed out for room %s (session=%s)",
-                room_id,
-                room_state.session_id,
-            )
-            if self._client and room_state.session_id:
-                try:
-                    await self._client.abort_session(room_state.session_id)
-                except Exception:
-                    logger.exception(
-                        "Failed to abort timed-out OpenCode session %s",
-                        room_state.session_id,
-                    )
-            await tools.send_event(
-                "OpenCode timed out before completing the turn.",
-                "error",
-            )
+        # NOTE: the turn timeout is owned solely by _watch_turn_completion (via
+        # asyncio.wait_for), which aborts the session and emits the error event.
+        # Nothing awaited here re-raises asyncio.TimeoutError, so on_message has no
+        # timeout handler of its own.
         except httpx.HTTPStatusError as exc:
             logger.exception("OpenCode request failed for room %s", room_id)
             await tools.send_event(
@@ -534,9 +520,10 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
                 if info.get("role") == "assistant":
                     if message_id:
                         room_state.assistant_message_ids.add(message_id)
-                        usage = self._usage_from_info(info)
-                        if not usage.is_empty:
-                            room_state.usage_by_message[message_id] = usage
+                        if Emit.USAGE in self.features.emit:
+                            usage = self._usage_from_info(info)
+                            if not usage.is_empty:
+                                room_state.usage_by_message[message_id] = usage
                     error = info.get("error")
                     if error:
                         room_state.last_error_message = self._format_opencode_error(
@@ -942,6 +929,9 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
                     "OpenCode timed out before completing the turn.",
                     "error",
                 )
+            # Tokens spent before the timeout were still spent — emit them, same
+            # as the success path (best-effort; no-op if none captured).
+            await self._emit_turn_usage(room_state)
             self._release_turn_wait(room_state)
         else:
             await self._deliver_fallback_text(room_state)
@@ -1039,12 +1029,12 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         room_state.pending_mentions = []
 
     async def _emit_turn_usage(self, room_state: _RoomState) -> None:
-        """Emit the turn's total token usage (summed across assistant messages).
+        """Sum the turn's per-assistant-message usage and emit it.
 
-        No-op unless ``Emit.USAGE`` is enabled or nothing was captured — a live
-        OpenCode server reports ``tokens`` on the assistant ``info``, but that is
-        not present in mocked/offline runs, so an empty total is simply skipped
-        by ``emit_usage``.
+        A no-op when usage reporting is off (``Emit.USAGE`` absent) or nothing was
+        captured — the base ``emit_usage`` skips an empty total. A live OpenCode
+        server reports ``tokens`` on each assistant ``info``; mocked/offline runs
+        don't, so the total is simply empty there.
         """
         if room_state.tools is None:
             return

--- a/src/band/adapters/opencode.py
+++ b/src/band/adapters/opencode.py
@@ -19,7 +19,13 @@ from band.converters.opencode import OpencodeHistoryConverter
 from band.core.exceptions import BandConfigError
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
-from band.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
+from band.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+    TurnUsage,
+)
 from band.integrations.mcp.backends import (
     BandMCPBackend,
     create_band_mcp_backend,
@@ -79,6 +85,10 @@ class _RoomState:
     pending_question: _PendingQuestion | None = None
     last_error_message: str | None = None
     persisted_session_id: str | None = None
+    # Per-assistant-message usage for the current turn (last-write-wins per id,
+    # since message.updated streams repeatedly). Summed across messages at turn
+    # end — a tool loop produces several assistant messages.
+    usage_by_message: dict[str, TurnUsage] = field(default_factory=dict)
 
 
 @dataclass
@@ -131,7 +141,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
     """
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset(
-        {Emit.EXECUTION, Emit.TASK_EVENTS}
+        {Emit.EXECUTION, Emit.TASK_EVENTS, Emit.USAGE}
     )
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
         {Capability.MEMORY, Capability.CONTACTS}
@@ -524,6 +534,9 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
                 if info.get("role") == "assistant":
                     if message_id:
                         room_state.assistant_message_ids.add(message_id)
+                        usage = self._usage_from_info(info)
+                        if not usage.is_empty:
+                            room_state.usage_by_message[message_id] = usage
                     error = info.get("error")
                     if error:
                         room_state.last_error_message = self._format_opencode_error(
@@ -896,6 +909,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         room_state.assistant_part_types.clear()
         room_state.reported_tool_calls.clear()
         room_state.reported_tool_results.clear()
+        room_state.usage_by_message.clear()
         room_state.last_error_message = None
 
     async def _watch_turn_completion(
@@ -931,6 +945,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
             self._release_turn_wait(room_state)
         else:
             await self._deliver_fallback_text(room_state)
+            await self._emit_turn_usage(room_state)
             self._release_turn_wait(room_state)
         finally:
             self._clear_turn_state(
@@ -1022,6 +1037,49 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
             mentions=room_state.pending_mentions,
         )
         room_state.pending_mentions = []
+
+    async def _emit_turn_usage(self, room_state: _RoomState) -> None:
+        """Emit the turn's total token usage (summed across assistant messages).
+
+        No-op unless ``Emit.USAGE`` is enabled or nothing was captured — a live
+        OpenCode server reports ``tokens`` on the assistant ``info``, but that is
+        not present in mocked/offline runs, so an empty total is simply skipped
+        by ``emit_usage``.
+        """
+        if room_state.tools is None:
+            return
+        total = TurnUsage()
+        for usage in room_state.usage_by_message.values():
+            total = total + usage
+        await self.emit_usage(room_state.tools, total)
+
+    @staticmethod
+    def _usage_from_info(info: dict[str, Any]) -> TurnUsage:
+        """Map an OpenCode assistant ``info.tokens`` onto TurnUsage.
+
+        Read defensively off the raw event dict (OpenCode's payloads are not
+        modeled in this integration): the server reports
+        ``tokens: {input, output, reasoning, cache: {read, write}}``. A missing
+        or malformed ``tokens`` yields empty usage.
+        """
+        tokens = info.get("tokens")
+        if not isinstance(tokens, dict):
+            return TurnUsage()
+        cache = tokens.get("cache")
+        cache = cache if isinstance(cache, dict) else {}
+        flat = {
+            "input": tokens.get("input"),
+            "output": tokens.get("output"),
+            "cache_read": cache.get("read"),
+            "cache_write": cache.get("write"),
+        }
+        return TurnUsage.from_mapping(
+            flat,
+            input="input",
+            output="output",
+            cache_read="cache_read",
+            cache_write="cache_write",
+        )
 
     async def _report_tool_call(
         self,

--- a/src/band/adapters/opencode.py
+++ b/src/band/adapters/opencode.py
@@ -1051,6 +1051,11 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         modeled in this integration): the server reports
         ``tokens: {input, output, reasoning, cache: {read, write}}``. A missing
         or malformed ``tokens`` yields empty usage.
+
+        OpenCode reports reasoning tokens *disjointly* from output (its own total
+        is ``input + output + reasoning + cache``), so fold reasoning into
+        ``output_tokens`` — otherwise reasoning-heavy turns undercount, and this
+        stays consistent with providers that already count reasoning inside output.
         """
         tokens = info.get("tokens")
         if not isinstance(tokens, dict):
@@ -1060,6 +1065,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         flat = {
             "input": tokens.get("input"),
             "output": tokens.get("output"),
+            "reasoning": tokens.get("reasoning"),
             "cache_read": cache.get("read"),
             "cache_write": cache.get("write"),
         }
@@ -1067,6 +1073,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
             flat,
             input="input",
             output="output",
+            reasoning="reasoning",
             cache_read="cache_read",
             cache_write="cache_write",
         )

--- a/src/band/adapters/opencode.py
+++ b/src/band/adapters/opencode.py
@@ -311,7 +311,12 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
             release_future = room_state.turn_release_future
             turn_future = room_state.turn_future
             turn_task = asyncio.create_task(
-                self._watch_turn_completion(room_state, room_id, turn_future)
+                self._watch_turn_completion(
+                    room_state,
+                    room_id,
+                    turn_future,
+                    room_state.usage_by_message,
+                )
             )
             room_state.turn_task = turn_task
 
@@ -896,7 +901,11 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         room_state.assistant_part_types.clear()
         room_state.reported_tool_calls.clear()
         room_state.reported_tool_results.clear()
-        room_state.usage_by_message.clear()
+        # A fresh dict, not .clear(): the previous turn's watch task drains the
+        # dict instance it captured, so a new turn must not empty it out from
+        # under a still-pending _emit_turn_usage (same snapshot idea as passing
+        # turn_future into _watch_turn_completion).
+        room_state.usage_by_message = {}
         room_state.last_error_message = None
 
     async def _watch_turn_completion(
@@ -904,6 +913,7 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         room_state: _RoomState,
         room_id: str,
         turn_future: asyncio.Future[None] | None,
+        usage_by_message: dict[str, TurnUsage],
     ) -> None:
         if turn_future is None:
             return
@@ -931,11 +941,11 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
                 )
             # Tokens spent before the timeout were still spent — emit them, same
             # as the success path (best-effort; no-op if none captured).
-            await self._emit_turn_usage(room_state)
+            await self._emit_turn_usage(room_state, usage_by_message)
             self._release_turn_wait(room_state)
         else:
             await self._deliver_fallback_text(room_state)
-            await self._emit_turn_usage(room_state)
+            await self._emit_turn_usage(room_state, usage_by_message)
             self._release_turn_wait(room_state)
         finally:
             self._clear_turn_state(
@@ -1028,18 +1038,25 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
         )
         room_state.pending_mentions = []
 
-    async def _emit_turn_usage(self, room_state: _RoomState) -> None:
+    async def _emit_turn_usage(
+        self,
+        room_state: _RoomState,
+        usage_by_message: dict[str, TurnUsage],
+    ) -> None:
         """Sum the turn's per-assistant-message usage and emit it.
 
-        A no-op when usage reporting is off (``Emit.USAGE`` absent) or nothing was
-        captured — the base ``emit_usage`` skips an empty total. A live OpenCode
-        server reports ``tokens`` on each assistant ``info``; mocked/offline runs
-        don't, so the total is simply empty there.
+        Takes the turn-owned dict captured by the watch task (not
+        ``room_state.usage_by_message``, which a new turn may have replaced by
+        the time this runs). A no-op when usage reporting is off
+        (``Emit.USAGE`` absent) or nothing was captured: the base
+        ``emit_usage`` skips an empty total. A live OpenCode server reports
+        ``tokens`` on each assistant ``info``; mocked/offline runs don't, so
+        the total is simply empty there.
         """
         if room_state.tools is None:
             return
         total = TurnUsage()
-        for usage in room_state.usage_by_message.values():
+        for usage in usage_by_message.values():
             total = total + usage
         await self.emit_usage(room_state.tools, total)
 

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -720,6 +720,10 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                     *self._message_history[room_id],
                     ModelRequest(parts=[UserPromptPart(content=user_message)]),
                 ]
+                # This turn spent tokens even though no result event fired, so
+                # still emit usage (summed from the captured responses) — the
+                # happy-path emit below is skipped by this early return.
+                await self.emit_usage(tools, self._usage_from_messages(captured))
                 return
             raise
         finally:
@@ -736,9 +740,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 "instead of using the band_send_message tool.",
             )
 
-        # Emit the turn's token usage (no-op unless Emit.USAGE is on). Skipped on
-        # the benign empty-final-response path above, which returns before here —
-        # that turn has no result event, so no usage to report.
+        # Emit the turn's token usage (no-op unless Emit.USAGE is on). The benign
+        # empty-final-response path above emits its own (from captured messages)
+        # and returns before here.
         await self.emit_usage(tools, turn_usage)
 
         logger.debug(
@@ -748,18 +752,13 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         )
 
     @staticmethod
-    def _usage_from_result(result: Any) -> TurnUsage:
-        """Map a pydantic-ai ``AgentRunResult.usage()`` onto TurnUsage.
+    def _usage_from_usage_obj(usage: Any) -> TurnUsage:
+        """Map a pydantic-ai usage object (RunUsage / RequestUsage) onto TurnUsage.
 
-        ``result.usage()`` is the run's total across all model requests. Field
-        names moved across pydantic-ai versions (``request_tokens`` /
+        Field names moved across pydantic-ai versions (``request_tokens`` /
         ``response_tokens`` → ``input_tokens`` / ``output_tokens``), so both are
-        read defensively.
+        read; the first int found wins.
         """
-        try:
-            usage = result.usage()
-        except Exception:  # pragma: no cover - defensive; usage is best-effort
-            return TurnUsage()
 
         def _int(*names: str) -> int:
             for name in names:
@@ -774,6 +773,30 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             cache_read_tokens=_int("cache_read_tokens"),
             cache_write_tokens=_int("cache_write_tokens"),
         )
+
+    @staticmethod
+    def _usage_from_result(result: Any) -> TurnUsage:
+        """The run's total usage across all model requests (happy path)."""
+        try:
+            usage = result.usage()
+        except Exception:  # pragma: no cover - defensive; usage is best-effort
+            return TurnUsage()
+        return PydanticAIAdapter._usage_from_usage_obj(usage)
+
+    @staticmethod
+    def _usage_from_messages(messages: list[ModelMessage]) -> TurnUsage:
+        """Sum per-response usage across captured run messages.
+
+        The fallback for the benign empty-final-response path, where no
+        ``AgentRunResultEvent`` fires (so ``result.usage()`` is unavailable) yet
+        the turn still spent tokens — each ``ModelResponse`` carries its own
+        ``usage``, so summing them reconstructs the turn total.
+        """
+        total = TurnUsage()
+        for message in messages:
+            if isinstance(message, ModelResponse):
+                total = total + PydanticAIAdapter._usage_from_usage_obj(message.usage)
+        return total
 
     async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
         """Send an error event to the room (best effort).

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -630,7 +630,12 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # history — merging adjacent same-type messages (e.g. the injected
         # participants + contacts requests) — so a length-based boundary would
         # slip; real API ModelResponses are never merged, so they keep identity.
-        prior_message_ids = {id(m) for m in self._message_history[room_id]}
+        # Built only when usage emission is on: the gated fallback in the
+        # finally is its sole consumer, and the set is O(history) per turn.
+        usage_enabled = Emit.USAGE in self.features.emit
+        prior_message_ids: set[int] = (
+            {id(m) for m in self._message_history[room_id]} if usage_enabled else set()
+        )
         # Capture the run's messages so a benign empty-final response — which raises
         # before the AgentRunResultEvent that normally records history — can still
         # persist the *full* turn (user prompt + the agent's tool calls/results), not
@@ -739,7 +744,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             # identity (captured also holds the prior history). Feature-gated
             # here so the fallback's history scan never runs when usage
             # emission is off.
-            if Emit.USAGE in self.features.emit:
+            if usage_enabled:
                 if turn_usage.is_empty:
                     this_run = self._new_run_messages(captured, prior_message_ids)
                     turn_usage = self._usage_from_messages(this_run)

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -622,11 +622,15 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # pydantic-ai's result.usage() is already summed across the run's model
         # calls, so it's set once (on the result event), not accumulated.
         turn_usage = TurnUsage()
-        # Snapshot the history length so the benign-path usage fallback can sum
-        # only THIS run's responses: capture_run_messages() records the passed
-        # message_history + the new turn, so summing the whole list would
-        # double-count every prior turn's usage.
-        history_len = len(self._message_history[room_id])
+        # Snapshot the prior messages' identities so the benign-path usage
+        # fallback can sum only THIS run's responses: capture_run_messages()
+        # records the passed message_history + the new turn, so summing the whole
+        # list would double-count every prior turn. Identity (not a positional
+        # slice) because pydantic-ai runs _clean_message_history() on the passed
+        # history — merging adjacent same-type messages (e.g. the injected
+        # participants + contacts requests) — so a length-based boundary would
+        # slip; real API ModelResponses are never merged, so they keep identity.
+        prior_message_ids = {id(m) for m in self._message_history[room_id]}
         # Capture the run's messages so a benign empty-final response — which raises
         # before the AgentRunResultEvent that normally records history — can still
         # persist the *full* turn (user prompt + the agent's tool calls/results), not
@@ -726,12 +730,12 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                     ModelRequest(parts=[UserPromptPart(content=user_message)]),
                 ]
                 # This turn spent tokens even though no result event fired, so
-                # still emit usage — summed from only THIS run's responses
-                # (captured[history_len:]), since captured also holds the prior
-                # history. The happy-path emit below is skipped by this return.
-                await self.emit_usage(
-                    tools, self._usage_from_messages(captured[history_len:])
-                )
+                # still emit usage — summed from only THIS run's responses (those
+                # in captured whose identity wasn't in the prior history), since
+                # captured also holds the prior history. The happy-path emit below
+                # is skipped by this return.
+                this_run = self._new_run_messages(captured, prior_message_ids)
+                await self.emit_usage(tools, self._usage_from_messages(this_run))
                 return
             raise
         finally:
@@ -792,15 +796,32 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         return PydanticAIAdapter._usage_from_usage_obj(usage)
 
     @staticmethod
+    def _new_run_messages(
+        captured: list[ModelMessage], prior_message_ids: set[int]
+    ) -> list[ModelMessage]:
+        """This run's messages: those in ``captured`` not in the prior history.
+
+        Identity, not a positional boundary: pydantic-ai runs
+        ``_clean_message_history`` on the passed history, merging adjacent
+        same-type messages (e.g. the injected participants + contacts requests),
+        which shifts positions and shortens the list — so a ``len(prior)`` slice
+        would drop this turn's leading response(s). Real API ``ModelResponse``s
+        are never merged, so they keep their identity and survive this filter;
+        any newly-merged prior request lands here too but carries no usage, so the
+        ``ModelResponse``-only sum in :meth:`_usage_from_messages` ignores it.
+        """
+        return [m for m in captured if id(m) not in prior_message_ids]
+
+    @staticmethod
     def _usage_from_messages(messages: list[ModelMessage]) -> TurnUsage:
         """Sum per-response usage across the given run messages.
 
         The fallback for the benign empty-final-response path, where no
         ``AgentRunResultEvent`` fires (so ``result.usage()`` is unavailable) yet
         the turn still spent tokens — each ``ModelResponse`` carries its own
-        ``usage``. Pass only the *current run's* messages (the caller slices off
-        the prior history); summing the full captured list would double-count
-        every prior turn.
+        ``usage``. Pass only the *current run's* messages (the caller filters out
+        the prior history by identity); summing the full captured list would
+        double-count every prior turn.
         """
         total = TurnUsage()
         for message in messages:

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -622,8 +622,8 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # pydantic-ai's result.usage() is already summed across the run's model
         # calls, so it's set once (on the result event), not accumulated.
         turn_usage = TurnUsage()
-        # Snapshot the prior messages' identities so the benign-path usage
-        # fallback can sum only THIS run's responses: capture_run_messages()
+        # Snapshot the prior messages' identities so the fallback usage path
+        # (any run that raises) can sum only THIS run's responses: capture_run_messages()
         # records the passed message_history + the new turn, so summing the whole
         # list would double-count every prior turn. Identity (not a positional
         # slice) because pydantic-ai runs _clean_message_history() on the passed
@@ -729,17 +729,21 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                     *self._message_history[room_id],
                     ModelRequest(parts=[UserPromptPart(content=user_message)]),
                 ]
-                # This turn spent tokens even though no result event fired, so
-                # still emit usage — summed from only THIS run's responses (those
-                # in captured whose identity wasn't in the prior history), since
-                # captured also holds the prior history. The happy-path emit below
-                # is skipped by this return.
-                this_run = self._new_run_messages(captured, prior_message_ids)
-                await self.emit_usage(tools, self._usage_from_messages(this_run))
                 return
             raise
         finally:
             capture_cm.__exit__(None, None, None)
+            # Single emit point for every exit. A run that raised (benign
+            # empty-final or a hard failure) never saw the result event, so
+            # fall back to summing only THIS run's captured responses by
+            # identity (captured also holds the prior history). Feature-gated
+            # here so the fallback's history scan never runs when usage
+            # emission is off.
+            if Emit.USAGE in self.features.emit:
+                if turn_usage.is_empty:
+                    this_run = self._new_run_messages(captured, prior_message_ids)
+                    turn_usage = self._usage_from_messages(this_run)
+                await self.emit_usage(tools, turn_usage)
 
         # A clean run with no terminal work means the model answered in plain text
         # without calling band_send_message — a silently dropped reply. Surface it
@@ -751,11 +755,6 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 "usually means the agent returned a final answer as plain text "
                 "instead of using the band_send_message tool.",
             )
-
-        # Emit the turn's token usage (no-op unless Emit.USAGE is on). The benign
-        # empty-final-response path above emits its own (from captured messages)
-        # and returns before here.
-        await self.emit_usage(tools, turn_usage)
 
         logger.debug(
             "Room %s: Pydantic AI agent completed (history now has %s messages)",

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -34,7 +34,13 @@ from band_rest.core.api_error import ApiError
 from band.core.exceptions import BandConfigError
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
-from band.core.types import AdapterFeatures, Capability, Emit, PlatformMessage
+from band.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+    TurnUsage,
+)
 from band.converters.pydantic_ai import (
     PydanticAIHistoryConverter,
     PydanticAIMessages,
@@ -140,7 +146,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         await agent.run()
     """
 
-    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION})
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
         {Capability.MEMORY, Capability.CONTACTS}
     )
@@ -613,6 +619,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # terminal, successful tool ran (excludes read-only lookups and failed
         # band tools) so we can tell a productive turn from a genuine no-op below.
         tool_executed = False
+        # pydantic-ai's result.usage() is already summed across the run's model
+        # calls, so it's set once (on the result event), not accumulated.
+        turn_usage = TurnUsage()
         # Capture the run's messages so a benign empty-final response — which raises
         # before the AgentRunResultEvent that normally records history — can still
         # persist the *full* turn (user prompt + the agent's tool calls/results), not
@@ -669,6 +678,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                         except Exception as e:
                             logger.warning("Failed to send tool_result event: %s", e)
                 elif isinstance(event, AgentRunResultEvent):
+                    turn_usage = self._usage_from_result(event.result)
                     # Keep native run history, but drop responses that replay as
                     # content:null (e.g. thinking-only) — providers reject them next request.
                     run_messages = list(event.result.all_messages())
@@ -726,10 +736,43 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 "instead of using the band_send_message tool.",
             )
 
+        # Emit the turn's token usage (no-op unless Emit.USAGE is on). Skipped on
+        # the benign empty-final-response path above, which returns before here —
+        # that turn has no result event, so no usage to report.
+        await self.emit_usage(tools, turn_usage)
+
         logger.debug(
             "Room %s: Pydantic AI agent completed (history now has %s messages)",
             room_id,
             len(self._message_history[room_id]),
+        )
+
+    @staticmethod
+    def _usage_from_result(result: Any) -> TurnUsage:
+        """Map a pydantic-ai ``AgentRunResult.usage()`` onto TurnUsage.
+
+        ``result.usage()`` is the run's total across all model requests. Field
+        names moved across pydantic-ai versions (``request_tokens`` /
+        ``response_tokens`` → ``input_tokens`` / ``output_tokens``), so both are
+        read defensively.
+        """
+        try:
+            usage = result.usage()
+        except Exception:  # pragma: no cover - defensive; usage is best-effort
+            return TurnUsage()
+
+        def _int(*names: str) -> int:
+            for name in names:
+                value = getattr(usage, name, None)
+                if isinstance(value, int):
+                    return value
+            return 0
+
+        return TurnUsage(
+            input_tokens=_int("input_tokens", "request_tokens"),
+            output_tokens=_int("output_tokens", "response_tokens"),
+            cache_read_tokens=_int("cache_read_tokens"),
+            cache_write_tokens=_int("cache_write_tokens"),
         )
 
     async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -622,6 +622,11 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # pydantic-ai's result.usage() is already summed across the run's model
         # calls, so it's set once (on the result event), not accumulated.
         turn_usage = TurnUsage()
+        # Snapshot the history length so the benign-path usage fallback can sum
+        # only THIS run's responses: capture_run_messages() records the passed
+        # message_history + the new turn, so summing the whole list would
+        # double-count every prior turn's usage.
+        history_len = len(self._message_history[room_id])
         # Capture the run's messages so a benign empty-final response — which raises
         # before the AgentRunResultEvent that normally records history — can still
         # persist the *full* turn (user prompt + the agent's tool calls/results), not
@@ -721,9 +726,12 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                     ModelRequest(parts=[UserPromptPart(content=user_message)]),
                 ]
                 # This turn spent tokens even though no result event fired, so
-                # still emit usage (summed from the captured responses) — the
-                # happy-path emit below is skipped by this early return.
-                await self.emit_usage(tools, self._usage_from_messages(captured))
+                # still emit usage — summed from only THIS run's responses
+                # (captured[history_len:]), since captured also holds the prior
+                # history. The happy-path emit below is skipped by this return.
+                await self.emit_usage(
+                    tools, self._usage_from_messages(captured[history_len:])
+                )
                 return
             raise
         finally:
@@ -785,12 +793,14 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
 
     @staticmethod
     def _usage_from_messages(messages: list[ModelMessage]) -> TurnUsage:
-        """Sum per-response usage across captured run messages.
+        """Sum per-response usage across the given run messages.
 
         The fallback for the benign empty-final-response path, where no
         ``AgentRunResultEvent`` fires (so ``result.usage()`` is unavailable) yet
         the turn still spent tokens — each ``ModelResponse`` carries its own
-        ``usage``, so summing them reconstructs the turn total.
+        ``usage``. Pass only the *current run's* messages (the caller slices off
+        the prior history); summing the full captured list would double-count
+        every prior turn.
         """
         total = TurnUsage()
         for message in messages:

--- a/src/band/core/simple_adapter.py
+++ b/src/band/core/simple_adapter.py
@@ -134,10 +134,14 @@ class SimpleAdapter(Generic[H], ABC):
         ``USAGE_EVENT_TYPE``.
 
         Adapters call this once per turn with the usage summed across the tool
-        loop. An adapter that cannot observe usage (server-side execution)
-        simply never calls it, so no event is emitted and the toolkit records
-        N-A rather than a false zero. An all-zero usage is likewise skipped so a
-        read never sees a zero-only record masquerading as real data.
+        loop, typically from a ``finally`` so every exit path is covered: it
+        never raises, and an empty total is skipped, so a turn that fails after
+        a successful model call still reports the tokens it spent while a
+        first-call failure emits nothing. An adapter that cannot observe usage
+        (server-side execution) simply never calls it, so no event is emitted
+        and the toolkit records N-A rather than a false zero. An all-zero usage
+        is likewise skipped so a read never sees a zero-only record
+        masquerading as real data.
         """
         if Emit.USAGE not in self.features.emit:
             return

--- a/src/band/core/simple_adapter.py
+++ b/src/band/core/simple_adapter.py
@@ -9,11 +9,14 @@ from typing import Any, ClassVar, Generic, TypeVar, cast
 
 from band.core.protocols import AgentToolsProtocol, HistoryConverter
 from band.core.types import (
+    USAGE_EVENT_TYPE,
+    USAGE_METADATA_KEY,
     AdapterFeatures,
     AgentInput,
     Capability,
     Emit,
     PlatformMessage,
+    TurnUsage,
 )
 
 logger = logging.getLogger(__name__)
@@ -118,6 +121,40 @@ class SimpleAdapter(Generic[H], ABC):
             room_id: The room identifier
         """
         ...
+
+    async def emit_usage(self, tools: AgentToolsProtocol, usage: TurnUsage) -> None:
+        """Emit a turn's token usage as a platform event, if enabled.
+
+        Additive and best-effort, mirroring how adapters emit ``tool_call``
+        events under ``Emit.EXECUTION``: gated on ``Emit.USAGE`` in the
+        adapter's features, and never allowed to crash the turn. The token
+        counts ride an accepted ``task`` event's structured ``metadata`` under
+        ``USAGE_METADATA_KEY`` (the read side filters on that key), since the
+        backend rejects an unknown ``usage`` message_type today; see
+        ``USAGE_EVENT_TYPE``.
+
+        Adapters call this once per turn with the usage summed across the tool
+        loop. An adapter that cannot observe usage (server-side execution)
+        simply never calls it, so no event is emitted and the toolkit records
+        N-A rather than a false zero. An all-zero usage is likewise skipped so a
+        read never sees a zero-only record masquerading as real data.
+        """
+        if Emit.USAGE not in self.features.emit:
+            return
+        if usage.is_empty:
+            logger.debug("Skipping empty usage event")
+            return
+        try:
+            await tools.send_event(
+                content=(
+                    f"Token usage: input={usage.input_tokens} "
+                    f"output={usage.output_tokens}"
+                ),
+                message_type=USAGE_EVENT_TYPE,
+                metadata={USAGE_METADATA_KEY: usage.to_dict()},
+            )
+        except Exception as e:  # best-effort: usage reporting must never crash a turn
+            logger.warning("Failed to send usage event: %s", e)
 
     async def on_cleanup(self, room_id: str) -> None:
         """Override for session cleanup."""

--- a/src/band/core/simple_adapter.py
+++ b/src/band/core/simple_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import warnings
 from abc import ABC, abstractmethod
@@ -137,16 +138,22 @@ class SimpleAdapter(Generic[H], ABC):
         loop, typically from a ``finally`` so every exit path is covered: it
         never raises, and an empty total is skipped, so a turn that fails after
         a successful model call still reports the tokens it spent while a
-        first-call failure emits nothing. An adapter that cannot observe usage
-        (server-side execution) simply never calls it, so no event is emitted
-        and the toolkit records N-A rather than a false zero. An all-zero usage
-        is likewise skipped so a read never sees a zero-only record
-        masquerading as real data.
+        first-call failure emits nothing. When the calling task is being
+        cancelled (shutdown, a turn timeout) the emit is skipped entirely, so
+        teardown never blocks on network I/O and a CancelledError can't fire
+        mid-send. An adapter that cannot observe usage (server-side execution)
+        simply never calls it, so no event is emitted and the toolkit records
+        N-A rather than a false zero. An all-zero usage is likewise skipped so
+        a read never sees a zero-only record masquerading as real data.
         """
         if Emit.USAGE not in self.features.emit:
             return
         if usage.is_empty:
             logger.debug("Skipping empty usage event")
+            return
+        task = asyncio.current_task()
+        if task is not None and task.cancelling():
+            logger.debug("Skipping usage emit during task cancellation")
             return
         try:
             await tools.send_event(

--- a/src/band/core/types.py
+++ b/src/band/core/types.py
@@ -134,13 +134,23 @@ class TurnUsage:
         output: str,
         cache_read: str | None,
         cache_write: str | None,
+        reasoning: str | None,
     ) -> TurnUsage:
         """Shared core of from_object/from_mapping: read the named fields via
         ``get`` and coerce each to a non-negative int. Values are passed through
-        raw (no cache folding) per the class convention."""
+        raw (no cache folding) per the class convention.
+
+        ``reasoning`` is for providers that report reasoning/thinking tokens
+        *disjointly* from output (codex, opencode, whose own totals are
+        ``input + output + reasoning``): when named, it is folded into
+        ``output_tokens`` so this four-field schema stays consistent with the
+        providers that already count reasoning inside output (Anthropic thinking,
+        OpenAI completion tokens). Leave it ``None`` when output already includes
+        reasoning, to avoid double-counting."""
         return cls(
             input_tokens=_as_int(get(input)),
-            output_tokens=_as_int(get(output)),
+            output_tokens=_as_int(get(output))
+            + (_as_int(get(reasoning)) if reasoning else 0),
             cache_read_tokens=_as_int(get(cache_read)) if cache_read else 0,
             cache_write_tokens=_as_int(get(cache_write)) if cache_write else 0,
         )
@@ -154,6 +164,7 @@ class TurnUsage:
         output: str,
         cache_read: str | None = None,
         cache_write: str | None = None,
+        reasoning: str | None = None,
     ) -> TurnUsage:
         """Build from a usage *object*, reading the named attributes.
 
@@ -161,6 +172,10 @@ class TurnUsage:
         a non-negative int (missing/non-int → 0). ``src=None`` (usage absent on
         the response) yields an empty ``TurnUsage`` — so an adapter's mapper is a
         one-liner over ``getattr(response, "...", None)`` with no guard of its own.
+
+        Pass ``reasoning`` only when the provider reports reasoning tokens
+        disjointly from output (see :meth:`_build`); it is folded into
+        ``output_tokens``.
         """
         if src is None:
             return cls()
@@ -170,6 +185,7 @@ class TurnUsage:
             output=output,
             cache_read=cache_read,
             cache_write=cache_write,
+            reasoning=reasoning,
         )
 
     @classmethod
@@ -181,11 +197,14 @@ class TurnUsage:
         output: str,
         cache_read: str | None = None,
         cache_write: str | None = None,
+        reasoning: str | None = None,
     ) -> TurnUsage:
         """Build from a usage *mapping* (dict), reading the named keys.
 
         The mapping-source twin of :meth:`from_object`; a non-mapping ``data``
-        (e.g. usage absent) yields an empty ``TurnUsage``.
+        (e.g. usage absent) yields an empty ``TurnUsage``. Pass ``reasoning`` only
+        when the provider reports reasoning tokens disjointly from output (see
+        :meth:`_build`); it is folded into ``output_tokens``.
         """
         if not isinstance(data, Mapping):
             return cls()
@@ -195,6 +214,7 @@ class TurnUsage:
             output=output,
             cache_read=cache_read,
             cache_write=cache_write,
+            reasoning=reasoning,
         )
 
 

--- a/src/band/core/types.py
+++ b/src/band/core/types.py
@@ -117,7 +117,7 @@ class TurnUsage:
         )
 
     def to_dict(self) -> dict[str, int]:
-        """Serialize for the usage event payload (content JSON + metadata)."""
+        """Serialize the four token counts for the usage event's metadata."""
         return {
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,

--- a/src/band/core/types.py
+++ b/src/band/core/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum, StrEnum
@@ -51,6 +51,11 @@ class Emit(str, Enum):
     THOUGHTS = "thoughts"
     TASK_EVENTS = "task_events"
     USAGE = "usage"
+
+
+def _as_int(value: object) -> int:
+    """Coerce a usage field to an int; anything non-int (None, missing) → 0."""
+    return value if isinstance(value, int) else 0
 
 
 @dataclass(frozen=True)
@@ -107,6 +112,58 @@ class TurnUsage:
             "cache_read_tokens": self.cache_read_tokens,
             "cache_write_tokens": self.cache_write_tokens,
         }
+
+    @classmethod
+    def from_object(
+        cls,
+        src: object,
+        *,
+        input: str,
+        output: str,
+        cache_read: str | None = None,
+        cache_write: str | None = None,
+    ) -> TurnUsage:
+        """Build from a usage *object*, reading the named attributes.
+
+        The framework-specific attribute names are passed in; each is coerced to
+        a non-negative int (missing/non-int → 0). ``src=None`` (usage absent on
+        the response) yields an empty ``TurnUsage`` — so an adapter's mapper is a
+        one-liner over ``getattr(response, "...", None)`` with no guard of its own.
+        """
+        if src is None:
+            return cls()
+        return cls(
+            input_tokens=_as_int(getattr(src, input, 0)),
+            output_tokens=_as_int(getattr(src, output, 0)),
+            cache_read_tokens=_as_int(getattr(src, cache_read, 0)) if cache_read else 0,
+            cache_write_tokens=(
+                _as_int(getattr(src, cache_write, 0)) if cache_write else 0
+            ),
+        )
+
+    @classmethod
+    def from_mapping(
+        cls,
+        data: object,
+        *,
+        input: str,
+        output: str,
+        cache_read: str | None = None,
+        cache_write: str | None = None,
+    ) -> TurnUsage:
+        """Build from a usage *mapping* (dict), reading the named keys.
+
+        The attribute-source twin of :meth:`from_object`; a non-mapping ``data``
+        (e.g. usage absent) yields an empty ``TurnUsage``.
+        """
+        if not isinstance(data, Mapping):
+            return cls()
+        return cls(
+            input_tokens=_as_int(data.get(input, 0)),
+            output_tokens=_as_int(data.get(output, 0)),
+            cache_read_tokens=_as_int(data.get(cache_read, 0)) if cache_read else 0,
+            cache_write_tokens=_as_int(data.get(cache_write, 0)) if cache_write else 0,
+        )
 
 
 # Usage rides an already-accepted ``task`` event's free-form metadata (the path

--- a/src/band/core/types.py
+++ b/src/band/core/types.py
@@ -79,15 +79,16 @@ class TurnUsage:
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
 
-    # Cross-provider convention (adapters MUST map onto this so the schema means
-    # one thing everywhere): ``input_tokens`` is the *total* prompt the model
-    # processed, INCLUDING cached tokens; ``cache_read_tokens`` / ``cache_write_tokens``
-    # are a *subset breakdown* of that total, not additive on top of it. So
-    # ``total_tokens = input_tokens + output_tokens`` is correct for every adapter,
-    # and cost math never double-counts (or under-counts) cache. Providers whose
-    # native "input" excludes cache (Anthropic, Claude SDK) fold cache back into
-    # ``input_tokens`` in their mapper; providers whose native "input" already
-    # includes cache (Gemini/ADK, LiteLLM-based crewai, LangChain) pass it through.
+    # Convention: each field is the provider's *raw* reported value — no folding.
+    # Whether cache is already counted inside ``input_tokens`` is provider-specific
+    # (Anthropic/Claude SDK report input EXCLUDING cache; OpenAI/Gemini/LangChain
+    # report input INCLUDING it; OpenCode reports cache as additive) — and a
+    # single adapter can hit multiple providers, so no cross-provider "input always
+    # includes cache" normalization is possible without per-provider logic. Treat
+    # ``cache_read_tokens`` / ``cache_write_tokens`` as informational, and use
+    # ``input_tokens + cache_read_tokens + cache_write_tokens`` as the robust
+    # measure of total prompt size. (A first-class, provider-normalized cost model
+    # is out of scope here; consumers have the raw fields.)
 
     def __add__(self, other: TurnUsage) -> TurnUsage:
         """Sum two per-call usages (used to aggregate across a tool loop)."""
@@ -100,9 +101,9 @@ class TurnUsage:
 
     @property
     def total_tokens(self) -> int:
-        """Total tokens for the turn: input (which already includes cache, per the
-        convention above) + output. Cache fields are a subset of input, so they
-        are not added again."""
+        """``input_tokens + output_tokens`` as raw-reported. Note this is NOT
+        cache-normalized across providers (for providers that report cache
+        separately from input it excludes cache); see the convention above."""
         return self.input_tokens + self.output_tokens
 
     @property
@@ -133,27 +134,15 @@ class TurnUsage:
         output: str,
         cache_read: str | None,
         cache_write: str | None,
-        cache_in_input: bool,
     ) -> TurnUsage:
         """Shared core of from_object/from_mapping: read the named fields via
-        ``get`` and apply the cache convention.
-
-        ``cache_in_input`` declares the provider's native shape: True when the
-        input field already includes cached tokens (Gemini/ADK, LiteLLM, LangChain
-        — the default), False when it excludes them (Anthropic, Claude SDK), in
-        which case cache is folded back into ``input_tokens`` so the schema always
-        means "input = total prompt incl. cache" (see the class convention).
-        """
-        cache_read_tokens = _as_int(get(cache_read)) if cache_read else 0
-        cache_write_tokens = _as_int(get(cache_write)) if cache_write else 0
-        input_tokens = _as_int(get(input))
-        if not cache_in_input:
-            input_tokens += cache_read_tokens + cache_write_tokens
+        ``get`` and coerce each to a non-negative int. Values are passed through
+        raw (no cache folding) per the class convention."""
         return cls(
-            input_tokens=input_tokens,
+            input_tokens=_as_int(get(input)),
             output_tokens=_as_int(get(output)),
-            cache_read_tokens=cache_read_tokens,
-            cache_write_tokens=cache_write_tokens,
+            cache_read_tokens=_as_int(get(cache_read)) if cache_read else 0,
+            cache_write_tokens=_as_int(get(cache_write)) if cache_write else 0,
         )
 
     @classmethod
@@ -165,7 +154,6 @@ class TurnUsage:
         output: str,
         cache_read: str | None = None,
         cache_write: str | None = None,
-        cache_in_input: bool = True,
     ) -> TurnUsage:
         """Build from a usage *object*, reading the named attributes.
 
@@ -173,7 +161,6 @@ class TurnUsage:
         a non-negative int (missing/non-int → 0). ``src=None`` (usage absent on
         the response) yields an empty ``TurnUsage`` — so an adapter's mapper is a
         one-liner over ``getattr(response, "...", None)`` with no guard of its own.
-        See :meth:`_build` for ``cache_in_input``.
         """
         if src is None:
             return cls()
@@ -183,7 +170,6 @@ class TurnUsage:
             output=output,
             cache_read=cache_read,
             cache_write=cache_write,
-            cache_in_input=cache_in_input,
         )
 
     @classmethod
@@ -195,13 +181,11 @@ class TurnUsage:
         output: str,
         cache_read: str | None = None,
         cache_write: str | None = None,
-        cache_in_input: bool = True,
     ) -> TurnUsage:
         """Build from a usage *mapping* (dict), reading the named keys.
 
         The mapping-source twin of :meth:`from_object`; a non-mapping ``data``
-        (e.g. usage absent) yields an empty ``TurnUsage``. See :meth:`_build` for
-        ``cache_in_input``.
+        (e.g. usage absent) yields an empty ``TurnUsage``.
         """
         if not isinstance(data, Mapping):
             return cls()
@@ -211,7 +195,6 @@ class TurnUsage:
             output=output,
             cache_read=cache_read,
             cache_write=cache_write,
-            cache_in_input=cache_in_input,
         )
 
 
@@ -235,8 +218,8 @@ def is_usage_event(metadata: object) -> bool:
     than a dedicated type, every ``task``-event consumer that should NOT treat
     usage as a lifecycle task calls this to skip it — the single source of truth
     for "is this a usage event", so a new consumer has one guard to reuse instead
-    of re-deriving the ``band_usage`` check. Retired once usage becomes a
-    first-class ``usage`` message_type (see INT-933)."""
+    of re-deriving the ``band_usage`` check. It would be retired if usage ever
+    became a first-class ``usage`` message_type."""
     return isinstance(metadata, Mapping) and USAGE_METADATA_KEY in metadata
 
 

--- a/src/band/core/types.py
+++ b/src/band/core/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum, StrEnum
@@ -79,6 +79,16 @@ class TurnUsage:
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
 
+    # Cross-provider convention (adapters MUST map onto this so the schema means
+    # one thing everywhere): ``input_tokens`` is the *total* prompt the model
+    # processed, INCLUDING cached tokens; ``cache_read_tokens`` / ``cache_write_tokens``
+    # are a *subset breakdown* of that total, not additive on top of it. So
+    # ``total_tokens = input_tokens + output_tokens`` is correct for every adapter,
+    # and cost math never double-counts (or under-counts) cache. Providers whose
+    # native "input" excludes cache (Anthropic, Claude SDK) fold cache back into
+    # ``input_tokens`` in their mapper; providers whose native "input" already
+    # includes cache (Gemini/ADK, LiteLLM-based crewai, LangChain) pass it through.
+
     def __add__(self, other: TurnUsage) -> TurnUsage:
         """Sum two per-call usages (used to aggregate across a tool loop)."""
         return TurnUsage(
@@ -90,8 +100,9 @@ class TurnUsage:
 
     @property
     def total_tokens(self) -> int:
-        """Input + output tokens (cache fields are a subset breakdown of input,
-        so they are not added again here)."""
+        """Total tokens for the turn: input (which already includes cache, per the
+        convention above) + output. Cache fields are a subset of input, so they
+        are not added again."""
         return self.input_tokens + self.output_tokens
 
     @property
@@ -114,6 +125,38 @@ class TurnUsage:
         }
 
     @classmethod
+    def _build(
+        cls,
+        get: Callable[[str], object],
+        *,
+        input: str,
+        output: str,
+        cache_read: str | None,
+        cache_write: str | None,
+        cache_in_input: bool,
+    ) -> TurnUsage:
+        """Shared core of from_object/from_mapping: read the named fields via
+        ``get`` and apply the cache convention.
+
+        ``cache_in_input`` declares the provider's native shape: True when the
+        input field already includes cached tokens (Gemini/ADK, LiteLLM, LangChain
+        — the default), False when it excludes them (Anthropic, Claude SDK), in
+        which case cache is folded back into ``input_tokens`` so the schema always
+        means "input = total prompt incl. cache" (see the class convention).
+        """
+        cache_read_tokens = _as_int(get(cache_read)) if cache_read else 0
+        cache_write_tokens = _as_int(get(cache_write)) if cache_write else 0
+        input_tokens = _as_int(get(input))
+        if not cache_in_input:
+            input_tokens += cache_read_tokens + cache_write_tokens
+        return cls(
+            input_tokens=input_tokens,
+            output_tokens=_as_int(get(output)),
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+        )
+
+    @classmethod
     def from_object(
         cls,
         src: object,
@@ -122,6 +165,7 @@ class TurnUsage:
         output: str,
         cache_read: str | None = None,
         cache_write: str | None = None,
+        cache_in_input: bool = True,
     ) -> TurnUsage:
         """Build from a usage *object*, reading the named attributes.
 
@@ -129,16 +173,17 @@ class TurnUsage:
         a non-negative int (missing/non-int → 0). ``src=None`` (usage absent on
         the response) yields an empty ``TurnUsage`` — so an adapter's mapper is a
         one-liner over ``getattr(response, "...", None)`` with no guard of its own.
+        See :meth:`_build` for ``cache_in_input``.
         """
         if src is None:
             return cls()
-        return cls(
-            input_tokens=_as_int(getattr(src, input, 0)),
-            output_tokens=_as_int(getattr(src, output, 0)),
-            cache_read_tokens=_as_int(getattr(src, cache_read, 0)) if cache_read else 0,
-            cache_write_tokens=(
-                _as_int(getattr(src, cache_write, 0)) if cache_write else 0
-            ),
+        return cls._build(
+            lambda name: getattr(src, name, 0),
+            input=input,
+            output=output,
+            cache_read=cache_read,
+            cache_write=cache_write,
+            cache_in_input=cache_in_input,
         )
 
     @classmethod
@@ -150,19 +195,23 @@ class TurnUsage:
         output: str,
         cache_read: str | None = None,
         cache_write: str | None = None,
+        cache_in_input: bool = True,
     ) -> TurnUsage:
         """Build from a usage *mapping* (dict), reading the named keys.
 
-        The attribute-source twin of :meth:`from_object`; a non-mapping ``data``
-        (e.g. usage absent) yields an empty ``TurnUsage``.
+        The mapping-source twin of :meth:`from_object`; a non-mapping ``data``
+        (e.g. usage absent) yields an empty ``TurnUsage``. See :meth:`_build` for
+        ``cache_in_input``.
         """
         if not isinstance(data, Mapping):
             return cls()
-        return cls(
-            input_tokens=_as_int(data.get(input, 0)),
-            output_tokens=_as_int(data.get(output, 0)),
-            cache_read_tokens=_as_int(data.get(cache_read, 0)) if cache_read else 0,
-            cache_write_tokens=_as_int(data.get(cache_write, 0)) if cache_write else 0,
+        return cls._build(
+            lambda name: data.get(name, 0),
+            input=input,
+            output=output,
+            cache_read=cache_read,
+            cache_write=cache_write,
+            cache_in_input=cache_in_input,
         )
 
 
@@ -176,6 +225,19 @@ class TurnUsage:
 # lifecycle one.
 USAGE_EVENT_TYPE: MessageType = MessageType.TASK
 USAGE_METADATA_KEY: str = "band_usage"
+
+
+def is_usage_event(metadata: object) -> bool:
+    """Whether an event's ``metadata`` marks it as a usage record (see
+    ``SimpleAdapter.emit_usage``).
+
+    Because usage currently rides ``USAGE_EVENT_TYPE`` (a ``task`` event) rather
+    than a dedicated type, every ``task``-event consumer that should NOT treat
+    usage as a lifecycle task calls this to skip it — the single source of truth
+    for "is this a usage event", so a new consumer has one guard to reuse instead
+    of re-deriving the ``band_usage`` check. Retired once usage becomes a
+    first-class ``usage`` message_type (see INT-933)."""
+    return isinstance(metadata, Mapping) and USAGE_METADATA_KEY in metadata
 
 
 @dataclass(frozen=True)

--- a/src/band/core/types.py
+++ b/src/band/core/types.py
@@ -23,6 +23,7 @@ class MessageType(StrEnum):
     THOUGHT = "thought"
     ERROR = "error"
     TASK = "task"
+    USAGE = "usage"
 
 
 # Subset of message types accepted by ``band_send_event`` — the non-history
@@ -49,6 +50,75 @@ class Emit(str, Enum):
     EXECUTION = "execution"
     THOUGHTS = "thoughts"
     TASK_EVENTS = "task_events"
+    USAGE = "usage"
+
+
+@dataclass(frozen=True)
+class TurnUsage:
+    """Token usage for a single agent turn, framework-agnostic.
+
+    Each adapter maps its response object's usage fields onto these four
+    dimensions (see the per-adapter table in the cost/token plan). A turn that
+    makes several LLM calls (a tool loop) sums the per-call usage into one
+    ``TurnUsage`` via ``+`` before emitting, so the record reflects the whole
+    turn, not the last call.
+
+    Zero is a valid value for any single dimension (a framework may not report
+    it); ``is_empty`` is the "nothing was reported at all" signal that gates
+    emission — an adapter that cannot observe usage never emits, and the toolkit
+    records N-A rather than a misleading all-zero record.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+    def __add__(self, other: TurnUsage) -> TurnUsage:
+        """Sum two per-call usages (used to aggregate across a tool loop)."""
+        return TurnUsage(
+            input_tokens=self.input_tokens + other.input_tokens,
+            output_tokens=self.output_tokens + other.output_tokens,
+            cache_read_tokens=self.cache_read_tokens + other.cache_read_tokens,
+            cache_write_tokens=self.cache_write_tokens + other.cache_write_tokens,
+        )
+
+    @property
+    def total_tokens(self) -> int:
+        """Input + output tokens (cache fields are a subset breakdown of input,
+        so they are not added again here)."""
+        return self.input_tokens + self.output_tokens
+
+    @property
+    def is_empty(self) -> bool:
+        """True when no dimension was reported — the signal to skip emission."""
+        return not (
+            self.input_tokens
+            or self.output_tokens
+            or self.cache_read_tokens
+            or self.cache_write_tokens
+        )
+
+    def to_dict(self) -> dict[str, int]:
+        """Serialize for the usage event payload (content JSON + metadata)."""
+        return {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_write_tokens": self.cache_write_tokens,
+        }
+
+
+# Usage rides an already-accepted ``task`` event's free-form metadata (the path
+# codex already proves) rather than a dedicated ``usage`` message_type: the
+# backend's message_type whitelist rejects unknown types today, so a first-class
+# ``usage`` type would need a platform change + deploy first. Emit and read both
+# key off these two constants, so when the platform gains a ``usage`` type this
+# is a one-line flip (``USAGE_EVENT_TYPE = MessageType.USAGE``) — the discriminator
+# key is what a read filters on to tell a usage-bearing task event apart from a
+# lifecycle one.
+USAGE_EVENT_TYPE: MessageType = MessageType.TASK
+USAGE_METADATA_KEY: str = "band_usage"
 
 
 @dataclass(frozen=True)

--- a/src/band/integrations/acp/event_converter.py
+++ b/src/band/integrations/acp/event_converter.py
@@ -17,7 +17,7 @@ from acp import (
 )
 
 from band.converters._tool_parsing import parse_tool_call, parse_tool_result
-from band.core.types import PlatformMessage
+from band.core.types import PlatformMessage, is_usage_event
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +52,12 @@ class EventConverter:
             case "error":
                 return update_agent_message_text(f"[Error] {msg.content}")
             case "task":
+                # Usage records ride task events (USAGE_EVENT_TYPE) but are not
+                # lifecycle tasks — don't render them as a (never-completing)
+                # plan entry in the editor. There's no ACP cost widget yet, so
+                # skip; a dedicated usage session-update is INT-933.
+                if is_usage_event(msg.metadata):
+                    return None
                 return update_plan([plan_entry(msg.content, status="in_progress")])
             case _:
                 logger.debug("Unmapped message type %s, skipping", msg.message_type)

--- a/src/band/integrations/acp/event_converter.py
+++ b/src/band/integrations/acp/event_converter.py
@@ -53,9 +53,8 @@ class EventConverter:
                 return update_agent_message_text(f"[Error] {msg.content}")
             case "task":
                 # Usage records ride task events (USAGE_EVENT_TYPE) but are not
-                # lifecycle tasks — don't render them as a (never-completing)
-                # plan entry in the editor. There's no ACP cost widget yet, so
-                # skip; a dedicated usage session-update is INT-933.
+                # lifecycle tasks — don't render them as a (never-completing) plan
+                # entry in the editor. No ACP cost widget yet, so skip them.
                 if is_usage_event(msg.metadata):
                     return None
                 return update_plan([plan_entry(msg.content, status="in_progress")])

--- a/tests/adapters/langgraph/test_stream_events.py
+++ b/tests/adapters/langgraph/test_stream_events.py
@@ -1,11 +1,67 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
 from band.adapters.langgraph import LangGraphAdapter
-from band.core.types import AdapterFeatures, Emit
+from band.core.types import (
+    USAGE_EVENT_TYPE,
+    USAGE_METADATA_KEY,
+    AdapterFeatures,
+    Emit,
+    TurnUsage,
+)
+
+
+class TestUsageReporting:
+    """Tests for the Emit.USAGE seam (usage mapping + emission)."""
+
+    def test_usage_from_on_chat_model_end(self):
+        """Maps AIMessage.usage_metadata (incl. cache token details) to TurnUsage."""
+        output = SimpleNamespace(
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "input_token_details": {"cache_read": 5, "cache_creation": 3},
+            }
+        )
+        event = {"event": "on_chat_model_end", "data": {"output": output}}
+        assert LangGraphAdapter._usage_from_stream_event(event) == TurnUsage(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=3,
+        )
+
+    def test_usage_from_non_model_event_is_empty(self):
+        """Non-model events (and non-dict events) contribute empty usage."""
+        assert (
+            LangGraphAdapter._usage_from_stream_event(
+                {"event": "on_tool_end", "data": {}}
+            )
+            == TurnUsage()
+        )
+        assert LangGraphAdapter._usage_from_stream_event("not a dict") == TurnUsage()
+
+    @pytest.mark.asyncio
+    async def test_emits_usage_event_when_enabled(
+        self, mock_tools, mock_llm, mock_checkpointer
+    ):
+        """With Emit.USAGE on, a non-empty TurnUsage rides a task event's metadata."""
+        adapter = LangGraphAdapter(
+            llm=mock_llm,
+            checkpointer=mock_checkpointer,
+            features=AdapterFeatures(emit=frozenset({Emit.USAGE})),
+        )
+        await adapter.emit_usage(
+            mock_tools, TurnUsage(input_tokens=100, output_tokens=20)
+        )
+        mock_tools.send_event.assert_awaited_once()
+        kwargs = mock_tools.send_event.call_args.kwargs
+        assert kwargs["message_type"] == USAGE_EVENT_TYPE
+        assert kwargs["metadata"][USAGE_METADATA_KEY]["input_tokens"] == 100
 
 
 class TestStreamEventHandling:

--- a/tests/adapters/test_anthropic_adapter.py
+++ b/tests/adapters/test_anthropic_adapter.py
@@ -14,7 +14,7 @@ import pytest
 from pydantic import BaseModel, Field
 
 from band.adapters.anthropic import AnthropicAdapter
-from band.core.types import PlatformMessage
+from band.core.types import AdapterFeatures, Emit, PlatformMessage, TurnUsage
 
 
 @pytest.fixture
@@ -317,6 +317,77 @@ class TestToolExecution:
 
         assert "Failed to send tool_call event: 403 Forbidden" in caplog.text
         assert "Failed to send tool_result event: 403 Forbidden" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_usage_from_response_maps_and_sums(self):
+        """`_usage_from_response` maps Anthropic usage; TurnUsage `+` sums a loop."""
+        first = MagicMock()
+        first.usage = MagicMock(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_input_tokens=5,
+            cache_creation_input_tokens=0,
+        )
+        second = MagicMock()
+        second.usage = MagicMock(
+            input_tokens=130,
+            output_tokens=8,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+        )
+        total = AnthropicAdapter._usage_from_response(
+            first
+        ) + AnthropicAdapter._usage_from_response(second)
+        assert total == TurnUsage(
+            input_tokens=230,
+            output_tokens=28,
+            cache_read_tokens=5,
+            cache_write_tokens=0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_emits_usage_event_when_enabled(self, mock_tools):
+        """With Emit.USAGE on, a non-empty TurnUsage rides a task event's metadata."""
+        from band.core.types import USAGE_EVENT_TYPE, USAGE_METADATA_KEY
+
+        adapter = AnthropicAdapter(features=AdapterFeatures(emit={Emit.USAGE}))
+
+        await adapter.emit_usage(
+            mock_tools, TurnUsage(input_tokens=100, output_tokens=20)
+        )
+
+        mock_tools.send_event.assert_awaited_once()
+        _, kwargs = mock_tools.send_event.call_args
+        assert kwargs["message_type"] == USAGE_EVENT_TYPE
+        payload = kwargs["metadata"][USAGE_METADATA_KEY]
+        assert payload["input_tokens"] == 100
+        assert payload["output_tokens"] == 20
+
+    @pytest.mark.asyncio
+    async def test_does_not_emit_usage_when_feature_off(self, mock_tools):
+        """Without Emit.USAGE, emit_usage is a no-op (no event)."""
+        adapter = AnthropicAdapter()  # no emit features
+        await adapter.emit_usage(
+            mock_tools, TurnUsage(input_tokens=100, output_tokens=20)
+        )
+        mock_tools.send_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_emit_empty_usage(self, mock_tools):
+        """An all-zero TurnUsage is skipped even with the feature on (no false zero)."""
+        adapter = AnthropicAdapter(features=AdapterFeatures(emit={Emit.USAGE}))
+        await adapter.emit_usage(mock_tools, TurnUsage())
+        mock_tools.send_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_usage_emit_failure_does_not_crash(self, mock_tools):
+        """A send_event failure during usage emit is swallowed (best-effort)."""
+        adapter = AnthropicAdapter(features=AdapterFeatures(emit={Emit.USAGE}))
+        mock_tools.send_event.side_effect = Exception("403 Forbidden")
+        # Should not raise.
+        await adapter.emit_usage(
+            mock_tools, TurnUsage(input_tokens=100, output_tokens=20)
+        )
 
     @pytest.mark.asyncio
     async def test_handles_tool_error(self, mock_tools):

--- a/tests/adapters/test_anthropic_adapter.py
+++ b/tests/adapters/test_anthropic_adapter.py
@@ -320,13 +320,17 @@ class TestToolExecution:
 
     @pytest.mark.asyncio
     async def test_usage_from_response_maps_and_sums(self):
-        """`_usage_from_response` maps Anthropic usage; TurnUsage `+` sums a loop."""
+        """`_usage_from_response` maps Anthropic usage; TurnUsage `+` sums a loop.
+
+        Anthropic's input_tokens EXCLUDES cache, so per the TurnUsage convention
+        the mapper folds cache_read+cache_write into input_tokens (total prompt).
+        """
         first = MagicMock()
         first.usage = MagicMock(
             input_tokens=100,
             output_tokens=20,
             cache_read_input_tokens=5,
-            cache_creation_input_tokens=0,
+            cache_creation_input_tokens=3,
         )
         second = MagicMock()
         second.usage = MagicMock(
@@ -338,11 +342,12 @@ class TestToolExecution:
         total = AnthropicAdapter._usage_from_response(
             first
         ) + AnthropicAdapter._usage_from_response(second)
+        # input = (100+5+3) + 130 = 238 (cache folded into total prompt)
         assert total == TurnUsage(
-            input_tokens=230,
+            input_tokens=238,
             output_tokens=28,
             cache_read_tokens=5,
-            cache_write_tokens=0,
+            cache_write_tokens=3,
         )
 
     @pytest.mark.asyncio

--- a/tests/adapters/test_anthropic_adapter.py
+++ b/tests/adapters/test_anthropic_adapter.py
@@ -320,10 +320,10 @@ class TestToolExecution:
 
     @pytest.mark.asyncio
     async def test_usage_from_response_maps_and_sums(self):
-        """`_usage_from_response` maps Anthropic usage; TurnUsage `+` sums a loop.
+        """`_usage_from_response` maps Anthropic usage raw; TurnUsage `+` sums a loop.
 
-        Anthropic's input_tokens EXCLUDES cache, so per the TurnUsage convention
-        the mapper folds cache_read+cache_write into input_tokens (total prompt).
+        Raw per the convention: Anthropic's input_tokens excludes cache (reported
+        separately), so it's passed through, not folded.
         """
         first = MagicMock()
         first.usage = MagicMock(
@@ -342,9 +342,8 @@ class TestToolExecution:
         total = AnthropicAdapter._usage_from_response(
             first
         ) + AnthropicAdapter._usage_from_response(second)
-        # input = (100+5+3) + 130 = 238 (cache folded into total prompt)
         assert total == TurnUsage(
-            input_tokens=238,
+            input_tokens=230,
             output_tokens=28,
             cache_read_tokens=5,
             cache_write_tokens=3,

--- a/tests/adapters/test_anthropic_adapter.py
+++ b/tests/adapters/test_anthropic_adapter.py
@@ -390,6 +390,85 @@ class TestToolExecution:
         )
 
     @pytest.mark.asyncio
+    async def test_emits_summed_usage_across_tool_loop(
+        self, sample_message, mock_tools
+    ):
+        """A multi-call tool loop emits ONE usage event carrying the SUM.
+
+        The turn makes two model calls (a tool_use round then a final answer);
+        the emitted usage must be call1 + call2, proving the adapter accumulates
+        across the loop rather than reporting only the first or last call. This
+        is the deterministic summing proof the live smoke can't give (it never
+        sees the per-call intermediates).
+        """
+        from types import SimpleNamespace
+
+        from anthropic.types import TextBlock, ToolUseBlock
+
+        from band.core.types import USAGE_EVENT_TYPE, USAGE_METADATA_KEY
+
+        adapter = AnthropicAdapter(features=AdapterFeatures(emit={Emit.USAGE}))
+
+        def _usage(inp: int, out: int) -> SimpleNamespace:
+            return SimpleNamespace(
+                input_tokens=inp,
+                output_tokens=out,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=0,
+            )
+
+        # Call 1: a tool_use round (continues the loop). Call 2: the final answer.
+        resp1 = SimpleNamespace(
+            stop_reason="tool_use",
+            content=[
+                ToolUseBlock(
+                    type="tool_use",
+                    id="tool-1",
+                    name="band_send_message",
+                    input={"content": "hi"},
+                )
+            ],
+            usage=_usage(100, 20),
+        )
+        resp2 = SimpleNamespace(
+            stop_reason="end_turn",
+            content=[TextBlock(type="text", text="Hello!")],
+            usage=_usage(130, 8),
+        )
+
+        mock_tools.execute_tool_call.return_value = {"status": "success"}
+        call_anthropic = AsyncMock(side_effect=[resp1, resp2])
+        with patch.object(adapter, "_call_anthropic", new=call_anthropic):
+            await adapter.on_message(
+                msg=sample_message,
+                tools=mock_tools,
+                history=[],
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-123",
+            )
+
+        # Exactly two model calls were made (the loop ran twice).
+        assert call_anthropic.call_count == 2
+        # Find the single usage event and assert it carries the SUM (230/28),
+        # not just the first (100/20) or last (130/8) call.
+        usage_payloads = [
+            call.kwargs["metadata"][USAGE_METADATA_KEY]
+            for call in mock_tools.send_event.await_args_list
+            if call.kwargs.get("message_type") == USAGE_EVENT_TYPE
+            and USAGE_METADATA_KEY in (call.kwargs.get("metadata") or {})
+        ]
+        assert usage_payloads == [
+            {
+                "input_tokens": 230,
+                "output_tokens": 28,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+            }
+        ], f"expected one summed usage event, got {usage_payloads}"
+
+    @pytest.mark.asyncio
     async def test_handles_tool_error(self, mock_tools):
         """Should handle tool execution errors gracefully."""
         from anthropic.types import ToolUseBlock

--- a/tests/adapters/test_anthropic_adapter.py
+++ b/tests/adapters/test_anthropic_adapter.py
@@ -8,6 +8,7 @@ message history management, tool execution, custom tools, and error handling.
 """
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -16,6 +17,20 @@ from pydantic import BaseModel, Field
 from band.adapters.anthropic import AnthropicAdapter
 from band.core.types import AdapterFeatures, Emit, PlatformMessage, TurnUsage
 from tests.adapters.usage_events import sent_usage_payloads
+
+
+def make_usage(inp: int, out: int) -> SimpleNamespace:
+    """Anthropic-shaped usage stub (cache fields zeroed).
+
+    One home for the provider's usage field spelling so a rename is a
+    single edit.
+    """
+    return SimpleNamespace(
+        input_tokens=inp,
+        output_tokens=out,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
 
 
 @pytest.fixture
@@ -395,6 +410,32 @@ class TestToolExecution:
         )
 
     @pytest.mark.asyncio
+    async def test_usage_emit_skipped_during_task_cancellation(self, mock_tools):
+        """A cancelled turn must not fire usage I/O from its finally: teardown
+        (shutdown, a turn timeout) would otherwise block on a REST call, and a
+        CancelledError raised mid-send could skip later cleanup."""
+        import asyncio
+
+        adapter = AnthropicAdapter(features=AdapterFeatures(emit={Emit.USAGE}))
+        started = asyncio.Event()
+
+        async def turn() -> None:
+            try:
+                started.set()
+                await asyncio.sleep(30)
+            finally:
+                await adapter.emit_usage(
+                    mock_tools, TurnUsage(input_tokens=1, output_tokens=1)
+                )
+
+        task = asyncio.create_task(turn())
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        mock_tools.send_event.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_emits_summed_usage_across_tool_loop(
         self, sample_message, mock_tools
     ):
@@ -406,19 +447,9 @@ class TestToolExecution:
         is the deterministic summing proof the live smoke can't give (it never
         sees the per-call intermediates).
         """
-        from types import SimpleNamespace
-
         from anthropic.types import TextBlock, ToolUseBlock
 
         adapter = AnthropicAdapter(features=AdapterFeatures(emit={Emit.USAGE}))
-
-        def _usage(inp: int, out: int) -> SimpleNamespace:
-            return SimpleNamespace(
-                input_tokens=inp,
-                output_tokens=out,
-                cache_read_input_tokens=0,
-                cache_creation_input_tokens=0,
-            )
 
         # Call 1: a tool_use round (continues the loop). Call 2: the final answer.
         resp1 = SimpleNamespace(
@@ -431,12 +462,12 @@ class TestToolExecution:
                     input={"content": "hi"},
                 )
             ],
-            usage=_usage(100, 20),
+            usage=make_usage(100, 20),
         )
         resp2 = SimpleNamespace(
             stop_reason="end_turn",
             content=[TextBlock(type="text", text="Hello!")],
-            usage=_usage(130, 8),
+            usage=make_usage(130, 8),
         )
 
         mock_tools.execute_tool_call.return_value = {"status": "success"}
@@ -456,7 +487,7 @@ class TestToolExecution:
         assert call_anthropic.call_count == 2
         # Find the single usage event and assert it carries the SUM (230/28),
         # not just the first (100/20) or last (130/8) call.
-        usage_payloads = sent_usage_payloads(mock_tools.send_event)
+        usage_payloads = sent_usage_payloads(mock_tools)
         assert usage_payloads == [
             {
                 "input_tokens": 230,
@@ -473,8 +504,6 @@ class TestToolExecution:
         """A tool loop that raises after a successful call still emits that
         call's usage: tokens spent before the failure were still spent. The
         exception still propagates (the turn is marked failed)."""
-        from types import SimpleNamespace
-
         from anthropic.types import ToolUseBlock
 
         adapter = AnthropicAdapter(features=AdapterFeatures(emit={Emit.USAGE}))
@@ -489,12 +518,7 @@ class TestToolExecution:
                     input={"content": "hi"},
                 )
             ],
-            usage=SimpleNamespace(
-                input_tokens=100,
-                output_tokens=20,
-                cache_read_input_tokens=0,
-                cache_creation_input_tokens=0,
-            ),
+            usage=make_usage(100, 20),
         )
 
         mock_tools.execute_tool_call.return_value = {"status": "success"}
@@ -511,7 +535,7 @@ class TestToolExecution:
                     room_id="room-123",
                 )
 
-        usage_payloads = sent_usage_payloads(mock_tools.send_event)
+        usage_payloads = sent_usage_payloads(mock_tools)
         assert usage_payloads == [
             {
                 "input_tokens": 100,

--- a/tests/adapters/test_anthropic_adapter.py
+++ b/tests/adapters/test_anthropic_adapter.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 
 from band.adapters.anthropic import AnthropicAdapter
 from band.core.types import AdapterFeatures, Emit, PlatformMessage, TurnUsage
+from tests.adapters.usage_events import sent_usage_payloads
 
 
 @pytest.fixture
@@ -409,8 +410,6 @@ class TestToolExecution:
 
         from anthropic.types import TextBlock, ToolUseBlock
 
-        from band.core.types import USAGE_EVENT_TYPE, USAGE_METADATA_KEY
-
         adapter = AnthropicAdapter(features=AdapterFeatures(emit={Emit.USAGE}))
 
         def _usage(inp: int, out: int) -> SimpleNamespace:
@@ -457,12 +456,7 @@ class TestToolExecution:
         assert call_anthropic.call_count == 2
         # Find the single usage event and assert it carries the SUM (230/28),
         # not just the first (100/20) or last (130/8) call.
-        usage_payloads = [
-            call.kwargs["metadata"][USAGE_METADATA_KEY]
-            for call in mock_tools.send_event.await_args_list
-            if call.kwargs.get("message_type") == USAGE_EVENT_TYPE
-            and USAGE_METADATA_KEY in (call.kwargs.get("metadata") or {})
-        ]
+        usage_payloads = sent_usage_payloads(mock_tools.send_event)
         assert usage_payloads == [
             {
                 "input_tokens": 230,
@@ -471,6 +465,61 @@ class TestToolExecution:
                 "cache_write_tokens": 0,
             }
         ], f"expected one summed usage event, got {usage_payloads}"
+
+    @pytest.mark.asyncio
+    async def test_emits_accumulated_usage_when_loop_fails_midway(
+        self, sample_message, mock_tools
+    ):
+        """A tool loop that raises after a successful call still emits that
+        call's usage: tokens spent before the failure were still spent. The
+        exception still propagates (the turn is marked failed)."""
+        from types import SimpleNamespace
+
+        from anthropic.types import ToolUseBlock
+
+        adapter = AnthropicAdapter(features=AdapterFeatures(emit={Emit.USAGE}))
+
+        resp1 = SimpleNamespace(
+            stop_reason="tool_use",
+            content=[
+                ToolUseBlock(
+                    type="tool_use",
+                    id="tool-1",
+                    name="band_send_message",
+                    input={"content": "hi"},
+                )
+            ],
+            usage=SimpleNamespace(
+                input_tokens=100,
+                output_tokens=20,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=0,
+            ),
+        )
+
+        mock_tools.execute_tool_call.return_value = {"status": "success"}
+        call_anthropic = AsyncMock(side_effect=[resp1, RuntimeError("boom")])
+        with patch.object(adapter, "_call_anthropic", new=call_anthropic):
+            with pytest.raises(RuntimeError, match="boom"):
+                await adapter.on_message(
+                    msg=sample_message,
+                    tools=mock_tools,
+                    history=[],
+                    participants_msg=None,
+                    contacts_msg=None,
+                    is_session_bootstrap=True,
+                    room_id="room-123",
+                )
+
+        usage_payloads = sent_usage_payloads(mock_tools.send_event)
+        assert usage_payloads == [
+            {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+            }
+        ], f"expected the first call's usage to be emitted, got {usage_payloads}"
 
     @pytest.mark.asyncio
     async def test_handles_tool_error(self, mock_tools):

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -44,20 +44,6 @@ def crewai_mocks(monkeypatch):
     mock_crewai_module.LLM = MagicMock()
     mock_crewai_tools_module.BaseTool = MockBaseTool
 
-    # The adapter reads token usage off CrewAI's event bus (LLMCallCompletedEvent);
-    # it imports ``crewai.events`` / ``crewai.events.types.llm_events`` locally in
-    # on_message. Submodule imports (`from crewai.events import ...`) need real
-    # sys.modules entries — a MagicMock on ``crewai`` alone doesn't satisfy them —
-    # so register lightweight module stubs. A real class stands in for the event
-    # type so isinstance/type hints behave.
-    class LLMCallCompletedEvent:  # minimal stand-in for the event type
-        usage: dict | None = None
-
-    mock_crewai_events = MagicMock()
-    mock_crewai_events.crewai_event_bus = MagicMock()
-    mock_crewai_llm_events = MagicMock()
-    mock_crewai_llm_events.LLMCallCompletedEvent = LLMCallCompletedEvent
-
     # Evict any cached integration modules so they pick up the freshly-mocked
     # `nest_asyncio`/`crewai.tools` from sys.modules on next import.
     for mod in (
@@ -70,10 +56,6 @@ def crewai_mocks(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "crewai", mock_crewai_module)
     monkeypatch.setitem(sys.modules, "crewai.tools", mock_crewai_tools_module)
-    monkeypatch.setitem(sys.modules, "crewai.events", mock_crewai_events)
-    monkeypatch.setitem(
-        sys.modules, "crewai.events.types.llm_events", mock_crewai_llm_events
-    )
     monkeypatch.setitem(sys.modules, "nest_asyncio", mock_nest_asyncio)
 
     try:
@@ -1875,53 +1857,3 @@ class TestCustomTools:
         result_data = json.loads(result)
         assert result_data["status"] == "error"
         assert "No room context available" in result_data["message"]
-
-
-class TestUsageMapping:
-    """The Emit.USAGE mapper: CrewAI LLMCallCompletedEvent.usage dict -> TurnUsage.
-
-    Usage is captured per LLM call from the event bus (and summed across the
-    turn in ``_process_message``), so it survives the benign empty-final-answer
-    path where kickoff raises and no result/usage_metrics is returned.
-    """
-
-    def test_maps_event_usage_dict(self, CrewAIAdapter):
-        """LLMCallCompletedEvent.usage (a LiteLLM-shaped dict) maps onto TurnUsage."""
-        from types import SimpleNamespace
-
-        from band.core.types import TurnUsage
-
-        event = SimpleNamespace(
-            usage={
-                "prompt_tokens": 100,
-                "completion_tokens": 20,
-                "total_tokens": 120,
-            }
-        )
-        assert CrewAIAdapter._usage_from_event(event) == TurnUsage(
-            input_tokens=100,
-            output_tokens=20,
-        )
-
-    def test_summing_across_calls(self, CrewAIAdapter):
-        """Per-call usages sum into the turn total (the loop accumulation)."""
-        from types import SimpleNamespace
-
-        from band.core.types import TurnUsage
-
-        call1 = SimpleNamespace(usage={"prompt_tokens": 100, "completion_tokens": 20})
-        call2 = SimpleNamespace(usage={"prompt_tokens": 130, "completion_tokens": 8})
-        total = CrewAIAdapter._usage_from_event(
-            call1
-        ) + CrewAIAdapter._usage_from_event(call2)
-        assert total == TurnUsage(input_tokens=230, output_tokens=28)
-
-    def test_missing_usage_is_empty(self, CrewAIAdapter):
-        """An event with usage=None yields empty usage."""
-        from types import SimpleNamespace
-
-        from band.core.types import TurnUsage
-
-        assert (
-            CrewAIAdapter._usage_from_event(SimpleNamespace(usage=None)) == TurnUsage()
-        )

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -44,6 +44,20 @@ def crewai_mocks(monkeypatch):
     mock_crewai_module.LLM = MagicMock()
     mock_crewai_tools_module.BaseTool = MockBaseTool
 
+    # The adapter reads token usage off CrewAI's event bus (LLMCallCompletedEvent);
+    # it imports ``crewai.events`` / ``crewai.events.types.llm_events`` locally in
+    # on_message. Submodule imports (`from crewai.events import ...`) need real
+    # sys.modules entries — a MagicMock on ``crewai`` alone doesn't satisfy them —
+    # so register lightweight module stubs. A real class stands in for the event
+    # type so isinstance/type hints behave.
+    class LLMCallCompletedEvent:  # minimal stand-in for the event type
+        usage: dict | None = None
+
+    mock_crewai_events = MagicMock()
+    mock_crewai_events.crewai_event_bus = MagicMock()
+    mock_crewai_llm_events = MagicMock()
+    mock_crewai_llm_events.LLMCallCompletedEvent = LLMCallCompletedEvent
+
     # Evict any cached integration modules so they pick up the freshly-mocked
     # `nest_asyncio`/`crewai.tools` from sys.modules on next import.
     for mod in (
@@ -56,6 +70,10 @@ def crewai_mocks(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "crewai", mock_crewai_module)
     monkeypatch.setitem(sys.modules, "crewai.tools", mock_crewai_tools_module)
+    monkeypatch.setitem(sys.modules, "crewai.events", mock_crewai_events)
+    monkeypatch.setitem(
+        sys.modules, "crewai.events.types.llm_events", mock_crewai_llm_events
+    )
     monkeypatch.setitem(sys.modules, "nest_asyncio", mock_nest_asyncio)
 
     try:
@@ -1860,36 +1878,50 @@ class TestCustomTools:
 
 
 class TestUsageMapping:
-    """The Emit.USAGE mapper: CrewAI usage_metrics dict -> TurnUsage."""
+    """The Emit.USAGE mapper: CrewAI LLMCallCompletedEvent.usage dict -> TurnUsage.
 
-    def test_maps_usage_metrics_dict(self, CrewAIAdapter):
-        """LiteAgentOutput.usage_metrics (a dict) maps onto TurnUsage."""
+    Usage is captured per LLM call from the event bus (and summed across the
+    turn in ``_process_message``), so it survives the benign empty-final-answer
+    path where kickoff raises and no result/usage_metrics is returned.
+    """
+
+    def test_maps_event_usage_dict(self, CrewAIAdapter):
+        """LLMCallCompletedEvent.usage (a LiteLLM-shaped dict) maps onto TurnUsage."""
         from types import SimpleNamespace
 
         from band.core.types import TurnUsage
 
-        result = SimpleNamespace(
-            usage_metrics={
+        event = SimpleNamespace(
+            usage={
                 "prompt_tokens": 100,
                 "completion_tokens": 20,
-                "cached_prompt_tokens": 5,
-                "cache_creation_tokens": 3,
+                "total_tokens": 120,
             }
         )
-        assert CrewAIAdapter._usage_from_result(result) == TurnUsage(
+        assert CrewAIAdapter._usage_from_event(event) == TurnUsage(
             input_tokens=100,
             output_tokens=20,
-            cache_read_tokens=5,
-            cache_write_tokens=3,
         )
 
-    def test_missing_usage_metrics_is_empty(self, CrewAIAdapter):
-        """A result with usage_metrics=None yields empty usage."""
+    def test_summing_across_calls(self, CrewAIAdapter):
+        """Per-call usages sum into the turn total (the loop accumulation)."""
+        from types import SimpleNamespace
+
+        from band.core.types import TurnUsage
+
+        call1 = SimpleNamespace(usage={"prompt_tokens": 100, "completion_tokens": 20})
+        call2 = SimpleNamespace(usage={"prompt_tokens": 130, "completion_tokens": 8})
+        total = CrewAIAdapter._usage_from_event(
+            call1
+        ) + CrewAIAdapter._usage_from_event(call2)
+        assert total == TurnUsage(input_tokens=230, output_tokens=28)
+
+    def test_missing_usage_is_empty(self, CrewAIAdapter):
+        """An event with usage=None yields empty usage."""
         from types import SimpleNamespace
 
         from band.core.types import TurnUsage
 
         assert (
-            CrewAIAdapter._usage_from_result(SimpleNamespace(usage_metrics=None))
-            == TurnUsage()
+            CrewAIAdapter._usage_from_event(SimpleNamespace(usage=None)) == TurnUsage()
         )

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -1857,3 +1857,39 @@ class TestCustomTools:
         result_data = json.loads(result)
         assert result_data["status"] == "error"
         assert "No room context available" in result_data["message"]
+
+
+class TestUsageMapping:
+    """The Emit.USAGE mapper: CrewAI usage_metrics dict -> TurnUsage."""
+
+    def test_maps_usage_metrics_dict(self, CrewAIAdapter):
+        """LiteAgentOutput.usage_metrics (a dict) maps onto TurnUsage."""
+        from types import SimpleNamespace
+
+        from band.core.types import TurnUsage
+
+        result = SimpleNamespace(
+            usage_metrics={
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "cached_prompt_tokens": 5,
+                "cache_creation_tokens": 3,
+            }
+        )
+        assert CrewAIAdapter._usage_from_result(result) == TurnUsage(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=3,
+        )
+
+    def test_missing_usage_metrics_is_empty(self, CrewAIAdapter):
+        """A result with usage_metrics=None yields empty usage."""
+        from types import SimpleNamespace
+
+        from band.core.types import TurnUsage
+
+        assert (
+            CrewAIAdapter._usage_from_result(SimpleNamespace(usage_metrics=None))
+            == TurnUsage()
+        )

--- a/tests/adapters/test_crewai_adapter_soak.py
+++ b/tests/adapters/test_crewai_adapter_soak.py
@@ -35,17 +35,6 @@ def crewai_mocks(monkeypatch):
     mock_crewai_module.LLM = MagicMock()
     mock_crewai_tools_module.BaseTool = MockBaseTool
 
-    # The adapter reads usage off CrewAI's event bus (imports crewai.events /
-    # crewai.events.types.llm_events locally in on_message); submodule imports
-    # need real sys.modules entries, so stub them.
-    class LLMCallCompletedEvent:
-        usage: dict | None = None
-
-    mock_crewai_events = MagicMock()
-    mock_crewai_events.crewai_event_bus = MagicMock()
-    mock_crewai_llm_events = MagicMock()
-    mock_crewai_llm_events.LLMCallCompletedEvent = LLMCallCompletedEvent
-
     for mod in (
         "band.adapters.crewai",
         "band.integrations.crewai",
@@ -56,10 +45,6 @@ def crewai_mocks(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "crewai", mock_crewai_module)
     monkeypatch.setitem(sys.modules, "crewai.tools", mock_crewai_tools_module)
-    monkeypatch.setitem(sys.modules, "crewai.events", mock_crewai_events)
-    monkeypatch.setitem(
-        sys.modules, "crewai.events.types.llm_events", mock_crewai_llm_events
-    )
     monkeypatch.setitem(sys.modules, "nest_asyncio", mock_nest_asyncio)
 
     try:

--- a/tests/adapters/test_crewai_adapter_soak.py
+++ b/tests/adapters/test_crewai_adapter_soak.py
@@ -35,6 +35,17 @@ def crewai_mocks(monkeypatch):
     mock_crewai_module.LLM = MagicMock()
     mock_crewai_tools_module.BaseTool = MockBaseTool
 
+    # The adapter reads usage off CrewAI's event bus (imports crewai.events /
+    # crewai.events.types.llm_events locally in on_message); submodule imports
+    # need real sys.modules entries, so stub them.
+    class LLMCallCompletedEvent:
+        usage: dict | None = None
+
+    mock_crewai_events = MagicMock()
+    mock_crewai_events.crewai_event_bus = MagicMock()
+    mock_crewai_llm_events = MagicMock()
+    mock_crewai_llm_events.LLMCallCompletedEvent = LLMCallCompletedEvent
+
     for mod in (
         "band.adapters.crewai",
         "band.integrations.crewai",
@@ -45,6 +56,10 @@ def crewai_mocks(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "crewai", mock_crewai_module)
     monkeypatch.setitem(sys.modules, "crewai.tools", mock_crewai_tools_module)
+    monkeypatch.setitem(sys.modules, "crewai.events", mock_crewai_events)
+    monkeypatch.setitem(
+        sys.modules, "crewai.events.types.llm_events", mock_crewai_llm_events
+    )
     monkeypatch.setitem(sys.modules, "nest_asyncio", mock_nest_asyncio)
 
     try:

--- a/tests/adapters/test_deprecation_shims.py
+++ b/tests/adapters/test_deprecation_shims.py
@@ -212,11 +212,11 @@ class TestUniversalBooleanShims:
         assert Emit.TASK_EVENTS not in adapter.features.emit
 
     def test_codex_supported_features_surface(self) -> None:
-        """SUPPORTED_EMIT advertises the three Codex-supported emit channels."""
+        """SUPPORTED_EMIT advertises the Codex-supported emit channels."""
         from band.adapters.codex import CodexAdapter
 
         assert CodexAdapter.SUPPORTED_EMIT == frozenset(
-            {Emit.EXECUTION, Emit.THOUGHTS, Emit.TASK_EVENTS}
+            {Emit.EXECUTION, Emit.THOUGHTS, Emit.TASK_EVENTS, Emit.USAGE}
         )
 
 

--- a/tests/adapters/test_opencode_adapter.py
+++ b/tests/adapters/test_opencode_adapter.py
@@ -15,9 +15,10 @@ from pydantic import BaseModel
 
 from band.adapters.opencode import OpencodeAdapter, OpencodeAdapterConfig
 from band.core.protocols import AgentToolsProtocol
-from band.core.types import PlatformMessage
+from band.core.types import AdapterFeatures, Emit, PlatformMessage, TurnUsage
 from band.integrations.opencode.types import OpencodeSessionState
 from band.testing import FakeAgentTools
+from tests.adapters.usage_events import recorded_usage_payloads
 
 
 def make_platform_message(
@@ -923,6 +924,43 @@ class TestOpencodeAdapter:
         error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert error_events
         assert "boom" in error_events[0]["content"].lower()
+
+    @pytest.mark.asyncio
+    async def test_new_turn_does_not_wipe_prior_turns_pending_usage(self) -> None:
+        """Regression: a message racing in between turn completion and the usage
+        drain must not empty the prior turn's usage. The dict is turn-owned (a
+        fresh instance per _begin_turn), so the watch task sums the instance it
+        captured, not whatever the room currently points at."""
+        adapter = OpencodeAdapter(
+            client_factory=lambda _config: FakeOpencodeClient(),
+            features=AdapterFeatures(emit={Emit.USAGE}),
+        )
+        tools = FakeAgentTools()
+        room_state = await adapter._get_or_create_room_state("room-1")
+        room_state.tools = tools_protocol(tools)
+
+        adapter._begin_turn(room_state, sender_id="user-1")
+        room_state.usage_by_message["msg-1"] = TurnUsage(
+            input_tokens=100, output_tokens=20
+        )
+        # What on_message hands this turn's watch task.
+        first_turn_usage = room_state.usage_by_message
+
+        # The next turn begins before the first turn's usage is drained.
+        adapter._begin_turn(room_state, sender_id="user-2")
+        assert room_state.usage_by_message == {}
+
+        await adapter._emit_turn_usage(room_state, first_turn_usage)
+
+        usage_payloads = recorded_usage_payloads(tools)
+        assert usage_payloads == [
+            {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+            }
+        ], f"expected the first turn's usage to survive, got {usage_payloads}"
 
     @pytest.mark.asyncio
     async def test_cleanup_is_idempotent(self) -> None:

--- a/tests/adapters/test_opencode_adapter.py
+++ b/tests/adapters/test_opencode_adapter.py
@@ -926,6 +926,58 @@ class TestOpencodeAdapter:
         assert "boom" in error_events[0]["content"].lower()
 
     @pytest.mark.asyncio
+    async def test_watch_task_drains_the_turn_that_started_it(self) -> None:
+        """Regression: the turn's future and usage dict are snapshotted before
+        the prompt await. When the turn completes while prompt_async's POST is
+        still open and a racing message begins the next turn, the resumed
+        on_message must still drain ITS turn's usage, not the new turn's
+        (empty) dict."""
+        fake_client = FakeOpencodeClient(prompt_event_sequences=[[]])
+        adapter = OpencodeAdapter(
+            client_factory=lambda _config: fake_client,
+            features=AdapterFeatures(emit={Emit.USAGE}),
+        )
+        tools = FakeAgentTools()
+        await adapter.on_started("OpenCode Agent", "A coding agent")
+
+        room_state = await adapter._get_or_create_room_state("room-1")
+        orig_prompt = fake_client.prompt_async
+
+        async def racing_prompt(*args: Any, **kwargs: Any) -> None:
+            # This turn's usage arrives and the turn completes while the
+            # prompt POST is still open...
+            room_state.usage_by_message["msg-1"] = TurnUsage(
+                input_tokens=100, output_tokens=20
+            )
+            adapter._finish_turn(room_state)
+            # ...and a racing message begins (and finishes) the next turn
+            # before the first on_message resumes.
+            adapter._begin_turn(room_state, sender_id="user-2")
+            adapter._finish_turn(room_state)
+            await orig_prompt(*args, **kwargs)
+
+        with patch.object(fake_client, "prompt_async", racing_prompt):
+            await adapter.on_message(
+                make_platform_message(),
+                tools_protocol(tools),
+                OpencodeSessionState(),
+                participants_msg=None,
+                contacts_msg=None,
+                is_session_bootstrap=True,
+                room_id="room-1",
+            )
+
+        usage_payloads = recorded_usage_payloads(tools)
+        assert usage_payloads == [
+            {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+            }
+        ], f"expected the first turn's snapshot to be drained, got {usage_payloads}"
+
+    @pytest.mark.asyncio
     async def test_new_turn_does_not_wipe_prior_turns_pending_usage(self) -> None:
         """Regression: a message racing in between turn completion and the usage
         drain must not empty the prior turn's usage. The dict is turn-owned (a

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -215,6 +215,53 @@ class TestUsageMapping:
             == TurnUsage()
         )
 
+    def test_new_run_messages_isolates_this_run_despite_history_merge(self):
+        """Identity (not position) isolates this run when pydantic-ai merges history.
+
+        Regression guard: pydantic-ai's ``_clean_message_history`` merges adjacent
+        same-type messages in the passed history (e.g. the injected participants +
+        contacts requests), so ``captured`` is *shorter* than the raw prior history
+        and a ``len(prior)`` slice would drop this turn's response. Real API
+        responses keep their identity, so the identity filter still isolates this
+        run — and combined with the ModelResponse-only sum, yields only this turn's
+        usage.
+        """
+        from types import SimpleNamespace
+
+        from pydantic_ai.messages import ModelRequest, ModelResponse, UserPromptPart
+
+        from band.core.types import TurnUsage
+
+        def response(inp, out):
+            r = ModelResponse.__new__(ModelResponse)
+            object.__setattr__(
+                r, "usage", SimpleNamespace(input_tokens=inp, output_tokens=out)
+            )
+            return r
+
+        # Prior history: a real response, then two instruction-less requests that
+        # pydantic-ai would merge into one on the next run.
+        prior_resp = response(100, 20)
+        req_participants = ModelRequest(parts=[UserPromptPart(content="[System]: p")])
+        req_contacts = ModelRequest(parts=[UserPromptPart(content="[System]: c")])
+        prior = [prior_resp, req_participants, req_contacts]
+        prior_ids = {id(m) for m in prior}
+
+        # captured after cleaning: prior_resp survives by identity, the two
+        # requests are merged into ONE new object, then this run's new response is
+        # appended. So len(captured)=3 < len(prior)=3+... a positional
+        # captured[len(prior):] would slice to empty and drop new_resp.
+        merged_req = ModelRequest(parts=[UserPromptPart(content="[System]: p\nc")])
+        new_resp = response(130, 8)
+        captured = [prior_resp, merged_req, new_resp]
+
+        this_run = PydanticAIAdapter._new_run_messages(captured, prior_ids)
+        # The merged request (new identity) rides along but carries no usage; only
+        # this run's response contributes.
+        assert PydanticAIAdapter._usage_from_messages(this_run) == TurnUsage(
+            input_tokens=130, output_tokens=8
+        )
+
 
 class TestInitialization:
     """Tests for adapter initialization."""

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -1077,6 +1077,74 @@ class TestEmptyFinalAnswer:
             )
 
     @pytest.mark.asyncio
+    async def test_failed_run_still_emits_captured_usage(
+        self, sample_message, mock_tools, mock_pydantic_agent
+    ):
+        """A run that raises still emits the usage its captured responses accrued.
+
+        Tokens spent before the failure were still spent: the finally-based emit
+        falls back to summing this run's captured ModelResponses when no result
+        event fired, so a hard mid-run failure doesn't silently drop usage."""
+        from contextlib import contextmanager
+        from types import SimpleNamespace
+
+        from band.core.types import Emit
+        from tests.adapters.usage_events import sent_usage_payloads
+
+        adapter = PydanticAIAdapter(
+            model="openai:gpt-5.4",
+            features=AdapterFeatures(emit={Emit.USAGE}),
+        )
+        with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
+            await adapter.on_started("TestBot", "Test bot")
+
+        adapter._agent.run_stream_events = MagicMock(
+            return_value=make_raising_stream(
+                UnexpectedModelBehavior("Received empty model response"),
+                tool_result=True,
+            )
+        )
+
+        # Simulate a run that captured a response with usage before raising.
+        failed_response = ModelResponse.__new__(ModelResponse)
+        object.__setattr__(
+            failed_response,
+            "usage",
+            SimpleNamespace(input_tokens=100, output_tokens=20),
+        )
+        object.__setattr__(failed_response, "parts", [TextPart(content="partial")])
+        captured_turn = [
+            ModelRequest(parts=[UserPromptPart(content="[Alice]: hi")]),
+            failed_response,
+        ]
+
+        @contextmanager
+        def fake_capture():
+            yield captured_turn
+
+        with patch("band.adapters.pydantic_ai.capture_run_messages", fake_capture):
+            with pytest.raises(UnexpectedModelBehavior):
+                await adapter.on_message(
+                    msg=sample_message,
+                    tools=mock_tools,
+                    history=[],
+                    participants_msg=None,
+                    contacts_msg=None,
+                    is_session_bootstrap=True,
+                    room_id="room-123",
+                )
+
+        usage_payloads = sent_usage_payloads(mock_tools.send_event)
+        assert usage_payloads == [
+            {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+            }
+        ], f"expected the captured run's usage to be emitted, got {usage_payloads}"
+
+    @pytest.mark.asyncio
     async def test_unrelated_model_error_propagates_even_after_tool(
         self, sample_message, mock_tools, mock_pydantic_agent
     ):

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -130,6 +130,53 @@ def mock_pydantic_agent():
     return agent
 
 
+class TestUsageMapping:
+    """Tests for the Emit.USAGE seam's usage mapping."""
+
+    def test_usage_from_result_current_field_names(self):
+        """Maps RunUsage.input_tokens/output_tokens to TurnUsage."""
+        from types import SimpleNamespace
+
+        from band.core.types import TurnUsage
+
+        result = MagicMock()
+        result.usage.return_value = SimpleNamespace(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=0,
+        )
+        assert PydanticAIAdapter._usage_from_result(result) == TurnUsage(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=0,
+        )
+
+    def test_usage_from_result_legacy_field_names(self):
+        """Falls back to the older request_tokens/response_tokens names."""
+        from types import SimpleNamespace
+
+        from band.core.types import TurnUsage
+
+        result = MagicMock()
+        result.usage.return_value = SimpleNamespace(
+            request_tokens=130,
+            response_tokens=8,
+        )
+        assert PydanticAIAdapter._usage_from_result(result) == TurnUsage(
+            input_tokens=130, output_tokens=8
+        )
+
+    def test_usage_from_result_swallows_errors(self):
+        """A usage() that raises yields empty usage, never propagates."""
+        from band.core.types import TurnUsage
+
+        result = MagicMock()
+        result.usage.side_effect = RuntimeError("no usage")
+        assert PydanticAIAdapter._usage_from_result(result) == TurnUsage()
+
+
 class TestInitialization:
     """Tests for adapter initialization."""
 

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -8,6 +8,7 @@ stream event handling, execution reporting, and custom tools.
 """
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -82,6 +83,21 @@ def make_stream_events(
         yield result_event
 
     return stream()
+
+
+def make_usage_response(
+    inp: int, out: int, parts: list[Any] | None = None
+) -> ModelResponse:
+    """A ModelResponse carrying explicit usage counts.
+
+    Real construction (fully initialized, so the dataclass stays repr-safe),
+    then the usage field is overridden past any frozen/validated assignment.
+    """
+    response = ModelResponse(parts=parts or [])
+    object.__setattr__(
+        response, "usage", SimpleNamespace(input_tokens=inp, output_tokens=out)
+    )
+    return response
 
 
 @pytest.fixture
@@ -182,23 +198,12 @@ class TestUsageMapping:
         Covers the empty-final-response path (no AgentRunResultEvent fires) where
         the turn still spent tokens — each ModelResponse carries its own usage.
         """
-        from types import SimpleNamespace
-
-        from pydantic_ai.messages import ModelRequest, ModelResponse
-
         from band.core.types import TurnUsage
-
-        def response(inp, out):
-            r = ModelResponse.__new__(ModelResponse)
-            object.__setattr__(
-                r, "usage", SimpleNamespace(input_tokens=inp, output_tokens=out)
-            )
-            return r
 
         messages = [
             ModelRequest(parts=[]),  # non-response: ignored
-            response(100, 20),
-            response(130, 8),
+            make_usage_response(100, 20),
+            make_usage_response(130, 8),
         ]
         assert PydanticAIAdapter._usage_from_messages(messages) == TurnUsage(
             input_tokens=230, output_tokens=28
@@ -226,22 +231,11 @@ class TestUsageMapping:
         run — and combined with the ModelResponse-only sum, yields only this turn's
         usage.
         """
-        from types import SimpleNamespace
-
-        from pydantic_ai.messages import ModelRequest, ModelResponse, UserPromptPart
-
         from band.core.types import TurnUsage
-
-        def response(inp, out):
-            r = ModelResponse.__new__(ModelResponse)
-            object.__setattr__(
-                r, "usage", SimpleNamespace(input_tokens=inp, output_tokens=out)
-            )
-            return r
 
         # Prior history: a real response, then two instruction-less requests that
         # pydantic-ai would merge into one on the next run.
-        prior_resp = response(100, 20)
+        prior_resp = make_usage_response(100, 20)
         req_participants = ModelRequest(parts=[UserPromptPart(content="[System]: p")])
         req_contacts = ModelRequest(parts=[UserPromptPart(content="[System]: c")])
         prior = [prior_resp, req_participants, req_contacts]
@@ -252,7 +246,7 @@ class TestUsageMapping:
         # appended. So len(captured)=3 < len(prior)=3+... a positional
         # captured[len(prior):] would slice to empty and drop new_resp.
         merged_req = ModelRequest(parts=[UserPromptPart(content="[System]: p\nc")])
-        new_resp = response(130, 8)
+        new_resp = make_usage_response(130, 8)
         captured = [prior_resp, merged_req, new_resp]
 
         this_run = PydanticAIAdapter._new_run_messages(captured, prior_ids)
@@ -1086,7 +1080,6 @@ class TestEmptyFinalAnswer:
         falls back to summing this run's captured ModelResponses when no result
         event fired, so a hard mid-run failure doesn't silently drop usage."""
         from contextlib import contextmanager
-        from types import SimpleNamespace
 
         from band.core.types import Emit
         from tests.adapters.usage_events import sent_usage_payloads
@@ -1106,16 +1099,9 @@ class TestEmptyFinalAnswer:
         )
 
         # Simulate a run that captured a response with usage before raising.
-        failed_response = ModelResponse.__new__(ModelResponse)
-        object.__setattr__(
-            failed_response,
-            "usage",
-            SimpleNamespace(input_tokens=100, output_tokens=20),
-        )
-        object.__setattr__(failed_response, "parts", [TextPart(content="partial")])
         captured_turn = [
             ModelRequest(parts=[UserPromptPart(content="[Alice]: hi")]),
-            failed_response,
+            make_usage_response(100, 20, parts=[TextPart(content="partial")]),
         ]
 
         @contextmanager
@@ -1134,7 +1120,7 @@ class TestEmptyFinalAnswer:
                     room_id="room-123",
                 )
 
-        usage_payloads = sent_usage_payloads(mock_tools.send_event)
+        usage_payloads = sent_usage_payloads(mock_tools)
         assert usage_payloads == [
             {
                 "input_tokens": 100,

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -176,6 +176,45 @@ class TestUsageMapping:
         result.usage.side_effect = RuntimeError("no usage")
         assert PydanticAIAdapter._usage_from_result(result) == TurnUsage()
 
+    def test_usage_from_messages_sums_model_responses(self):
+        """The benign-path fallback sums usage across captured ModelResponses.
+
+        Covers the empty-final-response path (no AgentRunResultEvent fires) where
+        the turn still spent tokens — each ModelResponse carries its own usage.
+        """
+        from types import SimpleNamespace
+
+        from pydantic_ai.messages import ModelRequest, ModelResponse
+
+        from band.core.types import TurnUsage
+
+        def response(inp, out):
+            r = ModelResponse.__new__(ModelResponse)
+            object.__setattr__(
+                r, "usage", SimpleNamespace(input_tokens=inp, output_tokens=out)
+            )
+            return r
+
+        messages = [
+            ModelRequest(parts=[]),  # non-response: ignored
+            response(100, 20),
+            response(130, 8),
+        ]
+        assert PydanticAIAdapter._usage_from_messages(messages) == TurnUsage(
+            input_tokens=230, output_tokens=28
+        )
+
+    def test_usage_from_messages_empty_when_no_responses(self):
+        """No ModelResponse in the captured messages → empty usage."""
+        from pydantic_ai.messages import ModelRequest
+
+        from band.core.types import TurnUsage
+
+        assert (
+            PydanticAIAdapter._usage_from_messages([ModelRequest(parts=[])])
+            == TurnUsage()
+        )
+
 
 class TestInitialization:
     """Tests for adapter initialization."""

--- a/tests/adapters/test_usage_mapping.py
+++ b/tests/adapters/test_usage_mapping.py
@@ -1,0 +1,94 @@
+"""Unit tests for the Emit.USAGE per-adapter usage-mapping helpers.
+
+Each adapter maps its framework's response/usage object onto the shared
+``TurnUsage``. These are pure static methods, so they're tested directly with
+lightweight stand-ins (SimpleNamespace / dict) — no live LLM, no full adapter
+construction. The emission path itself (gating on Emit.USAGE, empty-skip,
+best-effort) lives on ``SimpleAdapter.emit_usage`` and is covered in
+``test_anthropic_adapter.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from band.adapters.agno import AgnoAdapter
+from band.adapters.claude_sdk import ClaudeSDKAdapter
+from band.adapters.google_adk import GoogleADKAdapter
+from band.core.types import TurnUsage
+
+
+class TestClaudeSDKUsageMapping:
+    def test_maps_usage_dict(self):
+        """ResultMessage.usage (raw API dict) maps onto TurnUsage."""
+        result = SimpleNamespace(
+            usage={
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_input_tokens": 5,
+                "cache_creation_input_tokens": 3,
+            }
+        )
+        assert ClaudeSDKAdapter._usage_from_result(result) == TurnUsage(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=3,
+        )
+
+    def test_missing_usage_is_empty(self):
+        """A ResultMessage without a usage dict yields empty usage."""
+        assert (
+            ClaudeSDKAdapter._usage_from_result(SimpleNamespace(usage=None))
+            == TurnUsage()
+        )
+
+
+class TestAgnoUsageMapping:
+    def test_maps_run_metrics(self):
+        """RunOutput.metrics (aggregated) maps onto TurnUsage; names line up."""
+        metrics = SimpleNamespace(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=3,
+        )
+        response = SimpleNamespace(metrics=metrics)
+        assert AgnoAdapter._usage_from_response(response) == TurnUsage(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=3,
+        )
+
+    def test_missing_metrics_is_empty(self):
+        """A RunOutput without metrics yields empty usage."""
+        assert (
+            AgnoAdapter._usage_from_response(SimpleNamespace(metrics=None))
+            == TurnUsage()
+        )
+
+
+class TestGoogleADKUsageMapping:
+    def test_maps_event_usage_metadata(self):
+        """ADK event.usage_metadata maps onto TurnUsage (no cache-write dim)."""
+        event = SimpleNamespace(
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=100,
+                candidates_token_count=20,
+                cached_content_token_count=5,
+            )
+        )
+        assert GoogleADKAdapter._usage_from_event(event) == TurnUsage(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=0,
+        )
+
+    def test_event_without_usage_is_empty(self):
+        """A non-model event (no usage_metadata) contributes empty usage."""
+        assert (
+            GoogleADKAdapter._usage_from_event(SimpleNamespace(usage_metadata=None))
+            == TurnUsage()
+        )

--- a/tests/adapters/test_usage_mapping.py
+++ b/tests/adapters/test_usage_mapping.py
@@ -55,10 +55,59 @@ class TestTurnUsageConstructors:
         data = {"i": "oops", "o": None}  # non-int / missing
         assert TurnUsage.from_mapping(data, input="i", output="o") == TurnUsage()
 
+    def test_cache_in_input_false_folds_cache_into_input(self):
+        """Anthropic-style: input excludes cache, so cache is folded into total."""
+        data = {"i": 100, "o": 20, "cr": 5, "cw": 3}
+        assert TurnUsage.from_mapping(
+            data,
+            input="i",
+            output="o",
+            cache_read="cr",
+            cache_write="cw",
+            cache_in_input=False,
+        ) == TurnUsage(
+            input_tokens=108,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=3,
+        )
+
+    def test_cache_in_input_true_leaves_input_untouched(self):
+        """Gemini/LiteLLM-style: input already includes cache (the default)."""
+        data = {"i": 100, "o": 20, "cr": 5, "cw": 3}
+        assert TurnUsage.from_mapping(
+            data, input="i", output="o", cache_read="cr", cache_write="cw"
+        ) == TurnUsage(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=3,
+        )
+
+
+class TestIsUsageEvent:
+    """The shared discriminator task-event consumers use to skip usage records."""
+
+    def test_true_when_band_usage_present(self):
+        from band.core.types import USAGE_METADATA_KEY, is_usage_event
+
+        assert is_usage_event({USAGE_METADATA_KEY: {"input_tokens": 1}}) is True
+
+    def test_false_for_lifecycle_task_or_non_mapping(self):
+        from band.core.types import is_usage_event
+
+        assert is_usage_event({"codex_thread_id": "x"}) is False
+        assert is_usage_event(None) is False
+        assert is_usage_event("nope") is False
+
 
 class TestClaudeSDKUsageMapping:
     def test_maps_usage_dict(self):
-        """ResultMessage.usage (raw API dict) maps onto TurnUsage."""
+        """ResultMessage.usage (raw API dict) maps onto TurnUsage.
+
+        Claude's input_tokens EXCLUDES cache, so the mapper folds cache into the
+        total input (cache_in_input=False): input = 100 + 5 + 3 = 108.
+        """
         result = SimpleNamespace(
             usage={
                 "input_tokens": 100,
@@ -68,7 +117,7 @@ class TestClaudeSDKUsageMapping:
             }
         )
         assert ClaudeSDKAdapter._usage_from_result(result) == TurnUsage(
-            input_tokens=100,
+            input_tokens=108,
             output_tokens=20,
             cache_read_tokens=5,
             cache_write_tokens=3,

--- a/tests/adapters/test_usage_mapping.py
+++ b/tests/adapters/test_usage_mapping.py
@@ -55,25 +55,9 @@ class TestTurnUsageConstructors:
         data = {"i": "oops", "o": None}  # non-int / missing
         assert TurnUsage.from_mapping(data, input="i", output="o") == TurnUsage()
 
-    def test_cache_in_input_false_folds_cache_into_input(self):
-        """Anthropic-style: input excludes cache, so cache is folded into total."""
-        data = {"i": 100, "o": 20, "cr": 5, "cw": 3}
-        assert TurnUsage.from_mapping(
-            data,
-            input="i",
-            output="o",
-            cache_read="cr",
-            cache_write="cw",
-            cache_in_input=False,
-        ) == TurnUsage(
-            input_tokens=108,
-            output_tokens=20,
-            cache_read_tokens=5,
-            cache_write_tokens=3,
-        )
-
-    def test_cache_in_input_true_leaves_input_untouched(self):
-        """Gemini/LiteLLM-style: input already includes cache (the default)."""
+    def test_fields_are_raw_no_cache_folding(self):
+        """Per the convention, values pass through raw — cache is never folded
+        into input regardless of provider."""
         data = {"i": 100, "o": 20, "cr": 5, "cw": 3}
         assert TurnUsage.from_mapping(
             data, input="i", output="o", cache_read="cr", cache_write="cw"
@@ -103,11 +87,8 @@ class TestIsUsageEvent:
 
 class TestClaudeSDKUsageMapping:
     def test_maps_usage_dict(self):
-        """ResultMessage.usage (raw API dict) maps onto TurnUsage.
-
-        Claude's input_tokens EXCLUDES cache, so the mapper folds cache into the
-        total input (cache_in_input=False): input = 100 + 5 + 3 = 108.
-        """
+        """ResultMessage.usage (raw API dict) maps onto TurnUsage raw — Claude's
+        input_tokens excludes cache, reported separately in the cache fields."""
         result = SimpleNamespace(
             usage={
                 "input_tokens": 100,
@@ -117,7 +98,7 @@ class TestClaudeSDKUsageMapping:
             }
         )
         assert ClaudeSDKAdapter._usage_from_result(result) == TurnUsage(
-            input_tokens=108,
+            input_tokens=100,
             output_tokens=20,
             cache_read_tokens=5,
             cache_write_tokens=3,

--- a/tests/adapters/test_usage_mapping.py
+++ b/tests/adapters/test_usage_mapping.py
@@ -16,6 +16,7 @@ import pytest
 
 from band.adapters.agno import AgnoAdapter
 from band.adapters.claude_sdk import ClaudeSDKAdapter
+from band.adapters.codex import CodexAdapter
 from band.adapters.gemini import GeminiAdapter
 from band.adapters.google_adk import GoogleADKAdapter
 from band.adapters.letta import LettaAdapter
@@ -204,3 +205,16 @@ class TestOpencodeUsageMapping:
         """No tokens (or a non-dict tokens) yields empty usage."""
         assert OpencodeAdapter._usage_from_info({}) == TurnUsage()
         assert OpencodeAdapter._usage_from_info({"tokens": "nope"}) == TurnUsage()
+
+
+class TestCodexUsageMapping:
+    def test_maps_per_turn_deltas(self):
+        """Codex's per-turn token deltas (not thread cumulatives) map to TurnUsage."""
+        usage = SimpleNamespace(turn_input_tokens=130, turn_output_tokens=42)
+        assert CodexAdapter._turn_usage(usage) == TurnUsage(
+            input_tokens=130, output_tokens=42
+        )
+
+    def test_none_usage_is_empty(self):
+        """No usage object for the thread yields empty usage (no emit)."""
+        assert CodexAdapter._turn_usage(None) == TurnUsage()

--- a/tests/adapters/test_usage_mapping.py
+++ b/tests/adapters/test_usage_mapping.py
@@ -215,7 +215,12 @@ class TestLettaUsageMapping:
 
 class TestOpencodeUsageMapping:
     def test_maps_info_tokens_with_nested_cache(self):
-        """OpenCode assistant info.tokens (nested cache) maps onto TurnUsage."""
+        """OpenCode assistant info.tokens (nested cache) maps onto TurnUsage.
+
+        OpenCode reports reasoning disjointly from output (its own total is
+        input + output + reasoning + cache), so reasoning folds into
+        output_tokens: 20 + 7 = 27.
+        """
         info = {
             "tokens": {
                 "input": 100,
@@ -226,7 +231,7 @@ class TestOpencodeUsageMapping:
         }
         assert OpencodeAdapter._usage_from_info(info) == TurnUsage(
             input_tokens=100,
-            output_tokens=20,
+            output_tokens=27,
             cache_read_tokens=5,
             cache_write_tokens=3,
         )
@@ -239,10 +244,17 @@ class TestOpencodeUsageMapping:
 
 class TestCodexUsageMapping:
     def test_maps_per_turn_deltas(self):
-        """Codex's per-turn token deltas (not thread cumulatives) map to TurnUsage."""
-        usage = SimpleNamespace(turn_input_tokens=130, turn_output_tokens=42)
+        """Codex's per-turn token deltas (not thread cumulatives) map to TurnUsage.
+
+        Codex reports reasoning disjointly from output (its own total is
+        input + output + reasoning), so reasoning folds into output_tokens:
+        42 + 8 = 50.
+        """
+        usage = SimpleNamespace(
+            turn_input_tokens=130, turn_output_tokens=42, turn_reasoning_tokens=8
+        )
         assert CodexAdapter._turn_usage(usage) == TurnUsage(
-            input_tokens=130, output_tokens=42
+            input_tokens=130, output_tokens=50
         )
 
     def test_none_usage_is_empty(self):

--- a/tests/adapters/test_usage_mapping.py
+++ b/tests/adapters/test_usage_mapping.py
@@ -16,7 +16,10 @@ import pytest
 
 from band.adapters.agno import AgnoAdapter
 from band.adapters.claude_sdk import ClaudeSDKAdapter
+from band.adapters.gemini import GeminiAdapter
 from band.adapters.google_adk import GoogleADKAdapter
+from band.adapters.letta import LettaAdapter
+from band.adapters.opencode import OpencodeAdapter
 from band.core.types import TurnUsage
 
 
@@ -126,3 +129,78 @@ class TestGoogleADKUsageMapping:
             GoogleADKAdapter._usage_from_event(SimpleNamespace(usage_metadata=None))
             == TurnUsage()
         )
+
+
+class TestGeminiUsageMapping:
+    def test_maps_response_usage_metadata(self):
+        """GenerateContentResponse.usage_metadata maps onto TurnUsage."""
+        response = SimpleNamespace(
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=100,
+                candidates_token_count=20,
+                cached_content_token_count=5,
+            )
+        )
+        assert GeminiAdapter._usage_from_response(response) == TurnUsage(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=0,
+        )
+
+    def test_response_without_usage_is_empty(self):
+        """A response without usage_metadata yields empty usage."""
+        assert (
+            GeminiAdapter._usage_from_response(SimpleNamespace(usage_metadata=None))
+            == TurnUsage()
+        )
+
+
+class TestLettaUsageMapping:
+    def test_maps_response_usage(self):
+        """LettaResponse.usage (per_room mode) maps onto TurnUsage."""
+        response = SimpleNamespace(
+            usage=SimpleNamespace(
+                prompt_tokens=100,
+                completion_tokens=20,
+                cached_input_tokens=5,
+                cache_write_tokens=3,
+            )
+        )
+        assert LettaAdapter._usage_from_response(response) == TurnUsage(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=3,
+        )
+
+    def test_response_without_usage_is_empty(self):
+        """A response with no usage (e.g. shared-mode stream) yields empty usage."""
+        assert (
+            LettaAdapter._usage_from_response(SimpleNamespace(usage=None))
+            == TurnUsage()
+        )
+
+
+class TestOpencodeUsageMapping:
+    def test_maps_info_tokens_with_nested_cache(self):
+        """OpenCode assistant info.tokens (nested cache) maps onto TurnUsage."""
+        info = {
+            "tokens": {
+                "input": 100,
+                "output": 20,
+                "reasoning": 7,
+                "cache": {"read": 5, "write": 3},
+            }
+        }
+        assert OpencodeAdapter._usage_from_info(info) == TurnUsage(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=5,
+            cache_write_tokens=3,
+        )
+
+    def test_missing_or_malformed_tokens_is_empty(self):
+        """No tokens (or a non-dict tokens) yields empty usage."""
+        assert OpencodeAdapter._usage_from_info({}) == TurnUsage()
+        assert OpencodeAdapter._usage_from_info({"tokens": "nope"}) == TurnUsage()

--- a/tests/adapters/test_usage_mapping.py
+++ b/tests/adapters/test_usage_mapping.py
@@ -12,10 +12,44 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from band.adapters.agno import AgnoAdapter
 from band.adapters.claude_sdk import ClaudeSDKAdapter
 from band.adapters.google_adk import GoogleADKAdapter
 from band.core.types import TurnUsage
+
+
+class TestTurnUsageConstructors:
+    """The shared from_object / from_mapping constructors the adapters build on."""
+
+    def test_from_object_reads_named_attrs(self):
+        src = SimpleNamespace(inp=100, out=20, cr=5, cw=3)
+        assert TurnUsage.from_object(
+            src, input="inp", output="out", cache_read="cr", cache_write="cw"
+        ) == TurnUsage(100, 20, 5, 3)
+
+    def test_from_object_none_source_is_empty(self):
+        assert TurnUsage.from_object(None, input="i", output="o") == TurnUsage()
+
+    def test_from_object_omitted_cache_keys_stay_zero(self):
+        src = SimpleNamespace(i=100, o=20, cache_read_tokens=999)
+        # cache_read/cache_write not passed → not read even if present on src
+        assert TurnUsage.from_object(src, input="i", output="o") == TurnUsage(100, 20)
+
+    def test_from_mapping_reads_named_keys(self):
+        data = {"i": 100, "o": 20, "cr": 5, "cw": 3}
+        assert TurnUsage.from_mapping(
+            data, input="i", output="o", cache_read="cr", cache_write="cw"
+        ) == TurnUsage(100, 20, 5, 3)
+
+    @pytest.mark.parametrize("bad", [None, "not a mapping", 42, ["list"]])
+    def test_from_mapping_non_mapping_is_empty(self, bad):
+        assert TurnUsage.from_mapping(bad, input="i", output="o") == TurnUsage()
+
+    def test_missing_and_non_int_fields_default_to_zero(self):
+        data = {"i": "oops", "o": None}  # non-int / missing
+        assert TurnUsage.from_mapping(data, input="i", output="o") == TurnUsage()
 
 
 class TestClaudeSDKUsageMapping:

--- a/tests/adapters/usage_events.py
+++ b/tests/adapters/usage_events.py
@@ -1,0 +1,32 @@
+"""Helpers for reading emitted Emit.USAGE payloads back out of test doubles.
+
+Both filter with ``is_usage_event`` (the single source of truth for "is this
+a usage event") so tests don't re-derive the ``band_usage`` check the planned
+first-class usage event would retire.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+from band.core.types import USAGE_METADATA_KEY, is_usage_event
+from band.testing import FakeAgentTools
+
+
+def sent_usage_payloads(send_event: AsyncMock) -> list[dict[str, Any]]:
+    """Usage payloads from a mocked ``send_event``'s awaited calls."""
+    return [
+        call.kwargs["metadata"][USAGE_METADATA_KEY]
+        for call in send_event.await_args_list
+        if is_usage_event(call.kwargs.get("metadata"))
+    ]
+
+
+def recorded_usage_payloads(tools: FakeAgentTools) -> list[dict[str, Any]]:
+    """Usage payloads recorded by a ``FakeAgentTools``."""
+    return [
+        event["metadata"][USAGE_METADATA_KEY]
+        for event in tools.events_sent
+        if is_usage_event(event["metadata"])
+    ]

--- a/tests/adapters/usage_events.py
+++ b/tests/adapters/usage_events.py
@@ -8,17 +8,20 @@ first-class usage event would retire.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock
 
 from band.core.types import USAGE_METADATA_KEY, is_usage_event
 from band.testing import FakeAgentTools
 
 
-def sent_usage_payloads(send_event: AsyncMock) -> list[dict[str, Any]]:
-    """Usage payloads from a mocked ``send_event``'s awaited calls."""
+def sent_usage_payloads(tools: Any) -> list[dict[str, Any]]:
+    """Usage payloads from a mocked tools' awaited ``send_event`` calls.
+
+    Takes the whole tools double, like its ``FakeAgentTools`` sibling below;
+    typed ``Any`` because tests build it as a ``MagicMock``.
+    """
     return [
         call.kwargs["metadata"][USAGE_METADATA_KEY]
-        for call in send_event.await_args_list
+        for call in tools.send_event.await_args_list
         if is_usage_event(call.kwargs.get("metadata"))
     ]
 

--- a/tests/e2e/baseline/smoke/inspection/test_usage.py
+++ b/tests/e2e/baseline/smoke/inspection/test_usage.py
@@ -1,0 +1,61 @@
+"""Token-usage smokes for the baseline toolkit (Emit.USAGE seam).
+
+The cross-adapter proof for the cost/token seam: an agent running with
+``Emit.USAGE`` emits its per-turn token usage, read back via
+``ReplyCapture.usage`` and asserted with :class:`Usage`. This is the end-to-end
+de-risking test for the ``Emit.USAGE`` / ``capture.usage()`` design as it is
+templated across the bucket-B adapters (anthropic, langgraph, pydantic_ai,
+claude_sdk, agno in the CORE lane; google_adk in the google lane).
+
+Turn completion uses the delivery-status barrier (``wait_for_processed``): the
+platform marks the trigger ``processed`` only after the reply is emitted, by which
+point the turn's usage event is persisted — so the read is race-free.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.baseline.agents import Adapter, per_adapter
+from tests.e2e.baseline.smoke.samples.sample_agents import COST_AGENT
+from tests.e2e.baseline.toolkit.capture import CaptureFactory
+from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceManager
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+
+@per_adapter(
+    Adapter.ANTHROPIC,
+    Adapter.LANGGRAPH,
+    Adapter.PYDANTIC_AI,
+    Adapter.CLAUDE_SDK,
+    Adapter.AGNO,
+    Adapter.GOOGLE_ADK,
+    **COST_AGENT,
+)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_usage_recorded_for_a_turn(
+    agent: ProvisionedAgent,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """The proof: one turn emits a usage record with non-zero input and output.
+
+    Non-zero input tokens (the prompt was sent) AND non-zero output tokens (a
+    reply was generated) is exactly the ``assert_nonzero_input_and_output``
+    gate reused by L4 — here on an ordinary turn.
+    """
+    room_id = await resource_manager.provision_room(
+        title="e2e-usage-recorded", participants=[agent.id]
+    )
+    async with reply_capture(room_id) as capture:
+        mid = await user_ops.send_message(
+            room_id,
+            "Say hello in one short sentence.",
+            mention_id=agent.id,
+            mention_name=agent.name,
+        )
+        await capture.wait_for_processed(mid, agent.id)
+        usage = await capture.usage(sender_id=agent.id)
+
+    usage.assert_nonzero_input_and_output()

--- a/tests/e2e/baseline/smoke/inspection/test_usage.py
+++ b/tests/e2e/baseline/smoke/inspection/test_usage.py
@@ -5,7 +5,9 @@ The cross-adapter proof for the cost/token seam: an agent running with
 ``ReplyCapture.usage`` and asserted with :class:`Usage`. This is the end-to-end
 de-risking test for the ``Emit.USAGE`` / ``capture.usage()`` design as it is
 templated across the bucket-B adapters (anthropic, langgraph, pydantic_ai,
-claude_sdk, agno in the CORE lane; google_adk in the google lane).
+claude_sdk, agno in the CORE lane; google_adk and gemini in the google lane;
+crewai in the crewai lane; opencode in the backends lane). Letta captures usage
+too but is E2E-pending, so it's covered by unit mapping tests, not this smoke.
 
 Turn completion uses the delivery-status barrier (``wait_for_processed``): the
 platform marks the trigger ``processed`` only after the reply is emitted, by which
@@ -30,6 +32,9 @@ from tests.e2e.baseline.toolkit.user_ops import UserOps
     Adapter.CLAUDE_SDK,
     Adapter.AGNO,
     Adapter.GOOGLE_ADK,
+    Adapter.GEMINI,
+    Adapter.CREWAI,
+    Adapter.OPENCODE,
     **COST_AGENT,
 )
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/e2e/baseline/smoke/inspection/test_usage.py
+++ b/tests/e2e/baseline/smoke/inspection/test_usage.py
@@ -3,11 +3,18 @@
 The cross-adapter proof for the cost/token seam: an agent running with
 ``Emit.USAGE`` emits its per-turn token usage, read back via
 ``ReplyCapture.usage`` and asserted with :class:`Usage`. This is the end-to-end
-de-risking test for the ``Emit.USAGE`` / ``capture.usage()`` design as it is
-templated across the bucket-B adapters (anthropic, langgraph, pydantic_ai,
-claude_sdk, agno in the CORE lane; google_adk and gemini in the google lane;
-crewai in the crewai lane; opencode in the backends lane). Letta captures usage
-too but is E2E-pending, so it's covered by unit mapping tests, not this smoke.
+de-risking test for the ``Emit.USAGE`` / ``capture.usage()`` design across every
+usage-capable adapter.
+
+Coverage is registry-derived, not a hand-maintained list: the fan is the whole
+matrix minus ``CREWAI_FLOW`` (usage lives in user-supplied flow internals — N-A).
+``LETTA`` is auto-excluded because it is ``e2e_pending`` (it captures usage too,
+covered by unit mapping tests). Deriving from ``exclude=`` rather than an explicit
+include-list means a newly-registered usage-capable adapter is exercised
+automatically — and a new adapter that *cannot* emit usage fails loudly here until
+it's consciously added to the exclusion, which is the intended signal. The cells
+span several CI lanes (core / google / crewai / backends); each is a single-adapter
+``@per_adapter`` item, so each runs in its own lane's job — no ``@lane`` pin needed.
 
 Turn completion uses the delivery-status barrier (``wait_for_processed``): the
 platform marks the trigger ``processed`` only after the reply is emitted, by which
@@ -25,18 +32,11 @@ from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceMa
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
 
-@per_adapter(
-    Adapter.ANTHROPIC,
-    Adapter.LANGGRAPH,
-    Adapter.PYDANTIC_AI,
-    Adapter.CLAUDE_SDK,
-    Adapter.AGNO,
-    Adapter.GOOGLE_ADK,
-    Adapter.GEMINI,
-    Adapter.CREWAI,
-    Adapter.OPENCODE,
-    **COST_AGENT,
-)
+# crewai_flow is the one usage-incapable matrix adapter (usage lives in
+# user-supplied flow internals, not on the result the adapter sees), so exclude
+# it; every other registered adapter must emit usage. (LETTA is auto-excluded as
+# e2e_pending — covered by unit mapping tests.)
+@per_adapter(exclude={Adapter.CREWAI_FLOW}, **COST_AGENT)
 @pytest.mark.asyncio(loop_scope="session")
 async def test_usage_recorded_for_a_turn(
     agent: ProvisionedAgent,
@@ -44,11 +44,33 @@ async def test_usage_recorded_for_a_turn(
     user_ops: UserOps,
     reply_capture: CaptureFactory,
 ) -> None:
-    """The proof: one turn emits a usage record with non-zero input and output.
+    """The proof: one turn emits exactly one usage record with a plausible count.
 
-    Non-zero input tokens (the prompt was sent) AND non-zero output tokens (a
-    reply was generated) is exactly the ``assert_nonzero_input_and_output``
-    gate reused by L4 — here on an ordinary turn.
+    Three tolerant, deterministic checks (a floor and a broad band, never exact
+    magnitudes, so no LLM-variance flakiness):
+
+    - ``assert_nonzero_input_and_output`` — input tokens > 0 (the prompt was
+      sent) AND output tokens > 0 (a reply was generated); the same gate L4
+      reuses, here on an ordinary turn.
+    - exactly one record — one user message → one agent turn → the adapter sums
+      per-call usage into a single ``TurnUsage`` emitted once. Summing across
+      records would hide a double-emit or a per-call-instead-of-per-turn
+      regression, so assert the count too. The prompt (``COST_AGENT``) uses no
+      tools, so the turn is a single model call.
+    - a plausible count (estimation) — the total *prompt* tokens the model
+      processed clear a realistic floor, and the reply total stays under a
+      realistic ceiling. The prompt floor sums input + cache-read + cache-write
+      on purpose: caching adapters (e.g. claude_sdk) report most of the prompt
+      under cache_read and only a handful of *fresh* ``input_tokens`` (7, with
+      ~87k cached, in practice), so a floor on ``input_tokens`` alone would be
+      wrong. Every adapter sends a rendered system prompt + tool schemas, so the
+      processed prompt is realistically in the hundreds+; 20 sits well below that
+      yet still catches a garbage/tiny count a bare ``> 0`` would pass. A
+      one-line reply keeps ``total_tokens`` (input + output) far under the
+      ceiling. Both bounds stay loose enough that model/run variance never trips
+      them. (Exact per-call summing is proven deterministically in the adapter
+      unit tests, which — unlike this live read — can see the per-call
+      intermediates.)
     """
     room_id = await resource_manager.provision_room(
         title="e2e-usage-recorded", participants=[agent.id]
@@ -64,3 +86,25 @@ async def test_usage_recorded_for_a_turn(
         usage = await capture.usage(sender_id=agent.id)
 
     usage.assert_nonzero_input_and_output()
+    assert len(usage) == 1, (
+        f"expected exactly one usage record for one turn, got {usage}"
+    )
+    # Estimation: a realistic count, not just > 0. Sum the prompt the model
+    # actually processed — fresh input + cache-read + cache-write — because
+    # caching adapters report most of it under cache_* and only a few fresh
+    # input_tokens. A rendered system prompt + tool schemas puts that in the
+    # hundreds+, so 20 is a safe floor that still catches a garbage/tiny count;
+    # a one-line reply keeps input+output under the ceiling. Both bounds are
+    # loose enough that model/run variance never trips them.
+    record = usage[0]
+    prompt_tokens = (
+        record.input_tokens + record.cache_read_tokens + record.cache_write_tokens
+    )
+    assert prompt_tokens >= 20, (
+        f"prompt tokens implausibly low for a real turn: {prompt_tokens} "
+        f"(input={record.input_tokens}, cache_read={record.cache_read_tokens}, "
+        f"cache_write={record.cache_write_tokens})"
+    )
+    assert record.total_tokens < 100_000, (
+        f"total tokens implausibly high for a one-line reply: {record.total_tokens}"
+    )

--- a/tests/e2e/baseline/smoke/inspection/test_usage.py
+++ b/tests/e2e/baseline/smoke/inspection/test_usage.py
@@ -7,14 +7,16 @@ de-risking test for the ``Emit.USAGE`` / ``capture.usage()`` design across every
 usage-capable adapter.
 
 Coverage is registry-derived, not a hand-maintained list: the fan is the whole
-matrix minus ``CREWAI_FLOW`` (usage lives in user-supplied flow internals — N-A).
-``LETTA`` is auto-excluded because it is ``e2e_pending`` (it captures usage too,
-covered by unit mapping tests). Deriving from ``exclude=`` rather than an explicit
-include-list means a newly-registered usage-capable adapter is exercised
-automatically — and a new adapter that *cannot* emit usage fails loudly here until
-it's consciously added to the exclusion, which is the intended signal. The cells
-span several CI lanes (core / google / crewai / backends); each is a single-adapter
-``@per_adapter`` item, so each runs in its own lane's job — no ``@lane`` pin needed.
+matrix minus the adapters that don't emit usage — ``CREWAI_FLOW`` (usage lives in
+user-supplied flow internals — N-A) and ``CREWAI`` (usage capture deferred: its
+result counter is cumulative-lifetime, not per-turn). ``LETTA`` is auto-excluded
+because it is ``e2e_pending`` (it captures usage too, covered by unit mapping
+tests). Deriving from ``exclude=`` rather than an explicit include-list means a
+newly-registered usage-capable adapter is exercised automatically — and a new
+adapter that *cannot* emit usage fails loudly here until it's consciously added to
+the exclusion, which is the intended signal. The cells span several CI lanes
+(core / google / backends); each is a single-adapter ``@per_adapter`` item, so
+each runs in its own lane's job — no ``@lane`` pin needed.
 
 Turn completion uses the delivery-status barrier (``wait_for_processed``): the
 platform marks the trigger ``processed`` only after the reply is emitted, by which
@@ -32,11 +34,11 @@ from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceMa
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
 
-# crewai_flow is the one usage-incapable matrix adapter (usage lives in
-# user-supplied flow internals, not on the result the adapter sees), so exclude
-# it; every other registered adapter must emit usage. (LETTA is auto-excluded as
+# Adapters that don't emit usage: crewai_flow (usage in user-supplied flow
+# internals) and crewai (deferred — cumulative-lifetime counter, not per-turn).
+# Every other registered adapter must emit usage. (LETTA is auto-excluded as
 # e2e_pending — covered by unit mapping tests.)
-@per_adapter(exclude={Adapter.CREWAI_FLOW}, **COST_AGENT)
+@per_adapter(exclude={Adapter.CREWAI_FLOW, Adapter.CREWAI}, **COST_AGENT)
 @pytest.mark.asyncio(loop_scope="session")
 async def test_usage_recorded_for_a_turn(
     agent: ProvisionedAgent,
@@ -59,14 +61,14 @@ async def test_usage_recorded_for_a_turn(
       tools, so the turn is a single model call.
     - a plausible count (estimation) — the total *prompt* tokens the model
       processed clear a realistic floor, and the reply total stays under a
-      realistic ceiling. The prompt floor sums input + cache-read + cache-write
-      on purpose: caching adapters (e.g. claude_sdk) report most of the prompt
-      under cache_read and only a handful of *fresh* ``input_tokens`` (7, with
-      ~87k cached, in practice), so a floor on ``input_tokens`` alone would be
-      wrong. Every adapter sends a rendered system prompt + tool schemas, so the
-      processed prompt is realistically in the hundreds+; 20 sits well below that
-      yet still catches a garbage/tiny count a bare ``> 0`` would pass. A
-      one-line reply keeps ``total_tokens`` (input + output) far under the
+      realistic ceiling. The floor sums input + cache-read + cache-write because
+      TurnUsage fields are the provider's *raw* values and whether cache is
+      already inside ``input_tokens`` is provider-specific: caching adapters
+      (e.g. claude_sdk) report ~7 fresh ``input_tokens`` with the bulk (~87k) under
+      cache_read, so an ``input_tokens``-only floor would be wrong. The sum is a
+      robust lower bound on prompt size either way. A rendered system prompt +
+      tool schemas puts it in the hundreds+, so 20 catches a garbage/tiny count a
+      bare ``> 0`` would pass; a one-line reply keeps ``total_tokens`` under the
       ceiling. Both bounds stay loose enough that model/run variance never trips
       them. (Exact per-call summing is proven deterministically in the adapter
       unit tests, which — unlike this live read — can see the per-call
@@ -89,16 +91,21 @@ async def test_usage_recorded_for_a_turn(
     assert len(usage) == 1, (
         f"expected exactly one usage record for one turn, got {usage}"
     )
-    # Estimation: a realistic count, not just > 0. Per the TurnUsage convention
-    # input_tokens is the total prompt the model processed (cache folded in by
-    # each adapter's mapper), so a rendered system prompt + tool schemas puts it
-    # in the hundreds+ across every adapter, caching or not. 20 is a safe floor
-    # that still catches a garbage/tiny count; a one-line reply keeps input+output
-    # under the ceiling. Both bounds are loose enough that variance never trips them.
+    # Estimation: a realistic count, not just > 0. Sum the prompt the model
+    # processed — fresh input + cache-read + cache-write — because TurnUsage
+    # fields are raw provider values and caching adapters report most of the
+    # prompt under cache_* with only a few fresh input_tokens. The sum is a
+    # robust lower bound on prompt size regardless of whether the provider counts
+    # cache inside input; a rendered system prompt + tool schemas puts it well
+    # above 20, and a one-line reply keeps input+output under the ceiling.
     record = usage[0]
-    assert record.input_tokens >= 20, (
-        "input tokens (total prompt, cache incl.) implausibly low for a real turn: "
-        f"{record.input_tokens}"
+    prompt_tokens = (
+        record.input_tokens + record.cache_read_tokens + record.cache_write_tokens
+    )
+    assert prompt_tokens >= 20, (
+        f"prompt tokens implausibly low for a real turn: {prompt_tokens} "
+        f"(input={record.input_tokens}, cache_read={record.cache_read_tokens}, "
+        f"cache_write={record.cache_write_tokens})"
     )
     assert record.total_tokens < 100_000, (
         f"total tokens implausibly high for a one-line reply: {record.total_tokens}"

--- a/tests/e2e/baseline/smoke/inspection/test_usage.py
+++ b/tests/e2e/baseline/smoke/inspection/test_usage.py
@@ -21,6 +21,16 @@ each runs in its own lane's job — no ``@lane`` pin needed.
 Turn completion uses the delivery-status barrier (``wait_for_processed``): the
 platform marks the trigger ``processed`` only after the reply is emitted, by which
 point the turn's usage event is persisted — so the read is race-free.
+
+``test_usage_not_cumulative_across_turns`` extends the same fan to two turns and
+asserts each turn emits its *own* record scoped to that turn — the live guard for
+the per-turn convention. It catches the class of bug found in review where an
+adapter reports a *cumulative* count (a run/session total that grows every turn,
+e.g. pydantic_ai's benign fallback summing the replayed history, or crewai's
+lifetime ``usage_metrics``). It drives one long turn then one one-word turn: a
+correct per-turn second record sits far below the long turn, while a cumulative
+one (long + tiny) rises to ~= the long turn — a scale-immune split that ordinary
+reply-length variance can't cross.
 """
 
 from __future__ import annotations
@@ -28,7 +38,10 @@ from __future__ import annotations
 import pytest
 
 from tests.e2e.baseline.agents import Adapter, per_adapter
-from tests.e2e.baseline.smoke.samples.sample_agents import COST_AGENT
+from tests.e2e.baseline.smoke.samples.sample_agents import (
+    COST_AGENT,
+    COST_MULTI_TURN_AGENT,
+)
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
 from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceManager
 from tests.e2e.baseline.toolkit.user_ops import UserOps
@@ -109,4 +122,92 @@ async def test_usage_recorded_for_a_turn(
     )
     assert record.total_tokens < 100_000, (
         f"total tokens implausibly high for a one-line reply: {record.total_tokens}"
+    )
+
+
+# Same fan and exclusions as the single-turn smoke: every usage-emitting adapter,
+# minus the crewai pair (crewai_flow N-A; crewai deferred). LETTA auto-excluded
+# (e2e_pending). The prompt lets the user dictate length so the test can drive one
+# LONG turn then one TINY turn (see COST_MULTI_TURN_AGENT).
+@per_adapter(exclude={Adapter.CREWAI_FLOW, Adapter.CREWAI}, **COST_MULTI_TURN_AGENT)
+# Two turns, and the first drives a long multi-paragraph generation — so this test
+# legitimately needs roughly a second turn's budget on top of the per-turn default.
+@pytest.mark.timeout(extra=120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_usage_not_cumulative_across_turns(
+    agent: ProvisionedAgent,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Each turn emits its OWN usage record — a per-turn count, never a cumulative total.
+
+    The live guard for the per-turn convention. Review found two adapters that
+    reported a *cumulative* count — a run/session total that grows every turn
+    (pydantic_ai's benign fallback summed the replayed history; crewai's
+    ``usage_metrics`` is a lifetime counter). This drives two turns in one room and
+    checks the second turn's record is that turn alone, not turn1+turn2.
+
+    The turns are deliberately ASYMMETRIC — a long first turn, a one-word second
+    turn — because that makes the check immune to LLM reply-length variance. Two
+    equal turns would force a fragile "1x vs 2x" ratio whose margin collapses when
+    an ordinary turn runs a bit long; instead:
+
+    - a correct per-turn second record is the *tiny* turn alone → far BELOW the
+      long first turn's output;
+    - a cumulative second record is ``long + tiny`` → ``~=`` the long first turn.
+
+    So ``turn2.output < turn1.output`` cleanly separates them (asserted at half,
+    for headroom). Output, not input: history grows turn-over-turn, so input rises
+    even when correct — output is the clean per-turn discriminator, and it's
+    exactly what a cumulative bug inflates. Two tolerant checks:
+
+    - exactly two records, one per turn — a per-turn emitter produces one record
+      each turn; a double-emit or a per-run-instead-of-per-turn regression would
+      change the count. (Same reasoning as the single-turn smoke's ``len == 1``.)
+    - the second record is not cumulative (the ratio above), floored by a plausible
+      first-turn size so the ratio can't pass vacuously on a degenerate record.
+    """
+    room_id = await resource_manager.provision_room(
+        title="e2e-usage-not-cumulative", participants=[agent.id]
+    )
+    async with reply_capture(room_id) as capture:
+        first = await user_ops.send_message(
+            room_id,
+            "Explain in detail how ocean tides work. Write several full paragraphs.",
+            mention_id=agent.id,
+            mention_name=agent.name,
+        )
+        await capture.wait_for_processed(first, agent.id)
+        second = await user_ops.send_message(
+            room_id,
+            "Reply with a single word: yes.",
+            mention_id=agent.id,
+            mention_name=agent.name,
+        )
+        await capture.wait_for_processed(second, agent.id)
+        # Both turns are complete and persisted; read the whole room's usage,
+        # oldest-first — [0] is turn 1 (long), [1] is turn 2 (one word).
+        usage = await capture.usage(sender_id=agent.id)
+
+    # Baseline sanity: real usage was recorded on both turns (input from the
+    # prompt, output from the replies) — reuses the L4 gate.
+    usage.assert_nonzero_input_and_output()
+    assert len(usage) == 2, (
+        f"expected exactly one usage record per turn (two turns), got {usage}"
+    )
+    turn_one, turn_two = usage[0], usage[1]
+    # The long turn must actually be sizeable, else the ratio below is vacuous
+    # (a degenerate near-zero turn_one would let almost anything pass).
+    assert turn_one.output_tokens >= 20, (
+        f"first turn's output implausibly small for a multi-paragraph reply: "
+        f"{turn_one.output_tokens}"
+    )
+    # The non-cumulative discriminator: a per-turn record for the one-word turn is
+    # far below the long turn's output, while a cumulative one (long + tiny) is
+    # ~= the long turn. Half the long turn splits them with wide margin either way.
+    assert turn_two.output_tokens < turn_one.output_tokens * 0.5, (
+        "second turn's output looks cumulative (turn1+turn2), not per-turn: a "
+        f"one-word reply should be far below the long turn — turn1="
+        f"{turn_one.output_tokens}, turn2={turn_two.output_tokens}"
     )

--- a/tests/e2e/baseline/smoke/inspection/test_usage.py
+++ b/tests/e2e/baseline/smoke/inspection/test_usage.py
@@ -89,21 +89,16 @@ async def test_usage_recorded_for_a_turn(
     assert len(usage) == 1, (
         f"expected exactly one usage record for one turn, got {usage}"
     )
-    # Estimation: a realistic count, not just > 0. Sum the prompt the model
-    # actually processed — fresh input + cache-read + cache-write — because
-    # caching adapters report most of it under cache_* and only a few fresh
-    # input_tokens. A rendered system prompt + tool schemas puts that in the
-    # hundreds+, so 20 is a safe floor that still catches a garbage/tiny count;
-    # a one-line reply keeps input+output under the ceiling. Both bounds are
-    # loose enough that model/run variance never trips them.
+    # Estimation: a realistic count, not just > 0. Per the TurnUsage convention
+    # input_tokens is the total prompt the model processed (cache folded in by
+    # each adapter's mapper), so a rendered system prompt + tool schemas puts it
+    # in the hundreds+ across every adapter, caching or not. 20 is a safe floor
+    # that still catches a garbage/tiny count; a one-line reply keeps input+output
+    # under the ceiling. Both bounds are loose enough that variance never trips them.
     record = usage[0]
-    prompt_tokens = (
-        record.input_tokens + record.cache_read_tokens + record.cache_write_tokens
-    )
-    assert prompt_tokens >= 20, (
-        f"prompt tokens implausibly low for a real turn: {prompt_tokens} "
-        f"(input={record.input_tokens}, cache_read={record.cache_read_tokens}, "
-        f"cache_write={record.cache_write_tokens})"
+    assert record.input_tokens >= 20, (
+        "input tokens (total prompt, cache incl.) implausibly low for a real turn: "
+        f"{record.input_tokens}"
     )
     assert record.total_tokens < 100_000, (
         f"total tokens implausibly high for a one-line reply: {record.total_tokens}"

--- a/tests/e2e/baseline/smoke/samples/sample_agents.py
+++ b/tests/e2e/baseline/smoke/samples/sample_agents.py
@@ -59,12 +59,32 @@ COST_AGENT_SYSTEM_PROMPT = (
 )
 
 
+# A cost-smoke prompt for the multi-turn non-cumulative check: it must let the
+# *user* dictate reply length so the test can drive one LONG turn then one TINY
+# turn. That asymmetry is what makes the check robust — a correct per-turn record
+# has the tiny turn's output far below the long turn's, while a cumulative bug
+# (a running total) makes the second record ~= long + tiny, i.e. ~= the long
+# turn. Comparing a long turn against a tiny one is a scale-immune "small vs
+# large" split, unlike a "1x vs 2x" ratio of two equal turns, whose margin
+# collapses under ordinary LLM reply-length variance.
+COST_MULTI_TURN_SYSTEM_PROMPT = (
+    "You are a helpful assistant in a chat room. Follow the user's instructions "
+    "about reply length exactly: when they ask for detail, write several full "
+    "paragraphs; when they ask for a single word, reply with just that one word "
+    "and nothing else."
+)
+
+
 # Reusable agent shapes for ``@with_adapters(..., **SHAPE)``: the prompt (and
 # features) a smoke runs its agents under. Declared once here so every test shares
 # the same shape instead of re-spelling it.
 TOOL_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT}
 MEMORY_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT, "features": memory_features()}
 COST_AGENT = {"prompt": COST_AGENT_SYSTEM_PROMPT, "features": usage_features()}
+COST_MULTI_TURN_AGENT = {
+    "prompt": COST_MULTI_TURN_SYSTEM_PROMPT,
+    "features": usage_features(),
+}
 
 
 # Reply-oriented driving glue shared by the context-recall and rehydration

--- a/tests/e2e/baseline/smoke/samples/sample_agents.py
+++ b/tests/e2e/baseline/smoke/samples/sample_agents.py
@@ -45,11 +45,26 @@ def memory_features() -> AdapterFeatures:
     return AdapterFeatures(capabilities={Capability.MEMORY}, emit={Emit.EXECUTION})
 
 
+def usage_features() -> AdapterFeatures:
+    """Features for the cost/token smokes: emit each turn's token usage as a
+    ``usage`` event so the ``Usage`` observation layer is populated."""
+    return AdapterFeatures(emit={Emit.USAGE})
+
+
+# A plain reply-eliciting prompt for the cost smokes: the turn just needs to run
+# an LLM call (input tokens) and produce a reply (output tokens); no tools.
+COST_AGENT_SYSTEM_PROMPT = (
+    "You are a helpful assistant in a chat room. Reply directly to the user with "
+    "one short, friendly sentence."
+)
+
+
 # Reusable agent shapes for ``@with_adapters(..., **SHAPE)``: the prompt (and
 # features) a smoke runs its agents under. Declared once here so every test shares
 # the same shape instead of re-spelling it.
 TOOL_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT}
 MEMORY_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT, "features": memory_features()}
+COST_AGENT = {"prompt": COST_AGENT_SYSTEM_PROMPT, "features": usage_features()}
 
 
 # Reply-oriented driving glue shared by the context-recall and rehydration

--- a/tests/e2e/baseline/toolkit/capture.py
+++ b/tests/e2e/baseline/toolkit/capture.py
@@ -56,6 +56,7 @@ from tests.e2e.baseline.toolkit.observations import (
     Tasks,
     Thoughts,
     ToolCalls,
+    Usage,
 )
 from tests.e2e.baseline.toolkit.provisioning import (
     ProvisionedAgent,
@@ -297,6 +298,34 @@ class ReplyCapture:
             since=since,
             limit=limit,
             include_memory=include_memory,
+        )
+
+    async def usage(
+        self,
+        *,
+        sender_id: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> Usage:
+        """Read this room's per-turn token usage (call after the turn settles).
+
+        Reads the persisted ``usage`` events, so the agent must run with
+        ``Emit.USAGE`` on, and this should follow a completion barrier such as
+        ``wait_for_processed`` (the platform marks a message ``processed`` only
+        after the reply is emitted, by which point the turn's usage event is
+        already persisted). Pass ``sender_id`` to keep only one agent's usage.
+
+        Comes back empty for an adapter that cannot report usage (server-side
+        execution) — the honest N-A. Without ``since`` this returns *every*
+        usage record in the room; pass ``since`` (a server timestamp) to scope
+        to a single turn when reusing a capture across turns.
+        """
+        return await Usage.read(
+            self._require_user_ops(),
+            self.room_id,
+            sender_id=sender_id,
+            since=since,
+            limit=limit,
         )
 
     async def memory(

--- a/tests/e2e/baseline/toolkit/observations/__init__.py
+++ b/tests/e2e/baseline/toolkit/observations/__init__.py
@@ -15,6 +15,9 @@ methods, so a check lives with the data it inspects. ``ReplyCapture`` (see
 - :class:`Memories` -- the store-layer view: memory records that actually landed
   (agent-scoped). :class:`MemoryObservation` bundles both memory layers and is
   what ``ReplyCapture.memory`` returns.
+- :class:`UsageRecord` / :class:`Usage` -- the agent's per-turn token usage
+  (from ``usage`` events under ``Emit.USAGE``), what ``ReplyCapture.usage``
+  returns.
 """
 
 from __future__ import annotations
@@ -36,6 +39,7 @@ from tests.e2e.baseline.toolkit.observations.tool_calls import (
     ToolCall,
     ToolCalls,
 )
+from tests.e2e.baseline.toolkit.observations.usage import Usage, UsageRecord
 
 __all__ = [
     "Errors",
@@ -49,4 +53,6 @@ __all__ = [
     "Thoughts",
     "ToolCall",
     "ToolCalls",
+    "Usage",
+    "UsageRecord",
 ]

--- a/tests/e2e/baseline/toolkit/observations/events.py
+++ b/tests/e2e/baseline/toolkit/observations/events.py
@@ -24,7 +24,7 @@ from typing import ClassVar
 
 from band_rest import ChatMessage
 
-from band.core.types import MessageType
+from band.core.types import MessageType, is_usage_event
 
 from tests.e2e.baseline.toolkit.observations.assertions import ContentAssertions
 from tests.e2e.baseline.toolkit.user_ops import UserOps
@@ -78,12 +78,16 @@ class Events(ContentAssertions, list[ChatMessage]):
         messages = await user_ops.list_messages(
             room_id, message_type=mt, since=since, limit=limit
         )
-        events = cls()
-        for message in messages:
-            if sender_id is not None and message.sender_id != sender_id:
-                continue
-            events.append(message)
-        return events
+        # Keep only the requested sender's events, and drop usage records: they
+        # ride task events (USAGE_EVENT_TYPE) but are not lifecycle tasks (they
+        # have their own Usage observation). Only task events can carry usage, so
+        # the is_usage_event filter is a no-op for thought/error reads.
+        return cls(
+            message
+            for message in messages
+            if (sender_id is None or message.sender_id == sender_id)
+            and not is_usage_event(message.metadata)
+        )
 
     def present(self) -> bool:
         """True if any event of this type was captured."""

--- a/tests/e2e/baseline/toolkit/observations/usage.py
+++ b/tests/e2e/baseline/toolkit/observations/usage.py
@@ -53,7 +53,7 @@ class UsageRecord:
 
     @property
     def total_tokens(self) -> int:
-        """Input + output tokens (cache fields are a subset of input)."""
+        """Input + output tokens (raw; not cache-normalized across providers)."""
         return self.input_tokens + self.output_tokens
 
     @classmethod

--- a/tests/e2e/baseline/toolkit/observations/usage.py
+++ b/tests/e2e/baseline/toolkit/observations/usage.py
@@ -1,0 +1,172 @@
+"""Token-usage capture and assertions for live E2E tests.
+
+Captures the agent-under-test's per-turn token usage. When an adapter runs with
+usage reporting on (``Emit.USAGE``), each turn's aggregated usage is emitted (see
+``SimpleAdapter.emit_usage``) on an accepted ``task`` event whose ``metadata``
+carries the token counts under ``USAGE_METADATA_KEY`` — a dedicated ``usage``
+message_type would be cleaner but the backend rejects unknown types today (see
+``USAGE_EVENT_TYPE``). Those events are persisted and read back via the Human
+messages API (``UserOps.list_messages``), same read-after-barrier contract as
+:class:`ToolCalls`. Filtering on the metadata key is what tells a usage-bearing
+task event apart from an ordinary lifecycle one, so ``capture.usage`` and
+``capture.tasks`` don't collide even though both ride ``task`` events.
+
+This reads the durable record *after* the turn completes (pair it with the
+delivery-status barrier ``wait_for_processed``): the adapter emits the usage
+event before its reply, and the platform marks the trigger ``processed`` only
+after that reply, so once the barrier returns the turn's usage event is already
+persisted and queryable.
+
+Tests reach this through ``ReplyCapture.usage`` (see ``capture.py``), which
+returns a :class:`Usage` carrying the records plus fluent assertions —
+``assert_recorded`` and the L4 gate ``assert_nonzero_input_and_output``.
+
+An adapter that cannot observe usage (server-side execution) emits nothing, so
+``Usage`` comes back empty — the honest N-A, distinguishable from a real
+all-zero record, which ``SimpleAdapter.emit_usage`` refuses to emit.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+
+from band_rest import ChatMessage
+
+from band.core.types import USAGE_EVENT_TYPE, USAGE_METADATA_KEY
+
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UsageRecord:
+    """One turn's observed token usage."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    raw: ChatMessage | None = None
+
+    @property
+    def total_tokens(self) -> int:
+        """Input + output tokens (cache fields are a subset of input)."""
+        return self.input_tokens + self.output_tokens
+
+    @classmethod
+    def from_event(cls, message: ChatMessage) -> UsageRecord | None:
+        """Build a ``UsageRecord`` from a usage-bearing event's metadata.
+
+        Returns ``None`` for any event that does not carry usage under
+        ``USAGE_METADATA_KEY`` — this is the filter that ignores ordinary
+        ``task`` (lifecycle) events. Tolerant of shape drift: a non-dict
+        metadata or payload yields ``None`` (not raised); missing or
+        non-integer fields default to 0.
+        """
+        metadata = message.metadata
+        if not isinstance(metadata, dict):
+            return None
+        payload = metadata.get(USAGE_METADATA_KEY)
+        if not isinstance(payload, dict):
+            return None
+
+        def _int(key: str) -> int:
+            value = payload.get(key, 0)
+            return value if isinstance(value, int) else 0
+
+        return cls(
+            input_tokens=_int("input_tokens"),
+            output_tokens=_int("output_tokens"),
+            cache_read_tokens=_int("cache_read_tokens"),
+            cache_write_tokens=_int("cache_write_tokens"),
+            raw=message,
+        )
+
+
+class Usage(list[UsageRecord]):
+    """An agent's observed per-turn token usage: a ``list[UsageRecord]`` with
+    fluent assertions.
+
+    Being a list, it iterates, indexes, and ``len()``s like one. Read it once
+    (see ``Usage.read`` / ``ReplyCapture.usage``), then assert as many times as
+    needed against the same snapshot.
+    """
+
+    @classmethod
+    async def read(
+        cls,
+        user_ops: UserOps,
+        room_id: str,
+        *,
+        sender_id: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> Usage:
+        """Read a room's usage records, oldest-first.
+
+        Lists the room's usage-carrying events (``USAGE_EVENT_TYPE``) and keeps
+        those whose metadata carries usage (``from_event`` filters the rest).
+        Pass ``sender_id`` to keep only one agent's usage (rooms can hold
+        several agents). Call after the turn is known complete (e.g. after
+        ``wait_for_processed``); tests usually reach this via
+        ``ReplyCapture.usage``.
+
+        Without ``since`` this returns every usage record in the room — the turn
+        only when the capture spans a single turn. Pass ``since`` (a server
+        timestamp) to exclude earlier turns when reusing a capture.
+        """
+        messages = await user_ops.list_messages(
+            room_id, message_type=USAGE_EVENT_TYPE, since=since, limit=limit
+        )
+        records = cls()
+        for message in messages:
+            if sender_id is not None and message.sender_id != sender_id:
+                continue
+            record = UsageRecord.from_event(message)
+            if record is not None:
+                records.append(record)
+        return records
+
+    def total_input_tokens(self) -> int:
+        """Sum of input tokens across the observed turns."""
+        return sum(record.input_tokens for record in self)
+
+    def total_output_tokens(self) -> int:
+        """Sum of output tokens across the observed turns."""
+        return sum(record.output_tokens for record in self)
+
+    def total_tokens(self) -> int:
+        """Sum of input + output tokens across the observed turns."""
+        return self.total_input_tokens() + self.total_output_tokens()
+
+    def assert_recorded(self) -> None:
+        """Assert at least one usage record was observed (the adapter emitted)."""
+        if not self:
+            raise AssertionError(
+                "expected at least one usage record, but none were observed "
+                "(is the agent running with Emit.USAGE, and does its adapter "
+                "support it?)"
+            )
+
+    def assert_nonzero_input_and_output(self) -> None:
+        """Assert non-zero input AND output tokens across the observed turns.
+
+        This is the L4 rehydration gate: after a restart, non-zero input tokens
+        mean the rehydrated ``/context`` was re-sent to the model (history
+        replay), and non-zero output tokens mean the model produced a fresh
+        reply (new inference). Plain per-turn usage satisfies it — no finer
+        token-provenance split is needed (and none is exposed by the framework
+        APIs).
+        """
+        self.assert_recorded()
+        total_in = self.total_input_tokens()
+        total_out = self.total_output_tokens()
+        if total_in <= 0 or total_out <= 0:
+            raise AssertionError(
+                "expected non-zero input AND output tokens (the L4 replay + "
+                f"new-inference gate), but observed input={total_in}, "
+                f"output={total_out}"
+            )


### PR DESCRIPTION
Implements **INT-931** — per-turn LLM token/cost capture — as an additive SDK seam, read back in the E2E baseline toolkit, mirroring the execution-reporting pattern.

## SDK
- `TurnUsage` (input / output / cache-read / cache-write) + `Emit.USAGE` in `band.core.types`. **RAW convention:** each field carries the provider's raw value with **no cache folding** — whether cache is already counted inside `input_tokens` is provider-specific, so prompt-size / cost math uses `input + cache_read + cache_write`. **Reasoning tokens:** providers that report them *disjointly* from output (codex, opencode, gemini, google_adk — their own totals are `input + output + reasoning`) fold reasoning into `output_tokens` via `TurnUsage._build(reasoning=…)`, staying consistent with providers that already count reasoning inside output (Anthropic thinking, OpenAI / LangChain completion tokens). `from_object` / `from_mapping` share `_build`.
- `SimpleAdapter.emit_usage()`: shared, best-effort, gated on `Emit.USAGE`, empty-skip.
- **Adapters emitting usage (10):** anthropic, langgraph, pydantic_ai, claude_sdk, agno, google_adk, gemini, opencode, codex, letta (per-room). **N/A:** parlant (server-side execution), crewai_flow (usage lives in user flow internals). **Deferred:** crewai — its `result.usage_metrics` is a cumulative-lifetime counter, not per-turn (separate follow-up).
- Usage rides an accepted `task` event's metadata (`USAGE_METADATA_KEY = "band_usage"`) because the backend rejects an unknown `usage` message_type today; `USAGE_EVENT_TYPE` keeps the flip to a first-class type a one-liner (see INT-933 below).
- `is_usage_event()` discriminator so task-event consumers (ACP `event_converter`, toolkit `Tasks.read`) don't mistake usage records for lifecycle tasks.

## Toolkit
- `Usage` / `UsageRecord` observation + `capture.usage()` + `COST_AGENT` / `COST_MULTI_TURN_AGENT` shapes + `assert_nonzero_input_and_output()` (the L4 gate).
- E2E smokes: `test_usage_recorded_for_a_turn` (one per-turn record, plausible count) and `test_usage_not_cumulative_across_turns` (a long turn then a one-word turn — a per-turn record stays far below the long turn, a cumulative bug rises to ~= it).

## Review fixes (root-caused)
- **Reasoning undercount:** disjoint-reasoning providers (codex / opencode / gemini / google_adk) fold reasoning into output at the shared builder; agno is deliberately *not* folded — a multi-provider aggregator whose `output_tokens` already includes reasoning for some backends (OpenAI) and excludes it for others (Gemini), so no static fold is correct for all (mirrors the RAW cache stance).
- **pydantic benign-path usage:** scoped to this run by message *identity*, not a positional slice — pydantic-ai's `_clean_message_history` merges adjacent same-type requests, so a `len(prior)` boundary slips and dropped the turn's leading response.
- **task pollution:** ACP no longer renders usage as a bogus plan step; `Tasks.read` excludes usage records.
- **error-path usage loss:** adapters that observe usage before a turn can fail (anthropic, gemini, langgraph, google_adk, pydantic_ai, letta) now emit from a `finally`, so a turn that raises after a successful call still reports the tokens it spent (a first-call failure has accumulated nothing, so nothing is emitted). pydantic_ai's two emit sites collapsed into that single exit point, with the captured-messages fallback covering any raise.
- **opencode usage race:** the per-turn usage dict is now turn-owned (`_begin_turn` allocates a fresh dict; the watch task drains the instance it captured, same snapshot pattern as `turn_future`), so a message racing in between turn completion and the drain can no longer wipe the previous turn's usage.

## Cache & error-path semantics
- Cache is reported RAW (no per-adapter fold) — provider-dependent, so a static normalization isn't correct across adapters.
- Usage emits on every turn exit: the happy path, the benign empty-final-response path, and turns that raise (whatever accumulated before the failure; tokens spent are tokens spent). Adapters whose usage only exists in a terminal result (claude_sdk, agno) have nothing to report when that result never arrives.

## Testing
- Unit: per-adapter mapping (incl. reasoning fold), identity scoping, `is_usage_event`, emit gating, loop-summing, mid-loop-failure emission (anthropic), captured-usage emission on a hard raise (pydantic_ai), turn-owned usage dict survives a racing new turn (opencode).
- **Live E2E:** anthropic / claude_sdk / agno / gemini / google_adk / opencode green; langgraph / pydantic_ai / codex blocked only by an OpenAI account quota (429), not the seam.

## Related
- Implements **INT-931** (parent: INT-911, the L0–L4 baseline ladder).
- Follow-up **INT-933** — make token usage a first-class `usage` event (retires the `band_usage`-on-`task` carrier + the consumer filters).
- Follow-up — per-turn crewai usage (its counter is cumulative-lifetime today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

