### PR TITLE
feat: add GitHub Copilot SDK adapter INT-921

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,10 @@ name: E2E (baseline)
 #                  band-mcp), so the lane runs no Letta cells. Own lane (shares the
 #                  `dev` extra) kept defined for the follow-up; see toolkit/adapters.py.
 #
+# CopilotSDKAdapter (BYOK on Anthropic) runs in `core`: the SDK self-downloads its
+# CLI runtime (no setup step), so it needs no isolated lane — it only needs the
+# Copilot-entitled GITHUB_TOKEN, which every lane's job env carries.
+#
 # An unwired backend still fails loudly (the @requires gate reports the missing
 # CLI/server) until its setup block lands. `fail-fast: false`
 # keeps a red lane from blocking the others.
@@ -149,6 +153,11 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.E2E_ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.E2E_OPENAI_API_KEY }}
       GOOGLE_API_KEY: ${{ secrets.E2E_GOOGLE_API_KEY }}
+      # A PAT from a GitHub account with Copilot entitlement — NOT the ambient
+      # secrets.GITHUB_TOKEN (a repo-scoped installation token with no such
+      # entitlement). The copilot_sdk adapter (in the `core` lane) needs it;
+      # exposed to every lane's job env so `core` picks it up.
+      GITHUB_TOKEN: ${{ secrets.E2E_GITHUB_TOKEN }}
 
     steps:
     - name: Checkout code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This is a Python SDK that connects AI agents to the Band collaborative platform.
 
 ## Core Features
 
-1. Multi-framework support (LangGraph, Anthropic, CrewAI, Claude SDK, Codex, Pydantic AI, Parlant, Gemini, Letta, Google ADK, OpenCode, Agno)
+1. Multi-framework support (LangGraph, Anthropic, CrewAI, Claude SDK, Copilot SDK, Codex, Pydantic AI, Parlant, Gemini, Letta, Google ADK, OpenCode, Agno)
 2. A2A protocol support: Bridge to remote A2A agents and expose Band peers as A2A endpoints
 3. ACP integration: Editor-facing server and subprocess client adapters (Cursor, Codex, Claude Code)
 4. Platform tools for chat, contacts, and memory management
@@ -391,6 +391,7 @@ resolves each in a separate fork.
 - `GOOGLE_API_KEY`: Google API key for Gemini Developer API (for Gemini/Google ADK examples)
 - `GOOGLE_GENAI_USE_VERTEXAI`: Set to `true` to use Vertex AI instead of Gemini Developer API
 - `GOOGLE_CLOUD_PROJECT`: Google Cloud project ID (required when using Vertex AI)
+- `GITHUB_TOKEN`: A token from a GitHub account with Copilot entitlement, for the Copilot SDK adapter's runtime auth (BYOK inference reuses `ANTHROPIC_API_KEY`). Read by the baseline toolkit's `tests/e2e/baseline/settings.py`
 - `E2E_TESTS_ENABLED`: Set to `true` to enable E2E tests (default: disabled)
 - `E2E_LLM_MODEL`: OpenAI model for E2E tests (default: `gpt-5.4-mini`)
 - `E2E_ANTHROPIC_MODEL`: Anthropic model for E2E tests (legacy E2E default: `claude-3-haiku-20240307`; baseline toolkit default: `claude-haiku-4-5` — the baseline judge uses structured outputs, which `claude-3-haiku-20240307` does not support)
@@ -399,7 +400,7 @@ resolves each in a separate fork.
 
 Baseline lane scoping (see `tests/e2e/baseline/README.md`):
 
-- `BAND_E2E_LANE`: The CI lane (a job: a `uv` extra + optional server/CLI setup) to scope the run to. Lane ids are content-based and decoupled from the `uv` extra — `core` (anthropic/openai-family adapters, `dev` extra), `crewai` (`dev-crewai` extra), `google` (gemini/google_adk, split out for rate-limit isolation), `backends` (codex + opencode coding agents), `letta` (self-hosted letta server). Resolves the lane's adapters from the registry (`ci_lanes()`, derived from each adapter's `requires`); out-of-lane adapters skip-with-reason (they're covered by their own lane) while in-lane adapters keep fail-loud (an unwired backend stays red). Unset (the local default) = full matrix, no scoping. CI never lists adapters — it derives lanes from the registry. A test's lane is derived from **all** the frameworks it touches (a matrix cell's adapter plus its `@per_adapter(peer=...)`, or a `@with_adapters` set); a test whose frameworks span more than one home lane fails collection (`assert_every_item_is_schedulable`) unless pinned with `@lane(Lane.X)` to a lane whose extra hosts them all. To add a lane, see `tests/e2e/baseline/README.md` ("Adding a CI lane").
+- `BAND_E2E_LANE`: The CI lane (a job: a `uv` extra + optional server/CLI setup) to scope the run to. Lane ids are content-based and decoupled from the `uv` extra — `core` (anthropic/openai-family adapters plus `copilot_sdk`, which self-downloads its CLI runtime and needs a Copilot-entitled `GITHUB_TOKEN`; `dev` extra), `crewai` (`dev-crewai` extra), `google` (gemini/google_adk, split out for rate-limit isolation), `backends` (codex + opencode coding agents), `letta` (self-hosted letta server). Resolves the lane's adapters from the registry (`ci_lanes()`, derived from each adapter's `requires`); out-of-lane adapters skip-with-reason (they're covered by their own lane) while in-lane adapters keep fail-loud (an unwired backend stays red). Unset (the local default) = full matrix, no scoping. CI never lists adapters — it derives lanes from the registry. A test's lane is derived from **all** the frameworks it touches (a matrix cell's adapter plus its `@per_adapter(peer=...)`, or a `@with_adapters` set); a test whose frameworks span more than one home lane fails collection (`assert_every_item_is_schedulable`) unless pinned with `@lane(Lane.X)` to a lane whose extra hosts them all. To add a lane, see `tests/e2e/baseline/README.md` ("Adding a CI lane").
 
 Baseline provisioning/cleanup policy (see `tests/e2e/baseline/README.md`):
 

--- a/examples/copilot_sdk/01_basic_agent.py
+++ b/examples/copilot_sdk/01_basic_agent.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[copilot_sdk]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Basic GitHub Copilot SDK Agent Example.
+
+This example shows how to create a simple agent using the GitHub Copilot SDK
+connected to the Band platform. The SDK downloads and manages the Copilot CLI
+runtime automatically on first use.
+
+Prerequisites:
+    1. GitHub Copilot access (token or `gh auth login` / `copilot` login)
+    2. Add copilot_sdk_agent credentials to agent_config.yaml
+    3. Set environment variables in .env:
+       - BAND_WS_URL
+       - BAND_REST_URL
+       - GITHUB_TOKEN (optional — omit to use the logged-in GitHub user)
+
+Run with:
+    uv run examples/copilot_sdk/01_basic_agent.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+# Add examples directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import CopilotSDKAdapter, CopilotSDKAdapterConfig
+from band.core.types import AdapterFeatures, Emit
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    """Run the basic Copilot SDK agent."""
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    # Omitting `model` uses the Copilot CLI's default model; pass `model=`
+    # to pin one. With no GITHUB_TOKEN the locally logged-in user is used.
+    adapter = CopilotSDKAdapter(
+        CopilotSDKAdapterConfig(
+            custom_section="You are a helpful assistant. Be concise and friendly.",
+            # Auth resolves automatically: GITHUB_TOKEN wins when set,
+            # otherwise the logged-in GitHub user (gh auth login) is used.
+            github_token=os.getenv("GITHUB_TOKEN"),
+            # Pin a unique per-example session prefix.
+            session_id_prefix="band-copilot-basic-",
+        ),
+        features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
+    )
+
+    agent = Agent.from_config(
+        "copilot_sdk_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Starting Copilot SDK agent...")
+    logger.info("Agent ID: %s", agent.runtime.agent_id)
+    logger.info("Press Ctrl+C to stop")
+
+    try:
+        await agent.run()
+    except KeyboardInterrupt:
+        logger.info("Shutting down...")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/copilot_sdk/02_byok_anthropic.py
+++ b/examples/copilot_sdk/02_byok_anthropic.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[copilot_sdk]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Copilot SDK Agent with BYOK (bring your own key) — Anthropic provider.
+
+Runs the Copilot runtime while doing model inference against your own
+Anthropic API key instead of the Copilot subscription. The GitHub auth is
+still needed to boot the Copilot CLI runtime; the Anthropic key pays for
+the tokens.
+
+Prerequisites:
+    1. GitHub Copilot access (GITHUB_TOKEN or logged-in GitHub user)
+    2. Add copilot_sdk_agent credentials to agent_config.yaml
+    3. Set environment variables in .env:
+       - BAND_WS_URL
+       - BAND_REST_URL
+       - ANTHROPIC_API_KEY (BYOK inference)
+       - GITHUB_TOKEN (optional — omit to use the logged-in GitHub user)
+
+Run with:
+    uv run examples/copilot_sdk/02_byok_anthropic.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+# Add examples directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from copilot import ProviderConfig
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import CopilotSDKAdapter, CopilotSDKAdapterConfig
+from band.core.types import AdapterFeatures, Emit
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    """Run a Copilot SDK agent with Anthropic BYOK inference."""
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+    anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+    if not anthropic_api_key:
+        raise ValueError("ANTHROPIC_API_KEY environment variable is required for BYOK")
+
+    # With BYOK the `model` names the provider's model, not a Copilot one.
+    adapter = CopilotSDKAdapter(
+        CopilotSDKAdapterConfig(
+            model="claude-haiku-4-5",
+            provider=ProviderConfig(
+                type="anthropic",
+                # base_url is required by the runtime, even for known providers.
+                base_url="https://api.anthropic.com",
+                api_key=anthropic_api_key,
+            ),
+            custom_section="You are a helpful assistant. Be concise and friendly.",
+            github_token=os.getenv("GITHUB_TOKEN"),
+            # Pin a unique per-example session prefix.
+            session_id_prefix="band-copilot-byok-",
+        ),
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
+    )
+
+    agent = Agent.from_config(
+        "copilot_sdk_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Starting Copilot SDK agent with Anthropic BYOK...")
+    logger.info("Agent ID: %s", agent.runtime.agent_id)
+    logger.info("Press Ctrl+C to stop")
+
+    try:
+        await agent.run()
+    except KeyboardInterrupt:
+        logger.info("Shutting down...")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/copilot_sdk/03_tom_agent.py
+++ b/examples/copilot_sdk/03_tom_agent.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[copilot_sdk]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Tom the cat agent - tries to catch Jerry!
+
+This example shows how to create a character agent with a custom personality
+using the Copilot SDK adapter.
+
+The character prompt is loaded from a shared prompts module that can be
+reused across different adapter implementations.
+
+Run with (from repo root):
+    uv run examples/copilot_sdk/03_tom_agent.py
+
+Note: Run from the repo root so agent_config.yaml and .env resolve
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+# Add parent directory to path for prompts import
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from prompts.characters import generate_tom_prompt
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import CopilotSDKAdapter, CopilotSDKAdapterConfig
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    adapter = CopilotSDKAdapter(
+        CopilotSDKAdapterConfig(
+            custom_section=generate_tom_prompt("Tom"),
+            github_token=os.getenv("GITHUB_TOKEN"),
+        ),
+    )
+
+    agent = Agent.from_config(
+        "tom_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Tom is on the prowl, looking for Jerry...")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/copilot_sdk/04_jerry_agent.py
+++ b/examples/copilot_sdk/04_jerry_agent.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[copilot_sdk]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Jerry the mouse agent - outsmarts Tom!
+
+This example shows how to create a character agent with a custom personality
+using the Copilot SDK adapter.
+
+The character prompt is loaded from a shared prompts module that can be
+reused across different adapter implementations.
+
+Run with (from repo root):
+    uv run examples/copilot_sdk/04_jerry_agent.py
+
+Note: Run from the repo root so agent_config.yaml and .env resolve
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+# Add parent directory to path for prompts import
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from prompts.characters import generate_jerry_prompt
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import CopilotSDKAdapter, CopilotSDKAdapterConfig
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    adapter = CopilotSDKAdapter(
+        CopilotSDKAdapterConfig(
+            custom_section=generate_jerry_prompt("Jerry"),
+            github_token=os.getenv("GITHUB_TOKEN"),
+        ),
+    )
+
+    agent = Agent.from_config(
+        "jerry_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Jerry is ready to outsmart Tom...")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/copilot_sdk/05_contact_and_memory_agent.py
+++ b/examples/copilot_sdk/05_contact_and_memory_agent.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[copilot_sdk]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Copilot SDK agent with contact and memory tools enabled.
+
+This example shows a Copilot SDK adapter configured to:
+- use contact tools through normal LLM tool calling
+- enable memory tools for durable preferences and notes
+- broadcast contact changes back into active rooms
+
+Try prompts like:
+- "List my contacts and check whether @alice is already connected."
+- "Send a contact request to @alice with a short intro."
+- "Remember that I want concise status updates."
+- "What do you remember about my preferred update style?"
+
+Inference runs BYOK on your Anthropic key (ANTHROPIC_API_KEY in .env).
+
+Run with:
+    uv run examples/copilot_sdk/05_contact_and_memory_agent.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+from copilot import ProviderConfig
+from dotenv import load_dotenv
+
+# Add examples directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import CopilotSDKAdapter, CopilotSDKAdapterConfig
+from band.core.types import AdapterFeatures, Capability, Emit
+from band.runtime.types import ContactEventConfig, ContactEventStrategy
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+    anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not anthropic_api_key:
+        raise ValueError("ANTHROPIC_API_KEY environment variable is required for BYOK")
+
+    # The MEMORY/CONTACTS capabilities already inject full memory- and
+    # contact-tool instructions into the system prompt; custom_section only
+    # adds what the base prompt doesn't cover.
+    adapter = CopilotSDKAdapter(
+        CopilotSDKAdapterConfig(
+            custom_section=(
+                "When a [Contacts] system message reports that a contact was added "
+                "or removed, treat it as fresh room context."
+            ),
+            # BYOK: inference runs on the Anthropic key; GitHub auth still
+            # boots the Copilot runtime (base_url is required by the runtime).
+            model="claude-haiku-4-5",
+            provider=ProviderConfig(
+                type="anthropic",
+                base_url="https://api.anthropic.com",
+                api_key=anthropic_api_key,
+            ),
+            github_token=os.getenv("GITHUB_TOKEN"),
+            # Pin a unique per-example session prefix.
+            session_id_prefix="band-copilot-contact-memory-",
+        ),
+        features=AdapterFeatures(
+            capabilities={Capability.MEMORY, Capability.CONTACTS},
+            emit={Emit.EXECUTION},
+        ),
+    )
+
+    # Contact WebSocket events (requests arriving, contacts added/removed):
+    # DISABLED = never react automatically — no auto-approve, no hub room;
+    # the agent only touches contacts when a user asks it to via the tools
+    # above. broadcast_changes keeps the LLM informed anyway: on a real
+    # contact change the runtime injects a "[Contacts]: ..." system message
+    # into active rooms (the custom_section teaches the model to use it).
+    contact_config = ContactEventConfig(
+        strategy=ContactEventStrategy.DISABLED,
+        broadcast_changes=True,
+    )
+
+    agent = Agent.from_config(
+        "copilot_contact_memory_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+        contact_config=contact_config,
+    )
+
+    logger.info("Starting Copilot SDK contact-and-memory example agent")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/copilot_sdk/06_ask_user.py
+++ b/examples/copilot_sdk/06_ask_user.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[copilot_sdk]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Human-in-the-loop via Copilot's ``ask_user`` tool, answered in the room.
+
+``CopilotSDKAdapterConfig(ask_user="room")`` routes the model's built-in
+``ask_user`` tool to the people in the Band room: the question posts as
+a room message mentioning whoever triggered the turn, the turn ends, and
+the answer arrives as the next room message — the same persisted Copilot
+session picks it up with the pending question still in its history.
+
+The turn *must* end when the question posts: Band delivers a room's
+messages one at a time, so a turn that blocked waiting for the reply
+could never receive it. The room therefore stays responsive while a
+question is open — follow-up messages are processed normally.
+
+Try it in Band chat (agent must be mentioned to be triggered):
+
+    You:    @copilot-agent please deploy release v2.
+    Agent:  Which channel should I deploy release v2 to?
+
+            1. stable
+            2. beta
+            3. canary
+
+            Reply with a number or your own answer.
+    You:    @copilot-agent 2
+    Agent:  Deploying v2 to the beta channel.
+
+Prompts that reliably trigger a question:
+    "@copilot-agent should we ship today or wait for more QA?"
+    "@copilot-agent pick a codename for the next release."
+    "@copilot-agent I need approval to archive this room's notes."
+
+To answer from the agent's terminal instead (an operator supervising the
+process rather than someone in the room), pass a handler:
+``ask_user=OperatorConsole().ask`` — see the README's operator-console
+section.
+
+Prerequisites:
+    1. GitHub Copilot access (token or `gh auth login` / `copilot` login)
+    2. Add copilot_sdk_agent credentials to agent_config.yaml
+    3. Set environment variables in .env:
+       - BAND_WS_URL
+       - BAND_REST_URL
+       - GITHUB_TOKEN (optional — omit to use the logged-in GitHub user)
+
+Run with:
+    uv run examples/copilot_sdk/06_ask_user.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+# Add examples directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import CopilotSDKAdapter, CopilotSDKAdapterConfig
+from band.core.types import AdapterFeatures, Emit
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    """Run the Copilot SDK agent with room-routed ask_user."""
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    adapter = CopilotSDKAdapter(
+        CopilotSDKAdapterConfig(
+            # ask_user="room" already teaches the model when and how to ask
+            # (the adapter injects the contract into the system prompt);
+            # the custom section stays for unrelated behavior.
+            custom_section="Keep replies short and concrete.",
+            github_token=os.getenv("GITHUB_TOKEN"),
+            ask_user="room",
+            # Pin a unique per-example session prefix.
+            session_id_prefix="band-copilot-ask-user-",
+        ),
+        features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
+    )
+
+    agent = Agent.from_config(
+        "copilot_sdk_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Starting Copilot SDK ask_user agent...")
+    logger.info("Agent ID: %s", agent.runtime.agent_id)
+    logger.info("ask_user questions are posted into the room they came from.")
+    logger.info("Press Ctrl+C to stop")
+
+    try:
+        await agent.run()
+    except KeyboardInterrupt:
+        logger.info("Shutting down...")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/copilot_sdk/README.md
+++ b/examples/copilot_sdk/README.md
@@ -1,0 +1,168 @@
+# GitHub Copilot SDK Examples for Band
+
+Examples of using the [GitHub Copilot SDK](https://github.com/github/copilot-sdk)
+(`github-copilot-sdk`) with the Band platform.
+
+## Prerequisites
+
+### 1. GitHub Copilot access
+
+The SDK manages the Copilot CLI runtime internally. It needs a GitHub
+account **with Copilot access** (an authenticated account without a Copilot
+subscription fails at model-call time, not at login):
+
+```bash
+# Either authenticate the GitHub CLI locally...
+gh auth login
+
+# ...or provide a token via the environment
+export GITHUB_TOKEN=ghp_...
+```
+
+Auth resolves automatically: the token wins when set, otherwise the
+logged-in GitHub user is used — no adapter flags needed.
+
+### 2. Pre-fetch the runtime (recommended)
+
+The CLI runtime is auto-downloaded on first use; pre-fetch it so agent
+startup is instant:
+
+```bash
+python -m copilot download-runtime
+```
+
+### 3. Python dependencies
+
+```bash
+# Install with copilot_sdk extras (requires Python 3.11+)
+uv sync --extra copilot_sdk
+# or: pip install "band-sdk[copilot_sdk]"
+```
+
+### 4. Agent credentials
+
+Add a `copilot_sdk_agent` entry (and `tom_agent`/`jerry_agent` for the
+character examples) with `agent_id` and `api_key` to `agent_config.yaml` (copy `agent_config.yaml.example`)
+**in the repo root** — the loader resolves it from the current working
+directory — and set `BAND_WS_URL` / `BAND_REST_URL` in `.env`.
+
+## Examples
+
+| File | Description |
+|------|-------------|
+| `01_basic_agent.py` | Minimal Copilot agent that replies in Band rooms |
+| `02_byok_anthropic.py` | BYOK: inference on your own Anthropic key |
+| `03_tom_agent.py` | Tom character agent |
+| `04_jerry_agent.py` | Jerry character agent |
+| `05_contact_and_memory_agent.py` | Contact + memory platform tools |
+| `06_ask_user.py` | Human-in-the-loop: `ask_user` questions answered in the room |
+
+```bash
+# Run from the repo root (agent_config.yaml is resolved from the CWD)
+uv run examples/copilot_sdk/01_basic_agent.py
+```
+
+## Feature flags
+
+Event reporting and platform-tool exposure are **off by default** — opt in
+via `AdapterFeatures`:
+
+```python
+features=AdapterFeatures(
+    emit={Emit.EXECUTION, Emit.THOUGHTS},          # tool_call/thought events
+    capabilities={Capability.MEMORY, Capability.CONTACTS},  # band_* tool groups
+)
+```
+
+## Human-in-the-loop (`ask_user`)
+
+Copilot's built-in `ask_user` tool lets the model ask a human a question —
+freeform or multiple-choice. Off by default; route it with `ask_user`:
+
+```python
+config = CopilotSDKAdapterConfig(ask_user="room")   # ask the people in the room
+config = CopilotSDKAdapterConfig(ask_user=handler)  # ask someone outside it
+```
+
+### `ask_user="room"` — ask the room (recommended)
+
+The question posts into the room (mentioning whoever triggered the turn),
+the turn ends, and the answer arrives as the next room message — picked up
+by the same persisted Copilot session, which still holds the pending
+question in its history. `06_ask_user.py` demonstrates it.
+
+The turn must end when the question posts: Band delivers a room's messages
+one at a time, so a turn blocked waiting for the reply could never receive
+it — and Copilot keeps an unanswered `ask_user` pending forever (no
+timeout, not replayed on resume). Room mode therefore never blocks the
+room, never races `turn_timeout_s`, and survives restarts.
+
+### `ask_user=<handler>` — ask an operator
+
+A callable is awaited mid-turn with `(UserInputRequest, {"session_id"})`
+and returns `{"answer", "wasFreeform"}`. The turn stays open while it
+waits, so `turn_timeout_s` must exceed the handler's answer window (the
+defaults do: the console gives up gracefully at 90s, under the 120s turn
+default). Tell the model the operator exists — handler mode injects no
+prompt guidance — and raise both knobs for patient operators:
+
+```python
+config = CopilotSDKAdapterConfig(
+    custom_section=(
+        "A human operator supervises you. When a request needs a decision "
+        "you cannot make alone, consult them with the ask_user tool."
+    ),
+    ask_user=OperatorConsole(answer_timeout_s=300.0).ask,
+    turn_timeout_s=600.0,  # must stay above answer_timeout_s
+)
+```
+
+Prefer `OperatorConsole` (`band.integrations.copilot_sdk`) over a bare
+`input()` handler — the SDK leaves the edge cases to the host, and the
+console covers them: per-question deadline (`answer_timeout_s`), answer
+validation against `choices`/`allowFreeform`, one prompt owning the
+terminal across concurrent rooms, parked log output while a prompt is
+open, and a graceful "operator unavailable" answer on stdin EOF.
+
+### One process per agent
+
+The runtime refuses to start a second process for the same agent id on
+one host (duplicates steal in-flight room messages and resume the same
+on-disk Copilot sessions). Opt out with `AgentConfig(single_instance=False)`.
+
+## Models
+
+- `model=None` (default) uses the Copilot CLI's default model. List what
+  your account can use with `await client.list_models()`.
+- With **BYOK** (`provider=...`) the `model` names the *provider's* model
+  (e.g. `claude-haiku-4-5` for Anthropic) — not a Copilot model id, and `base_url` is required. BYOK moves
+  inference billing to your key; GitHub auth is still required to boot the
+  Copilot runtime.
+
+## Notes
+
+- Each Band room maps to its own Copilot session (`band-{agent-id}-{room_id}`),
+  so conversations stay isolated — per room *and* per agent — and can resume
+  across restarts on the same host.
+- Copilot's built-in shell/file tools are disabled by the adapter; the model
+  only sees Band platform tools (and any custom tools you add via
+  `additional_tools`).
+- Agents sharing a host or one `CopilotClient` (`client=`) are kept apart by
+  their names in the default session ids; set `session_id_prefix` only to
+  override that scheme, and use per-agent `base_directory` for full on-disk
+  state isolation.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `FileNotFoundError: Config file not found at .../agent_config.yaml` | Example run from a subdirectory (config resolves from CWD) | Run from the repo root |
+| `BandConfigError: Not authenticated with GitHub Copilot` at startup | No `gh auth login` and no `GITHUB_TOKEN` | Log in with the GitHub CLI or set a token |
+| Turns fail with model-call errors despite valid login | Account has no Copilot entitlement | Use an account with a Copilot subscription, or BYOK |
+| BYOK turns fail: `Session error: Failed to get response from the AI model … 429 You exceeded your current quota` | Provider key out of quota or invalid | Fund/replace the provider key, or drop `provider=` to use the Copilot subscription |
+| Agent startup is slow | Runtime downloading/spawning at boot | Pre-fetch with `python -m copilot download-runtime` |
+| Turn raises after `turn_timeout_s` (default 120s) | Long-running turn | Raise `CopilotSDKAdapterConfig(turn_timeout_s=...)` |
+| Agent replies but no tool/thought events appear | `Emit` flags not set | Pass `features=AdapterFeatures(emit={...})` |
+| `BandConfigError: … already running on this host` at startup | Another process runs the same agent id | Stop it, or set `AgentConfig(single_instance=False)` |
+| Room reply says the operator did not answer (console handler) | `ask_user` question expired unanswered | Answer within `answer_timeout_s`, or raise it (keep it below `turn_timeout_s`) |
+| Every question answers "no operator is attached" (console handler) | stdin closed (headless run / piped input exhausted) | Run in a real terminal, or use `ask_user="room"` |

--- a/examples/copilot_sdk/__init__.py
+++ b/examples/copilot_sdk/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub Copilot SDK examples for Band platform."""

--- a/examples/copilot_sdk/setup_logging.py
+++ b/examples/copilot_sdk/setup_logging.py
@@ -1,0 +1,17 @@
+"""Shared logging configuration for Copilot SDK examples."""
+
+from __future__ import annotations
+
+import os
+
+from band import LogLevel, configure_logging
+
+
+def setup_logging(level: LogLevel | None = None) -> None:
+    """Configure logging to show only band logs, hiding noisy dependencies."""
+    if level is None:
+        # Tolerate LOG_LEVEL= (empty) and numeric forms like LOG_LEVEL=20;
+        # configure_logging rejects both as level-name strings.
+        raw = os.environ.get("LOG_LEVEL") or "INFO"
+        level = int(raw) if raw.isdecimal() else raw
+    configure_logging(level)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ langgraph = [
 claude_sdk = [
     "claude-agent-sdk>=0.1.16",  # Requires Node.js 20+ and @anthropic-ai/claude-code CLI
 ]
+copilot_sdk = [
+    "github-copilot-sdk>=1.0.5",  # Bundles/downloads the Copilot CLI runtime; needs GitHub Copilot auth
+]
 parlant = [
     "parlant>=3.0.0",
     "openai>=1.0.0",
@@ -153,6 +156,8 @@ dev = [
     "anthropic>=0.75.0",
     # Include claude_sdk for testing
     "claude-agent-sdk>=0.1.16",
+    # Include copilot_sdk for testing
+    "github-copilot-sdk>=1.0.5",
     # Include langgraph for testing
     "langchain>=1.0.0",
     "langchain-core>=1.2.11",

--- a/src/band/adapters/__init__.py
+++ b/src/band/adapters/__init__.py
@@ -7,6 +7,7 @@ Install the extra you need::
     uv add band-sdk[anthropic]
     uv add band-sdk[pydantic_ai]
     uv add band-sdk[claude_sdk]
+    uv add band-sdk[copilot_sdk]
     uv add band-sdk[parlant]
     uv add band-sdk[crewai]
     uv add band-sdk[gemini]
@@ -20,6 +21,7 @@ Install the extra you need::
 
 from __future__ import annotations
 
+import importlib
 from typing import TYPE_CHECKING
 
 # Type-only imports for static analysis (pyrefly, mypy, etc.)
@@ -28,6 +30,10 @@ if TYPE_CHECKING:
     from band.adapters.anthropic import AnthropicAdapter as AnthropicAdapter
     from band.adapters.pydantic_ai import PydanticAIAdapter as PydanticAIAdapter
     from band.adapters.claude_sdk import ClaudeSDKAdapter as ClaudeSDKAdapter
+    from band.adapters.copilot_sdk import CopilotSDKAdapter as CopilotSDKAdapter
+    from band.adapters.copilot_sdk import (
+        CopilotSDKAdapterConfig as CopilotSDKAdapterConfig,
+    )
     from band.adapters.parlant import ParlantAdapter as ParlantAdapter
     from band.adapters.crewai import CrewAIAdapter as CrewAIAdapter
     from band.adapters.crewai_flow import (
@@ -58,6 +64,8 @@ __all__ = [
     "AnthropicAdapter",
     "PydanticAIAdapter",
     "ClaudeSDKAdapter",
+    "CopilotSDKAdapter",
+    "CopilotSDKAdapterConfig",
     "ParlantAdapter",
     "CrewAIAdapter",
     "CrewAIFlowAdapter",
@@ -81,102 +89,41 @@ __all__ = [
 ]
 
 
+# Submodule (under band.adapters) providing each lazily imported name.
+_LAZY_IMPORTS: dict[str, str] = {
+    "LangGraphAdapter": "langgraph",
+    "AnthropicAdapter": "anthropic",
+    "PydanticAIAdapter": "pydantic_ai",
+    "ClaudeSDKAdapter": "claude_sdk",
+    "CopilotSDKAdapter": "copilot_sdk",
+    "CopilotSDKAdapterConfig": "copilot_sdk",
+    "ParlantAdapter": "parlant",
+    "CrewAIAdapter": "crewai",
+    "CrewAIFlowAdapter": "crewai_flow",
+    "A2AAdapter": "a2a",
+    "A2AGatewayAdapter": "a2a_gateway",
+    "CodexAdapter": "codex",
+    "CodexAdapterConfig": "codex",
+    "ACPClientAdapter": "acp",
+    "ACPServer": "acp",
+    "BandACPServerAdapter": "acp",
+    "AgnoAdapter": "agno",
+    "GeminiAdapter": "gemini",
+    "GoogleADKAdapter": "google_adk",
+    "OpencodeAdapter": "opencode",
+    "OpencodeAdapterConfig": "opencode",
+    "LettaAdapter": "letta",
+    "LettaAdapterConfig": "letta",
+    "SlackAdapter": "slack",
+    "SlackApp": "slack",
+    "SlackSessionState": "slack",
+}
+
+
 def __getattr__(name: str) -> type:
     """Lazy import adapters to avoid loading optional dependencies."""
-    if name == "LangGraphAdapter":
-        from band.adapters.langgraph import LangGraphAdapter
-
-        return LangGraphAdapter
-    elif name == "AnthropicAdapter":
-        from band.adapters.anthropic import AnthropicAdapter
-
-        return AnthropicAdapter
-    elif name == "PydanticAIAdapter":
-        from band.adapters.pydantic_ai import PydanticAIAdapter
-
-        return PydanticAIAdapter
-    elif name == "ClaudeSDKAdapter":
-        from band.adapters.claude_sdk import ClaudeSDKAdapter
-
-        return ClaudeSDKAdapter
-    elif name == "ParlantAdapter":
-        from band.adapters.parlant import ParlantAdapter
-
-        return ParlantAdapter
-    elif name == "CrewAIAdapter":
-        from band.adapters.crewai import CrewAIAdapter
-
-        return CrewAIAdapter
-    elif name == "CrewAIFlowAdapter":
-        from band.adapters.crewai_flow import CrewAIFlowAdapter
-
-        return CrewAIFlowAdapter
-    elif name == "A2AAdapter":
-        from band.adapters.a2a import A2AAdapter
-
-        return A2AAdapter
-    elif name == "A2AGatewayAdapter":
-        from band.adapters.a2a_gateway import A2AGatewayAdapter
-
-        return A2AGatewayAdapter
-    elif name == "CodexAdapter":
-        from band.adapters.codex import CodexAdapter
-
-        return CodexAdapter
-    elif name == "CodexAdapterConfig":
-        from band.adapters.codex import CodexAdapterConfig
-
-        return CodexAdapterConfig
-    elif name in (
-        "ACPClientAdapter",
-        "ACPServer",
-        "BandACPServerAdapter",
-    ):
-        from band.adapters.acp import (
-            ACPClientAdapter,
-            ACPServer,
-            BandACPServerAdapter,
-        )
-
-        if name == "ACPClientAdapter":
-            return ACPClientAdapter
-        elif name == "ACPServer":
-            return ACPServer
-        return BandACPServerAdapter
-    elif name == "AgnoAdapter":
-        from band.adapters.agno import AgnoAdapter
-
-        return AgnoAdapter
-    elif name == "GeminiAdapter":
-        from band.adapters.gemini import GeminiAdapter
-
-        return GeminiAdapter
-    elif name == "GoogleADKAdapter":
-        from band.adapters.google_adk import GoogleADKAdapter
-
-        return GoogleADKAdapter
-    elif name == "OpencodeAdapter":
-        from band.adapters.opencode import OpencodeAdapter
-
-        return OpencodeAdapter
-    elif name == "OpencodeAdapterConfig":
-        from band.adapters.opencode import OpencodeAdapterConfig
-
-        return OpencodeAdapterConfig
-    elif name == "LettaAdapter":
-        from band.adapters.letta import LettaAdapter
-
-        return LettaAdapter
-    elif name == "LettaAdapterConfig":
-        from band.adapters.letta import LettaAdapterConfig
-
-        return LettaAdapterConfig
-    elif name in ("SlackAdapter", "SlackApp", "SlackSessionState"):
-        from band.adapters.slack import SlackAdapter, SlackApp, SlackSessionState
-
-        if name == "SlackAdapter":
-            return SlackAdapter
-        elif name == "SlackApp":
-            return SlackApp
-        return SlackSessionState
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name = _LAZY_IMPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(f".{module_name}", __name__)
+    return getattr(module, name)

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -45,7 +45,9 @@ from band.runtime.custom_tools import (
     custom_tool_to_openai_schema,
     execute_custom_tool,
     find_custom_tool,
+    format_validation_error,
 )
+from band.runtime.tools import SELF_REPORTING_TOOL_NAMES
 from band.runtime.prompts import render_system_prompt
 
 logger = logging.getLogger(__name__)
@@ -56,16 +58,12 @@ ApprovalDecision = Literal["accept", "acceptForSession", "decline"]
 _REASONING_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
 _REASONING_SUMMARIES = {"auto", "concise", "detailed", "none"}
 
-# Platform tools whose execution should not be reported as tool_call/tool_result
-# events — they already produce visible output (messages or events) on the platform.
-_SILENT_REPORTING_TOOLS: frozenset[str] = frozenset(
-    {
-        "band_send_message",
-        "band_send_event",
-        "setmodel",
-        "setreasoning",
-    }
-)
+# Shared platform set plus codex-local slash commands, which also surface
+# their outcome in the room themselves.
+_SILENT_REPORTING_TOOLS: frozenset[str] = SELF_REPORTING_TOOL_NAMES | {
+    "setmodel",
+    "setreasoning",
+}
 
 # Slash commands recognised by _extract_local_command().
 _LOCAL_COMMANDS: frozenset[str] = frozenset(
@@ -1362,9 +1360,7 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                         message_type="tool_result",
                     )
             except ValidationError as exc:
-                errors = "; ".join(
-                    f"{err['loc'][0]}: {err['msg']}" for err in exc.errors()
-                )
+                errors = format_validation_error(exc)
                 error_text = f"Invalid arguments for {tool_name}: {errors}"
                 logger.error("Validation error for tool %s: %s", tool_name, exc)
                 await self._client.respond(

--- a/src/band/adapters/copilot_sdk.py
+++ b/src/band/adapters/copilot_sdk.py
@@ -1,0 +1,902 @@
+"""GitHub Copilot SDK adapter for Band.
+
+Bridges Band rooms to the GitHub Copilot SDK (``github-copilot-sdk``),
+which manages the Copilot CLI runtime subprocess internally. One adapter
+owns one Copilot client; each room gets its own Copilot session so
+history, memory, and context stay isolated per room.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+from pydantic import ValidationError
+
+from band.converters.copilot_sdk import (
+    SESSION_ID_METADATA_KEY,
+    CopilotSDKHistoryConverter,
+    CopilotSDKSessionState,
+)
+from band.core.exceptions import BandConfigError
+from band.core.simple_adapter import SimpleAdapter
+from band.core.tool_filter import filter_tool_schemas
+from band.core.types import Capability, Emit, MessageType, TurnUsage
+from band.integrations.copilot_sdk import CopilotSessionManager
+from band.integrations.copilot_sdk.prompts import TURN_COMPLETION_GUIDANCE
+from band.integrations.copilot_sdk.room_ask_user import (
+    ASK_USER_ROOM,
+    ROOM_ASK_USER_GUIDANCE,
+    delivery_failed_answer,
+    question_delivered_answer,
+    render_room_question,
+    room_inactive_answer,
+)
+from band.runtime.custom_tools import (
+    custom_tools_to_schemas,
+    execute_custom_tool,
+    find_custom_tool,
+    format_validation_error,
+)
+from band.runtime.prompts import render_system_prompt
+from band.runtime.tools import SELF_REPORTING_TOOL_NAMES, get_band_tool_category
+
+try:
+    from copilot import CopilotClient, PermissionHandler, Tool, ToolResult
+    from copilot.generated.session_events import (
+        AssistantReasoningData,
+        AssistantUsageData,
+    )
+
+    _COPILOT_SDK_AVAILABLE = True
+except ImportError:
+    _COPILOT_SDK_AVAILABLE = False
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from copilot import (
+        CopilotSession,
+        ProviderConfig,
+        SessionEvent,
+        ToolInvocation,
+        UserInputHandler,
+        UserInputRequest,
+        UserInputResponse,
+    )
+
+    from band.core.protocols import AgentToolsProtocol, HistoryConverter
+    from band.core.types import AdapterFeatures, PlatformMessage
+    from band.runtime.custom_tools import CustomToolDef
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CopilotSDKAdapterConfig:
+    """Runtime configuration for Copilot SDK adapter sessions.
+
+    Attributes:
+        model: Copilot model to use (None = Copilot CLI default).
+        custom_section: Extra system-prompt section.
+        reasoning_effort: Reasoning effort for reasoning-capable models.
+        provider: BYOK ``ProviderConfig`` (e.g. ``ProviderConfig(
+            type="openai", base_url=..., api_key=...)``) to run inference
+            against your own key instead of the Copilot subscription;
+            ``model`` then names the provider's model.
+        inject_history_on_resume_failure: Inject text history into a
+            fresh session when resuming a persisted session fails.
+        session_id_prefix: Prefix for per-room Copilot session ids. None
+            (default) derives ``band-{agent-id}-`` from the immutable Band
+            agent id, so agents sharing a host or client never resume each
+            other's sessions; when set explicitly it must be unique per
+            agent.
+        base_directory: Copilot state directory (COPILOT_HOME). Set a
+            per-agent directory to fully isolate on-disk state between
+            agents sharing a host.
+        github_token: GitHub token for Copilot auth. Auth resolves
+            automatically: the token wins when set, otherwise the locally
+            logged-in GitHub user is used — so both fields can usually stay
+            at their defaults.
+        use_logged_in_user: Force using the logged-in GitHub user; None
+            (default) lets the SDK resolve it from ``github_token``.
+        turn_timeout_s: Max seconds to wait for a turn to complete.
+        ask_user: Routing for Copilot's built-in ``ask_user``
+            human-in-the-loop tool; ``None`` (default) keeps the tool
+            disabled.
+
+            ``"room"`` routes questions to the people in the Band room:
+            the question posts as a room message mentioning whoever
+            triggered the turn, the tool call resolves immediately with
+            a delivery acknowledgement so the turn ends, and the answer
+            arrives as the next room message on the same persisted
+            session. This is the only routing that fits both runtimes —
+            Band delivers a room's messages strictly one at a time, so
+            a turn blocked on a room reply could never receive it, and
+            Copilot keeps an unanswered ``ask_user`` pending forever
+            (no timeout, no cancellation, not replayed on resume). See
+            ``band.integrations.copilot_sdk.room_ask_user``.
+
+            A callable answers on behalf of someone *outside* the room
+            (terminal operator, approval service). It is awaited
+            mid-turn with ``(UserInputRequest, {"session_id"})`` and
+            must return ``{"answer", "wasFreeform"}``; the turn keeps
+            counting against ``turn_timeout_s`` while it waits, so
+            raise ``turn_timeout_s`` above the handler's own answer
+            window or the turn dies before the human can answer. For a
+            terminal-backed handler use
+            :class:`band.integrations.copilot_sdk.OperatorConsole` — it
+            covers the edge cases the SDK leaves to the host (no
+            handler timeout, no cancellation on abort, no answer
+            validation). Its default answer window fits under this
+            default turn timeout; when raising ``answer_timeout_s``,
+            raise ``turn_timeout_s`` above it (e.g. 300/600).
+    """
+
+    model: str | None = None
+    custom_section: str = ""
+    reasoning_effort: str | None = None
+    provider: ProviderConfig | None = None
+    inject_history_on_resume_failure: bool = True
+    session_id_prefix: str | None = None
+    base_directory: str | None = None
+    github_token: str | None = None
+    use_logged_in_user: bool | None = None
+    turn_timeout_s: float = 120.0
+    ask_user: UserInputHandler | Literal["room"] | None = None
+
+
+@dataclass
+class RoomSessionIds:
+    """The room's Copilot session id: current vs last persisted to platform."""
+
+    current: str | None = None
+    persisted: str | None = None
+
+
+@dataclass
+class TurnState:
+    """Mutable per-turn scratch state; turns are serialized per room."""
+
+    # Mention target for anything this turn posts to the room: whoever
+    # sent the message that triggered it.
+    sender_mention: dict[str, str]
+    # True once the turn produced a room message (band_send_message or a
+    # room-routed ask_user question) — the final text then must not be
+    # auto-sent on top of it.
+    replied_in_room: bool = False
+    # Reasoning blocks keyed by reasoning_id: the CLI re-emits a block's
+    # ``assistant.reasoning`` event several times per turn (same id), so keying
+    # by id posts each block once, not 2-3x. Last write wins.
+    reasonings: dict[str, str] = field(default_factory=dict)
+    # Summed across the turn's per-call assistant.usage events; emitted once.
+    usage: TurnUsage = field(default_factory=TurnUsage)
+
+
+class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
+    """Adapter for the GitHub Copilot SDK.
+
+    Maps each Band room to a dedicated Copilot session (stable
+    ``session_id`` per room enables resume across restarts). Band platform
+    tools and developer custom tools are bridged as native Copilot tools
+    whose handlers execute in-process; Copilot built-in tools (shell/file)
+    stay disabled so the agent only sees Band's tool surface.
+
+    Example:
+        adapter = CopilotSDKAdapter(
+            CopilotSDKAdapterConfig(model="gpt-5"),
+            # Event reporting is off by default; opt in explicitly.
+            features=AdapterFeatures(emit={Emit.EXECUTION, Emit.THOUGHTS}),
+        )
+        agent = Agent.create(adapter=adapter, agent_id=..., api_key=...)
+    """
+
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset(
+        {Emit.EXECUTION, Emit.THOUGHTS, Emit.USAGE}
+    )
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY, Capability.CONTACTS}
+    )
+
+    def __init__(
+        self,
+        config: CopilotSDKAdapterConfig | None = None,
+        *,
+        history_converter: HistoryConverter[CopilotSDKSessionState] | None = None,
+        additional_tools: list[CustomToolDef] | None = None,
+        features: AdapterFeatures | None = None,
+        client: Any | None = None,
+        client_factory: Callable[[], Any] | None = None,
+    ):
+        """Initialize the Copilot SDK adapter.
+
+        Args:
+            config: Value settings for sessions (model, provider, auth,
+                prompts, timeouts) — see :class:`CopilotSDKAdapterConfig`.
+            history_converter: Override the default history converter.
+            additional_tools: Developer custom tools as (InputModel, handler).
+            features: Shared adapter feature settings.
+            client: Externally-owned ``CopilotClient`` shared with other
+                adapters (one client, many sessions). The adapter borrows it —
+                it never calls ``stop()`` on it; the caller owns its lifecycle.
+                Give each sharing agent a distinct ``session_id_prefix`` so
+                per-room session ids can't collide.
+            client_factory: Factory returning a Copilot client the adapter
+                owns (created and stopped by the adapter; test seam).
+        """
+        if not _COPILOT_SDK_AVAILABLE:
+            raise ImportError(
+                "github-copilot-sdk is required for CopilotSDKAdapter.\n"
+                "Install with: pip install 'band-sdk[copilot_sdk]'\n"
+                "Requires GitHub Copilot authentication (token or logged-in user)."
+            )
+        if client is not None and client_factory is not None:
+            raise BandConfigError(
+                "Pass either client (shared, caller-owned) or client_factory "
+                "(adapter-owned), not both."
+            )
+
+        super().__init__(
+            history_converter=history_converter or CopilotSDKHistoryConverter(),
+            features=features,
+        )
+        self.config = config or CopilotSDKAdapterConfig()
+        ask_user = self.config.ask_user
+        if (
+            ask_user is not None
+            and not callable(ask_user)
+            and ask_user != ASK_USER_ROOM
+        ):
+            raise BandConfigError(
+                f"ask_user must be {ASK_USER_ROOM!r}, a handler callable, or "
+                f"None — got {ask_user!r}."
+            )
+
+        self._shared_client = client
+        self._client_factory = client_factory
+        self._custom_tools: list[CustomToolDef] = list(additional_tools or [])
+        self._session_manager: CopilotSessionManager | None = None
+        # Refreshed every on_message; tool handlers resolve through this so
+        # they never stay bound to a stale tools object from an earlier turn.
+        self._room_tools: dict[str, AgentToolsProtocol] = {}
+        self._session_ids: dict[str, RoomSessionIds] = {}
+        self._turn_state: dict[str, TurnState] = {}
+        self._system_prompt: str = ""
+
+    # --- Lifecycle -------------------------------------------------------
+
+    async def on_started(self, agent_name: str, agent_description: str) -> None:
+        await super().on_started(agent_name, agent_description)
+        # Fixed for the adapter's lifetime — render once, not per session.
+        # Adapter-contributed SDK-contract sections (not developer instructions):
+        # turn-completion is always required (the CLI runtime's continue-nudge
+        # affects every turn); room-mode ask_user adds its own section on top.
+        extra_sections = [TURN_COMPLETION_GUIDANCE]
+        if self.config.ask_user == ASK_USER_ROOM:
+            extra_sections.append(ROOM_ASK_USER_GUIDANCE)
+        self._system_prompt = render_system_prompt(
+            agent_name=self.agent_name,
+            agent_description=self.agent_description,
+            custom_section=self.config.custom_section,
+            features=self.features,
+            extra_sections=tuple(extra_sections),
+        )
+
+        if self._shared_client is not None:
+            client = self._shared_client
+        elif self._client_factory is not None:
+            client = self._client_factory()
+        else:
+            client = CopilotClient(
+                base_directory=self.config.base_directory,
+                github_token=self.config.github_token,
+                use_logged_in_user=self.config.use_logged_in_user,
+            )
+        self._session_manager = CopilotSessionManager(
+            client, owns_client=self._shared_client is None
+        )
+        # Start eagerly so the runtime download/spawn cost lands at boot
+        # (visible in logs) instead of inside the first message's turn.
+        await self._session_manager.ensure_started()
+        try:
+            await self._check_auth(client)
+        except BaseException:
+            # Failed startup must not leak a running owned client
+            # (Agent.stop is never called when start() raises).
+            await self._session_manager.stop()
+            raise
+        logger.info(
+            "CopilotSDKAdapter started (agent=%s, model=%s)",
+            agent_name,
+            self.config.model or "<copilot default>",
+        )
+
+    @staticmethod
+    async def _check_auth(client: Any) -> None:
+        """Fail fast with an actionable message when Copilot auth is missing."""
+        get_auth_status = getattr(client, "get_auth_status", None)
+        if get_auth_status is None:  # test fakes / exotic clients
+            return
+        status = await get_auth_status()
+        if not getattr(status, "isAuthenticated", True):
+            raise BandConfigError(
+                "Not authenticated with GitHub Copilot: "
+                f"{getattr(status, 'statusMessage', None) or 'no credentials found'}. "
+                "Log in with the GitHub CLI (gh auth login) or set a token via "
+                "CopilotSDKAdapterConfig(github_token=...)."
+            )
+
+    async def on_cleanup(self, room_id: str) -> None:
+        """Clean up the room's Copilot session when the agent leaves.
+
+        The client stays alive for the adapter's lifetime (it serves all
+        rooms); ``cleanup_all`` stops it at shutdown (unless it was borrowed
+        via ``client=`` — then its owner stops it).
+        """
+        if self._session_manager:
+            await self._session_manager.cleanup_session(room_id)
+        self._room_tools.pop(room_id, None)
+        self._session_ids.pop(room_id, None)
+        self._turn_state.pop(room_id, None)
+
+    async def cleanup_all(self) -> None:
+        """Stop all sessions and, if adapter-owned, the Copilot client."""
+        if self._session_manager:
+            await self._session_manager.stop()
+        self._room_tools.clear()
+        self._session_ids.clear()
+        self._turn_state.clear()
+
+    # --- Message handling --------------------------------------------------
+
+    async def on_message(
+        self,
+        msg: PlatformMessage,
+        tools: AgentToolsProtocol,
+        history: CopilotSDKSessionState,
+        participants_msg: str | None,
+        contacts_msg: str | None,
+        *,
+        is_session_bootstrap: bool,
+        room_id: str,
+    ) -> None:
+        if self._session_manager is None:
+            raise RuntimeError(
+                "CopilotSDKAdapter session manager not initialized — was on_started() called?"
+            )
+
+        self._room_tools[room_id] = tools
+        if is_session_bootstrap and history.session_id:
+            ids = self._session_ids.setdefault(room_id, RoomSessionIds())
+            ids.persisted = ids.persisted or history.session_id
+
+        # Same-session calls must not interleave; other rooms run concurrently.
+        async with self._session_manager.turn_lock(room_id):
+            session, inject_text = await self._obtain_session(
+                room_id, history, tools, is_session_bootstrap=is_session_bootstrap
+            )
+            prompt = self._compose_prompt(
+                msg,
+                participants_msg,
+                contacts_msg,
+                room_id=room_id,
+                inject_text=inject_text,
+            )
+
+            # The session's tool handler records band_send_message calls in
+            # this slot; safe because the turn lock serializes turns per room.
+            turn = TurnState(
+                sender_mention={
+                    "id": msg.sender_id,
+                    "name": msg.sender_name or msg.sender_type,
+                }
+            )
+            self._turn_state[room_id] = turn
+            try:
+                final_text = await self._run_turn(session, prompt, turn)
+            except Exception as exc:
+                logger.exception("Room %s: Copilot turn failed", room_id)
+                # Abort any work the runtime is still doing for this turn and
+                # drop the session; the next message resumes it fresh by id.
+                await self._session_manager.evict_session(room_id)
+                await self._report_error(tools, str(exc))
+                raise
+            finally:
+                self._turn_state.pop(room_id, None)
+                # No-op unless Emit.USAGE is on / usage is non-empty; best-effort,
+                # never raises. In the finally so a turn that errors or times out
+                # AFTER a model call still reports the tokens it spent.
+                await self.emit_usage(tools, turn.usage)
+
+            await self._emit_thoughts(turn, tools)
+
+            # Session errors raise out of send_and_wait, so a None here
+            # with no room output means the model genuinely said nothing.
+            if final_text is None and not turn.replied_in_room:
+                await self._report_error(tools, "no assistant reply")
+                raise RuntimeError("Copilot turn produced no reply")
+
+            # The turn may already have replied into the room; sending its
+            # final text too would duplicate the reply.
+            if final_text and not turn.replied_in_room:
+                await tools.send_message(final_text, mentions=[turn.sender_mention])
+
+            await self._persist_session_id(room_id, tools)
+
+        logger.debug("Room %s: message %s processed", room_id, msg.id)
+
+    # --- Session handling --------------------------------------------------
+
+    def _ids(self, room_id: str) -> RoomSessionIds:
+        """Return (creating if needed) the room's session-id record."""
+        return self._session_ids.setdefault(room_id, RoomSessionIds())
+
+    def _session_prefix(self) -> str:
+        """Return the per-room session-id prefix.
+
+        The default folds in the Band agent id (set by the runtime before
+        ``on_started``; immutable, unlike the display name) so two agents
+        in the same room never compute the same session id — and a rename
+        doesn't orphan persisted sessions.
+        """
+        if self.config.session_id_prefix is not None:
+            return self.config.session_id_prefix
+        if agent_id := getattr(self, "_band_agent_id", None):
+            return f"band-{agent_id}-"
+        # Adapters driven without the Band runtime fall back to the name.
+        agent_slug = re.sub(r"[^a-z0-9]+", "-", self.agent_name.lower()).strip("-")
+        return f"band-{agent_slug or 'agent'}-"
+
+    async def _obtain_session(
+        self,
+        room_id: str,
+        history: CopilotSDKSessionState,
+        tools: AgentToolsProtocol,
+        *,
+        is_session_bootstrap: bool,
+    ) -> tuple[CopilotSession, str | None]:
+        """Return the room's session plus history text to inject, if any.
+
+        Resume is attempted when a persisted session id is known; on miss
+        the session is created fresh and the converter's text history is
+        injected (subject to ``inject_history_on_resume_failure``) so
+        context survives a fresh process/host.
+        """
+        manager = self._session_manager
+        assert manager is not None  # guarded by on_message
+
+        session = manager.get_session(room_id)
+        if session is not None:
+            return session, None
+
+        stored_id = self._ids(room_id).current
+        if is_session_bootstrap:
+            stored_id = history.session_id or stored_id
+
+        await manager.ensure_started()
+        kwargs = self._session_kwargs(
+            room_id, self._build_bridged_tools(room_id, tools)
+        )
+        session = (
+            await self._resume_session(room_id, stored_id, kwargs)
+            if stored_id
+            else None
+        )
+        resumed = session is not None
+        if session is None:
+            session = await self._create_session(room_id, kwargs)
+        manager.store_session(room_id, session)
+
+        inject = (
+            not resumed
+            and bool(history.text)
+            and (stored_id is None or self.config.inject_history_on_resume_failure)
+        )
+        return session, history.text if inject else None
+
+    async def _resume_session(
+        self, room_id: str, stored_id: str, kwargs: dict[str, Any]
+    ) -> CopilotSession | None:
+        """Resume a persisted session, or return None when its state is absent."""
+        assert self._session_manager is not None
+        try:
+            session = await self._session_manager.client.resume_session(
+                stored_id, **kwargs
+            )
+        except Exception as exc:
+            logger.warning(
+                "Room %s: resume failed for session %s: %s — creating fresh",
+                room_id,
+                stored_id,
+                exc,
+            )
+            return None
+        self._ids(room_id).current = stored_id
+        logger.info("Room %s: resumed Copilot session %s", room_id, stored_id)
+        return session
+
+    async def _create_session(
+        self, room_id: str, kwargs: dict[str, Any]
+    ) -> CopilotSession:
+        """Create a fresh session under the room's deterministic id."""
+        assert self._session_manager is not None
+        new_id = f"{self._session_prefix()}{room_id}"
+        session = await self._session_manager.client.create_session(
+            session_id=new_id, **kwargs
+        )
+        self._ids(room_id).current = new_id
+        logger.info("Room %s: created Copilot session %s", room_id, new_id)
+        return session
+
+    def _session_kwargs(
+        self, room_id: str, bridged_tools: list[Tool]
+    ) -> dict[str, Any]:
+        """Return the shared kwargs for create_session / resume_session."""
+        # Restrict the session to our bridged tools — keeps Copilot's
+        # built-in shell/file tools off, which also makes approve_all safe.
+        available_tools = [tool.name for tool in bridged_tools]
+        kwargs: dict[str, Any] = {
+            "model": self.config.model,
+            "reasoning_effort": self.config.reasoning_effort,
+            "provider": self.config.provider,
+            "tools": bridged_tools,
+            "system_message": {"mode": "replace", "content": self._system_prompt},
+            "available_tools": available_tools,
+            "on_permission_request": PermissionHandler.approve_all,
+        }
+        if self.config.ask_user is not None:
+            # ask_user is session-isolated (no shell/file/host access), so
+            # allowing it does not weaken the approve_all stance above.
+            available_tools.append("ask_user")
+            kwargs["on_user_input_request"] = (
+                self.config.ask_user
+                if callable(self.config.ask_user)
+                else self._make_room_ask_user_handler(room_id)
+            )
+        return kwargs
+
+    def _make_room_ask_user_handler(self, room_id: str) -> UserInputHandler:
+        """Bind the room id for the session's ask_user → room bridge."""
+
+        async def handle(
+            request: UserInputRequest, _context: dict[str, str]
+        ) -> UserInputResponse:
+            return await self._deliver_question_to_room(room_id, request)
+
+        return handle
+
+    async def _deliver_question_to_room(
+        self, room_id: str, request: UserInputRequest
+    ) -> UserInputResponse:
+        """Post an ask_user question to the room and resolve the tool call.
+
+        Never blocks the turn on the reply: the room's messages are
+        processed one at a time, so an answer could not be delivered while
+        this turn holds the loop — and Copilot would keep the request
+        pending forever (no timeout, not replayed on resume). The question
+        becomes the turn's room output and the answer arrives as the next
+        message on the same persisted session.
+        """
+        room_tools = self._room_tools.get(room_id)
+        turn = self._turn_state.get(room_id)
+        if room_tools is None or turn is None:
+            # A late dispatch after the turn/room ended (the SDK never
+            # cancels pending asks) must degrade, not crash the RPC.
+            return room_inactive_answer()
+        rendered = render_room_question(request)
+        try:
+            await room_tools.send_message(rendered, mentions=[turn.sender_mention])
+        except Exception as exc:
+            logger.warning(
+                "Room %s: ask_user question delivery failed: %s", room_id, exc
+            )
+            return delivery_failed_answer(exc)
+        # The question is this turn's reply; suppress the final-text
+        # fallback so a "waiting for your answer" wrap-up can't shadow it.
+        self._mark_replied_in_room(room_id, turn)
+        # The ack echoes the rendered form so the model knows exactly what
+        # the user sees — e.g. that a bare "2" means numbered choice 2.
+        return question_delivered_answer(rendered)
+
+    def _mark_replied_in_room(self, room_id: str, turn: TurnState) -> None:
+        """Record that ``turn`` produced a room message.
+
+        Guarded by identity: an operation orphaned by a turn timeout (the
+        SDK never cancels in-flight dispatches) must not mark a LATER turn
+        as having replied.
+        """
+        if self._turn_state.get(room_id) is turn:
+            turn.replied_in_room = True
+
+    # --- Tool bridging -------------------------------------------------------
+
+    def _build_bridged_tools(
+        self, room_id: str, tools: AgentToolsProtocol
+    ) -> list[Tool]:
+        """Bridge Band platform tools + developer custom tools as Copilot tools."""
+        schemas = tools.get_openai_tool_schemas(
+            include_memory=Capability.MEMORY in self.features.capabilities,
+            include_contacts=Capability.CONTACTS in self.features.capabilities,
+        )
+        schemas = filter_tool_schemas(
+            schemas,
+            self.features,
+            get_name=lambda s: s.get("function", {}).get("name", ""),
+            get_category=lambda s: get_band_tool_category(
+                s.get("function", {}).get("name", "")
+            ),
+        )
+        merged = schemas + custom_tools_to_schemas(self._custom_tools, "openai")
+
+        handler = self._make_tool_handler(room_id)
+        bridged: list[Tool] = []
+        seen: set[str] = set()
+        for schema in merged:
+            function = schema.get("function") or {}
+            name = function.get("name")
+            if name and name not in seen:
+                seen.add(name)
+                bridged.append(
+                    Tool(
+                        name=name,
+                        description=function.get("description") or "",
+                        parameters=function.get("parameters")
+                        or {"type": "object", "properties": {}},
+                        handler=handler,
+                        # Band/custom tools execute in-process against the
+                        # platform API — Copilot's permission flow adds nothing.
+                        skip_permission=True,
+                    )
+                )
+        return bridged
+
+    def _make_tool_handler(self, room_id: str) -> Callable[[ToolInvocation], Any]:
+        """Build the per-room tool handler Copilot invokes for bridged tools.
+
+        A closure only to bind ``room_id``; the logic lives in
+        :meth:`_execute_bridged_tool`.
+        """
+
+        async def handle(invocation: ToolInvocation) -> ToolResult:
+            return await self._execute_bridged_tool(room_id, invocation)
+
+        return handle
+
+    async def _execute_bridged_tool(
+        self, room_id: str, invocation: ToolInvocation
+    ) -> ToolResult:
+        """Execute one bridged tool call, reporting it as platform events."""
+        tool_name = invocation.tool_name
+        arguments = (
+            invocation.arguments if isinstance(invocation.arguments, dict) else {}
+        )
+        # Resolve at call time: sessions outlive any single message, and a
+        # fresh AgentToolsProtocol arrives with every on_message. The turn
+        # is captured here (before any await) so a call orphaned by a turn
+        # timeout can never mark a LATER turn as having replied.
+        turn = self._turn_state.get(room_id)
+        room_tools = self._room_tools.get(room_id)
+        if room_tools is None:
+            return ToolResult(
+                text_result_for_llm=f"Room {room_id} is no longer active",
+                result_type="failure",
+                error="room inactive",
+            )
+
+        should_report = (
+            Emit.EXECUTION in self.features.emit
+            and tool_name not in SELF_REPORTING_TOOL_NAMES
+        )
+        if should_report:
+            await self._report_tool_call(room_tools, invocation, arguments)
+
+        try:
+            custom_tool = find_custom_tool(self._custom_tools, tool_name)
+            if custom_tool:
+                result = await execute_custom_tool(custom_tool, arguments)
+            else:
+                result = await room_tools.execute_tool_call(tool_name, arguments)
+        except ValidationError as exc:
+            logger.error("Validation error for tool %s: %s", tool_name, exc)
+            error_text = (
+                f"Invalid arguments for {tool_name}: {format_validation_error(exc)}"
+            )
+            return await self._fail_tool_call(
+                room_tools, invocation, error_text, report=should_report
+            )
+        except Exception as exc:
+            logger.exception("Tool execution failed for %s", tool_name)
+            return await self._fail_tool_call(
+                room_tools, invocation, f"Error: {exc}", report=should_report
+            )
+
+        text_result = (
+            result if isinstance(result, str) else json.dumps(result, default=str)
+        )
+        if tool_name == "band_send_message" and turn is not None:
+            self._mark_replied_in_room(room_id, turn)
+        if should_report:
+            await self._report_tool_result(room_tools, invocation, text_result)
+        return ToolResult(text_result_for_llm=text_result)
+
+    async def _fail_tool_call(
+        self,
+        room_tools: AgentToolsProtocol,
+        invocation: ToolInvocation,
+        error_text: str,
+        *,
+        report: bool,
+    ) -> ToolResult:
+        """Report a failed tool call and wrap it as an LLM-readable failure."""
+        if report:
+            await self._report_tool_result(room_tools, invocation, error_text)
+        return ToolResult(
+            text_result_for_llm=error_text,
+            result_type="failure",
+            error=error_text,
+        )
+
+    # Payload keys (name/args/output/tool_call_id) are what the history
+    # converters parse back out of tool events — keep them in sync.
+
+    async def _report_tool_call(
+        self,
+        room_tools: AgentToolsProtocol,
+        invocation: ToolInvocation,
+        arguments: dict[str, Any],
+    ) -> None:
+        await self._send_event_safe(
+            room_tools,
+            json.dumps(
+                {
+                    "name": invocation.tool_name,
+                    "args": arguments,
+                    "tool_call_id": invocation.tool_call_id,
+                }
+            ),
+            MessageType.TOOL_CALL,
+        )
+
+    async def _report_tool_result(
+        self,
+        room_tools: AgentToolsProtocol,
+        invocation: ToolInvocation,
+        output: str,
+    ) -> None:
+        await self._send_event_safe(
+            room_tools,
+            json.dumps(
+                {
+                    "name": invocation.tool_name,
+                    "output": output,
+                    "tool_call_id": invocation.tool_call_id,
+                }
+            ),
+            MessageType.TOOL_RESULT,
+        )
+
+    # --- Turn execution ------------------------------------------------------
+
+    def _compose_prompt(
+        self,
+        msg: PlatformMessage,
+        participants_msg: str | None,
+        contacts_msg: str | None,
+        *,
+        room_id: str,
+        inject_text: str | None,
+    ) -> str:
+        room_context = f"[room_id: {room_id}]"
+        parts: list[str] = []
+        if inject_text:
+            parts.append(f"[Previous conversation context:]\n{inject_text}")
+        if participants_msg:
+            parts.append(f"{room_context}[System]: {participants_msg}")
+        if contacts_msg:
+            parts.append(f"{room_context}[System]: {contacts_msg}")
+        parts.append(f"{room_context}{msg.format_for_llm()}")
+        return "\n\n".join(parts)
+
+    async def _run_turn(
+        self, session: CopilotSession, prompt: str, turn: TurnState
+    ) -> str | None:
+        """Send one prompt, wait for idle, and return the final assistant text.
+
+        Session errors need no collecting here: ``send_and_wait`` raises on
+        any session error event, which surfaces through on_message's
+        turn-failure path.
+        """
+
+        def collect(event: SessionEvent) -> None:
+            data = event.data
+            if isinstance(data, AssistantReasoningData) and data.content:
+                turn.reasonings[data.reasoning_id] = data.content
+            elif isinstance(data, AssistantUsageData):
+                turn.usage += self._usage_from_event(data)  # sum per-call usage
+
+        unsubscribe = session.on(collect)
+        try:
+            final_event = await session.send_and_wait(
+                prompt, timeout=self.config.turn_timeout_s
+            )
+        finally:
+            unsubscribe()
+
+        content = getattr(final_event.data, "content", None) if final_event else None
+        # An empty final message means no reply — same as no final event.
+        return content.strip() or None if isinstance(content, str) else None
+
+    @staticmethod
+    def _usage_from_event(data: AssistantUsageData) -> TurnUsage:
+        """Map one assistant.usage event onto TurnUsage.
+
+        assistant.usage is per-API-call, so a turn's events are summed by the
+        caller. reasoning_tokens is NOT folded into output_tokens — the
+        providers Copilot relays (OpenAI/Anthropic) already count reasoning
+        inside their output/completion tokens, so folding would double-count
+        (unlike codex/opencode, whose SDK totals report reasoning disjointly).
+        cache_* may arrive as 0 — a Copilot CLI runtime limitation, not a
+        schema bug — mapped anyway: harmless at 0, correct once the runtime
+        populates them.
+        """
+        return TurnUsage.from_object(
+            data,
+            input="input_tokens",
+            output="output_tokens",
+            cache_read="cache_read_tokens",
+            cache_write="cache_write_tokens",
+        )
+
+    # --- Event emission ------------------------------------------------------
+
+    async def _emit_thoughts(self, turn: TurnState, tools: AgentToolsProtocol) -> None:
+        if Emit.THOUGHTS in self.features.emit:
+            for reasoning in turn.reasonings.values():
+                await self._send_event_safe(tools, reasoning, MessageType.THOUGHT)
+
+    async def _persist_session_id(
+        self, room_id: str, tools: AgentToolsProtocol
+    ) -> None:
+        """Persist the room's session id as a task event (enables rehydration).
+
+        Always emitted (once per id) — resume across restarts depends on it,
+        so it is bookkeeping, not opt-in observability.
+        """
+        ids = self._ids(room_id)
+        if ids.current and ids.persisted != ids.current:
+            sent = await self._send_event_safe(
+                tools,
+                "Copilot SDK session",
+                MessageType.TASK,
+                metadata={SESSION_ID_METADATA_KEY: ids.current},
+            )
+            if sent:
+                # Only mark persisted on success so a transient send failure
+                # is retried next turn instead of silently losing resume.
+                ids.persisted = ids.current
+
+    async def _send_event_safe(
+        self,
+        tools: AgentToolsProtocol,
+        content: str,
+        message_type: MessageType,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """Send a platform event, downgrading failures to a warning.
+
+        Returns True when the event was accepted by the platform.
+        """
+        try:
+            await tools.send_event(
+                content=content, message_type=message_type, metadata=metadata
+            )
+        except Exception as exc:
+            logger.warning("Failed to send %s event: %s", message_type, exc)
+            return False
+        return True
+
+    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
+        await self._send_event_safe(tools, f"Error: {error}", MessageType.ERROR)

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -38,6 +38,7 @@ from band.runtime.custom_tools import (
     CustomToolDef,
     execute_custom_tool,
     find_custom_tool,
+    format_validation_error,
     get_custom_tool_name,
 )
 from band.runtime.prompts import render_system_prompt
@@ -545,10 +546,7 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                 )
                 is_error = False
             except ValidationError as exc:
-                errors = "; ".join(
-                    f"{err['loc'][0] if err.get('loc') else 'unknown'}: {err['msg']}"
-                    for err in exc.errors()
-                )
+                errors = format_validation_error(exc)
                 result_str = f"Invalid arguments for {tool_name}: {errors}"
                 is_error = True
                 logger.warning("Validation error for tool %s: %s", tool_name, errors)

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -22,17 +22,9 @@ from band.core.types import (
     TurnUsage,
 )
 from band.runtime.prompts import render_system_prompt
+from band.runtime.tools import SELF_REPORTING_TOOL_NAMES
 
 logger = logging.getLogger(__name__)
-
-# Platform tools whose execution should not be reported as tool_call/tool_result
-# events — they already produce visible output (messages or events) on the platform.
-_SILENT_REPORTING_TOOLS: frozenset[str] = frozenset(
-    {
-        "band_send_message",
-        "band_send_event",
-    }
-)
 
 # Letta-specific preamble prepended to the system prompt when writing to the
 # agent's instruction block.  In practice, models routed through Letta
@@ -551,7 +543,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                     used_send_message = True
 
                 if Emit.EXECUTION in self.features.emit:
-                    if tool_name not in _SILENT_REPORTING_TOOLS:
+                    if tool_name not in SELF_REPORTING_TOOL_NAMES:
                         await tools.send_event(
                             content=json.dumps(
                                 {
@@ -568,7 +560,7 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                 # MCP tool result — observe for reporting
                 if Emit.EXECUTION in self.features.emit:
                     tool_name = getattr(resp_msg, "tool_name", "unknown")
-                    if tool_name not in _SILENT_REPORTING_TOOLS:
+                    if tool_name not in SELF_REPORTING_TOOL_NAMES:
                         await tools.send_event(
                             content=json.dumps(
                                 {

--- a/src/band/agent.py
+++ b/src/band/agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import weakref
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _get_version
 from pathlib import Path
@@ -34,6 +35,17 @@ except PackageNotFoundError:
 
 # Default graceful shutdown timeout in seconds
 DEFAULT_SHUTDOWN_TIMEOUT: float = 30.0
+
+# Agents started in this process and not yet stopped. Weak so a dropped
+# agent never leaks through the registry; exists for harnesses whose
+# failure paths can abandon an agent without unwinding it (e.g.
+# pytest-timeout's signal kill), which need to find and stop it.
+_running_agents: weakref.WeakSet[Agent] = weakref.WeakSet()
+
+
+def running_agents() -> list[Agent]:
+    """Agents started in this process that have not been stopped yet."""
+    return list(_running_agents)
 
 
 class _TimeoutNotSet:
@@ -212,23 +224,40 @@ class Agent:
             logger.warning("Agent already started")
             return
 
-        # 1. Initialize runtime (fetch metadata via REST, no WebSocket yet)
-        await self._runtime.initialize()
+        # 0. Refuse a duplicate instance BEFORE the adapter boots anything
+        # (subprocesses, on-disk sessions). runtime.start() re-claims
+        # idempotently for callers driving PlatformRuntime directly.
+        self._runtime.claim_single_instance()
+        try:
+            # 1. Initialize runtime (fetch metadata via REST, no WebSocket yet)
+            await self._runtime.initialize()
 
-        # 2. Initialize adapter with agent metadata BEFORE message processing
-        setattr(self._adapter, "_band_agent_id", self._runtime.agent_id)
-        await self._adapter.on_started(
-            self._runtime.agent_name,
-            self._runtime.agent_description,
-        )
+            # 2. Initialize adapter with agent metadata BEFORE message processing
+            setattr(self._adapter, "_band_agent_id", self._runtime.agent_id)
+            await self._adapter.on_started(
+                self._runtime.agent_name,
+                self._runtime.agent_description,
+            )
 
-        # 3. NOW start message processing (connects WebSocket)
-        await self._runtime.start(
-            on_execute=self._on_execute,
-            on_cleanup=self._adapter.on_cleanup,
-        )
+            # 3. NOW start message processing (connects WebSocket)
+            try:
+                await self._runtime.start(
+                    on_execute=self._on_execute,
+                    on_cleanup=self._adapter.on_cleanup,
+                )
+            except BaseException:
+                # on_started may have acquired resources (e.g. a CLI runtime
+                # subprocess); a failed start must release them — stop() won't
+                # run for an agent that never started.
+                await self._cleanup_adapter()
+                raise
+        except BaseException:
+            # Idempotent: a failure inside runtime.start() already released.
+            self._runtime.release_single_instance()
+            raise
 
         self._started = True
+        _running_agents.add(self)
         logger.info(
             "Agent started: %s (band-sdk %s)", self._runtime.agent_name, _SDK_VERSION
         )
@@ -252,12 +281,27 @@ class Agent:
         if not self._started:
             return True
 
-        graceful = await self._runtime.stop(timeout=timeout)
-        self._started = False
+        try:
+            graceful = await self._runtime.stop(timeout=timeout)
+        finally:
+            # Always release adapter-wide resources (e.g. a CLI runtime
+            # subprocess), even when the runtime fails to stop cleanly.
+            await self._cleanup_adapter()
+            self._started = False
+            _running_agents.discard(self)
         logger.info(
             "Agent stopped: %s (graceful=%s)", self._runtime.agent_name, graceful
         )
         return graceful
+
+    async def _cleanup_adapter(self) -> None:
+        """Release adapter-wide resources, best-effort."""
+        cleanup_all = getattr(self._adapter, "cleanup_all", None)
+        if cleanup_all is not None:
+            try:
+                await cleanup_all()
+            except Exception:
+                logger.exception("Adapter cleanup_all failed")
 
     async def run(
         self, shutdown_timeout: float | None = DEFAULT_SHUTDOWN_TIMEOUT

--- a/src/band/converters/__init__.py
+++ b/src/band/converters/__init__.py
@@ -18,6 +18,7 @@ Install the extra you need::
 
 from __future__ import annotations
 
+import importlib
 from typing import TYPE_CHECKING
 
 # Type-only imports for static analysis (pyrefly, mypy, etc.)
@@ -36,6 +37,10 @@ if TYPE_CHECKING:
     )
     from band.converters.claude_sdk import (
         ClaudeSDKHistoryConverter as ClaudeSDKHistoryConverter,
+    )
+    from band.converters.copilot_sdk import (
+        CopilotSDKHistoryConverter as CopilotSDKHistoryConverter,
+        CopilotSDKSessionState as CopilotSDKSessionState,
     )
     from band.converters.parlant import (
         ParlantHistoryConverter as ParlantHistoryConverter,
@@ -88,6 +93,8 @@ __all__ = [
     "PydanticAIHistoryConverter",
     "PydanticAIMessages",
     "ClaudeSDKHistoryConverter",
+    "CopilotSDKHistoryConverter",
+    "CopilotSDKSessionState",
     "ParlantHistoryConverter",
     "ParlantMessages",
     "CrewAIHistoryConverter",
@@ -109,122 +116,42 @@ __all__ = [
 ]
 
 
+# Submodule (under band.converters) providing each lazily imported name.
+_LAZY_IMPORTS: dict[str, str] = {
+    "LangChainHistoryConverter": "langchain",
+    "LangChainMessages": "langchain",
+    "AnthropicHistoryConverter": "anthropic",
+    "AnthropicMessages": "anthropic",
+    "PydanticAIHistoryConverter": "pydantic_ai",
+    "PydanticAIMessages": "pydantic_ai",
+    "ClaudeSDKHistoryConverter": "claude_sdk",
+    "CopilotSDKHistoryConverter": "copilot_sdk",
+    "CopilotSDKSessionState": "copilot_sdk",
+    "ParlantHistoryConverter": "parlant",
+    "ParlantMessages": "parlant",
+    "CrewAIHistoryConverter": "crewai",
+    "CrewAIMessages": "crewai",
+    "CrewAIFlowStateConverter": "crewai_flow",
+    "CrewAIFlowSessionState": "crewai_flow",
+    "A2AHistoryConverter": "a2a",
+    "GatewayHistoryConverter": "a2a_gateway",
+    "CodexHistoryConverter": "codex",
+    "ACPServerHistoryConverter": "acp_server",
+    "ACPClientHistoryConverter": "acp_client",
+    "AgnoHistoryConverter": "agno",
+    "AgnoMessages": "agno",
+    "GeminiHistoryConverter": "gemini",
+    "GeminiMessages": "gemini",
+    "GoogleADKHistoryConverter": "google_adk",
+    "GoogleADKMessages": "google_adk",
+    "OpencodeHistoryConverter": "opencode",
+}
+
+
 def __getattr__(name: str) -> type:
     """Lazy import converters to avoid loading optional dependencies."""
-    if name in ("LangChainHistoryConverter", "LangChainMessages"):
-        from band.converters.langchain import (
-            LangChainHistoryConverter,
-            LangChainMessages,
-        )
-
-        if name == "LangChainHistoryConverter":
-            return LangChainHistoryConverter
-        return LangChainMessages
-
-    elif name in ("AnthropicHistoryConverter", "AnthropicMessages"):
-        from band.converters.anthropic import (
-            AnthropicHistoryConverter,
-            AnthropicMessages,
-        )
-
-        if name == "AnthropicHistoryConverter":
-            return AnthropicHistoryConverter
-        return AnthropicMessages
-
-    elif name in ("PydanticAIHistoryConverter", "PydanticAIMessages"):
-        from band.converters.pydantic_ai import (
-            PydanticAIHistoryConverter,
-            PydanticAIMessages,
-        )
-
-        if name == "PydanticAIHistoryConverter":
-            return PydanticAIHistoryConverter
-        return PydanticAIMessages
-
-    elif name == "ClaudeSDKHistoryConverter":
-        from band.converters.claude_sdk import ClaudeSDKHistoryConverter
-
-        return ClaudeSDKHistoryConverter
-
-    elif name in ("ParlantHistoryConverter", "ParlantMessages"):
-        from band.converters.parlant import (
-            ParlantHistoryConverter,
-            ParlantMessages,
-        )
-
-        if name == "ParlantHistoryConverter":
-            return ParlantHistoryConverter
-        return ParlantMessages
-
-    elif name in ("CrewAIHistoryConverter", "CrewAIMessages"):
-        from band.converters.crewai import (
-            CrewAIHistoryConverter,
-            CrewAIMessages,
-        )
-
-        if name == "CrewAIHistoryConverter":
-            return CrewAIHistoryConverter
-        return CrewAIMessages
-
-    elif name in ("CrewAIFlowStateConverter", "CrewAIFlowSessionState"):
-        from band.converters.crewai_flow import (
-            CrewAIFlowSessionState,
-            CrewAIFlowStateConverter,
-        )
-
-        if name == "CrewAIFlowStateConverter":
-            return CrewAIFlowStateConverter
-        return CrewAIFlowSessionState
-
-    elif name == "A2AHistoryConverter":
-        from band.converters.a2a import A2AHistoryConverter
-
-        return A2AHistoryConverter
-
-    elif name == "GatewayHistoryConverter":
-        from band.converters.a2a_gateway import GatewayHistoryConverter
-
-        return GatewayHistoryConverter
-    elif name == "CodexHistoryConverter":
-        from band.converters.codex import CodexHistoryConverter
-
-        return CodexHistoryConverter
-    elif name in ("AgnoHistoryConverter", "AgnoMessages"):
-        from band.converters.agno import AgnoHistoryConverter, AgnoMessages
-
-        if name == "AgnoHistoryConverter":
-            return AgnoHistoryConverter
-        return AgnoMessages
-
-    elif name in ("GeminiHistoryConverter", "GeminiMessages"):
-        from band.converters.gemini import GeminiHistoryConverter, GeminiMessages
-
-        if name == "GeminiHistoryConverter":
-            return GeminiHistoryConverter
-        return GeminiMessages
-
-    elif name == "ACPServerHistoryConverter":
-        from band.converters.acp_server import ACPServerHistoryConverter
-
-        return ACPServerHistoryConverter
-
-    elif name == "ACPClientHistoryConverter":
-        from band.converters.acp_client import ACPClientHistoryConverter
-
-        return ACPClientHistoryConverter
-
-    elif name in ("GoogleADKHistoryConverter", "GoogleADKMessages"):
-        from band.converters.google_adk import (
-            GoogleADKHistoryConverter,
-            GoogleADKMessages,
-        )
-
-        if name == "GoogleADKHistoryConverter":
-            return GoogleADKHistoryConverter
-        return GoogleADKMessages
-    elif name == "OpencodeHistoryConverter":
-        from band.converters.opencode import OpencodeHistoryConverter
-
-        return OpencodeHistoryConverter
-
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name = _LAZY_IMPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(f".{module_name}", __name__)
+    return getattr(module, name)

--- a/src/band/converters/copilot_sdk.py
+++ b/src/band/converters/copilot_sdk.py
@@ -1,0 +1,92 @@
+"""Copilot SDK history converters."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from band.core.protocols import HistoryConverter
+from band.core.types import MessageType
+
+logger = logging.getLogger(__name__)
+
+# Task-event metadata key carrying the room's Copilot session id — the single
+# source of truth shared by the adapter (writer) and this converter (reader).
+SESSION_ID_METADATA_KEY = "copilot_session_id"
+
+
+@dataclass
+class CopilotSDKSessionState:
+    """Composite state returned by the Copilot SDK converter.
+
+    Combines the text history (for context injection) with an optional
+    ``session_id`` extracted from persisted task events, enabling session
+    resume after process restart.
+    """
+
+    text: str = ""
+    session_id: str | None = None
+
+
+def _format_line(hist: dict[str, Any]) -> str | None:
+    """Format one platform message as a history line, or None to skip it."""
+    message_type = hist.get("message_type", MessageType.TEXT)
+    content = hist.get("content", "")
+
+    if not content or message_type == MessageType.TASK:
+        # Task events are internal bookkeeping — never include in text.
+        return None
+
+    if message_type == MessageType.TEXT:
+        # Own agent text is included too: the adapter posts replies as plain
+        # text and silences band_send_message tool reporting, so this line is
+        # the only record of the agent's side of the conversation.
+        return f"[{hist.get('sender_name', 'Unknown')}]: {content}"
+
+    if message_type in (MessageType.TOOL_CALL, MessageType.TOOL_RESULT):
+        return content
+
+    return None
+
+
+class CopilotSDKHistoryConverter(HistoryConverter[CopilotSDKSessionState]):
+    """Convert platform history to Copilot SDK text format with session state.
+
+    Returns a :class:`CopilotSDKSessionState` containing the text history
+    and an optional ``session_id`` extracted from persisted task events,
+    enabling session resume after process restart.
+
+    Output example::
+
+        [Alice]: What's the weather?
+        {"name": "get_weather", "args": {"location": "NYC"}, "tool_call_id": "call_123"}
+        {"name": "get_weather", "output": "{\"temperature\": 72}", "tool_call_id": "call_123"}
+        [WeatherAgent]: It's 72 and sunny.
+    """
+
+    def __init__(self, agent_name: str = ""):
+        # Kept for the converter protocol (SimpleAdapter propagates the agent
+        # name); this converter includes own-agent lines, so it never filters.
+        self._agent_name = agent_name
+
+    def set_agent_name(self, name: str) -> None:
+        self._agent_name = name
+
+    def convert(self, raw: list[dict[str, Any]]) -> CopilotSDKSessionState:
+        if not raw:
+            return CopilotSDKSessionState(text="")
+
+        # Scan history in reverse for the latest task event with a session_id.
+        session_id = next(
+            (
+                sid
+                for hist in reversed(raw)
+                if hist.get("message_type") == MessageType.TASK
+                and (sid := (hist.get("metadata") or {}).get(SESSION_ID_METADATA_KEY))
+            ),
+            None,
+        )
+
+        lines = [line for hist in raw if (line := _format_line(hist))]
+        return CopilotSDKSessionState(text="\n".join(lines), session_id=session_id)

--- a/src/band/core/simple_adapter.py
+++ b/src/band/core/simple_adapter.py
@@ -171,6 +171,13 @@ class SimpleAdapter(Generic[H], ABC):
         """Override for session cleanup."""
         pass
 
+    async def cleanup_all(self) -> None:
+        """Override to release adapter-wide resources (clients, servers).
+
+        Called by ``Agent.stop()`` after every room's ``on_cleanup``.
+        """
+        pass
+
     async def on_started(self, agent_name: str, agent_description: str) -> None:
         """Override for post-start setup."""
         self.agent_name = agent_name

--- a/src/band/integrations/copilot_sdk/__init__.py
+++ b/src/band/integrations/copilot_sdk/__init__.py
@@ -1,0 +1,29 @@
+"""Copilot SDK integration for Band."""
+
+from .operator_console import (
+    NO_ANSWER_TEXT,
+    UNAVAILABLE_TEXT,
+    LogGate,
+    OperatorConsole,
+)
+from .prompts import TURN_COMPLETION_GUIDANCE
+from .room_ask_user import (
+    ASK_USER_ROOM,
+    QUESTION_DELIVERED_ANSWER,
+    ROOM_ASK_USER_GUIDANCE,
+    render_room_question,
+)
+from .session_manager import CopilotSessionManager
+
+__all__ = [
+    "ASK_USER_ROOM",
+    "NO_ANSWER_TEXT",
+    "QUESTION_DELIVERED_ANSWER",
+    "ROOM_ASK_USER_GUIDANCE",
+    "TURN_COMPLETION_GUIDANCE",
+    "UNAVAILABLE_TEXT",
+    "CopilotSessionManager",
+    "LogGate",
+    "OperatorConsole",
+    "render_room_question",
+]

--- a/src/band/integrations/copilot_sdk/operator_console.py
+++ b/src/band/integrations/copilot_sdk/operator_console.py
@@ -1,0 +1,357 @@
+"""Terminal operator console for Copilot's ``ask_user`` tool.
+
+A handler for ``CopilotSDKAdapterConfig(ask_user=...)`` that answers from
+the terminal of whoever runs the agent process: the model's question
+renders as a prompt, the operator's typed line becomes the answer. Use it
+when the answering human is the process operator; when the answering
+human is in the Band room, use ``ask_user="room"`` instead (see
+``room_ask_user``). Built to stay correct under the failure
+modes a naive ``input()`` handler hits in a multi-room agent — each one
+grounded in how the Copilot SDK actually behaves:
+
+- **Buried prompts** — every root-logger handler is wrapped in a
+  :class:`LogGate`; while a question is open, log records are parked and
+  re-emitted after the answer, so output never interleaves with typing.
+- **Concurrent rooms** — the SDK dispatches each ``userInput.request``
+  as its own task with no serialization, so questions from different
+  rooms can arrive simultaneously. They queue on a lock here; one prompt
+  owns the terminal at a time.
+- **Abandoned prompts** — the SDK never cancels a pending question (not
+  even on session abort) and has no handler timeout, so a blocked
+  ``input()`` would leak forever and its eventual line would answer the
+  wrong room's question. A single persistent reader owns stdin instead:
+  answers pair only with the question currently displayed, and lines
+  typed while no question is open are discarded.
+- **Slow operators** — each question carries a deadline
+  (``answer_timeout_s``). On expiry the model gets an explicit "operator
+  did not answer" reply instead of the room's whole turn dying on the
+  adapter's ``turn_timeout_s``. Keep ``answer_timeout_s`` *below* the
+  adapter's turn timeout, or the turn dies first and the answer is lost.
+- **Invalid answers** — the SDK forwards the response verbatim without
+  checking it against ``choices``/``allowFreeform``, so enforcement
+  happens here: choice lists accept a number or exact choice text, and
+  freeform text is re-prompted when the request forbids it.
+- **Headless runs** — on stdin EOF (piped input exhausted, no terminal)
+  every question immediately answers "operator unavailable" instead of
+  crashing the turn (a raised error would surface to the runtime as an
+  opaque RPC failure).
+
+Multiple agents in one process must **share one console instance** — it
+owns process-wide resources (stdin, the root logger), so per-agent
+instances would fight over both.
+
+The module depends only on the wire *shape* of the Copilot SDK's
+``UserInputRequest``/``UserInputResponse`` TypedDicts (plain dicts at
+runtime), so it imports nothing from ``copilot``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import queue
+import sys
+import threading
+from collections.abc import Iterator
+from typing import IO, Any
+
+logger = logging.getLogger(__name__)
+
+NO_ANSWER_TEXT = "(The operator did not answer in time — proceed without them.)"
+UNAVAILABLE_TEXT = "(No operator is attached to this agent — proceed without them.)"
+
+
+class LogGate(logging.Handler):
+    """Wraps a real log handler so the console can pause its output.
+
+    While paused, records are parked instead of written; the matching
+    ``resume()`` re-emits them in order. Pauses are counted, so gates
+    shared by several consoles stay paused until every open prompt has
+    resumed. Log lines are deferred — never lost — and can never bury an
+    open operator prompt.
+
+    The gate snapshots the target's *level* at wrap time and delegates
+    records to the target's own formatter; reconfigure logging before
+    gating (or re-run ``gate_logging``) rather than mutating a wrapped
+    handler afterwards.
+    """
+
+    def __init__(self, target: logging.Handler) -> None:
+        super().__init__(target.level)
+        self._target = target
+        self._parked: list[logging.LogRecord] = []
+        self._pauses = 0
+
+    def emit(self, record: logging.LogRecord) -> None:
+        # Handler.handle() already holds this handler's lock here.
+        if self._pauses:
+            self._parked.append(record)
+        else:
+            self._target.handle(record)
+
+    def flush(self) -> None:
+        self._target.flush()
+
+    def close(self) -> None:
+        self._target.close()
+        super().close()
+
+    def pause(self) -> None:
+        self.acquire()
+        try:
+            self._pauses += 1
+        finally:
+            self.release()
+
+    def resume(self) -> None:
+        # The backlog flushes under the gate lock: records emitted from
+        # other threads meanwhile queue behind it instead of jumping it.
+        self.acquire()
+        try:
+            self._pauses = max(0, self._pauses - 1)
+            if self._pauses == 0:
+                parked, self._parked = self._parked, []
+                for record in parked:
+                    self._target.handle(record)
+        finally:
+            self.release()
+
+
+class OperatorConsole:
+    """Owns the terminal for operator Q&A; ``ask`` is the adapter handler.
+
+    Pass ``ask`` as ``CopilotSDKAdapterConfig(ask_user=...)``; log gating
+    engages automatically on the first question.
+
+    Args:
+        answer_timeout_s: Seconds a question waits for the operator before
+            answering :data:`NO_ANSWER_TEXT` on their behalf. Must stay
+            below the adapter's ``turn_timeout_s`` or the turn dies first
+            and the answer is lost — the default deliberately sits under
+            the adapter's default 120s so the out-of-the-box pairing
+            degrades gracefully; raise BOTH for patient operators (e.g.
+            ``answer_timeout_s=300`` with ``turn_timeout_s=600``).
+        input_stream: Where operator answers are read from (stdin by
+            default; primarily a test seam).
+    """
+
+    def __init__(
+        self,
+        *,
+        answer_timeout_s: float = 90.0,
+        input_stream: IO[str] | None = None,
+    ) -> None:
+        self.answer_timeout_s = answer_timeout_s
+        self._input = input_stream if input_stream is not None else sys.stdin
+        self._lock = asyncio.Lock()
+        self._gates: list[LogGate] = []
+        # A plain thread queue, not an asyncio one: the reader thread must
+        # outlive any single event loop (agents may be restarted on a new
+        # loop while the thread is still blocked on the terminal).
+        self._lines: queue.Queue[str | None] = queue.Queue()
+        self._reader: threading.Thread | None = None
+        self._eof = False
+
+    def gate_logging(self) -> None:
+        """Route every root-logger handler through a pausable gate.
+
+        Runs automatically on the first question, when logging is
+        guaranteed to be configured; call it explicitly only to adopt the
+        root handlers at a specific point in setup.
+
+        Idempotent: an already-gated root logger is not re-wrapped — the
+        existing gates are adopted instead, so a second console sharing
+        the process still parks logs while its prompts are open.
+        """
+        root = logging.getLogger()
+        gates = [h for h in root.handlers if isinstance(h, LogGate)]
+        if not gates:
+            gates = [LogGate(handler) for handler in root.handlers]
+            root.handlers[:] = gates
+        self._gates = gates
+
+    async def ask(
+        self, request: dict[str, Any], context: dict[str, str]
+    ) -> dict[str, Any]:
+        """Render the model's question and read the operator's answer.
+
+        A numeric answer picks the matching choice; other text is passed
+        through as freeform (when the request allows it) or re-prompted.
+        """
+        self._ensure_reader()
+        if not self._gates:
+            self.gate_logging()
+        async with self._lock:
+            for gate in self._gates:
+                gate.pause()
+            try:
+                return await self._prompt_operator(request, context)
+            finally:
+                for gate in self._gates:
+                    gate.resume()
+
+    async def _prompt_operator(
+        self, request: dict[str, Any], context: dict[str, str]
+    ) -> dict[str, Any]:
+        """Run one prompt cycle under the console lock with gates paused."""
+        self._discard_unsolicited_lines()
+        deadline = asyncio.get_running_loop().time() + self.answer_timeout_s
+        self._write(self._render(request, context))
+        while True:
+            answer = await self._read_line(deadline)
+            if answer is None:
+                self._write("(no answer — replying on the operator's behalf)\n")
+                text = UNAVAILABLE_TEXT if self._eof else NO_ANSWER_TEXT
+                return {"answer": text, "wasFreeform": True}
+            response = self._match_answer(answer, request)
+            if response is not None:
+                return response
+            self._write(self._reprompt_text(request))
+
+    def _ensure_reader(self) -> None:
+        """Start the input reader thread once.
+
+        The thread talks only to the thread-safe line queue — never to an
+        event loop — so it survives agent/loop restarts and keeps serving
+        whichever loop is asking.
+        """
+        if self._reader is not None or self._eof:
+            return
+        source = self._input
+        lines = self._lines
+
+        def read_lines() -> None:
+            for line in source:
+                lines.put(line)
+            lines.put(None)
+
+        # Daemon: a blocked readline must never hold up process exit.
+        self._reader = threading.Thread(
+            target=read_lines, name="operator-console-input", daemon=True
+        )
+        self._reader.start()
+
+    async def _read_line(self, deadline: float) -> str | None:
+        """Return the next typed line, or None on timeout/EOF."""
+        if self._eof:
+            return None
+        remaining = deadline - asyncio.get_running_loop().time()
+        try:
+            if remaining <= 0:
+                # Deadline hit: still honor an answer that already arrived.
+                line = self._lines.get_nowait()
+            else:
+                # The timeout goes to Queue.get so it bounds the worker
+                # THREAD; a timed-out read leaves no thread blocked to eat
+                # the next typed line. Do NOT swap this for
+                # wait_for(to_thread(get)) — that cancels only the await
+                # and leaks the blocked thread.
+                line = await asyncio.to_thread(self._lines.get, timeout=remaining)
+        except queue.Empty:
+            return None
+        return self._line_or_eof(line)
+
+    def _line_or_eof(self, line: str | None) -> str | None:
+        """Strip a real line; latch EOF and return None on the sentinel."""
+        if line is None:
+            self._eof = True
+            return None
+        return line.strip()
+
+    def _drain_buffered_lines(self) -> Iterator[str | None]:
+        """Yield every line currently queued, emptying it without blocking."""
+        while True:
+            try:
+                yield self._lines.get_nowait()
+            except queue.Empty:
+                return
+
+    def _discard_unsolicited_lines(self) -> None:
+        """Drop lines typed while no question was open.
+
+        They answered nothing — most likely an operator hitting enter on
+        a prompt that had already expired — and must not leak into the
+        next question. An EOF sentinel found here is honored, not dropped.
+        """
+        dropped = sum(
+            self._line_or_eof(line) is not None for line in self._drain_buffered_lines()
+        )
+        if dropped:
+            self._write(
+                f"(ignored {dropped} line(s) typed while no question was open)\n"
+            )
+
+    @staticmethod
+    def _choices(request: dict[str, Any]) -> list[str]:
+        return request.get("choices") or []
+
+    def _match_answer(
+        self, answer: str, request: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Map a typed line to a response, or None to re-prompt.
+
+        Accepts a choice number or exact choice text; freeform text is
+        accepted only when the request allows it. Empty input re-prompts.
+        """
+        choices = self._choices(request)
+        matched = [c for c in choices if c.casefold() == answer.casefold()]
+        # isdecimal, not isdigit: isdigit also accepts characters (e.g.
+        # superscripts) that int() rejects with a ValueError.
+        if answer.isdecimal() and choices:
+            index = int(answer)
+            if 1 <= index <= len(choices):
+                return {"answer": choices[index - 1], "wasFreeform": False}
+            if matched:  # a numeric-labeled choice typed by its label
+                return {"answer": matched[0], "wasFreeform": False}
+            # A bare number against a numbered list signals choice-selection
+            # intent; an out-of-range one is a typo, not a freeform answer.
+            return None
+        if matched:
+            return {"answer": matched[0], "wasFreeform": False}
+        freeform_ok = request.get("allowFreeform", True) or not choices
+        if answer and freeform_ok:
+            return {"answer": answer, "wasFreeform": True}
+        return None
+
+    @classmethod
+    def _answer_hint(cls, request: dict[str, Any]) -> str:
+        """The accepted-answer shapes, honoring ``allowFreeform``."""
+        choices = cls._choices(request)
+        if not choices:
+            return "text"
+        numbers = f"1-{len(choices)}"
+        return f"{numbers} or text" if request.get("allowFreeform", True) else numbers
+
+    @classmethod
+    def _reprompt_text(cls, request: dict[str, Any]) -> str:
+        return f"Please answer [{cls._answer_hint(request)}]: "
+
+    @classmethod
+    def _render(cls, request: dict[str, Any], context: dict[str, str]) -> str:
+        choices = cls._choices(request)
+        return "\n".join(
+            [
+                "",
+                "-" * 60,
+                f"Copilot asks (session {context.get('session_id', '?')}):",
+                f"  {request.get('question', '')}",
+                *(f"    {i}) {choice}" for i, choice in enumerate(choices, 1)),
+                f"Answer [{cls._answer_hint(request)}]: ",
+            ]
+        )
+
+    @staticmethod
+    def _write(text: str) -> None:
+        """Write console UI text straight to stdout (this *is* the UI).
+
+        Write failures (e.g. stdout is a pipe whose reader closed) are
+        downgraded to a log warning: a broken display must degrade to the
+        timeout/EOF answer path, not blow up the turn as an RPC error.
+        """
+        try:
+            sys.stdout.write(text)
+            sys.stdout.flush()
+        # ValueError: a fully CLOSED stdout (not just a broken pipe) raises
+        # "I/O operation on closed file", which is not an OSError.
+        except (OSError, ValueError) as exc:
+            logger.warning("Operator console cannot write to stdout: %s", exc)

--- a/src/band/integrations/copilot_sdk/prompts.py
+++ b/src/band/integrations/copilot_sdk/prompts.py
@@ -1,0 +1,32 @@
+"""Copilot-runtime prompt-contract sections.
+
+Text the adapter must contribute to its ``mode="replace"`` system prompt because
+the Copilot CLI runtime behaves differently from a plain chat model. Kept here
+(SDK contract text) rather than in the developer-facing ``custom_section`` so it
+is always present and never masquerades as developer instructions.
+"""
+
+from __future__ import annotations
+
+# Copilot's CLI runtime is a coding-agent orchestrator: after every turn that
+# ends in a tool call it injects a synthetic "continue from where you left off"
+# nudge, and it only marks the session idle once the model answers with a plain
+# (tool-free) assistant message. Band drives it in ``mode="replace"``, so Band
+# owns the whole system prompt — including the "task completion" guidance the CLI
+# normally supplies (its ``last_instructions`` section). Without it, a model told
+# only "reply via band_send_message; plain text isn't delivered" answers the
+# nudge with yet another band_send_message, looping until the turn times out.
+# This section supplies the missing contract: end the turn in plain text once the
+# work is done. It is Copilot-specific (other adapters run Band's own tool loop
+# and get no such nudge), so it lives on the adapter, not in shared BASE_INSTRUCTIONS.
+TURN_COMPLETION_GUIDANCE = (
+    "## Turn completion\n\n"
+    "This runtime may prompt you to continue after you act (for example, "
+    '"continue from where you left off"). Treat that as a check, not a new '
+    "request. Your turn is complete once you have taken every action the current "
+    "message requires — including sending your reply with band_send_message. "
+    "When nothing remains to do, end the turn with a brief plain-text response "
+    '(for example, "Done."); do not call band_send_message again just to report '
+    "that you are finished. Plain text is not delivered to the room — which is "
+    "exactly why it cleanly ends a turn."
+)

--- a/src/band/integrations/copilot_sdk/room_ask_user.py
+++ b/src/band/integrations/copilot_sdk/room_ask_user.py
@@ -1,0 +1,119 @@
+"""Room routing for Copilot's ``ask_user`` tool.
+
+``CopilotSDKAdapterConfig(ask_user="room")`` bridges the model's built-in
+``ask_user`` tool to the Band room itself: the question is posted as a
+room message (mentioning whoever triggered the turn) and the tool call
+resolves immediately with :data:`QUESTION_DELIVERED_ANSWER`, so the turn
+ends and the user's reply arrives as the *next* message on the same
+persisted Copilot session.
+
+That turn-split is forced by how the two runtimes work, not a styling
+choice:
+
+- **Band** processes each room's messages strictly one at a time
+  (``ExecutionContext._process_loop``). A handler that blocked the turn
+  waiting for the user's reply could never receive it — the reply sits
+  in the room queue until the turn it is supposed to unblock finishes.
+- **Copilot** services ``ask_user`` as a ``userInput.request`` JSON-RPC
+  call that stays pending until answered: no timeout, no cancellation
+  on abort, and the pending state is ephemeral — it is not replayed
+  when a session is resumed, so an answer "owed" across a restart is
+  simply lost.
+
+Answering immediately with a delivery acknowledgement is the only shape
+that survives both: the room stays responsive, the turn cannot dead-hang
+against ``turn_timeout_s``, and the pending question lives where it is
+actually durable — in the session's own conversation history.
+
+The module depends only on the wire *shape* of the Copilot SDK's
+``UserInputRequest``/``UserInputResponse`` TypedDicts (plain dicts at
+runtime), so it imports nothing from ``copilot`` at runtime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from copilot import UserInputResponse
+
+ASK_USER_ROOM = "room"
+
+# Echoes the rendered question so the model knows exactly what the user
+# sees — e.g. that a bare-number answer refers to the numbered choices.
+QUESTION_DELIVERED_ANSWER = (
+    "(Your question was posted to the chat room as shown below, and the "
+    "user was notified. Their answer is NOT available in this turn — it "
+    "will arrive as a later user message; a bare number picks the matching "
+    "numbered option. End your turn now: do not repeat the question, do "
+    "not answer it yourself, and do not call ask_user again until their "
+    "answer arrives.\n---\n{rendered}\n---)"
+)
+
+ROOM_INACTIVE_ANSWER = (
+    "(The chat room is no longer active, so the question could not be "
+    "delivered. Proceed without the user's input.)"
+)
+
+DELIVERY_FAILED_ANSWER = (
+    "(The question could not be delivered to the chat room: {error}. "
+    "Proceed without the user's input, or try again later.)"
+)
+
+# Injected into the system prompt (as its own section, not developer
+# text) so the model learns the turn-split contract before its first
+# ask, not from the first tool result.
+ROOM_ASK_USER_GUIDANCE = (
+    "## Asking the user\n\n"
+    "When you need an answer, a decision, or an approval from the people "
+    "in this conversation, call the ask_user tool — offer choices when "
+    "they exist. The question is posted into the chat room on your "
+    "behalf; the answer never arrives inside the same turn, it comes "
+    "back as a later user message. After calling ask_user, end your turn "
+    "and wait for that message."
+)
+
+
+def freeform_answer(text: str) -> UserInputResponse:
+    """Wrap text as the ask_user tool's freeform-answer response shape."""
+    return {"answer": text, "wasFreeform": True}
+
+
+# Composed answers: template text and placeholder names stay inside this
+# module; the adapter only ever calls these.
+
+
+def question_delivered_answer(rendered_question: str) -> UserInputResponse:
+    """The ack for a question that posted: echoes what the user sees."""
+    return freeform_answer(QUESTION_DELIVERED_ANSWER.format(rendered=rendered_question))
+
+
+def delivery_failed_answer(error: Exception) -> UserInputResponse:
+    """The answer when posting the question to the room failed."""
+    return freeform_answer(DELIVERY_FAILED_ANSWER.format(error=error))
+
+
+def room_inactive_answer() -> UserInputResponse:
+    """The answer for a dispatch whose room/turn is already gone."""
+    return freeform_answer(ROOM_INACTIVE_ANSWER)
+
+
+def render_room_question(request: Mapping[str, Any]) -> str:
+    """Render an ``ask_user`` request as a room-readable message.
+
+    Choices become a numbered list so a bare-number reply maps cleanly
+    back to one option; the trailing hint tells the user which reply
+    shapes the request accepts.
+    """
+    question = str(request.get("question") or "").strip()
+    choices = [str(choice) for choice in request.get("choices") or []]
+    if not choices:
+        return question
+    numbered = "\n".join(f"{i}. {choice}" for i, choice in enumerate(choices, 1))
+    hint = (
+        "Reply with a number or your own answer."
+        if request.get("allowFreeform", True)
+        else "Reply with the number of one of the options."
+    )
+    return f"{question}\n\n{numbered}\n\n{hint}"

--- a/src/band/integrations/copilot_sdk/session_manager.py
+++ b/src/band/integrations/copilot_sdk/session_manager.py
@@ -1,0 +1,127 @@
+"""Session manager for Copilot SDK sessions.
+
+Maps each Band room to its own Copilot session so history, memory, and
+context stay isolated per room. A single client serves all rooms; sessions
+run concurrently across rooms, but calls on the *same* session must never
+interleave — the manager owns a per-room turn lock enforcing that.
+
+Concurrency model: all state lives on one asyncio event loop (the SDK's
+internal reader threads marshal callbacks back onto it, so there is no
+cross-thread state access).
+Turns hold the room's lock; ``cleanup_session`` takes the same lock, so a
+session is never disconnected under an in-flight turn. Turn locks are never
+dropped — every waiter for a room always contends on the same lock object.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Bound on abort/disconnect RPCs against a possibly-dead runtime.
+_EVICT_OP_TIMEOUT_S = 5.0
+
+
+class CopilotSessionManager:
+    """Owns the Copilot client, per-room turn locks, and the session registry.
+
+    Session *creation policy* (resume vs create, tool bridging, system
+    message) belongs to the adapter; the manager only stores the result.
+    """
+
+    def __init__(self, client: Any, *, owns_client: bool = True) -> None:
+        """Wrap a Copilot client.
+
+        A borrowed client (``owns_client=False``) is shared with other
+        managers: ``stop()`` releases this manager's sessions but never
+        stops the client itself — its owner does.
+        """
+        self._client = client
+        self._owns_client = owns_client
+        self._sessions: dict[str, Any] = {}
+        self._turn_locks: dict[str, asyncio.Lock] = {}
+        self._start_lock = asyncio.Lock()
+
+    @property
+    def client(self) -> Any:
+        return self._client
+
+    async def ensure_started(self) -> None:
+        """Start — or revive — the underlying client.
+
+        Delegates liveness to the client itself: ``CopilotClient.start()``
+        is a no-op while connected and respawns the runtime after a crash
+        (its state flips to "disconnected"), so no flag is cached here —
+        a cached flag would skip exactly the restart that heals a dead CLI.
+        """
+        async with self._start_lock:
+            await self._client.start()
+
+    def turn_lock(self, room_id: str) -> asyncio.Lock:
+        """Return the room's lock serializing turns and cleanup on its session."""
+        return self._turn_locks.setdefault(room_id, asyncio.Lock())
+
+    def get_session(self, room_id: str) -> Any | None:
+        """Return the room's session, or None if it has none."""
+        return self._sessions.get(room_id)
+
+    def store_session(self, room_id: str, session: Any) -> None:
+        """Register the room's session."""
+        self._sessions[room_id] = session
+        logger.info("Room %s: Copilot session registered", room_id)
+
+    async def cleanup_session(self, room_id: str) -> None:
+        """Disconnect and drop the room's session (disk state is preserved).
+
+        Takes the room's turn lock, so an in-flight turn is never
+        disconnected under itself.
+        """
+        async with self.turn_lock(room_id):
+            session = self._sessions.pop(room_id, None)
+            if session is not None:
+                try:
+                    await session.disconnect()
+                except Exception as exc:
+                    logger.warning(
+                        "Room %s: session disconnect failed: %s", room_id, exc
+                    )
+                logger.info("Room %s: Copilot session cleaned up", room_id)
+
+    async def evict_session(self, room_id: str) -> None:
+        """Abort and drop the room's session after a failed turn.
+
+        The caller already holds the room's turn lock. Abort stops any
+        work the runtime is still executing for the timed-out/failed turn
+        (so stale tool calls can't fire later); each RPC is timeout-bounded
+        because the runtime may already be dead. Disk state is preserved,
+        so the next message can resume the session fresh.
+        """
+        session = self._sessions.pop(room_id, None)
+        if session is not None:
+            for close_op in (session.abort, session.disconnect):
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(close_op(), timeout=_EVICT_OP_TIMEOUT_S)
+            logger.info("Room %s: Copilot session evicted after failed turn", room_id)
+
+    async def cleanup_all(self) -> None:
+        """Disconnect and drop every session, each under its room's lock."""
+        for room_id in list(self._sessions):
+            await self.cleanup_session(room_id)
+
+    async def stop(self) -> None:
+        """Clean up all sessions; stop the client only if this manager owns it.
+
+        Turn locks are deliberately retained — lock identity must stay
+        stable for any waiter still queued on a room.
+        """
+        await self.cleanup_all()
+        if self._owns_client:
+            try:
+                await self._client.stop()
+            except Exception as exc:
+                logger.warning("Copilot client stop failed: %s", exc)
+            logger.info("Copilot client stopped")

--- a/src/band/runtime/custom_tools.py
+++ b/src/band/runtime/custom_tools.py
@@ -161,6 +161,18 @@ def find_custom_tool(
     return None
 
 
+def format_validation_error(exc: ValidationError) -> str:
+    """Format a pydantic ValidationError as an LLM-readable field list.
+
+    Model-level validators report an empty ``loc``, so the field name
+    falls back to "unknown" instead of raising IndexError.
+    """
+    return "; ".join(
+        f"{err['loc'][0] if err.get('loc') else 'unknown'}: {err['msg']}"
+        for err in exc.errors()
+    )
+
+
 @lru_cache(maxsize=256)
 def _custom_tool_accepts_input(func: Callable[..., Any]) -> bool:
     try:

--- a/src/band/runtime/platform_runtime.py
+++ b/src/band/runtime/platform_runtime.py
@@ -12,6 +12,7 @@ from band.platform.event import ContactEvent, MessageEvent, PlatformEvent
 from band.runtime.contact_handler import ContactEventHandler
 from band.runtime.runtime import AgentRuntime
 from band.runtime.execution import ExecutionContext
+from band.runtime.single_instance import SingleInstanceGuard
 from band.runtime.types import (
     AgentConfig,
     ContactEventConfig,
@@ -66,6 +67,7 @@ class PlatformRuntime:
 
         self._link: BandLink | None = None
         self._runtime: AgentRuntime | None = None
+        self._instance_guard: SingleInstanceGuard | None = None
         self._agent_name: str = ""
         self._agent_description: str = ""
         self._contact_handler: ContactEventHandler | None = None
@@ -149,29 +151,63 @@ class PlatformRuntime:
         Args:
             on_execute: Callback for message execution
             on_cleanup: Callback for session cleanup
+
+        Raises:
+            BandConfigError: When another process on this host already runs
+                this agent id (see ``AgentConfig.single_instance``).
         """
-        # Auto-initialize if not already done
-        await self.initialize()
+        # Duplicates corrupt message claiming, so refuse before any
+        # processing starts. A failed start releases the lock: the guard
+        # must never block a retry within this same process.
+        self.claim_single_instance()
+        try:
+            # Auto-initialize if not already done
+            await self.initialize()
 
-        # Type narrowing: initialize() guarantees _link is set
-        assert self._link is not None
+            # Type narrowing: initialize() guarantees _link is set
+            assert self._link is not None
 
-        self._runtime = AgentRuntime(
-            link=self._link,
-            agent_id=self._agent_id,
-            on_execute=on_execute,
-            session_config=self._session_config,
-            on_session_cleanup=on_cleanup or self._noop_cleanup,
-            on_participant_added=self._on_participant_added,
-            on_participant_removed=self._on_participant_removed,
-        )
+            self._runtime = AgentRuntime(
+                link=self._link,
+                agent_id=self._agent_id,
+                on_execute=on_execute,
+                session_config=self._session_config,
+                on_session_cleanup=on_cleanup or self._noop_cleanup,
+                on_participant_added=self._on_participant_added,
+                on_participant_removed=self._on_participant_removed,
+            )
 
-        await self._runtime.start()
+            await self._runtime.start()
 
-        # Set up contact event handling after WebSocket is connected
-        await self._setup_contact_handling()
+            # Set up contact event handling after WebSocket is connected
+            await self._setup_contact_handling()
+        except BaseException:
+            self.release_single_instance()
+            raise
 
         logger.info("Platform runtime started for agent: %s", self._agent_name)
+
+    def claim_single_instance(self) -> None:
+        """Take this agent id's host-wide run lock (idempotent).
+
+        ``start()`` claims it anyway; ``Agent.start()`` claims it earlier —
+        before the adapter boots subprocesses or touches on-disk session
+        state — so a duplicate is refused before any side effects.
+        No-op when ``AgentConfig.single_instance`` is off.
+
+        Raises:
+            BandConfigError: When another process already holds the lock.
+        """
+        if self._config.single_instance and self._instance_guard is None:
+            guard = SingleInstanceGuard(self._agent_id)
+            guard.acquire()
+            self._instance_guard = guard
+
+    def release_single_instance(self) -> None:
+        """Release the run lock (idempotent; safe in ``finally`` blocks)."""
+        if self._instance_guard is not None:
+            self._instance_guard.release()
+            self._instance_guard = None
 
     async def stop(self, timeout: float | None = None) -> bool:
         """
@@ -184,18 +220,21 @@ class PlatformRuntime:
         Returns:
             True if stopped gracefully, False if cancelled mid-processing.
         """
-        graceful = True
-        if self._runtime:
-            graceful = await self._runtime.stop(timeout=timeout)
+        try:
+            graceful = True
+            if self._runtime:
+                graceful = await self._runtime.stop(timeout=timeout)
 
-        # Unsubscribe from contacts channel before disconnecting
-        if self._link and self._contacts_subscribed:
-            await self._link.unsubscribe_agent_contacts()
-            self._contacts_subscribed = False
-            logger.debug("Unsubscribed from contacts channel")
+            # Unsubscribe from contacts channel before disconnecting
+            if self._link and self._contacts_subscribed:
+                await self._link.unsubscribe_agent_contacts()
+                self._contacts_subscribed = False
+                logger.debug("Unsubscribed from contacts channel")
 
-        if self._link:
-            await self._link.disconnect()
+            if self._link:
+                await self._link.disconnect()
+        finally:
+            self.release_single_instance()
         logger.info("Platform runtime stopped")
         return graceful
 

--- a/src/band/runtime/prompts.py
+++ b/src/band/runtime/prompts.py
@@ -19,6 +19,8 @@ Example:
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from band.core.memory_types import (
     MEMORY_SYSTEM_TYPE_MAP,
     MemorySegment,
@@ -151,6 +153,7 @@ def render_system_prompt(
     template: str = "default",
     include_base_instructions: bool = True,
     features: AdapterFeatures | None = None,
+    extra_sections: Sequence[str] = (),
 ) -> str:
     """
     Render system prompt: agent identity + custom section + optionally base instructions.
@@ -163,6 +166,10 @@ def render_system_prompt(
         include_base_instructions: Whether to include SDK's BASE_INSTRUCTIONS.
                                    Set False if providing fully custom behavior.
         features: AdapterFeatures controlling which capability sections to include.
+        extra_sections: Adapter-contributed sections (each with its own
+            heading), rendered between the capability sections and the
+            developer's custom section — SDK contract text must not
+            masquerade as developer instructions.
 
     Returns:
         Rendered system prompt
@@ -170,8 +177,8 @@ def render_system_prompt(
     identity = f"You are {agent_name}, {agent_description}."
 
     if not include_base_instructions:
-        # Minimal prompt: identity + custom section only
-        parts = [identity]
+        # Minimal prompt: identity + adapter sections + custom section only
+        parts = [identity, *(s.strip() for s in extra_sections)]
         if custom_section:
             parts.append(custom_section)
         return "\n\n".join(parts)
@@ -185,6 +192,8 @@ def render_system_prompt(
             parts.append(MEMORY_SECTION.strip())
         if Capability.CONTACTS in features.capabilities:
             parts.append(CONTACT_SECTION.strip())
+
+    parts.extend(s.strip() for s in extra_sections)
 
     # Developer instructions at the end
     if custom_section:

--- a/src/band/runtime/single_instance.py
+++ b/src/band/runtime/single_instance.py
@@ -1,0 +1,125 @@
+"""Single-instance guard: one running process per agent id per host.
+
+Two processes running the same agent id silently corrupt each other:
+both claim in-flight room messages (the startup recovery sweep has no
+liveness check), and stateful adapters resume the same on-disk sessions,
+splitting one conversation across two processes. The runtime therefore
+holds an OS-level lock per agent id for as long as the agent runs.
+
+The lock is advisory and held on an open file descriptor, so the OS
+releases it the moment the process exits — crashes included. Lock files
+are never unlinked (removing a lock file races against a concurrent
+acquire on the recreated path); a leftover file without a holder carries
+no lock and is harmless.
+
+Scope, honestly stated: the lock file lives in the process's temp dir,
+so the guard only catches duplicates that share it. Processes with
+divergent ``TMPDIR`` (e.g. systemd ``PrivateTmp``), separate containers,
+or different hosts do not contend — deployments that shard one agent id
+across such boundaries need platform-level dedup, not this guard. It
+also guards only the long-lived Agent runtime; one-shot invocations
+(``band.runtime.oneshot``) rely on server-arbitrated message claiming
+instead of host locks.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from band.core.exceptions import BandConfigError
+
+try:
+    import fcntl
+except ImportError:  # non-POSIX; the guard degrades to a warning
+    fcntl = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+# Live holders in this process, by agent id. Exists for lifecycles that
+# skip normal unwinding (e.g. a test runner's signal kill bypasses
+# ``Agent.stop``): the leaked fd would otherwise pin the lock for the
+# process lifetime. ``release_all_held`` lets such harnesses reap.
+_held: dict[str, SingleInstanceGuard] = {}
+
+
+def release_all_held() -> list[str]:
+    """Release every lock still held by this process; return the agent ids.
+
+    A cleanup tool for harnesses whose failure paths can kill an agent
+    without unwinding it (pytest-timeout's signal method). Normal code
+    paths release via ``PlatformRuntime.stop`` and never need this.
+    """
+    released = list(_held)
+    for guard in list(_held.values()):
+        guard.release()
+    return released
+
+
+class SingleInstanceGuard:
+    """Holds the host-wide run lock for one agent id.
+
+    ``acquire()`` raises :class:`BandConfigError` when another process
+    (or another guard in this process) already holds the agent's lock.
+    ``release()`` is idempotent and safe to call from ``finally`` blocks.
+    """
+
+    def __init__(self, agent_id: str, *, lock_dir: str | Path | None = None) -> None:
+        directory = Path(lock_dir) if lock_dir else Path(tempfile.gettempdir())
+        self.lock_path = directory / f"band-agent-{agent_id}.lock"
+        self._agent_id = agent_id
+        self._fd: int | None = None
+
+    def acquire(self) -> None:
+        """Take the agent's run lock, failing fast when it is held."""
+        if self._fd is not None:
+            return
+        try:
+            fd = os.open(self.lock_path, os.O_RDWR | os.O_CREAT, 0o644)
+        except OSError as exc:
+            # e.g. EACCES on another user's lock file in a shared temp dir.
+            raise BandConfigError(
+                f"Cannot open the single-instance lock file {self.lock_path} "
+                f"for agent {self._agent_id}: {exc}. Fix the file's "
+                "permissions, or set AgentConfig(single_instance=False) to "
+                "bypass the guard."
+            ) from exc
+        try:
+            if fcntl is None:  # non-POSIX platform; degrade openly
+                logger.warning("No file-locking primitive; single-instance guard inert")
+            else:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:  # the one errno that means contention
+            os.close(fd)
+            raise BandConfigError(
+                f"Agent {self._agent_id} is already running on this host "
+                f"(lock: {self.lock_path}). Two instances of one agent steal "
+                "each other's room messages and split conversations — stop "
+                "the other process first, or set "
+                "AgentConfig(single_instance=False) to bypass the guard."
+            ) from exc
+        except OSError as exc:  # flock unsupported (e.g. some NFS mounts)
+            os.close(fd)
+            raise BandConfigError(
+                f"Cannot take the single-instance lock at {self.lock_path} "
+                f"for agent {self._agent_id}: {exc}. Locking may be "
+                "unsupported on this filesystem — set "
+                "AgentConfig(single_instance=False) to bypass the guard."
+            ) from exc
+        self._fd = fd
+        _held[self._agent_id] = self
+
+    def release(self) -> None:
+        """Drop the lock; the file stays behind (holderless, harmless)."""
+        if self._fd is None:
+            return
+        if _held.get(self._agent_id) is self:
+            del _held[self._agent_id]
+        fd, self._fd = self._fd, None
+        try:
+            if fcntl is not None:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -1121,6 +1121,14 @@ def get_band_tool_category(name: str) -> str | None:
     return _TOOL_CATEGORIES.get(name)
 
 
+# Platform tools whose execution is already visible in the room (they post
+# messages/events themselves), so adapters must not also report them as
+# tool_call/tool_result events. Adapters may extend this with local names.
+SELF_REPORTING_TOOL_NAMES: frozenset[str] = frozenset(
+    {"band_send_message", "band_send_event"}
+)
+
+
 def mcp_tool_names(names: frozenset[str]) -> list[str]:
     """Convert base tool names to MCP-prefixed names for Claude SDK.
 
@@ -1379,10 +1387,14 @@ class AgentTools(AgentToolsProtocol):
             ChatMessageRequestMentionsItem,
         )
 
-        # Deprecation warning for dict-style mentions
-        if mentions and isinstance(mentions[0], dict):
+        # Deprecation warning for dict-style mentions WITHOUT an id: those
+        # lean on name/handle resolution, which list[str] does better.
+        # Id-bearing dicts are adapter-supplied ground truth (the message's
+        # own sender_id) — the one shape that can never miss the
+        # participants cache — and stay first-class.
+        if any(isinstance(m, dict) and not m.get("id") for m in mentions or []):
             warnings.warn(
-                "Passing mentions as list[dict] is deprecated. "
+                "Passing mentions as list[dict] without an 'id' is deprecated. "
                 "Use list[str] with handles instead.",
                 DeprecationWarning,
                 stacklevel=2,

--- a/src/band/runtime/types.py
+++ b/src/band/runtime/types.py
@@ -72,6 +72,11 @@ class AgentConfig:
     """Configuration for agent runtime."""
 
     auto_subscribe_existing_rooms: bool = True
+    # Refuse to start when another process on this host already runs the
+    # same agent id: duplicates steal each other's in-flight room messages
+    # (the recovery sweep has no liveness check) and stateful adapters
+    # resume the same on-disk sessions, splitting one conversation.
+    single_instance: bool = True
 
 
 # Platform-side TTL (seconds) for the boolean working-state indicator. The

--- a/tests/adapters/copilot_sdk/__init__.py
+++ b/tests/adapters/copilot_sdk/__init__.py
@@ -1,0 +1,4 @@
+"""Tests for CopilotSDKAdapter, one file per test class.
+
+Shared fakes and helpers live in ``fakes.py``.
+"""

--- a/tests/adapters/copilot_sdk/fakes.py
+++ b/tests/adapters/copilot_sdk/fakes.py
@@ -1,0 +1,224 @@
+"""Shared fakes and helpers for CopilotSDKAdapter tests.
+
+The Copilot SDK client/session are faked at the adapter's ``client_factory``
+seam (mirroring FakeCodexClient); the adapter, converter, and tool bridging
+under test are real, exercised through the SDK's standard FakeAgentTools
+test double.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from band.adapters.copilot_sdk import (
+    _COPILOT_SDK_AVAILABLE,
+    CopilotSDKAdapter,
+    CopilotSDKAdapterConfig,
+)
+from band.converters.copilot_sdk import CopilotSDKSessionState
+from band.core.types import PlatformMessage
+from band.testing import FakeAgentTools
+
+requires_copilot_sdk = pytest.mark.skipif(
+    not _COPILOT_SDK_AVAILABLE,
+    reason="github-copilot-sdk not installed (pip install band-sdk[copilot_sdk])",
+)
+
+if _COPILOT_SDK_AVAILABLE:
+    from copilot.generated.session_events import SessionErrorData
+
+
+def make_platform_message(
+    room_id: str = "room-1", content: str = "hello"
+) -> PlatformMessage:
+    return PlatformMessage(
+        id=str(uuid4()),
+        room_id=room_id,
+        content=content,
+        sender_id="user-1",
+        sender_type="User",
+        sender_name="Alice",
+        message_type="text",
+        metadata={},
+        created_at=datetime.now(),
+    )
+
+
+class ToolSchemaFakeTools(FakeAgentTools):
+    def get_openai_tool_schemas(self, **kwargs: Any) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "band_send_message",
+                    "description": "Send a message",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "content": {"type": "string"},
+                            "mentions": {"type": "array", "items": {"type": "string"}},
+                        },
+                        "required": ["content", "mentions"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "band_get_participants",
+                    "description": "List room participants",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ]
+
+
+class FakeCopilotSession:
+    """Fake session: records prompts, replays scripted events to subscribers."""
+
+    def __init__(
+        self,
+        session_id: str | None,
+        kwargs: dict[str, Any],
+        *,
+        resumed: bool = False,
+        reply_content: str | None = "Hello from Copilot",
+        turn_events: list[Any] | None = None,
+    ):
+        self.session_id = session_id
+        self.kwargs = kwargs
+        self.resumed = resumed
+        self.reply_content = reply_content
+        self.turn_events = turn_events or []
+        self.send_error: Exception | None = None
+        self.prompts: list[str] = []
+        self.handlers: list[Any] = []
+        self.aborted = False
+        self.disconnected = False
+
+    def on(self, handler: Any) -> Any:
+        self.handlers.append(handler)
+        return lambda: self.handlers.remove(handler)
+
+    def find_tool(self, name: str) -> Any:
+        return next(t for t in self.kwargs.get("tools") or [] if t.name == name)
+
+    async def send_and_wait(
+        self, prompt: str, *, timeout: float = 60.0, **_: Any
+    ) -> Any:
+        self.prompts.append(prompt)
+        if self.send_error:
+            raise self.send_error
+        for data in self.turn_events:
+            event = SimpleNamespace(data=data)
+            for handler in list(self.handlers):
+                if callable(data):
+                    continue
+                handler(event)
+        # A callable in turn_events simulates mid-turn tool execution.
+        for data in self.turn_events:
+            if callable(data):
+                await data(self)
+        # Mirror the real SDK: any session error event makes send_and_wait
+        # raise (there is no non-fatal error path).
+        for data in self.turn_events:
+            if isinstance(data, SessionErrorData):
+                raise Exception(f"Session error: {data.message}")
+        if self.reply_content is None:
+            return None
+        return SimpleNamespace(data=SimpleNamespace(content=self.reply_content))
+
+    async def abort(self) -> None:
+        self.aborted = True
+
+    async def disconnect(self) -> None:
+        self.disconnected = True
+
+
+class FakeCopilotClient:
+    """Fake client: records create/resume calls, mints FakeCopilotSessions."""
+
+    def __init__(
+        self,
+        *,
+        resume_error: Exception | None = None,
+        reply_content: str | None = "Hello from Copilot",
+        turn_events: list[Any] | None = None,
+    ):
+        self.resume_error = resume_error
+        self.reply_content = reply_content
+        self.turn_events = turn_events or []
+        self.started = False
+        self.stopped = False
+        self.sessions: list[FakeCopilotSession] = []
+        self.resume_calls: list[str] = []
+
+    async def start(self) -> None:
+        self.started = True
+        self.start_calls = getattr(self, "start_calls", 0) + 1
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def create_session(
+        self, *, session_id: str | None = None, **kwargs: Any
+    ) -> Any:
+        session = FakeCopilotSession(
+            session_id,
+            kwargs,
+            reply_content=self.reply_content,
+            turn_events=self.turn_events,
+        )
+        self.sessions.append(session)
+        return session
+
+    async def resume_session(self, session_id: str, **kwargs: Any) -> Any:
+        self.resume_calls.append(session_id)
+        if self.resume_error:
+            raise self.resume_error
+        session = FakeCopilotSession(
+            session_id,
+            kwargs,
+            resumed=True,
+            reply_content=self.reply_content,
+            turn_events=self.turn_events,
+        )
+        self.sessions.append(session)
+        return session
+
+
+async def make_started_adapter(
+    client: FakeCopilotClient,
+    config: CopilotSDKAdapterConfig | None = None,
+    **adapter_kwargs: Any,
+) -> CopilotSDKAdapter:
+    adapter = CopilotSDKAdapter(config, client_factory=lambda: client, **adapter_kwargs)
+    await adapter.on_started("Copilot Agent", "A helpful test agent")
+    return adapter
+
+
+async def run_message(
+    adapter: CopilotSDKAdapter,
+    tools: FakeAgentTools,
+    *,
+    room_id: str = "room-1",
+    content: str = "hello",
+    history: CopilotSDKSessionState | None = None,
+    is_session_bootstrap: bool = True,
+) -> PlatformMessage:
+    msg = make_platform_message(room_id=room_id, content=content)
+    await adapter.on_message(
+        msg=msg,
+        tools=tools,
+        history=history or CopilotSDKSessionState(),
+        participants_msg=None,
+        contacts_msg=None,
+        is_session_bootstrap=is_session_bootstrap,
+        room_id=room_id,
+    )
+    return msg

--- a/tests/adapters/copilot_sdk/test_ask_user_room.py
+++ b/tests/adapters/copilot_sdk/test_ask_user_room.py
@@ -1,0 +1,137 @@
+"""ask_user="room": questions post to the room, the turn ends, answers come later.
+
+The room bridge is exercised through the session's registered
+``on_user_input_request`` handler — the same seam the Copilot SDK
+dispatches ``userInput.request`` RPCs to — via the fakes' callable
+turn-event hook that simulates mid-turn tool execution.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from band.adapters.copilot_sdk import CopilotSDKAdapterConfig
+from band.integrations.copilot_sdk import ASK_USER_ROOM, render_room_question
+from band.integrations.copilot_sdk.room_ask_user import (
+    delivery_failed_answer,
+    question_delivered_answer,
+    room_inactive_answer,
+)
+from band.testing import FakeAgentTools
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    make_started_adapter,
+    requires_copilot_sdk,
+    run_message,
+)
+
+pytestmark = requires_copilot_sdk
+
+QUESTION = {
+    "question": "Which channel should I deploy to?",
+    "choices": ["stable", "beta", "canary"],
+    "allowFreeform": True,
+}
+
+
+def ask_mid_turn(request: dict[str, Any], answers: list[dict[str, Any]]) -> Any:
+    """Turn-event callable: dispatch ``request`` to the session's handler."""
+
+    async def invoke(session: Any) -> None:
+        handler = session.kwargs["on_user_input_request"]
+        answers.append(await handler(request, {"session_id": session.session_id}))
+
+    return invoke
+
+
+class TestAskUserRoom:
+    @pytest.mark.asyncio
+    async def test_question_posts_to_room_and_acks_the_tool_call(self):
+        answers: list[dict[str, Any]] = []
+        client = FakeCopilotClient(turn_events=[ask_mid_turn(QUESTION, answers)])
+        adapter = await make_started_adapter(
+            client, CopilotSDKAdapterConfig(ask_user=ASK_USER_ROOM)
+        )
+        tools = FakeAgentTools()
+
+        await run_message(adapter, tools)
+
+        rendered = render_room_question(QUESTION)
+        assert len(tools.messages_sent) == 1
+        posted = tools.messages_sent[0]
+        assert posted["content"] == rendered
+        # The question addresses whoever triggered the turn.
+        assert posted["mentions"] == [{"id": "user-1", "name": "Alice"}]
+        # The ack echoes the rendered form so the model can map a bare
+        # numeric answer back to its numbered choices.
+        assert answers == [question_delivered_answer(rendered)]
+
+    @pytest.mark.asyncio
+    async def test_question_is_the_turn_reply_final_text_suppressed(self):
+        """A "waiting for your answer" wrap-up must not shadow the question."""
+        answers: list[dict[str, Any]] = []
+        client = FakeCopilotClient(
+            reply_content="I'll wait for your answer.",
+            turn_events=[ask_mid_turn(QUESTION, answers)],
+        )
+        adapter = await make_started_adapter(
+            client, CopilotSDKAdapterConfig(ask_user=ASK_USER_ROOM)
+        )
+        tools = FakeAgentTools()
+
+        await run_message(adapter, tools)
+
+        contents = [m["content"] for m in tools.messages_sent]
+        assert contents == [render_room_question(QUESTION)]
+
+    @pytest.mark.asyncio
+    async def test_delivery_failure_degrades_to_answer_not_rpc_error(self):
+        """A failed post must not blow up the turn as an opaque RPC failure."""
+
+        class FailingOnceTools(FakeAgentTools):
+            def __init__(self) -> None:
+                super().__init__()
+                self.failed = False
+
+            async def send_message(self, content, mentions=None):
+                if not self.failed:
+                    self.failed = True
+                    raise RuntimeError("platform down")
+                return await super().send_message(content, mentions)
+
+        answers: list[dict[str, Any]] = []
+        client = FakeCopilotClient(
+            reply_content="Proceeding without input.",
+            turn_events=[ask_mid_turn(QUESTION, answers)],
+        )
+        adapter = await make_started_adapter(
+            client, CopilotSDKAdapterConfig(ask_user=ASK_USER_ROOM)
+        )
+        tools = FailingOnceTools()
+
+        await run_message(adapter, tools)
+
+        assert answers == [delivery_failed_answer(RuntimeError("platform down"))]
+        # The turn itself survives: the model's reply reaches the room.
+        assert [m["content"] for m in tools.messages_sent] == [
+            "Proceeding without input."
+        ]
+
+    @pytest.mark.asyncio
+    async def test_late_dispatch_after_turn_end_degrades_gracefully(self):
+        """The SDK never cancels a pending ask; a post-turn dispatch must
+        answer benignly instead of crashing on missing turn state."""
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, CopilotSDKAdapterConfig(ask_user=ASK_USER_ROOM)
+        )
+        tools = FakeAgentTools()
+        await run_message(adapter, tools)
+
+        handler = client.sessions[0].kwargs["on_user_input_request"]
+        answer = await handler(QUESTION, {"session_id": "s"})
+
+        assert answer == room_inactive_answer()
+        assert len(tools.messages_sent) == 1  # only the turn's own reply

--- a/tests/adapters/copilot_sdk/test_cleanup.py
+++ b/tests/adapters/copilot_sdk/test_cleanup.py
@@ -1,0 +1,56 @@
+"""Room cleanup disconnects sessions; only cleanup_all stops the client."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    ToolSchemaFakeTools,
+    make_started_adapter,
+    requires_copilot_sdk,
+    run_message,
+)
+
+pytestmark = requires_copilot_sdk
+
+
+class TestCleanup:
+    @pytest.mark.asyncio
+    async def test_cleanup_disconnects_room_but_keeps_client_alive(self):
+        """The client serves the whole adapter lifetime; only cleanup_all stops it."""
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+        await run_message(adapter, tools, room_id="room-a")
+        await run_message(adapter, tools, room_id="room-b")
+
+        await adapter.on_cleanup("room-a")
+        await adapter.on_cleanup("room-b")
+
+        assert client.sessions[0].disconnected
+        assert client.sessions[1].disconnected
+        assert not client.stopped
+
+        # A room joined after all others left must not pay a client restart.
+        await run_message(adapter, tools, room_id="room-c")
+        assert client.sessions[2].prompts
+
+    @pytest.mark.asyncio
+    async def test_cleanup_all_stops_client(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+        await run_message(adapter, tools)
+
+        await adapter.cleanup_all()
+
+        assert client.sessions[0].disconnected
+        assert client.stopped
+
+    @pytest.mark.asyncio
+    async def test_cleanup_unknown_room_is_safe(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+
+        await adapter.on_cleanup("never-seen-room")

--- a/tests/adapters/copilot_sdk/test_per_room_isolation.py
+++ b/tests/adapters/copilot_sdk/test_per_room_isolation.py
@@ -1,0 +1,46 @@
+"""One Copilot session per room; same room reuses its session."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    ToolSchemaFakeTools,
+    make_started_adapter,
+    requires_copilot_sdk,
+    run_message,
+)
+
+pytestmark = requires_copilot_sdk
+
+
+class TestPerRoomIsolation:
+    @pytest.mark.asyncio
+    async def test_two_rooms_get_two_sessions(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools_a, tools_b = ToolSchemaFakeTools(), ToolSchemaFakeTools()
+
+        await run_message(adapter, tools_a, room_id="room-a", content="for A")
+        await run_message(adapter, tools_b, room_id="room-b", content="for B")
+
+        assert len(client.sessions) == 2
+        session_a, session_b = client.sessions
+        assert session_a.session_id == "band-copilot-agent-room-a"
+        assert session_b.session_id == "band-copilot-agent-room-b"
+        # No prompt leakage across rooms.
+        assert "for B" not in session_a.prompts[0]
+        assert "for A" not in session_b.prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_same_room_reuses_session(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+        await run_message(adapter, tools, is_session_bootstrap=False)
+
+        assert len(client.sessions) == 1
+        assert len(client.sessions[0].prompts) == 2

--- a/tests/adapters/copilot_sdk/test_reply.py
+++ b/tests/adapters/copilot_sdk/test_reply.py
@@ -1,0 +1,109 @@
+"""Final-reply delivery: mentions, prompt shape, and failure surfacing."""
+
+from __future__ import annotations
+
+import pytest
+
+from band.adapters.copilot_sdk import _COPILOT_SDK_AVAILABLE
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    FakeCopilotSession,
+    ToolSchemaFakeTools,
+    make_started_adapter,
+    requires_copilot_sdk,
+    run_message,
+)
+
+pytestmark = requires_copilot_sdk
+
+if _COPILOT_SDK_AVAILABLE:
+    from copilot import ToolInvocation
+    from copilot.generated.session_events import SessionErrorData
+
+
+class TestReply:
+    @pytest.mark.asyncio
+    async def test_reply_sent_with_sender_mention(self):
+        client = FakeCopilotClient(reply_content="Hi Alice!")
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        assert len(tools.messages_sent) == 1
+        sent = tools.messages_sent[0]
+        assert sent["content"] == "Hi Alice!"
+        assert sent["mentions"] == [{"id": "user-1", "name": "Alice"}]
+
+    @pytest.mark.asyncio
+    async def test_prompt_contains_room_context_and_message(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools, content="What's up?")
+
+        prompt = client.sessions[0].prompts[0]
+        assert "[room_id: room-1]" in prompt
+        assert "[Alice]: What's up?" in prompt
+
+    @pytest.mark.asyncio
+    async def test_no_reply_raises_and_reports_error(self):
+        client = FakeCopilotClient(reply_content=None)
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        with pytest.raises(RuntimeError, match="no reply"):
+            await run_message(adapter, tools)
+
+        assert not tools.messages_sent
+        error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
+        assert error_events
+
+    @pytest.mark.asyncio
+    async def test_session_error_raises_reports_and_evicts(self):
+        """A session error makes send_and_wait raise (the real SDK has no
+        non-fatal error path): the adapter must report it, evict the
+        session, and re-raise — not fall through to the no-reply branch."""
+        client = FakeCopilotClient(
+            turn_events=[SessionErrorData(error_type="model_error", message="boom")],
+        )
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        with pytest.raises(Exception, match="boom"):
+            await run_message(adapter, tools)
+
+        session = client.sessions[0]
+        assert session.aborted and session.disconnected
+        error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
+        assert error_events and "boom" in error_events[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_fallback_send_suppressed_when_band_send_message_fired(self):
+        async def model_sends_message(session: FakeCopilotSession) -> None:
+            handler = session.find_tool("band_send_message").handler
+            await handler(
+                ToolInvocation(
+                    tool_call_id="call-1",
+                    tool_name="band_send_message",
+                    arguments={"content": "sent via tool", "mentions": ["user-1"]},
+                )
+            )
+
+        client = FakeCopilotClient(
+            reply_content="Duplicate reply", turn_events=[model_sends_message]
+        )
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        # Tool call executed, but the adapter must not also send its final text.
+        assert tools.tool_calls == [
+            {
+                "tool_name": "band_send_message",
+                "arguments": {"content": "sent via tool", "mentions": ["user-1"]},
+            }
+        ]
+        assert not tools.messages_sent

--- a/tests/adapters/copilot_sdk/test_resume_and_rehydration.py
+++ b/tests/adapters/copilot_sdk/test_resume_and_rehydration.py
@@ -1,0 +1,144 @@
+"""Session resume, history injection fallback, and session-id persistence."""
+
+from __future__ import annotations
+
+import pytest
+
+from band.adapters.copilot_sdk import CopilotSDKAdapterConfig
+from band.converters.copilot_sdk import CopilotSDKSessionState
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    ToolSchemaFakeTools,
+    make_started_adapter,
+    requires_copilot_sdk,
+    run_message,
+)
+
+pytestmark = requires_copilot_sdk
+
+
+class TestResumeAndRehydration:
+    @pytest.mark.asyncio
+    async def test_resumes_session_from_history(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        await run_message(
+            adapter,
+            tools,
+            history=CopilotSDKSessionState(
+                text="[Alice]: earlier", session_id="band-room-1"
+            ),
+        )
+
+        assert client.resume_calls == ["band-room-1"]
+        session = client.sessions[0]
+        assert session.resumed
+        # Resumed sessions restore history from disk — no re-injection.
+        assert "[Previous conversation context:]" not in session.prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_resume_failure_creates_fresh_and_injects_history(self):
+        client = FakeCopilotClient(resume_error=RuntimeError("no session state"))
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        await run_message(
+            adapter,
+            tools,
+            history=CopilotSDKSessionState(
+                text="[Alice]: earlier", session_id="band-room-1"
+            ),
+        )
+
+        session = client.sessions[0]
+        assert not session.resumed
+        assert (
+            "[Previous conversation context:]\n[Alice]: earlier" in session.prompts[0]
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_failure_injection_disabled(self):
+        client = FakeCopilotClient(resume_error=RuntimeError("no session state"))
+        adapter = await make_started_adapter(
+            client, CopilotSDKAdapterConfig(inject_history_on_resume_failure=False)
+        )
+        tools = ToolSchemaFakeTools()
+
+        await run_message(
+            adapter,
+            tools,
+            history=CopilotSDKSessionState(
+                text="[Alice]: earlier", session_id="band-room-1"
+            ),
+        )
+
+        assert "[Previous conversation context:]" not in client.sessions[0].prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_fresh_room_with_history_text_injects_it(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        await run_message(
+            adapter, tools, history=CopilotSDKSessionState(text="[Alice]: earlier")
+        )
+
+        assert (
+            "[Previous conversation context:]\n[Alice]: earlier"
+            in (client.sessions[0].prompts[0])
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_id_persisted_as_task_event(self):
+        """Persistence is unconditional bookkeeping — no Emit gate needed."""
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+        await run_message(adapter, tools, is_session_bootstrap=False)
+
+        task_events = [e for e in tools.events_sent if e["message_type"] == "task"]
+        assert len(task_events) == 1  # persisted once, not per turn
+        assert task_events[0]["metadata"] == {
+            "copilot_session_id": "band-copilot-agent-room-1"
+        }
+
+    @pytest.mark.asyncio
+    async def test_persist_retried_after_send_failure(self):
+        """A transient task-event send failure must be retried next turn."""
+
+        class FlakyEventTools(ToolSchemaFakeTools):
+            fail_once = True
+
+            async def send_event(self, content, message_type, metadata=None):
+                if message_type == "task" and self.fail_once:
+                    self.fail_once = False
+                    raise RuntimeError("transient REST error")
+                return await super().send_event(content, message_type, metadata)
+
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = FlakyEventTools()
+
+        await run_message(adapter, tools)
+        assert not [e for e in tools.events_sent if e["message_type"] == "task"]
+
+        await run_message(adapter, tools, is_session_bootstrap=False)
+        task_events = [e for e in tools.events_sent if e["message_type"] == "task"]
+        assert len(task_events) == 1  # retried and then not re-persisted
+
+    @pytest.mark.asyncio
+    async def test_known_session_id_not_repersisted(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        await run_message(
+            adapter, tools, history=CopilotSDKSessionState(session_id="band-room-1")
+        )
+
+        assert not [e for e in tools.events_sent if e["message_type"] == "task"]

--- a/tests/adapters/copilot_sdk/test_session_configuration.py
+++ b/tests/adapters/copilot_sdk/test_session_configuration.py
@@ -1,0 +1,169 @@
+"""Session creation kwargs: system prompt, model, tools, provider, session id."""
+
+from __future__ import annotations
+
+import pytest
+
+from band.adapters.copilot_sdk import (
+    _COPILOT_SDK_AVAILABLE,
+    CopilotSDKAdapter,
+    CopilotSDKAdapterConfig,
+)
+from band.core.exceptions import BandConfigError
+from band.integrations.copilot_sdk import (
+    ASK_USER_ROOM,
+    ROOM_ASK_USER_GUIDANCE,
+    TURN_COMPLETION_GUIDANCE,
+)
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    ToolSchemaFakeTools,
+    make_started_adapter,
+    requires_copilot_sdk,
+    run_message,
+)
+
+pytestmark = requires_copilot_sdk
+
+if _COPILOT_SDK_AVAILABLE:
+    from copilot import ProviderConfig
+
+
+class TestSessionConfiguration:
+    @pytest.mark.asyncio
+    async def test_system_message_replaces_with_rendered_prompt(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, CopilotSDKAdapterConfig(custom_section="Always rhyme.")
+        )
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        system_message = client.sessions[0].kwargs["system_message"]
+        assert system_message["mode"] == "replace"
+        assert "Copilot Agent" in system_message["content"]
+        assert "Always rhyme." in system_message["content"]
+        # Turn-completion guidance is unconditional (no ask_user here): "replace"
+        # mode strips the CLI's own task-completion section, so without this the
+        # model loops on the runtime's "continue" nudge, never going idle.
+        assert TURN_COMPLETION_GUIDANCE in system_message["content"]
+
+    @pytest.mark.asyncio
+    async def test_model_and_reasoning_effort_forwarded(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, CopilotSDKAdapterConfig(model="gpt-5", reasoning_effort="high")
+        )
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        kwargs = client.sessions[0].kwargs
+        assert kwargs["model"] == "gpt-5"
+        assert kwargs["reasoning_effort"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_available_tools_restricted_to_bridged_names(self):
+        """Built-in Copilot tools stay off: only bridged tools are available."""
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        kwargs = client.sessions[0].kwargs
+        bridged_names = [t.name for t in kwargs["tools"]]
+        assert bridged_names == ["band_send_message", "band_get_participants"]
+        assert kwargs["available_tools"] == bridged_names
+        assert all(t.skip_permission for t in kwargs["tools"])
+
+    @pytest.mark.asyncio
+    async def test_ask_user_handler_forwarded_and_tool_enabled(self):
+        async def ask_operator(request, context):
+            return {"answer": "beta", "wasFreeform": False}
+
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, CopilotSDKAdapterConfig(ask_user=ask_operator)
+        )
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        kwargs = client.sessions[0].kwargs
+        assert kwargs["on_user_input_request"] is ask_operator
+        # ask_user must be allowlisted alongside the bridged Band tools,
+        # or the built-in tool stays filtered out and the handler is dead.
+        assert "ask_user" in kwargs["available_tools"]
+        assert "band_send_message" in kwargs["available_tools"]
+        # A caller-supplied handler answers from outside the room; the
+        # room-mode turn-split contract must stay out of its prompt.
+        assert ROOM_ASK_USER_GUIDANCE not in kwargs["system_message"]["content"]
+
+    @pytest.mark.asyncio
+    async def test_ask_user_room_registers_adapter_bridge(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, CopilotSDKAdapterConfig(ask_user=ASK_USER_ROOM)
+        )
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        kwargs = client.sessions[0].kwargs
+        assert callable(kwargs["on_user_input_request"])
+        assert "ask_user" in kwargs["available_tools"]
+        # The model learns the turn-split contract from the system prompt,
+        # not first-hand from its first tool result.
+        assert ROOM_ASK_USER_GUIDANCE in kwargs["system_message"]["content"]
+
+    @pytest.mark.asyncio
+    async def test_ask_user_off_by_default(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        kwargs = client.sessions[0].kwargs
+        assert "on_user_input_request" not in kwargs
+        assert "ask_user" not in kwargs["available_tools"]
+
+    def test_invalid_ask_user_value_rejected(self):
+        with pytest.raises(BandConfigError, match="ask_user"):
+            CopilotSDKAdapter(
+                CopilotSDKAdapterConfig(ask_user="console"),  # type: ignore[arg-type]
+                client_factory=FakeCopilotClient,
+            )
+
+    @pytest.mark.asyncio
+    async def test_byok_provider_forwarded(self):
+        provider = ProviderConfig(
+            type="openai",
+            base_url="https://api.openai.com/v1",
+            api_key="sk-test",
+        )
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, CopilotSDKAdapterConfig(model="gpt-4o-mini", provider=provider)
+        )
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        kwargs = client.sessions[0].kwargs
+        assert kwargs["provider"] == provider
+        assert kwargs["model"] == "gpt-4o-mini"
+
+    @pytest.mark.asyncio
+    async def test_deterministic_session_id_from_room(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, CopilotSDKAdapterConfig(session_id_prefix="myagent-")
+        )
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools, room_id="room-42")
+
+        assert client.sessions[0].session_id == "myagent-room-42"

--- a/tests/adapters/copilot_sdk/test_shared_client.py
+++ b/tests/adapters/copilot_sdk/test_shared_client.py
@@ -1,0 +1,109 @@
+"""One CopilotClient shared by several adapters (one client, many sessions)."""
+
+from __future__ import annotations
+
+import pytest
+
+from band.adapters.copilot_sdk import CopilotSDKAdapter, CopilotSDKAdapterConfig
+from band.core.exceptions import BandConfigError
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    ToolSchemaFakeTools,
+    make_started_adapter,
+    requires_copilot_sdk,
+    run_message,
+)
+
+pytestmark = requires_copilot_sdk
+
+
+class TestSharedClient:
+    @pytest.mark.asyncio
+    async def test_client_and_client_factory_are_mutually_exclusive(self):
+        client = FakeCopilotClient()
+        with pytest.raises(BandConfigError):
+            CopilotSDKAdapter(client=client, client_factory=lambda: client)
+
+    @pytest.mark.asyncio
+    async def test_two_adapters_share_one_client_with_isolated_sessions(self):
+        shared = FakeCopilotClient()
+        tom = CopilotSDKAdapter(
+            CopilotSDKAdapterConfig(session_id_prefix="tom-"), client=shared
+        )
+        jerry = CopilotSDKAdapter(
+            CopilotSDKAdapterConfig(session_id_prefix="jerry-"), client=shared
+        )
+        await tom.on_started("Tom", "cat")
+        await jerry.on_started("Jerry", "mouse")
+
+        # Both agents in the SAME room: distinct prefixes keep sessions apart.
+        await run_message(
+            tom, ToolSchemaFakeTools(), room_id="room-1", content="for Tom"
+        )
+        await run_message(
+            jerry, ToolSchemaFakeTools(), room_id="room-1", content="for Jerry"
+        )
+
+        assert [s.session_id for s in shared.sessions] == ["tom-room-1", "jerry-room-1"]
+        assert "for Jerry" not in shared.sessions[0].prompts[0]
+        assert "for Tom" not in shared.sessions[1].prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_default_session_ids_isolated_per_agent(self):
+        """Two default-config agents in the same room never share a session.
+
+        The default prefix folds in the immutable Band agent id, so Tom and
+        Jerry on the same host cannot resume each other's persisted state.
+        """
+        shared = FakeCopilotClient()
+        tom = CopilotSDKAdapter(client=shared)
+        jerry = CopilotSDKAdapter(client=shared)
+        # The Band runtime sets the immutable agent id before on_started.
+        tom._band_agent_id = "agent-tom-id"
+        jerry._band_agent_id = "agent-jerry-id"
+        await tom.on_started("Tom", "cat")
+        await jerry.on_started("Jerry", "mouse")
+
+        await run_message(tom, ToolSchemaFakeTools(), room_id="room-1")
+        await run_message(jerry, ToolSchemaFakeTools(), room_id="room-1")
+
+        ids = [session.session_id for session in shared.sessions]
+        assert ids == ["band-agent-tom-id-room-1", "band-agent-jerry-id-room-1"]
+
+    @pytest.mark.asyncio
+    async def test_borrowed_client_never_stopped(self):
+        shared = FakeCopilotClient()
+        tom = CopilotSDKAdapter(
+            CopilotSDKAdapterConfig(session_id_prefix="tom-"), client=shared
+        )
+        jerry = CopilotSDKAdapter(
+            CopilotSDKAdapterConfig(session_id_prefix="jerry-"), client=shared
+        )
+        await tom.on_started("Tom", "cat")
+        await jerry.on_started("Jerry", "mouse")
+        await run_message(tom, ToolSchemaFakeTools(), room_id="room-1")
+        await run_message(jerry, ToolSchemaFakeTools(), room_id="room-1")
+
+        # Tom leaving (last room) or shutting down must not kill Jerry's client.
+        await tom.on_cleanup("room-1")
+        await tom.cleanup_all()
+
+        assert shared.sessions[0].disconnected  # Tom's session released
+        assert not shared.sessions[1].disconnected  # Jerry's untouched
+        assert not shared.stopped
+
+        # Jerry keeps working on the shared client afterwards.
+        await run_message(
+            jerry, ToolSchemaFakeTools(), room_id="room-1", is_session_bootstrap=False
+        )
+        assert len(shared.sessions[1].prompts) == 2
+
+    @pytest.mark.asyncio
+    async def test_owned_client_still_stopped(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        await run_message(adapter, ToolSchemaFakeTools())
+
+        await adapter.cleanup_all()
+
+        assert client.stopped

--- a/tests/adapters/copilot_sdk/test_startup_failure.py
+++ b/tests/adapters/copilot_sdk/test_startup_failure.py
@@ -1,0 +1,46 @@
+"""A failed startup must not leak a running owned client."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from band.adapters.copilot_sdk import CopilotSDKAdapter
+from band.core.exceptions import BandConfigError
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    requires_copilot_sdk,
+)
+
+pytestmark = requires_copilot_sdk
+
+
+class TestStartupFailure:
+    class UnauthenticatedClient(FakeCopilotClient):
+        async def get_auth_status(self) -> Any:
+            return SimpleNamespace(
+                isAuthenticated=False, statusMessage="Not authenticated"
+            )
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_stops_owned_client(self):
+        client = self.UnauthenticatedClient()
+        adapter = CopilotSDKAdapter(client_factory=lambda: client)
+
+        with pytest.raises(BandConfigError, match="Not authenticated"):
+            await adapter.on_started("Copilot Agent", "desc")
+
+        assert client.started
+        assert client.stopped
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_leaves_borrowed_client_running(self):
+        client = self.UnauthenticatedClient()
+        adapter = CopilotSDKAdapter(client=client)
+
+        with pytest.raises(BandConfigError, match="Not authenticated"):
+            await adapter.on_started("Copilot Agent", "desc")
+
+        assert not client.stopped  # its owner decides its lifecycle

--- a/tests/adapters/copilot_sdk/test_thoughts.py
+++ b/tests/adapters/copilot_sdk/test_thoughts.py
@@ -1,0 +1,97 @@
+"""Reasoning events surfaced as thought events, gated by Emit.THOUGHTS."""
+
+from __future__ import annotations
+
+import pytest
+
+from band.adapters.copilot_sdk import _COPILOT_SDK_AVAILABLE
+from band.core.types import AdapterFeatures, Emit
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    ToolSchemaFakeTools,
+    make_started_adapter,
+    requires_copilot_sdk,
+    run_message,
+)
+
+pytestmark = requires_copilot_sdk
+
+if _COPILOT_SDK_AVAILABLE:
+    from copilot.generated.session_events import AssistantReasoningData
+
+
+class TestThoughts:
+    @pytest.mark.asyncio
+    async def test_reasoning_emitted_as_thought_events(self):
+        client = FakeCopilotClient(
+            turn_events=[
+                AssistantReasoningData(content="pondering...", reasoning_id="r1")
+            ]
+        )
+        adapter = await make_started_adapter(
+            client, features=AdapterFeatures(emit={Emit.THOUGHTS})
+        )
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        thoughts = [e for e in tools.events_sent if e["message_type"] == "thought"]
+        assert len(thoughts) == 1
+        assert thoughts[0]["content"] == "pondering..."
+
+    @pytest.mark.asyncio
+    async def test_repeated_reasoning_id_collapses_to_one_thought(self):
+        # The Copilot CLI re-emits a block's complete-text reasoning event
+        # more than once per turn (same reasoning_id) — keying by id must
+        # collapse the repeats so the room shows the thought once, not 2-3x.
+        client = FakeCopilotClient(
+            turn_events=[
+                AssistantReasoningData(content="pondering...", reasoning_id="r1"),
+                AssistantReasoningData(content="pondering...", reasoning_id="r1"),
+                AssistantReasoningData(content="pondering...", reasoning_id="r1"),
+            ]
+        )
+        adapter = await make_started_adapter(
+            client, features=AdapterFeatures(emit={Emit.THOUGHTS})
+        )
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        thoughts = [e for e in tools.events_sent if e["message_type"] == "thought"]
+        assert len(thoughts) == 1
+        assert thoughts[0]["content"] == "pondering..."
+
+    @pytest.mark.asyncio
+    async def test_distinct_reasoning_blocks_stay_separate(self):
+        # Genuinely distinct reasoning blocks (different ids) are each their
+        # own thought — dedup keys on the id, not the content.
+        client = FakeCopilotClient(
+            turn_events=[
+                AssistantReasoningData(content="first thought", reasoning_id="r1"),
+                AssistantReasoningData(content="second thought", reasoning_id="r2"),
+            ]
+        )
+        adapter = await make_started_adapter(
+            client, features=AdapterFeatures(emit={Emit.THOUGHTS})
+        )
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        thoughts = [e for e in tools.events_sent if e["message_type"] == "thought"]
+        assert [t["content"] for t in thoughts] == ["first thought", "second thought"]
+
+    @pytest.mark.asyncio
+    async def test_reasoning_not_emitted_when_thoughts_disabled(self):
+        client = FakeCopilotClient(
+            turn_events=[
+                AssistantReasoningData(content="pondering...", reasoning_id="r1")
+            ]
+        )
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        assert not [e for e in tools.events_sent if e["message_type"] == "thought"]

--- a/tests/adapters/copilot_sdk/test_tool_bridging.py
+++ b/tests/adapters/copilot_sdk/test_tool_bridging.py
@@ -1,0 +1,198 @@
+"""Band/custom tool bridging: execution, reporting, and validation failures."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from band.adapters.copilot_sdk import _COPILOT_SDK_AVAILABLE
+from band.core.types import AdapterFeatures, Emit
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    ToolSchemaFakeTools,
+    make_started_adapter,
+    requires_copilot_sdk,
+    run_message,
+)
+
+pytestmark = requires_copilot_sdk
+
+if _COPILOT_SDK_AVAILABLE:
+    from copilot import ToolInvocation
+
+
+class TestToolBridging:
+    @pytest.mark.asyncio
+    async def test_band_tool_executes_and_reports_events(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, features=AdapterFeatures(emit={Emit.EXECUTION})
+        )
+        tools = ToolSchemaFakeTools()
+        await run_message(adapter, tools)
+
+        handler = client.sessions[0].find_tool("band_get_participants").handler
+        result = await handler(
+            ToolInvocation(
+                tool_call_id="call-9", tool_name="band_get_participants", arguments={}
+            )
+        )
+
+        assert result.result_type == "success"
+        assert tools.tool_calls[-1]["tool_name"] == "band_get_participants"
+        event_types = [e["message_type"] for e in tools.events_sent]
+        assert "tool_call" in event_types
+        assert "tool_result" in event_types
+
+    @pytest.mark.asyncio
+    async def test_silent_tools_not_reported(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, features=AdapterFeatures(emit={Emit.EXECUTION})
+        )
+        tools = ToolSchemaFakeTools()
+        await run_message(adapter, tools)
+
+        handler = client.sessions[0].find_tool("band_send_message").handler
+        await handler(
+            ToolInvocation(
+                tool_call_id="call-1",
+                tool_name="band_send_message",
+                arguments={"content": "hi", "mentions": []},
+            )
+        )
+
+        assert not [e for e in tools.events_sent if e["message_type"] == "tool_call"]
+
+    @pytest.mark.asyncio
+    async def test_no_execution_events_when_emit_disabled(self):
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+        await run_message(adapter, tools)
+
+        handler = client.sessions[0].find_tool("band_get_participants").handler
+        await handler(
+            ToolInvocation(
+                tool_call_id="call-9", tool_name="band_get_participants", arguments={}
+            )
+        )
+
+        assert not [
+            e
+            for e in tools.events_sent
+            if e["message_type"] in ("tool_call", "tool_result")
+        ]
+
+    @pytest.mark.asyncio
+    async def test_custom_tool_takes_precedence(self):
+        class EchoInput(BaseModel):
+            text: str
+
+        async def echo(params: EchoInput) -> str:
+            return f"echo: {params.text}"
+
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, additional_tools=[(EchoInput, echo)]
+        )
+        tools = ToolSchemaFakeTools()
+        await run_message(adapter, tools)
+
+        session = client.sessions[0]
+        assert "echo" in [t.name for t in session.kwargs["tools"]]
+        result = await session.find_tool("echo").handler(
+            ToolInvocation(
+                tool_call_id="c1", tool_name="echo", arguments={"text": "hi"}
+            )
+        )
+
+        assert result.text_result_for_llm == "echo: hi"
+        assert not tools.tool_calls  # platform executor not used
+
+    @pytest.mark.asyncio
+    async def test_invalid_custom_tool_args_return_llm_readable_failure(self):
+        class EchoInput(BaseModel):
+            text: str
+
+        async def echo(params: EchoInput) -> str:
+            return params.text
+
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, additional_tools=[(EchoInput, echo)]
+        )
+        tools = ToolSchemaFakeTools()
+        await run_message(adapter, tools)
+
+        result = (
+            await client.sessions[0]
+            .find_tool("echo")
+            .handler(
+                ToolInvocation(
+                    tool_call_id="c1", tool_name="echo", arguments={"wrong": 1}
+                )
+            )
+        )
+
+        assert result.result_type == "failure"
+        assert "echo" in result.text_result_for_llm
+
+    @pytest.mark.asyncio
+    async def test_model_level_validation_error_is_llm_readable(self):
+        """Model-validator errors have loc=() and must not crash the handler."""
+        from pydantic import model_validator
+
+        class PairInput(BaseModel):
+            a: int
+            b: int
+
+            @model_validator(mode="after")
+            def check_order(self) -> "PairInput":
+                if self.a >= self.b:
+                    raise ValueError("a must be less than b")
+                return self
+
+        async def pair(params: PairInput) -> str:
+            return "ok"
+
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(
+            client, additional_tools=[(PairInput, pair)]
+        )
+        tools = ToolSchemaFakeTools()
+        await run_message(adapter, tools)
+
+        result = (
+            await client.sessions[0]
+            .find_tool("pair")
+            .handler(
+                ToolInvocation(
+                    tool_call_id="c1", tool_name="pair", arguments={"a": 2, "b": 1}
+                )
+            )
+        )
+
+        assert result.result_type == "failure"
+        assert "a must be less than b" in result.text_result_for_llm
+
+    @pytest.mark.asyncio
+    async def test_handler_uses_current_room_tools(self):
+        """Handlers must resolve tools at call time, not capture turn-1 tools."""
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        first_tools = ToolSchemaFakeTools()
+        await run_message(adapter, first_tools)
+
+        second_tools = ToolSchemaFakeTools()
+        await run_message(adapter, second_tools, is_session_bootstrap=False)
+
+        handler = client.sessions[0].find_tool("band_get_participants").handler
+        await handler(
+            ToolInvocation(
+                tool_call_id="c1", tool_name="band_get_participants", arguments={}
+            )
+        )
+
+        assert not first_tools.tool_calls
+        assert second_tools.tool_calls

--- a/tests/adapters/copilot_sdk/test_turn_failure.py
+++ b/tests/adapters/copilot_sdk/test_turn_failure.py
@@ -1,0 +1,72 @@
+"""Failed turns: session eviction, runtime revival, and empty-reply handling."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    ToolSchemaFakeTools,
+    make_started_adapter,
+    requires_copilot_sdk,
+    run_message,
+)
+
+pytestmark = requires_copilot_sdk
+
+
+class TestTurnFailure:
+    @pytest.mark.asyncio
+    async def test_failed_turn_aborts_and_evicts_session(self):
+        """A failed/timed-out turn must not leave a dead session cached."""
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+        await run_message(adapter, tools)
+
+        dead = client.sessions[0]
+        dead.send_error = TimeoutError("turn timed out")
+        with pytest.raises(TimeoutError):
+            await run_message(adapter, tools, is_session_bootstrap=False)
+
+        # The stale turn is aborted on the runtime and the session dropped...
+        assert dead.aborted
+        assert dead.disconnected
+        error_events = [e for e in tools.events_sent if e["message_type"] == "error"]
+        assert error_events
+
+        # ...so the next message starts clean, resuming by the stored id.
+        await run_message(adapter, tools, is_session_bootstrap=False)
+        assert client.resume_calls == ["band-copilot-agent-room-1"]
+        assert client.sessions[-1].prompts
+
+    @pytest.mark.asyncio
+    async def test_crashed_runtime_revived_on_next_message(self):
+        """After a failed turn evicts the session, the next message must
+        re-run client.start() — a crashed CLI only heals through start()."""
+        client = FakeCopilotClient()
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+        await run_message(adapter, tools)
+
+        client.sessions[0].send_error = RuntimeError("broken pipe")
+        with pytest.raises(RuntimeError):
+            await run_message(adapter, tools, is_session_bootstrap=False)
+        starts_before = client.start_calls
+
+        await run_message(adapter, tools, is_session_bootstrap=False)
+
+        assert client.start_calls > starts_before  # revival attempted
+        assert client.sessions[-1].prompts  # and the turn ran
+
+    @pytest.mark.asyncio
+    async def test_empty_final_text_raises_no_reply(self):
+        """An empty final assistant message is a failed turn, not a silent no-op."""
+        client = FakeCopilotClient(reply_content="   ")
+        adapter = await make_started_adapter(client)
+        tools = ToolSchemaFakeTools()
+
+        with pytest.raises(RuntimeError, match="no reply"):
+            await run_message(adapter, tools)
+
+        assert not tools.messages_sent

--- a/tests/adapters/copilot_sdk/test_unsupported_feature_warnings.py
+++ b/tests/adapters/copilot_sdk/test_unsupported_feature_warnings.py
@@ -1,0 +1,31 @@
+"""Supported features must not trigger unsupported-feature warnings."""
+
+from __future__ import annotations
+
+import pytest
+
+from band.adapters.copilot_sdk import CopilotSDKAdapter
+from band.core.types import AdapterFeatures, Capability, Emit
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    requires_copilot_sdk,
+)
+
+pytestmark = requires_copilot_sdk
+
+
+class TestUnsupportedFeatureWarnings:
+    @pytest.mark.asyncio
+    async def test_no_warning_for_supported_features(self, recwarn):
+        client = FakeCopilotClient()
+        adapter = CopilotSDKAdapter(
+            client_factory=lambda: client,
+            features=AdapterFeatures(
+                emit={Emit.EXECUTION, Emit.THOUGHTS},
+                capabilities={Capability.MEMORY, Capability.CONTACTS},
+            ),
+        )
+
+        await adapter.on_started("Agent", "desc")
+
+        assert not [w for w in recwarn.list if issubclass(w.category, UserWarning)]

--- a/tests/adapters/copilot_sdk/test_usage.py
+++ b/tests/adapters/copilot_sdk/test_usage.py
@@ -1,0 +1,139 @@
+"""Per-turn token usage capture (Emit.USAGE) for the Copilot SDK adapter.
+
+Copilot streams usage as per-API-call ``assistant.usage`` events, so the
+adapter sums them across the turn and emits one record from ``on_message``'s
+finally. These tests lock that summing + the no-fold rule (reasoning_tokens is
+a subset of output_tokens) and the finally contract on the failure path — the
+generic emit_usage behaviors (cancellation-skip, best-effort) are base-class
+and covered by the anthropic suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from band.adapters.copilot_sdk import _COPILOT_SDK_AVAILABLE, CopilotSDKAdapter
+from band.core.types import AdapterFeatures, Emit, TurnUsage
+from tests.adapters.copilot_sdk.fakes import (
+    FakeCopilotClient,
+    ToolSchemaFakeTools,
+    make_started_adapter,
+    requires_copilot_sdk,
+    run_message,
+)
+from tests.adapters.usage_events import recorded_usage_payloads
+
+pytestmark = requires_copilot_sdk
+
+if _COPILOT_SDK_AVAILABLE:
+    from copilot.generated.session_events import AssistantUsageData, SessionErrorData
+
+
+class TestUsage:
+    def test_mapper_maps_fields_and_does_not_fold_reasoning(self):
+        usage = CopilotSDKAdapter._usage_from_event(
+            AssistantUsageData(
+                model="m",
+                input_tokens=10,
+                output_tokens=5,
+                reasoning_tokens=7,
+                cache_read_tokens=3,
+                cache_write_tokens=2,
+            )
+        )
+        # reasoning_tokens is a SUBSET of output_tokens (rpc.py:9247), so output
+        # stays 5 — folding it in would double-count to 12 (regression guard).
+        assert usage == TurnUsage(
+            input_tokens=10, output_tokens=5, cache_read_tokens=3, cache_write_tokens=2
+        )
+        assert usage.output_tokens == 5
+
+        # Summing primitive used to aggregate a turn's per-call events.
+        other = CopilotSDKAdapter._usage_from_event(
+            AssistantUsageData(model="m", input_tokens=1, output_tokens=2)
+        )
+        assert usage + other == TurnUsage(
+            input_tokens=11, output_tokens=7, cache_read_tokens=3, cache_write_tokens=2
+        )
+
+    @pytest.mark.asyncio
+    async def test_usage_summed_across_turn_and_emitted_once(self):
+        client = FakeCopilotClient(
+            turn_events=[
+                AssistantUsageData(model="m", input_tokens=10, output_tokens=5),
+                AssistantUsageData(model="m", input_tokens=3, output_tokens=7),
+            ]
+        )
+        adapter = await make_started_adapter(
+            client, features=AdapterFeatures(emit={Emit.USAGE})
+        )
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        payloads = recorded_usage_payloads(tools)
+        assert len(payloads) == 1
+        assert payloads[0] == {
+            "input_tokens": 13,
+            "output_tokens": 12,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_usage_emitted_when_feature_disabled(self):
+        client = FakeCopilotClient(
+            turn_events=[
+                AssistantUsageData(model="m", input_tokens=10, output_tokens=5),
+                AssistantUsageData(model="m", input_tokens=3, output_tokens=7),
+            ]
+        )
+        adapter = await make_started_adapter(client)  # default features: no USAGE
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        assert recorded_usage_payloads(tools) == []
+
+    @pytest.mark.asyncio
+    async def test_usage_emitted_even_when_turn_fails(self):
+        # send_and_wait dispatches the usage event to collect, then raises on
+        # the SessionErrorData — so on_message evicts/reports/re-raises and the
+        # finally still emits the tokens spent before the error surfaced.
+        client = FakeCopilotClient(
+            turn_events=[
+                AssistantUsageData(model="m", input_tokens=100, output_tokens=20),
+                SessionErrorData(error_type="model_error", message="boom"),
+            ]
+        )
+        adapter = await make_started_adapter(
+            client, features=AdapterFeatures(emit={Emit.USAGE})
+        )
+        tools = ToolSchemaFakeTools()
+
+        with pytest.raises(Exception, match="boom"):
+            await run_message(adapter, tools)
+
+        payloads = recorded_usage_payloads(tools)
+        assert len(payloads) == 1
+        # Full-dict assert so the failure path locks cache fields at 0 too,
+        # matching test_usage_summed_across_turn_and_emitted_once.
+        assert payloads[0] == {
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_usage_emitted_for_empty_turn(self):
+        client = FakeCopilotClient(turn_events=[])  # no usage events this turn
+        adapter = await make_started_adapter(
+            client, features=AdapterFeatures(emit={Emit.USAGE})
+        )
+        tools = ToolSchemaFakeTools()
+
+        await run_message(adapter, tools)
+
+        # TurnUsage().is_empty gates emission — no false all-zero record.
+        assert recorded_usage_payloads(tools) == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,9 @@ return SDK-native types for pattern matching compatibility.
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -47,28 +49,79 @@ from band.platform.event import (
 )
 from band.runtime.types import PlatformMessage
 
-# E402: module-level import not at top of file. Grouped after first-party SDK
-# imports to keep test-utility imports separate. The original interleaved
-# ordering triggered ruff E402 because a non-import comment sat between imports.
-from thenvoi_testing.markers import pytest_ignore_collect_in_ci as _ignore_collect_in_ci
-
 # Enable the `pytester` fixture (must live in the root conftest) so hook/plugin behaviour
 # can be exercised in a real sub-run — used by tests/e2e/baseline/guards/test_agent_wiring.py.
 pytest_plugins = ["pytester"]
 
 
-def pytest_ignore_collect(collection_path):
-    """Skip integration tests in CI; defer to pytest otherwise.
+def pytest_ignore_collect(collection_path: Path) -> bool | None:
+    """Skip real-API integration tests (tests/integration/) in CI.
 
-    ``pytest_ignore_collect`` is a firstresult hook: ``True`` ignores the path,
-    but returning ``False`` *vetoes* pytest's own ``--ignore``/``--ignore-glob``
-    handling for every path. Returning ``None`` (not ``False``) when we don't
-    want to force-ignore keeps the built-in ``--ignore`` flags working — without
-    it, ``pytest tests/ --ignore=tests/e2e`` silently collects e2e anyway.
+    Matches the exact path segment: the substring check it replaces also
+    swallowed tests/integrations/ — the mocked framework-integration unit
+    tests — silently dropping them from every CI run. Returns None (not
+    False) when not ignoring, so other mechanisms like --ignore still
+    apply locally.
     """
-    if _ignore_collect_in_ci(str(collection_path), "integration"):
+    if os.environ.get("CI") == "true" and "integration" in collection_path.parts:
         return True
     return None
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Skip e2e-marked tests unless explicitly enabled.
+
+    tests/e2e/ gates itself through its own conftest; this covers
+    e2e-marked tests living elsewhere (e.g. the codex ACP protocol
+    tests), which spawn real backends and must never ride a normal
+    unit run.
+    """
+    if os.environ.get("E2E_TESTS_ENABLED") == "true":
+        return
+    skip = pytest.mark.skip(reason="set E2E_TESTS_ENABLED=true to run e2e tests")
+    for item in items:
+        if item.get_closest_marker("e2e"):
+            item.add_marker(skip)
+
+
+@pytest.fixture(autouse=True)
+def isolated_single_instance_lock(request, tmp_path_factory, monkeypatch):
+    """Give every unit test its own single-instance lock dir.
+
+    The guard is host-global by design (one process per agent id); unit
+    tests reuse agent ids and may start runtimes they never stop, which
+    would otherwise hold the shared lock for the rest of the pytest
+    process. The lock dir is minted lazily (per test, on first guard
+    construction) so the 3000+ tests that never build a guard pay nothing.
+
+    Live tests (e2e/integration) keep the REAL host-global guard: there,
+    two same-id agents genuinely corrupt each other, and a loud
+    BandConfigError beats silent message stealing.
+    """
+    if {"e2e", "integration"} & set(request.node.path.parts):
+        yield
+        return
+
+    from band.runtime.single_instance import SingleInstanceGuard
+
+    lock_dir: list = []
+    created: list[SingleInstanceGuard] = []
+
+    def isolated_guard(agent_id):
+        if not lock_dir:
+            lock_dir.append(tmp_path_factory.mktemp("agent-locks"))
+        guard = SingleInstanceGuard(agent_id, lock_dir=lock_dir[0])
+        created.append(guard)
+        return guard
+
+    monkeypatch.setattr(
+        "band.runtime.platform_runtime.SingleInstanceGuard", isolated_guard
+    )
+    yield
+    # A test that starts a runtime and never stops it would otherwise leak
+    # the lock fd (and its process-registry entry) for the whole session.
+    for guard in created:
+        guard.release()
 
 
 # =============================================================================

--- a/tests/converters/copilot_sdk/__init__.py
+++ b/tests/converters/copilot_sdk/__init__.py
@@ -1,0 +1,8 @@
+"""Tests for CopilotSDKHistoryConverter, one file per test class.
+
+Tests for shared converter behavior (user messages, agent filtering, empty
+history, edge cases, output shape) live in
+tests/framework_conformance/test_converter_conformance.py.
+This package contains CopilotSDK-specific multi-message joining, tool event
+handling, session ID extraction, and mixed history integration tests.
+"""

--- a/tests/converters/copilot_sdk/test_basic_conversion.py
+++ b/tests/converters/copilot_sdk/test_basic_conversion.py
@@ -1,0 +1,38 @@
+"""Tests for CopilotSDK-specific message conversion to text."""
+
+from __future__ import annotations
+
+from band.converters.copilot_sdk import (
+    CopilotSDKHistoryConverter,
+    CopilotSDKSessionState,
+)
+
+
+class TestBasicConversion:
+    def test_converts_multiple_messages(self):
+        """Multiple messages are joined with newlines."""
+        converter = CopilotSDKHistoryConverter()
+        raw = [
+            {
+                "role": "user",
+                "content": "Hello!",
+                "sender_name": "Alice",
+                "message_type": "text",
+            },
+            {
+                "role": "user",
+                "content": "Hi there!",
+                "sender_name": "Bob",
+                "message_type": "text",
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert result.text == "[Alice]: Hello!\n[Bob]: Hi there!"
+
+    def test_returns_session_state(self):
+        """convert() returns a CopilotSDKSessionState instance."""
+        converter = CopilotSDKHistoryConverter()
+        result = converter.convert([])
+        assert isinstance(result, CopilotSDKSessionState)

--- a/tests/converters/copilot_sdk/test_edge_cases.py
+++ b/tests/converters/copilot_sdk/test_edge_cases.py
@@ -1,0 +1,64 @@
+"""CopilotSDK-specific edge cases not covered by conformance tests.
+
+The conformance test ``test_defaults_to_user_role`` skips CopilotSDK
+because ``has_role_concept=False`` (output is a flat string).  This
+module covers the missing-role behavior directly.
+"""
+
+from __future__ import annotations
+
+from band.converters.copilot_sdk import CopilotSDKHistoryConverter
+
+
+class TestEdgeCases:
+    def test_missing_role_defaults_to_user(self):
+        """Messages without a 'role' key are treated as user messages."""
+        converter = CopilotSDKHistoryConverter(agent_name="MyAgent")
+        raw = [
+            {
+                "content": "Hello",
+                "sender_name": "Bob",
+                "message_type": "text",
+            }
+        ]
+
+        result = converter.convert(raw)
+
+        assert "[Bob]: Hello" in result.text
+
+    def test_includes_own_agent_messages(self):
+        """Own replies are kept: they are the only record of the agent's side
+        (band_send_message tool reporting is silenced by the adapter)."""
+        converter = CopilotSDKHistoryConverter(agent_name="MyAgent")
+        raw = [
+            {
+                "role": "assistant",
+                "content": "Here's my answer",
+                "sender_name": "MyAgent",
+                "message_type": "text",
+            }
+        ]
+
+        result = converter.convert(raw)
+
+        assert result.text == "[MyAgent]: Here's my answer"
+
+    def test_unknown_message_type_skipped(self):
+        """Unknown message types (e.g. thought) never reach the text blob."""
+        converter = CopilotSDKHistoryConverter()
+        raw = [
+            {
+                "content": "internal reasoning",
+                "sender_name": "MyAgent",
+                "message_type": "thought",
+            },
+            {
+                "content": "Hello",
+                "sender_name": "Alice",
+                "message_type": "text",
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert result.text == "[Alice]: Hello"

--- a/tests/converters/copilot_sdk/test_mixed_history.py
+++ b/tests/converters/copilot_sdk/test_mixed_history.py
@@ -1,0 +1,109 @@
+"""Integration tests with mixed message types."""
+
+from __future__ import annotations
+
+import json
+
+from band.converters.copilot_sdk import CopilotSDKHistoryConverter
+
+
+class TestMixedHistory:
+    def test_full_conversation_flow(self):
+        """Should handle a realistic conversation with mixed message types."""
+        converter = CopilotSDKHistoryConverter(agent_name="WeatherAgent")
+        tool_call_json = json.dumps(
+            {
+                "name": "get_weather",
+                "args": {"city": "NYC"},
+                "tool_call_id": "call_123",
+            }
+        )
+        tool_result_json = json.dumps(
+            {"output": "sunny, 72F", "tool_call_id": "call_123"}
+        )
+        raw = [
+            {
+                "role": "user",
+                "content": "What's the weather?",
+                "sender_name": "Alice",
+                "message_type": "text",
+            },
+            {
+                "role": "assistant",
+                "content": tool_call_json,
+                "message_type": "tool_call",
+            },
+            {
+                "role": "assistant",
+                "content": tool_result_json,
+                "message_type": "tool_result",
+            },
+            # Agent's own reply is kept — it's the only record of the answer.
+            {
+                "role": "assistant",
+                "content": "It's sunny today!",
+                "sender_name": "WeatherAgent",
+                "message_type": "text",
+            },
+            {
+                "role": "user",
+                "content": "Thanks!",
+                "sender_name": "Alice",
+                "message_type": "text",
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert "[Alice]: What's the weather?" in result.text
+        assert "[Alice]: Thanks!" in result.text
+        assert tool_call_json in result.text
+        assert tool_result_json in result.text
+        assert "[WeatherAgent]: It's sunny today!" in result.text
+
+    def test_multi_agent_conversation(self):
+        """Handles multiple agents in conversation."""
+        converter = CopilotSDKHistoryConverter(agent_name="MyAgent")
+        raw = [
+            {
+                "role": "user",
+                "content": "Hi team!",
+                "sender_name": "Alice",
+                "message_type": "text",
+            },
+            {
+                "role": "assistant",
+                "content": "Hello!",
+                "sender_name": "OtherAgent",
+                "message_type": "text",
+            },
+            {
+                "role": "assistant",
+                "content": "Hi Alice!",
+                "sender_name": "MyAgent",
+                "message_type": "text",
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert "[Alice]: Hi team!" in result.text
+        assert "[OtherAgent]: Hello!" in result.text
+        assert "[MyAgent]: Hi Alice!" in result.text
+
+    def test_preserves_message_order(self):
+        """Messages appear in the same order as input."""
+        converter = CopilotSDKHistoryConverter()
+        raw = [
+            {"content": "First", "sender_name": "A", "message_type": "text"},
+            {"content": "Second", "sender_name": "B", "message_type": "text"},
+            {"content": "Third", "sender_name": "C", "message_type": "text"},
+        ]
+
+        result = converter.convert(raw)
+        lines = result.text.split("\n")
+
+        assert len(lines) == 3
+        assert "First" in lines[0]
+        assert "Second" in lines[1]
+        assert "Third" in lines[2]

--- a/tests/converters/copilot_sdk/test_session_id_extraction.py
+++ b/tests/converters/copilot_sdk/test_session_id_extraction.py
@@ -1,0 +1,135 @@
+"""Tests for session_id extraction from task events."""
+
+from __future__ import annotations
+
+from band.converters.copilot_sdk import CopilotSDKHistoryConverter
+
+
+class TestSessionIdExtraction:
+    def test_extracts_session_id_from_task_event(self):
+        """Should extract session_id from task event metadata."""
+        converter = CopilotSDKHistoryConverter()
+        raw = [
+            {
+                "role": "user",
+                "content": "Hello",
+                "sender_name": "Alice",
+                "message_type": "text",
+            },
+            {
+                "content": "Copilot SDK session",
+                "message_type": "task",
+                "metadata": {"copilot_session_id": "band-room-abc"},
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert result.session_id == "band-room-abc"
+
+    def test_returns_latest_session_id(self):
+        """When multiple task events exist, return the latest session_id."""
+        converter = CopilotSDKHistoryConverter()
+        raw = [
+            {
+                "content": "Copilot SDK session",
+                "message_type": "task",
+                "metadata": {"copilot_session_id": "sess-old"},
+            },
+            {
+                "role": "user",
+                "content": "Hello",
+                "sender_name": "Alice",
+                "message_type": "text",
+            },
+            {
+                "content": "Copilot SDK session",
+                "message_type": "task",
+                "metadata": {"copilot_session_id": "sess-new"},
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert result.session_id == "sess-new"
+
+    def test_returns_none_when_no_task_events(self):
+        """Should return None when no task events exist."""
+        converter = CopilotSDKHistoryConverter()
+        raw = [
+            {
+                "role": "user",
+                "content": "Hello",
+                "sender_name": "Alice",
+                "message_type": "text",
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert result.session_id is None
+
+    def test_ignores_task_events_without_session_id_key(self):
+        """Should ignore task events that don't have copilot_session_id."""
+        converter = CopilotSDKHistoryConverter()
+        raw = [
+            {
+                "content": "Some other task event",
+                "message_type": "task",
+                "metadata": {"other_key": "value"},
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert result.session_id is None
+
+    def test_tolerates_task_events_with_missing_metadata(self):
+        """Task events without metadata (or metadata=None) are skipped."""
+        converter = CopilotSDKHistoryConverter()
+        raw = [
+            {"content": "junk", "message_type": "task"},
+            {"content": "junk", "message_type": "task", "metadata": None},
+            {
+                "content": "Copilot SDK session",
+                "message_type": "task",
+                "metadata": {"copilot_session_id": "sess-good"},
+            },
+            {"content": "junk", "message_type": "task", "metadata": {}},
+        ]
+
+        result = converter.convert(raw)
+
+        assert result.session_id == "sess-good"
+
+    def test_task_events_not_included_in_text(self):
+        """Task events should never appear in the text output."""
+        converter = CopilotSDKHistoryConverter()
+        raw = [
+            {
+                "role": "user",
+                "content": "Hello",
+                "sender_name": "Alice",
+                "message_type": "text",
+            },
+            {
+                "content": "Copilot SDK session",
+                "message_type": "task",
+                "metadata": {"copilot_session_id": "sess-abc"},
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert "Copilot SDK session" not in result.text
+        assert "sess-abc" not in result.text
+        assert result.text == "[Alice]: Hello"
+
+    def test_empty_history_returns_empty_state(self):
+        """Empty history should return empty state with no session_id."""
+        converter = CopilotSDKHistoryConverter()
+
+        result = converter.convert([])
+
+        assert result.text == ""
+        assert result.session_id is None

--- a/tests/converters/copilot_sdk/test_tool_event_handling.py
+++ b/tests/converters/copilot_sdk/test_tool_event_handling.py
@@ -1,0 +1,99 @@
+"""Tests for tool_call and tool_result inclusion."""
+
+from __future__ import annotations
+
+import json
+
+from band.converters.copilot_sdk import CopilotSDKHistoryConverter
+
+
+class TestToolEventHandling:
+    def test_includes_tool_call_as_raw_json(self):
+        """tool_call messages are included as raw JSON."""
+        converter = CopilotSDKHistoryConverter(agent_name="MyAgent")
+        tool_call_json = json.dumps(
+            {
+                "name": "get_weather",
+                "args": {"city": "NYC"},
+                "tool_call_id": "call_123",
+            }
+        )
+        raw = [
+            {
+                "role": "user",
+                "content": "Hello",
+                "sender_name": "User",
+                "message_type": "text",
+            },
+            {
+                "role": "assistant",
+                "content": tool_call_json,
+                "message_type": "tool_call",
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert "[User]: Hello" in result.text
+        assert tool_call_json in result.text
+
+    def test_includes_tool_result_as_raw_json(self):
+        """tool_result messages are included as raw JSON."""
+        converter = CopilotSDKHistoryConverter(agent_name="MyAgent")
+        tool_result_json = json.dumps(
+            {"output": "sunny, 72F", "tool_call_id": "call_123"}
+        )
+        raw = [
+            {
+                "role": "assistant",
+                "content": tool_result_json,
+                "message_type": "tool_result",
+            }
+        ]
+
+        result = converter.convert(raw)
+
+        assert result.text == tool_result_json
+
+    def test_tool_events_included_regardless_of_agent_name(self):
+        """Tool events are included as raw JSON regardless of agent_name."""
+        converter = CopilotSDKHistoryConverter(agent_name="WeatherBot")
+        tool_call_json = json.dumps({"name": "search", "args": {}})
+        raw = [
+            {
+                "content": tool_call_json,
+                "message_type": "tool_call",
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert result.text == tool_call_json
+
+    def test_skips_empty_tool_call_content(self):
+        """Should skip tool_call with empty content."""
+        converter = CopilotSDKHistoryConverter()
+        raw = [
+            {
+                "content": "",
+                "message_type": "tool_call",
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert result.text == ""
+
+    def test_skips_empty_tool_result_content(self):
+        """Should skip tool_result with empty content."""
+        converter = CopilotSDKHistoryConverter()
+        raw = [
+            {
+                "content": "",
+                "message_type": "tool_result",
+            },
+        ]
+
+        result = converter.convert(raw)
+
+        assert result.text == ""

--- a/tests/core/test_agent_lifecycle.py
+++ b/tests/core/test_agent_lifecycle.py
@@ -1,0 +1,82 @@
+"""Tests for Agent lifecycle wiring to the adapter.
+
+Room-scoped ``on_cleanup`` is exercised by the runtime tests; these cover
+the adapter-wide ``cleanup_all`` hook that Agent.stop() invokes so owned
+resources (e.g. a CLI runtime subprocess) don't outlive the agent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from band.agent import Agent
+
+
+def make_agent(adapter: object) -> Agent:
+    runtime = AsyncMock()
+    runtime.stop.return_value = True
+    agent = Agent(runtime=runtime, adapter=adapter)  # type: ignore[arg-type]
+    agent._started = True
+    return agent
+
+
+class TestStartFailureCleansUpAdapter:
+    @pytest.mark.asyncio
+    async def test_runtime_start_failure_rolls_back_adapter(self):
+        """on_started may spawn resources; a failed runtime.start must free them."""
+        adapter = AsyncMock()
+        runtime = AsyncMock()
+        runtime.start.side_effect = RuntimeError("websocket refused")
+        agent = Agent(runtime=runtime, adapter=adapter)  # type: ignore[arg-type]
+
+        with pytest.raises(RuntimeError, match="websocket refused"):
+            await agent.start()
+
+        adapter.cleanup_all.assert_awaited_once()
+
+
+class TestStopCleansUpAdapter:
+    @pytest.mark.asyncio
+    async def test_stop_calls_adapter_cleanup_all(self):
+        adapter = AsyncMock()
+        agent = make_agent(adapter)
+
+        assert await agent.stop() is True
+
+        adapter.cleanup_all.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_cleans_up_adapter_even_when_runtime_stop_raises(self):
+        """A broken websocket close must not leak adapter-owned resources."""
+        adapter = AsyncMock()
+        agent = make_agent(adapter)
+        agent._runtime.stop.side_effect = RuntimeError("close failed")
+
+        with pytest.raises(RuntimeError, match="close failed"):
+            await agent.stop()
+
+        adapter.cleanup_all.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_survives_cleanup_all_failure(self):
+        """A failing adapter cleanup must not break shutdown."""
+        adapter = AsyncMock()
+        adapter.cleanup_all.side_effect = RuntimeError("runtime already gone")
+        agent = make_agent(adapter)
+
+        assert await agent.stop() is True
+
+    @pytest.mark.asyncio
+    async def test_stop_tolerates_adapter_without_cleanup_all(self):
+        """Bare FrameworkAdapter implementations without the hook still stop."""
+
+        class MinimalAdapter:
+            async def on_event(self, inp: object) -> None: ...
+            async def on_cleanup(self, room_id: str) -> None: ...
+            async def on_started(self, name: str, description: str) -> None: ...
+
+        agent = make_agent(MinimalAdapter())
+
+        assert await agent.stop() is True

--- a/tests/e2e/baseline/README.md
+++ b/tests/e2e/baseline/README.md
@@ -225,7 +225,7 @@ These three are why the toolkit is shaped the way it is — keep them when exten
 | `smoke/matrix/` | runs across the adapter matrix: `test_adapter_matrix.py`, `test_capability_matrix.py` (memory store + recall), `test_context_recall.py` (in-session + rejoin), `test_rehydration_offline.py` / `test_rehydration_partial.py` (cold-boot / partial-reboot `/context` recall), `test_rehydration_cross_framework.py` (a different-framework `peer=` authors, A rehydrates), `test_room_isolation.py`, `test_noisy_room.py`, `test_tool_round_trip.py` (custom-tool subgroup) |
 | `smoke/behavior/` | platform/transport + scenario behavior: `test_delivery_status.py`, `test_processing_barrier.py`, `test_isolation.py`, `test_agent_scenarios.py` |
 | `smoke/inspection/` | `capture.*` observation worked-examples: `test_tool_calls.py`, `test_events.py`, `test_memory.py` |
-| `smoke/adapters/` | adapter-specific showcases: `test_agno.py`, `test_crewai.py`, `test_letta.py`, `test_parlant.py` |
+| `smoke/adapters/` | adapter-specific showcases: `test_agno.py`, `test_copilot_sdk.py`, `test_crewai.py`, `test_letta.py`, `test_parlant.py` |
 
 The `toolkit/` modules are pytest-free and reusable anywhere. The package root
 (`settings`, `requires`, `agents`, `conftest`) is the pytest wiring.
@@ -529,7 +529,7 @@ the `dev` extra but are split out for isolation.
 
 | Lane | `uv` extra | Adapters | Backend the CI job provides |
 |------|-----------|----------|------------------------------|
-| `core` | `dev` | anthropic, claude_sdk, agno, langgraph, pydantic_ai | provider keys (secrets) |
+| `core` | `dev` | anthropic, claude_sdk, agno, langgraph, pydantic_ai, copilot_sdk | provider keys (secrets); copilot_sdk self-downloads its CLI runtime and needs a Copilot-entitled `GITHUB_TOKEN` (BYOK inference reuses `ANTHROPIC_API_KEY`) |
 | `crewai` | `dev-crewai` | crewai, crewai_flow | provider keys; isolated venv (crewai conflicts with `dev`'s deps — `pyproject.toml [tool.uv] conflicts`) |
 | `google` | `dev` | gemini, google_adk | provider keys; split from `core` so Google free-tier rate-limit flakiness is isolated |
 | `backends` | `dev` | codex, opencode | the CLI/server coding agents in one job: the `codex` CLI + login + a disposable `CODEX_CWD` (+ the codex-acp e2e), and a running `opencode serve` (`OPENCODE_BASE_URL`) |

--- a/tests/e2e/baseline/conftest.py
+++ b/tests/e2e/baseline/conftest.py
@@ -28,6 +28,7 @@ from tests.e2e.baseline.fixtures.platform import (
     baseline_user_client,
     baseline_ws,
     orphan_sweep,
+    reap_leaked_agents,
     resource_manager,
     user_ops,
 )
@@ -57,6 +58,7 @@ __all__ = [
     "judge",
     "orphan_sweep",
     "peer",
+    "reap_leaked_agents",
     "reply_capture",
     "resource_manager",
     "user_ops",

--- a/tests/e2e/baseline/fixtures/platform.py
+++ b/tests/e2e/baseline/fixtures/platform.py
@@ -1,8 +1,10 @@
 """Platform/session fixtures: settings, the user REST client, WS observer, and
-provision/reap lifecycle (including the session-start orphan sweep)."""
+provision/reap lifecycle (including the session-start orphan sweep and the
+per-test reaper for agents a killed test abandons)."""
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncGenerator
 
 import pytest
@@ -18,12 +20,15 @@ from tests.e2e.baseline.toolkit.provisioning import (
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 from tests.e2e.baseline.toolkit.ws import TrackingWebSocketClient
 
+logger = logging.getLogger(__name__)
+
 __all__ = [
     "baseline_run_id",
     "baseline_settings",
     "baseline_user_client",
     "baseline_ws",
     "orphan_sweep",
+    "reap_leaked_agents",
     "resource_manager",
     "user_ops",
 ]
@@ -126,3 +131,41 @@ async def orphan_sweep(
         run_id=baseline_run_id,
     )
     await resources.sweep_orphans()
+
+
+@pytest.fixture(autouse=True)
+async def reap_leaked_agents() -> AsyncGenerator[None, None]:
+    """Stop agents (and free their locks) abandoned by a killed test.
+
+    pytest-timeout's signal method aborts a test without unwinding its
+    ``async with agent`` blocks: the agent's tasks stay alive on the
+    session loop (a zombie that keeps consuming room messages) and its
+    single-instance lock stays held, refusing every rerun and later test
+    using the same agent id. Stopping the agent — not merely releasing
+    its lock — removes the zombie so the next start is a true singleton.
+    Reruns re-run function fixtures, so reaping here heals them too.
+    """
+    from band import agent as agent_module
+    from band.runtime import single_instance
+
+    yield
+    for leaked_agent in agent_module.running_agents():
+        logger.warning(
+            "Stopping agent leaked by a killed test: %s",
+            leaked_agent.runtime.agent_id,
+        )
+        try:
+            await leaked_agent.stop(timeout=None)
+        except Exception:
+            # A zombie's transport may already be dead; the lock backstop
+            # below must still run for the remaining leaks.
+            logger.exception("Leaked agent %s did not stop cleanly", leaked_agent)
+    # Backstop for guards whose owner is unreachable (e.g. a runtime
+    # driven without Agent): a held lock with no live owner can only
+    # block, never protect.
+    leaked_locks = single_instance.release_all_held()
+    if leaked_locks:
+        logger.warning(
+            "Released single-instance lock(s) abandoned by a killed test: %s",
+            ", ".join(leaked_locks),
+        )

--- a/tests/e2e/baseline/settings.py
+++ b/tests/e2e/baseline/settings.py
@@ -97,7 +97,7 @@ class LLMCredentials(BaseSettings):
 
 
 class Backends(BaseSettings):
-    """Config for the external-backend adapters (codex / opencode / letta).
+    """Config for the external-backend adapters (codex / opencode / letta / copilot_sdk).
 
     Reads each backend's standard env vars (no shared prefix). Defaults that the
     matrix relies on live here -- the single source -- not scattered through the
@@ -131,6 +131,10 @@ class Backends(BaseSettings):
     letta_api_key: str = ""  # LETTA_API_KEY (Letta Cloud)
     letta_model: str = "openai/gpt-5.4-mini"  # LETTA_MODEL
     mcp_server_url: str = ""  # MCP_SERVER_URL (band-mcp SSE endpoint)
+
+    # Copilot SDK. BYOK inference reuses llm_credentials.anthropic_api_key; this is
+    # only the runtime-auth token, from a GitHub account with Copilot entitlement.
+    github_token: str = ""  # GITHUB_TOKEN
 
 
 class LLMModels(BaseSettings):

--- a/tests/e2e/baseline/smoke/adapters/test_copilot_sdk.py
+++ b/tests/e2e/baseline/smoke/adapters/test_copilot_sdk.py
@@ -1,0 +1,368 @@
+"""Copilot SDK showcase smokes — the toolkit driving the Copilot adapter live.
+
+Copilot SDK is a ``copilot``-lane matrix adapter (its own lane: it needs a
+GitHub token from a Copilot-entitled account, not a plain provider key — see
+``requirements.py``), so the generic matrix (``smoke/matrix/``) already runs the
+standard scenarios against it via the registry builder. These are Copilot-focused
+instead: ``ask_user`` routing (handler and room mode), recall when Copilot's
+*native* session resume misses, and one client shared across adapter lifecycles —
+none of which the generic builder's ``prompt``/``features``/``tools`` contract can
+express, so each test constructs ``CopilotSDKAdapter`` by hand (like
+``test_parlant.py``) and hands it to the toolkit's run primitives.
+
+Because construction is bespoke, gating is explicit (``@requires``) rather than
+riding on ``@with_adapters``/``@per_adapter``.
+
+Run with:
+    E2E_TESTS_ENABLED=true BAND_E2E_LANE=copilot uv run pytest \\
+        tests/e2e/baseline/smoke/adapters/test_copilot_sdk.py -v -s --no-cov
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import uuid
+from typing import Any
+
+import pytest
+
+from band.adapters.copilot_sdk import ASK_USER_ROOM, _COPILOT_SDK_AVAILABLE
+
+from tests.e2e.baseline.requires import Dep, requires
+from tests.e2e.baseline.settings import BaselineSettings
+from tests.e2e.baseline.toolkit.capture import CaptureFactory
+from tests.e2e.baseline.toolkit.provisioning import (
+    ResourceManager,
+    running_agent,
+    running_provisioned_agent,
+)
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+pytestmark = pytest.mark.skipif(
+    not _COPILOT_SDK_AVAILABLE,
+    reason="github-copilot-sdk not installed (pip install band-sdk[copilot_sdk])",
+)
+
+
+def _copilot_config(settings: BaselineSettings, **overrides: Any) -> Any:
+    """The showcase's base ``CopilotSDKAdapterConfig`` (BYOK on Anthropic).
+
+    Mirrors the registry builder's shape (``toolkit/builders.py``) so these
+    bespoke tests don't re-derive it; ``overrides`` layers the one knob each
+    test actually cares about (``ask_user=``, ``base_directory=``).
+    """
+    from copilot import ProviderConfig
+
+    from band.adapters.copilot_sdk import CopilotSDKAdapterConfig
+
+    return CopilotSDKAdapterConfig(
+        model=settings.llm_models.anthropic_model,
+        provider=ProviderConfig(
+            type="anthropic",
+            base_url="https://api.anthropic.com",
+            api_key=settings.llm_credentials.anthropic_api_key,
+        ),
+        github_token=settings.backends.github_token,
+        custom_section=overrides.pop(
+            "custom_section", "Keep responses short and concise."
+        ),
+        **overrides,
+    )
+
+
+def _chosen_word(reply: str) -> str:
+    """Extract the word the agent chose from its phase-1 reply.
+
+    The prompt asks for exactly one word; tolerate mentions/punctuation by
+    taking the last alphabetic token of meaningful length.
+    """
+    words = re.findall(r"[A-Za-z]{4,}", reply)
+    assert words, f"phase-1 reply contains no candidate word: {reply!r}"
+    return words[-1]
+
+
+@requires(Dep.COPILOT_GITHUB_TOKEN, Dep.ANTHROPIC)
+@pytest.mark.flaky(reruns=2, rerun_except=["AssertionError"])
+# ask_user adds a second model round trip (ask -> handler answers -> final
+# reply) on top of Copilot's own runtime boot.
+@pytest.mark.timeout(extra=120)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_copilot_ask_user_handler_round_trips_to_room_reply(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """``ask_user=<handler>`` pauses the turn, a programmatic operator answers.
+
+    The operator's answer is a high-entropy token the user never utters, so the
+    reply containing it proves the answer flowed through the handler — not
+    model invention. Guards the adapter's ``ask_user`` allowlisting and handler
+    forwarding (without either, the model cannot ask and the handler never
+    fires).
+    """
+    from band.adapters.copilot_sdk import CopilotSDKAdapter
+
+    operator_channel = f"channel-{uuid.uuid4().hex[:6]}"
+    asked: list[dict[str, Any]] = []
+
+    async def fake_operator(
+        request: dict[str, Any], context: dict[str, str]
+    ) -> dict[str, Any]:
+        asked.append(dict(request))
+        return {"answer": operator_channel, "wasFreeform": True}
+
+    adapter = CopilotSDKAdapter(
+        _copilot_config(
+            baseline_settings,
+            ask_user=fake_operator,
+            custom_section=(
+                "Keep responses short and concise. A human operator is "
+                "available through the ask_user tool for decisions you "
+                "cannot make alone."
+            ),
+        )
+    )
+
+    async with running_provisioned_agent(
+        adapter, resource_manager, label="copilot-ask-user"
+    ) as agent:
+        room_id = await resource_manager.provision_room(
+            title="e2e-copilot-ask-user", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                "I need to deploy release v2. Use the ask_user tool to ask "
+                "your operator which channel to deploy to and wait for my "
+                "response before continuing. Then reply stating exactly "
+                "the channel the operator chose.",
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(
+                mid, agent.id, deadline_s=baseline_settings.e2e_timeout * 2
+            )
+
+    assert asked, "the model never called ask_user (handler did not fire)"
+    assert asked[0].get("question"), f"ask_user carried no question: {asked[0]!r}"
+    # Only the operator handler can supply this token; the reply containing it
+    # proves the answer round-tripped through the turn.
+    capture.messages.assert_contains_any([operator_channel])
+
+
+@requires(Dep.COPILOT_GITHUB_TOKEN, Dep.ANTHROPIC)
+@pytest.mark.flaky(reruns=2, rerun_except=["AssertionError"])
+@pytest.mark.timeout(extra=180)  # two full turns (question turn + answer turn)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_copilot_ask_user_room_question_answered_by_next_message(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """``ask_user="room"`` posts the question into the room and ends the turn;
+    the user's next room message answers it on the same persisted session.
+
+    The answer is a high-entropy token never uttered before the answer, so a
+    reply containing it proves the answer flowed through the room round trip —
+    not model invention.
+    """
+    from band.adapters.copilot_sdk import CopilotSDKAdapter
+
+    secret_channel = f"channel-{uuid.uuid4().hex[:6]}"
+    adapter = CopilotSDKAdapter(
+        _copilot_config(
+            baseline_settings,
+            ask_user=ASK_USER_ROOM,
+            custom_section=(
+                "Keep responses short and concise. Never invent answers to "
+                "questions you asked — wait for the user."
+            ),
+        )
+    )
+
+    async with running_provisioned_agent(
+        adapter, resource_manager, label="copilot-ask-user-room"
+    ) as agent:
+        room_id = await resource_manager.provision_room(
+            title="e2e-copilot-ask-user-room", participants=[agent.id]
+        )
+        async with reply_capture(room_id) as capture:
+            # Turn 1: the trigger makes the model call ask_user; the question
+            # must land in the room, not anywhere else.
+            mark = capture.messages.snapshot()
+            mid = await user_ops.send_message(
+                room_id,
+                "Use the ask_user tool to ask me which channel to deploy "
+                "release v2 to. After I answer, reply stating exactly the "
+                "channel I chose.",
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(
+                mid, agent.id, deadline_s=baseline_settings.e2e_timeout * 2
+            )
+            capture.messages.since(mark).assert_contains_any(["channel"])
+
+            # Turn 2: the user's next room message is the answer.
+            mark = capture.messages.snapshot()
+            mid = await user_ops.send_message(
+                room_id,
+                f"Deploy to the {secret_channel} channel.",
+                mention_id=agent.id,
+                mention_name=agent.name,
+            )
+            await capture.wait_for_processed(
+                mid, agent.id, deadline_s=baseline_settings.e2e_timeout * 2
+            )
+            # Only the answer message contains this token; the reply relaying
+            # it proves the question/answer round-tripped through the room.
+            capture.messages.since(mark).assert_contains_any([secret_channel])
+
+
+@requires(Dep.COPILOT_GITHUB_TOKEN, Dep.ANTHROPIC)
+@pytest.mark.flaky(reruns=2, rerun_except=["AssertionError"])
+# Two agent lifecycles, each booting a fresh Copilot runtime into an empty
+# base_directory (the resume-miss setup) — the heaviest boot path in this file.
+@pytest.mark.timeout(extra=180)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_copilot_recall_via_injected_history_when_resume_misses(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+    tmp_path: Any,
+) -> None:
+    """Recall must survive a restart that invalidates Copilot's *native* resume.
+
+    A rejoin against the same on-disk state (a plain stop/restart) would let
+    Copilot's own session resume answer for free. This test gives each phase a
+    fresh ``base_directory``, so phase 2's resume finds no state and recall
+    must flow through the converter's injected text history instead. Two facts
+    are asserted after the restart: a code the USER stated (plain injected-
+    history recall), and a word the AGENT itself chose in phase 1 — the user
+    never utters it, so the agent's own injected replies are its only possible
+    source (the regression case for one-sided injected history).
+    """
+    from band.adapters.copilot_sdk import CopilotSDKAdapter
+
+    secret_code = f"CODE_{uuid.uuid4().hex[:6]}"
+
+    def make_adapter(phase: str) -> CopilotSDKAdapter:
+        # A fresh base_directory per phase: phase 2 has no on-disk session
+        # state, so Copilot's native resume cannot help.
+        return CopilotSDKAdapter(
+            _copilot_config(baseline_settings, base_directory=str(tmp_path / phase))
+        )
+
+    identity = await resource_manager.provision_agent("copilot-resume-miss")
+    room_id = await resource_manager.provision_room(
+        title="e2e-copilot-resume-miss", participants=[identity.id]
+    )
+
+    # Phase 1: seed a user fact and make the agent produce its own fact.
+    async with running_agent(identity, make_adapter("phase1"), baseline_settings):
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                f"Remember this secret code: {secret_code}. Now choose one "
+                "uncommon English word yourself and reply with exactly that "
+                "single word, nothing else.",
+                mention_id=identity.id,
+                mention_name=identity.name,
+            )
+            await capture.wait_for_processed(
+                mid, identity.id, deadline_s=baseline_settings.e2e_timeout
+            )
+            agent_word = _chosen_word(capture.messages[-1].content)
+
+    # Phase 2: fresh process state AND fresh Copilot state directory — recall
+    # can only come from the platform history the adapter injects.
+    async with running_agent(identity, make_adapter("phase2"), baseline_settings):
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                "What was the secret code I told you, and what was the "
+                "single word you chose earlier? Reply with both.",
+                mention_id=identity.id,
+                mention_name=identity.name,
+            )
+            await capture.wait_for_processed(
+                mid, identity.id, deadline_s=baseline_settings.e2e_timeout
+            )
+            capture.messages.assert_contains_any([secret_code])
+            # The user never uttered this word — only the agent's own injected
+            # phase-1 reply can supply it.
+            capture.messages.assert_contains_any([agent_word])
+
+
+@requires(Dep.COPILOT_GITHUB_TOKEN, Dep.ANTHROPIC)
+@pytest.mark.flaky(reruns=2, rerun_except=["AssertionError"])
+# Two sequential adapter lifecycles on one shared runtime, the first serving
+# two concurrent room sessions — several live turns, so widen the outer budget.
+@pytest.mark.timeout(extra=180)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_copilot_shared_client_across_adapter_lifecycles(
+    baseline_settings: BaselineSettings,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Proves the Copilot SDK's one-client/many-sessions model through the
+    adapter against the live platform:
+
+    1. one ``CopilotClient`` is created by the test (the owner);
+    2. an adapter *borrows* it and serves TWO rooms with turns in flight
+       CONCURRENTLY — two isolated parallel sessions on one runtime;
+    3. the first adapter shuts down and a successor adapter reuses the same
+       still-running client — the borrowed client must survive an adapter's
+       full cleanup (``owns_client=False`` contract).
+    """
+    from copilot import CopilotClient
+
+    from band.adapters.copilot_sdk import CopilotSDKAdapter
+
+    identity = await resource_manager.provision_agent("copilot-shared-client")
+    room_a = await resource_manager.provision_room(
+        title="e2e-copilot-shared-a", participants=[identity.id]
+    )
+    room_b = await resource_manager.provision_room(
+        title="e2e-copilot-shared-b", participants=[identity.id]
+    )
+
+    async def smoke(room_id: str) -> None:
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                "Please say hello.",
+                mention_id=identity.id,
+                mention_name=identity.name,
+            )
+            await capture.wait_for_processed(
+                mid, identity.id, deadline_s=baseline_settings.e2e_timeout
+            )
+        capture.messages.assert_present(what="a copilot_sdk[shared-client] reply")
+
+    def make_shared_adapter(client: Any) -> CopilotSDKAdapter:
+        return CopilotSDKAdapter(_copilot_config(baseline_settings), client=client)
+
+    # The test owns the client; adapters only borrow it.
+    client = CopilotClient(github_token=baseline_settings.backends.github_token)
+    try:
+        async with running_agent(
+            identity, make_shared_adapter(client), baseline_settings
+        ):
+            # Two rooms with turns in flight AT THE SAME TIME — parallel
+            # sessions on one runtime, serialized only per room.
+            await asyncio.gather(smoke(room_a), smoke(room_b))
+
+        # First adapter fully cleaned up; the borrowed client must have
+        # survived — a successor adapter reuses it without a restart.
+        async with running_agent(
+            identity, make_shared_adapter(client), baseline_settings
+        ):
+            await smoke(room_a)
+    finally:
+        await client.stop()

--- a/tests/e2e/baseline/toolkit/adapters.py
+++ b/tests/e2e/baseline/toolkit/adapters.py
@@ -83,6 +83,7 @@ class Adapter(StrEnum):
 
     ANTHROPIC = "anthropic"
     CLAUDE_SDK = "claude_sdk"
+    COPILOT_SDK = "copilot_sdk"
     LANGGRAPH = "langgraph"
     PYDANTIC_AI = "pydantic_ai"
     GEMINI = "gemini"

--- a/tests/e2e/baseline/toolkit/builders.py
+++ b/tests/e2e/baseline/toolkit/builders.py
@@ -72,6 +72,41 @@ def _build_claude_sdk(
     )
 
 
+@adapter(
+    Adapter.COPILOT_SDK,
+    requires=[Dep.COPILOT_GITHUB_TOKEN, Dep.ANTHROPIC],
+    supports=_LLM_TOOL_LOOP,
+)
+def _build_copilot_sdk(
+    s: BaselineSettings,
+    *,
+    prompt: str | None,
+    features: AdapterFeatures | None,
+    tools: list[ToolSpec] | None = None,
+) -> SimpleAdapter[Any]:
+    # The generic matrix builder is BYOK-on-Anthropic, matching claude_sdk's model;
+    # ask_user / base_directory / a shared client are bespoke knobs exercised by
+    # tests/e2e/baseline/smoke/adapters/test_copilot_sdk.py, not by this builder.
+    from copilot import ProviderConfig
+
+    from band.adapters.copilot_sdk import CopilotSDKAdapter, CopilotSDKAdapterConfig
+
+    return CopilotSDKAdapter(
+        CopilotSDKAdapterConfig(
+            model=s.llm_models.anthropic_model,
+            provider=ProviderConfig(
+                type="anthropic",
+                base_url="https://api.anthropic.com",
+                api_key=s.llm_credentials.anthropic_api_key,
+            ),
+            github_token=s.backends.github_token,
+            custom_section=prompt or "",
+        ),
+        additional_tools=_custom_tool_defs(tools),
+        features=features,
+    )
+
+
 @adapter(Adapter.LANGGRAPH, requires=[Dep.OPENAI], supports=_LLM_TOOL_LOOP)
 def _build_langgraph(
     s: BaselineSettings,

--- a/tests/e2e/baseline/toolkit/requirements.py
+++ b/tests/e2e/baseline/toolkit/requirements.py
@@ -131,6 +131,7 @@ class Dep(Enum):
     OPENCODE_SERVER = "opencode_server"  # OPENCODE_BASE_URL of a running server
     LETTA = "letta"  # a self-hosted LETTA_BASE_URL (or a Letta Cloud key)
     CREWAI = "crewai"  # the crewai package is importable (the dev-crewai lane)
+    COPILOT_GITHUB_TOKEN = "copilot_github_token"  # GITHUB_TOKEN, Copilot-entitled
 
 
 @dataclass(frozen=True)
@@ -237,6 +238,15 @@ _DEPS: dict[Dep, DepSpec] = {
         lambda _s: importlib.util.find_spec("crewai") is not None,
         "crewai is not importable (install the dev-crewai lane)",
         lane=Lane.CREWAI,
+    ),
+    # The Copilot SDK self-downloads its own CLI runtime (no Node/CLI-on-PATH
+    # setup), so it needs no isolated lane — it runs in the shared ``core`` lane
+    # (DEFAULT_LANE). It does need a GitHub token from a Copilot-entitled account
+    # rather than a plain provider key; ``core`` carries that token too.
+    Dep.COPILOT_GITHUB_TOKEN: DepSpec(
+        lambda s: bool(s.backends.github_token),
+        "GITHUB_TOKEN not set (a token from a GitHub account with Copilot "
+        "entitlement is required to boot the Copilot runtime)",
     ),
 }
 

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 
 from tests.framework_configs._sentinel import MISSING, STRICT_CI, _MissingSentinel
 from band.adapters.claude_sdk import _CLAUDE_SDK_AVAILABLE as _HAS_CLAUDE_SDK
+from band.adapters.copilot_sdk import _COPILOT_SDK_AVAILABLE as _HAS_COPILOT_SDK
 
 __all__ = ["AdapterConfig", "ADAPTER_CONFIGS", "ADAPTER_EXCLUDED_MODULES"]
 
@@ -492,6 +493,42 @@ def _build_crewai_flow_config() -> AdapterConfig:
     )
 
 
+def _copilot_sdk_factory(**kw: Any) -> Any:
+    from band.adapters.copilot_sdk import CopilotSDKAdapter
+
+    return CopilotSDKAdapter(**kw)
+
+
+def _build_copilot_sdk_config() -> AdapterConfig | None:
+    from band.adapters.copilot_sdk import (
+        _COPILOT_SDK_AVAILABLE,
+        CopilotSDKAdapterConfig,
+    )
+
+    if not _COPILOT_SDK_AVAILABLE:
+        return None  # optional dep not installed; skip in CI
+
+    custom = CopilotSDKAdapterConfig(
+        model="gpt-5",
+        custom_section="Be helpful.",
+        reasoning_effort="high",
+        session_id_prefix="custom-",
+        turn_timeout_s=45.0,
+    )
+    return AdapterConfig(
+        framework_id="copilot_sdk",
+        display_name="CopilotSDK",
+        adapter_factory=_copilot_sdk_factory,
+        expected_initial_values={
+            "_custom_tools": [],
+            "config": CopilotSDKAdapterConfig(),
+        },
+        custom_kwargs={"config": custom},
+        custom_expected={"config": custom},
+        skip_on_started_conformance=True,  # on_started creates a real CopilotClient; tested in test_copilot_sdk_adapter
+    )
+
+
 def _build_claude_sdk_config() -> AdapterConfig | None:
     from band.adapters.claude_sdk import _CLAUDE_SDK_AVAILABLE, ClaudeSDKAdapter
 
@@ -729,10 +766,13 @@ def _build_gemini_config() -> AdapterConfig:
 # and adds Slack ingress/egress; it has no model/LLM contract of its own, so it
 # cannot share the framework-adapter conformance tests (same rationale as a2a/acp).
 # claude_sdk is excluded when claude-agent-sdk optional dep is not installed.
+# copilot_sdk is excluded when github-copilot-sdk optional dep is not installed.
 
 _excluded = {"a2a", "a2a_gateway", "acp", "slack"}
 if not _HAS_CLAUDE_SDK:
     _excluded = _excluded | {"claude_sdk"}
+if not _HAS_COPILOT_SDK:
+    _excluded = _excluded | {"copilot_sdk"}
 ADAPTER_EXCLUDED_MODULES: frozenset[str] = frozenset(_excluded)
 
 
@@ -771,6 +811,7 @@ _ADAPTER_CONFIG_BUILDERS: list[Callable[[], AdapterConfig]] = [
     _build_crewai_config,
     _build_crewai_flow_config,
     _build_claude_sdk_config,
+    _build_copilot_sdk_config,
     _build_pydantic_ai_config,
     _build_parlant_config,
     _build_codex_config,

--- a/tests/framework_configs/converters.py
+++ b/tests/framework_configs/converters.py
@@ -100,6 +100,12 @@ def _claude_sdk_factory(**kw: Any) -> Any:
     return ClaudeSDKHistoryConverter(**kw)
 
 
+def _copilot_sdk_factory(**kw: Any) -> Any:
+    from band.converters.copilot_sdk import CopilotSDKHistoryConverter
+
+    return CopilotSDKHistoryConverter(**kw)
+
+
 def _pydantic_ai_factory(**kw: Any) -> Any:
     from band.converters.pydantic_ai import PydanticAIHistoryConverter
 
@@ -200,6 +206,26 @@ def _build_claude_sdk_config() -> ConverterConfig:
         skips_empty_content=True,
         has_role_concept=False,
         output_adapter=ClaudeSDKOutputAdapter(),
+    )
+
+
+def _build_copilot_sdk_config() -> ConverterConfig:
+    from band.converters.copilot_sdk import CopilotSDKSessionState
+    from tests.framework_configs.output_adapters import CopilotSDKOutputAdapter
+
+    return ConverterConfig(
+        framework_id="copilot_sdk",
+        display_name="CopilotSDK",
+        converter_factory=_copilot_sdk_factory,
+        empty_result=CopilotSDKSessionState(text=""),
+        # Own-agent text is kept: the adapter silences band_send_message tool
+        # reporting, so these lines are the only record of the agent's replies.
+        filters_own_messages=False,
+        empty_sender_behavior=SenderBehavior.BRACKETS_EMPTY,
+        missing_sender_behavior=SenderBehavior.UNKNOWN_PREFIX,
+        skips_empty_content=True,
+        has_role_concept=False,
+        output_adapter=CopilotSDKOutputAdapter(),
     )
 
 
@@ -324,6 +350,7 @@ _CONVERTER_CONFIG_BUILDERS: list[Callable[[], ConverterConfig]] = [
     _build_langchain_config,
     _build_crewai_config,
     _build_claude_sdk_config,
+    _build_copilot_sdk_config,
     _build_pydantic_ai_config,
     _build_parlant_config,
     _build_agno_config,

--- a/tests/framework_configs/output_adapters.py
+++ b/tests/framework_configs/output_adapters.py
@@ -14,6 +14,7 @@ __all__ = [
     "OutputAdapter",
     "BaseDictListOutputAdapter",
     "ClaudeSDKOutputAdapter",
+    "CopilotSDKOutputAdapter",
     "DictListOutputAdapter",
     "GoogleADKOutputAdapter",
     "LangChainOutputAdapter",
@@ -609,6 +610,20 @@ class ClaudeSDKOutputAdapter(OutputAdapter):
         sender_type: str | None = None,
     ) -> None:
         self._inner.assert_sender_metadata(result.text, index, sender_name, sender_type)
+
+
+class CopilotSDKOutputAdapter(ClaudeSDKOutputAdapter):
+    """Adapter for CopilotSDK converter output (:class:`CopilotSDKSessionState`).
+
+    Same flat-string shape as ClaudeSDK — only the session-state type differs.
+    """
+
+    def assert_result_type(self, result: Any) -> None:
+        from band.converters.copilot_sdk import CopilotSDKSessionState
+
+        assert isinstance(result, CopilotSDKSessionState), (
+            f"Expected CopilotSDKSessionState, got {type(result).__name__}"
+        )
 
 
 class GoogleADKOutputAdapter(BaseDictListOutputAdapter):

--- a/tests/integrations/copilot_sdk/__init__.py
+++ b/tests/integrations/copilot_sdk/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Copilot SDK integration."""

--- a/tests/integrations/copilot_sdk/test_operator_console.py
+++ b/tests/integrations/copilot_sdk/test_operator_console.py
@@ -1,0 +1,336 @@
+"""Tests for the ask_user operator console.
+
+The console reads answers from an injected input stream; tests drive it
+through an ``os.pipe`` so lines arrive exactly when written and EOF is
+explicit (closing the write end), mirroring real terminal behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from collections.abc import Iterator
+
+import pytest
+
+from band.integrations.copilot_sdk.operator_console import (
+    NO_ANSWER_TEXT,
+    UNAVAILABLE_TEXT,
+    LogGate,
+    OperatorConsole,
+)
+
+CHOICES_REQUEST = {
+    "question": "Which channel?",
+    "choices": ["stable", "beta", "canary"],
+    "allowFreeform": True,
+}
+CONTEXT = {"session_id": "band-agent-room-1"}
+
+
+class PipeOperator:
+    """Test double for the human: writes lines into the console's stdin."""
+
+    def __init__(self) -> None:
+        read_fd, self._write_fd = os.pipe()
+        self.stream = os.fdopen(read_fd, "r")
+
+    def types(self, line: str) -> None:
+        os.write(self._write_fd, f"{line}\n".encode())
+
+    def leaves(self) -> None:
+        """Close the write end — the console sees EOF."""
+        os.close(self._write_fd)
+
+
+@pytest.fixture(autouse=True)
+def pristine_root_handlers() -> Iterator[None]:
+    """Undo the console's (deliberate) root-handler gating after each test.
+
+    ``ask()`` gates root logging lazily; leaked gates would wrap pytest's
+    own handlers and double-count records in later log-asserting tests.
+    """
+    root = logging.getLogger()
+    saved = root.handlers[:]
+    yield
+    root.handlers[:] = saved
+
+
+@pytest.fixture
+def operator() -> Iterator[PipeOperator]:
+    op = PipeOperator()
+    yield op
+    try:
+        op.leaves()
+    except OSError:
+        pass  # already closed by the test
+    # The reader thread exits on the EOF above; close the read end too so
+    # fds don't accumulate across the suite.
+    op.stream.close()
+
+
+def make_console(operator: PipeOperator, **kwargs) -> OperatorConsole:
+    kwargs.setdefault("answer_timeout_s", 5.0)
+    return OperatorConsole(input_stream=operator.stream, **kwargs)
+
+
+async def ask_after_prompt(
+    console: OperatorConsole,
+    operator: PipeOperator,
+    lines: list[str],
+    request: dict | None = None,
+    capsys=None,
+) -> dict:
+    """Start an ask and type ``lines`` once the prompt has rendered."""
+    task = asyncio.create_task(console.ask(request or CHOICES_REQUEST, CONTEXT))
+    await asyncio.sleep(0.05)  # let the prompt render and the reader start
+    for line in lines:
+        operator.types(line)
+    return await asyncio.wait_for(task, timeout=5)
+
+
+class TestAnswerMatching:
+    @pytest.mark.asyncio
+    async def test_numeric_answer_picks_choice(self, operator):
+        console = make_console(operator)
+        result = await ask_after_prompt(console, operator, ["2"])
+        assert result == {"answer": "beta", "wasFreeform": False}
+
+    @pytest.mark.asyncio
+    async def test_exact_choice_text_matches_case_insensitively(self, operator):
+        console = make_console(operator)
+        result = await ask_after_prompt(console, operator, ["CANARY"])
+        assert result == {"answer": "canary", "wasFreeform": False}
+
+    @pytest.mark.asyncio
+    async def test_freeform_text_passes_through_when_allowed(self, operator):
+        console = make_console(operator)
+        result = await ask_after_prompt(console, operator, ["ship it tomorrow"])
+        assert result == {"answer": "ship it tomorrow", "wasFreeform": True}
+
+    @pytest.mark.asyncio
+    async def test_freeform_rejected_when_not_allowed_then_reprompts(
+        self, operator, capsys
+    ):
+        console = make_console(operator)
+        request = {**CHOICES_REQUEST, "allowFreeform": False}
+        result = await ask_after_prompt(
+            console, operator, ["purple", "1"], request=request
+        )
+        assert result == {"answer": "stable", "wasFreeform": False}
+        out = capsys.readouterr().out
+        # Both the initial prompt and the reprompt must advertise only the
+        # answer shapes the request accepts — no "or text" invitation.
+        assert "Answer [1-3]: " in out
+        assert "Please answer [1-3]: " in out
+        assert "or text" not in out
+
+    @pytest.mark.asyncio
+    async def test_unicode_digit_answer_reprompts_instead_of_crashing(self, operator):
+        """'²' is isdigit()-true but int()-invalid; it must re-prompt, not
+        blow up the ask_user RPC with a ValueError."""
+        console = make_console(operator)
+        request = {**CHOICES_REQUEST, "allowFreeform": False}
+        result = await ask_after_prompt(console, operator, ["²", "2"], request=request)
+        assert result == {"answer": "beta", "wasFreeform": False}
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_number_reprompts_not_freeform(self, operator):
+        """A bare number against a numbered list signals choice intent; a
+        typo like '5' must re-prompt, not pass through as freeform text."""
+        console = make_console(operator)
+        result = await ask_after_prompt(console, operator, ["5", "2"])
+        assert result == {"answer": "beta", "wasFreeform": False}
+
+    @pytest.mark.asyncio
+    async def test_numeric_choice_label_matches_by_text(self, operator):
+        """Numeric-labeled choices (ports, years) stay selectable by label;
+        positional numbers still win inside the 1..N range."""
+        console = make_console(operator)
+        request = {"question": "Which port?", "choices": ["8080", "9090"]}
+        result = await ask_after_prompt(console, operator, ["9090"], request)
+        assert result == {"answer": "9090", "wasFreeform": False}
+
+    @pytest.mark.asyncio
+    async def test_empty_answer_reprompts(self, operator):
+        console = make_console(operator)
+        result = await ask_after_prompt(console, operator, ["", "3"])
+        assert result == {"answer": "canary", "wasFreeform": False}
+
+    @pytest.mark.asyncio
+    async def test_question_without_choices_takes_any_text(self, operator):
+        console = make_console(operator)
+        request = {"question": "Deploy notes?", "allowFreeform": False}
+        result = await ask_after_prompt(console, operator, ["all clear"], request)
+        assert result == {"answer": "all clear", "wasFreeform": True}
+
+
+class TestTimeoutsAndEof:
+    @pytest.mark.asyncio
+    async def test_unanswered_question_expires_with_explicit_text(self, operator):
+        console = make_console(operator, answer_timeout_s=0.1)
+        result = await asyncio.wait_for(
+            console.ask(CHOICES_REQUEST, CONTEXT), timeout=5
+        )
+        assert result == {"answer": NO_ANSWER_TEXT, "wasFreeform": True}
+
+    @pytest.mark.asyncio
+    async def test_eof_answers_operator_unavailable(self, operator):
+        console = make_console(operator)
+        operator.leaves()
+        result = await asyncio.wait_for(
+            console.ask(CHOICES_REQUEST, CONTEXT), timeout=5
+        )
+        assert result == {"answer": UNAVAILABLE_TEXT, "wasFreeform": True}
+        # Subsequent questions fail fast instead of waiting out the timeout.
+        started = time.monotonic()
+        result = await asyncio.wait_for(
+            console.ask(CHOICES_REQUEST, CONTEXT), timeout=5
+        )
+        assert result == {"answer": UNAVAILABLE_TEXT, "wasFreeform": True}
+        assert time.monotonic() - started < 1
+
+    @pytest.mark.asyncio
+    async def test_line_typed_between_questions_is_discarded(self, operator, capsys):
+        """A late answer to an expired prompt must not answer the next one."""
+        console = make_console(operator)
+        task = asyncio.create_task(console.ask(CHOICES_REQUEST, CONTEXT))
+        await asyncio.sleep(0.05)
+        operator.types("2")
+        assert (await task)["answer"] == "beta"
+
+        operator.types("1")  # stray line: no question is open
+        await asyncio.sleep(0.1)  # let it reach the queue
+        result = await ask_after_prompt(console, operator, ["3"])
+        assert result == {"answer": "canary", "wasFreeform": False}
+        assert "ignored 1 line(s)" in capsys.readouterr().out
+
+
+class TestLoopRestart:
+    def test_console_survives_event_loop_restart(self, operator):
+        """One console must keep serving after its first event loop closes.
+
+        Agents can be stopped and restarted on a fresh loop while the
+        reader thread is still blocked on the terminal; the console must
+        not stay bound to the dead loop.
+        """
+        console = make_console(operator)
+
+        async def first_loop() -> dict:
+            return await ask_after_prompt(console, operator, ["1"])
+
+        async def second_loop() -> dict:
+            return await ask_after_prompt(console, operator, ["2"])
+
+        assert asyncio.run(first_loop())["answer"] == "stable"
+        assert asyncio.run(second_loop())["answer"] == "beta"
+
+
+class TestConcurrency:
+    @pytest.mark.asyncio
+    async def test_concurrent_questions_serialize_and_get_own_answers(self, operator):
+        """Two rooms asking at once: prompts never interleave, answers pair up."""
+        console = make_console(operator)
+        first = asyncio.create_task(console.ask(CHOICES_REQUEST, CONTEXT))
+        second = asyncio.create_task(
+            console.ask(CHOICES_REQUEST, {"session_id": "band-agent-room-2"})
+        )
+        await asyncio.sleep(0.05)
+        operator.types("1")  # answers the prompt that owns the terminal
+        assert (await asyncio.wait_for(first, timeout=5))["answer"] == "stable"
+        await asyncio.sleep(0.05)  # queued prompt takes over the terminal
+        operator.types("2")
+        assert (await asyncio.wait_for(second, timeout=5))["answer"] == "beta"
+
+
+class TestLogGate:
+    def _root_with_capture(self) -> tuple[logging.Logger, list[str]]:
+        written: list[str] = []
+
+        class Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                written.append(record.getMessage())
+
+        root = logging.getLogger()
+        self._saved = root.handlers[:]
+        root.handlers[:] = [Capture()]
+        return root, written
+
+    def _restore(self, root: logging.Logger) -> None:
+        root.handlers[:] = self._saved
+
+    def test_paused_records_are_deferred_not_lost(self):
+        root, written = self._root_with_capture()
+        try:
+            console = OperatorConsole()
+            console.gate_logging()
+            gate = root.handlers[0]
+            assert isinstance(gate, LogGate)
+
+            gate.pause()
+            logging.getLogger("band.test").warning("during prompt")
+            assert written == []
+            gate.resume()
+            assert written == ["during prompt"]
+            logging.getLogger("band.test").warning("after prompt")
+            assert written == ["during prompt", "after prompt"]
+        finally:
+            self._restore(root)
+
+    def test_second_console_adopts_existing_gates(self):
+        """No double-wrap — and the second console still gates its prompts."""
+        root, _ = self._root_with_capture()
+        try:
+            first = OperatorConsole()
+            first.gate_logging()
+            gated_once = root.handlers[:]
+
+            second = OperatorConsole()
+            second.gate_logging()
+            assert root.handlers == gated_once
+            assert not isinstance(gated_once[0]._target, LogGate)
+            # The second console must pause the same gates, not none.
+            assert second._gates == first._gates == gated_once
+        finally:
+            self._restore(root)
+
+    @pytest.mark.asyncio
+    async def test_first_ask_gates_root_logging_automatically(self, operator):
+        """No setup ritual: the first question adopts the root handlers."""
+        root, written = self._root_with_capture()
+        try:
+            console = make_console(operator)
+            task = asyncio.create_task(console.ask(CHOICES_REQUEST, CONTEXT))
+            await asyncio.sleep(0.05)
+            assert all(isinstance(h, LogGate) for h in root.handlers)
+            # Logs emitted while the prompt is open are parked, not shown.
+            logging.getLogger("band.test").warning("mid prompt")
+            assert written == []
+            operator.types("2")
+            answer = await asyncio.wait_for(task, timeout=5)
+            assert answer == {"answer": "beta", "wasFreeform": False}
+            assert written == ["mid prompt"]
+        finally:
+            self._restore(root)
+
+    def test_shared_gates_stay_paused_until_every_prompt_resumes(self):
+        """Pauses are counted: with two consoles sharing gates, the first
+        resume must not un-park logs while the other prompt is open."""
+        root, written = self._root_with_capture()
+        try:
+            console = OperatorConsole()
+            console.gate_logging()
+            gate = root.handlers[0]
+            assert isinstance(gate, LogGate)
+
+            gate.pause()  # console A's prompt opens
+            gate.pause()  # console B's concurrent prompt opens
+            logging.getLogger("band.test").warning("during B")
+            gate.resume()  # A answers first
+            assert written == []  # B's prompt is still open
+            gate.resume()
+            assert written == ["during B"]
+        finally:
+            self._restore(root)

--- a/tests/integrations/copilot_sdk/test_room_ask_user.py
+++ b/tests/integrations/copilot_sdk/test_room_ask_user.py
@@ -1,0 +1,43 @@
+"""Rendering of ask_user questions as room messages."""
+
+from __future__ import annotations
+
+from band.integrations.copilot_sdk import render_room_question
+
+
+class TestRenderRoomQuestion:
+    def test_choices_render_numbered_with_freeform_hint(self):
+        text = render_room_question(
+            {
+                "question": "Which channel should I deploy to?",
+                "choices": ["stable", "beta", "canary"],
+                "allowFreeform": True,
+            }
+        )
+        assert text == (
+            "Which channel should I deploy to?\n"
+            "\n"
+            "1. stable\n"
+            "2. beta\n"
+            "3. canary\n"
+            "\n"
+            "Reply with a number or your own answer."
+        )
+
+    def test_freeform_forbidden_hint_asks_for_a_number(self):
+        text = render_room_question(
+            {
+                "question": "Proceed?",
+                "choices": ["yes", "no"],
+                "allowFreeform": False,
+            }
+        )
+        assert text.endswith("Reply with the number of one of the options.")
+
+    def test_no_choices_renders_bare_question(self):
+        text = render_room_question({"question": "  What codename?  "})
+        assert text == "What codename?"
+
+    def test_missing_fields_default_sanely(self):
+        assert render_room_question({}) == ""
+        assert render_room_question({"question": "Q", "choices": None}) == "Q"

--- a/tests/runtime/test_single_instance.py
+++ b/tests/runtime/test_single_instance.py
@@ -1,0 +1,70 @@
+"""SingleInstanceGuard: one running process per agent id per host."""
+
+from __future__ import annotations
+
+import pytest
+
+from band.core.exceptions import BandConfigError
+from band.runtime.single_instance import SingleInstanceGuard, release_all_held
+
+
+class TestSingleInstanceGuard:
+    def test_second_holder_is_refused(self, tmp_path):
+        first = SingleInstanceGuard("agent-1", lock_dir=tmp_path)
+        second = SingleInstanceGuard("agent-1", lock_dir=tmp_path)
+        first.acquire()
+        try:
+            with pytest.raises(BandConfigError, match="already running"):
+                second.acquire()
+        finally:
+            first.release()
+
+    def test_release_frees_the_lock_for_reacquire(self, tmp_path):
+        first = SingleInstanceGuard("agent-1", lock_dir=tmp_path)
+        first.acquire()
+        first.release()
+
+        second = SingleInstanceGuard("agent-1", lock_dir=tmp_path)
+        second.acquire()
+        second.release()
+
+    def test_different_agent_ids_do_not_contend(self, tmp_path):
+        one = SingleInstanceGuard("agent-1", lock_dir=tmp_path)
+        two = SingleInstanceGuard("agent-2", lock_dir=tmp_path)
+        one.acquire()
+        try:
+            two.acquire()
+            two.release()
+        finally:
+            one.release()
+
+    def test_acquire_and_release_are_idempotent(self, tmp_path):
+        guard = SingleInstanceGuard("agent-1", lock_dir=tmp_path)
+        guard.acquire()
+        guard.acquire()  # holder re-acquiring is a no-op, not a conflict
+        guard.release()
+        guard.release()
+
+    def test_lock_file_is_left_behind_holderless(self, tmp_path):
+        """Files are never unlinked (unlink races a concurrent reacquire)."""
+        guard = SingleInstanceGuard("agent-1", lock_dir=tmp_path)
+        guard.acquire()
+        guard.release()
+        assert guard.lock_path.exists()
+
+    def test_release_all_held_reaps_abandoned_locks(self, tmp_path):
+        """A lock leaked by a killed owner must be reapable so the same
+        process can run the agent again (e2e reruns depend on this)."""
+        leaked = SingleInstanceGuard("agent-1", lock_dir=tmp_path)
+        leaked.acquire()  # owner "dies" without release
+
+        assert release_all_held() == ["agent-1"]
+        fresh = SingleInstanceGuard("agent-1", lock_dir=tmp_path)
+        fresh.acquire()
+        fresh.release()
+
+    def test_release_all_held_is_empty_after_clean_release(self, tmp_path):
+        guard = SingleInstanceGuard("agent-1", lock_dir=tmp_path)
+        guard.acquire()
+        guard.release()
+        assert release_all_held() == []

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -483,6 +483,12 @@ class TestStartupRaceCondition:
                 """Initialize without starting message processing."""
                 pass
 
+            def claim_single_instance(self) -> None:
+                pass
+
+            def release_single_instance(self) -> None:
+                pass
+
             async def start(self, on_execute, on_cleanup=None):
                 self._on_execute = on_execute
 

--- a/tests/test_platform_runtime.py
+++ b/tests/test_platform_runtime.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from band.core.exceptions import BandConfigError
 from band.runtime.platform_runtime import PlatformRuntime
 from band.runtime.types import AgentConfig, SessionConfig
 
@@ -459,6 +460,63 @@ class TestRunForever:
 
         # Should not raise (just does nothing)
         await runtime.run_forever()
+
+
+@pytest.fixture
+def platform_mocks(mock_link, mock_runtime):
+    """Run a test with BandLink and AgentRuntime replaced by the mocks."""
+    with (
+        patch("band.runtime.platform_runtime.BandLink", return_value=mock_link),
+        patch("band.runtime.platform_runtime.AgentRuntime", return_value=mock_runtime),
+    ):
+        yield
+
+
+class TestSingleInstance:
+    """One running process per agent id (see runtime/single_instance.py)."""
+
+    @pytest.mark.asyncio
+    async def test_second_start_of_same_agent_is_refused(self, platform_mocks):
+        first = PlatformRuntime(agent_id="agent-123", api_key="k")
+        second = PlatformRuntime(agent_id="agent-123", api_key="k")
+
+        await first.start(on_execute=AsyncMock())
+        with pytest.raises(BandConfigError, match="already running"):
+            await second.start(on_execute=AsyncMock())
+        await first.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_releases_the_agent_for_restart(self, platform_mocks):
+        first = PlatformRuntime(agent_id="agent-123", api_key="k")
+        await first.start(on_execute=AsyncMock())
+        await first.stop()
+
+        second = PlatformRuntime(agent_id="agent-123", api_key="k")
+        await second.start(on_execute=AsyncMock())
+        await second.stop()
+
+    @pytest.mark.asyncio
+    async def test_failed_start_does_not_hold_the_lock(
+        self, platform_mocks, mock_runtime
+    ):
+        """A retry in the same process must not see its own dead lock."""
+        mock_runtime.start.side_effect = [RuntimeError("boom"), None]
+        runtime = PlatformRuntime(agent_id="agent-123", api_key="k")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await runtime.start(on_execute=AsyncMock())
+        await runtime.start(on_execute=AsyncMock())
+        await runtime.stop()
+
+    @pytest.mark.asyncio
+    async def test_opt_out_allows_duplicates(self, platform_mocks):
+        config = AgentConfig(single_instance=False)
+        first = PlatformRuntime(agent_id="agent-123", api_key="k", config=config)
+        second = PlatformRuntime(agent_id="agent-123", api_key="k", config=config)
+        await first.start(on_execute=AsyncMock())
+        await second.start(on_execute=AsyncMock())
+        await first.stop()
+        await second.stop()
 
 
 class TestNoopCleanup:

--- a/uv.lock
+++ b/uv.lock
@@ -560,6 +560,9 @@ claude-sdk = [
 codex = [
     { name = "websockets" },
 ]
+copilot-sdk = [
+    { name = "github-copilot-sdk" },
+]
 crewai = [
     { name = "crewai" },
     { name = "nest-asyncio" },
@@ -577,6 +580,7 @@ dev = [
     { name = "claude-agent-sdk" },
     { name = "click", version = "8.3.2", source = { registry = "https://pypi.org/simple" } },
     { name = "commitizen" },
+    { name = "github-copilot-sdk" },
     { name = "google-adk" },
     { name = "google-genai" },
     { name = "httpx" },
@@ -705,6 +709,8 @@ requires-dist = [
     { name = "crewai", marker = "extra == 'dev-crewai'", specifier = "==1.14.3" },
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "fastapi", marker = "extra == 'agentcore-runtime'", specifier = ">=0.110" },
+    { name = "github-copilot-sdk", marker = "extra == 'copilot-sdk'", specifier = ">=1.0.5" },
+    { name = "github-copilot-sdk", marker = "extra == 'dev'", specifier = ">=1.0.5" },
     { name = "google-adk", marker = "extra == 'dev'", specifier = ">=1.0.0,<2" },
     { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=1.0.0,<2" },
     { name = "google-genai", marker = "extra == 'dev'", specifier = ">=1.43.0" },
@@ -798,7 +804,7 @@ requires-dist = [
     { name = "werkzeug", marker = "extra == 'dev'", specifier = ">=3.1.6" },
     { name = "werkzeug", marker = "extra == 'parlant'", specifier = ">=3.1.6" },
 ]
-provides-extras = ["logging", "codex", "opencode", "letta", "pydantic-ai", "anthropic", "langgraph", "claude-sdk", "parlant", "crewai", "gemini", "a2a", "a2a-gateway", "a2a-gateway-demo", "acp", "slack", "bridge", "bridge-agentcore", "agentcore-runtime", "google-adk", "agno", "dev", "dev-crewai"]
+provides-extras = ["logging", "codex", "opencode", "letta", "pydantic-ai", "anthropic", "langgraph", "claude-sdk", "copilot-sdk", "parlant", "crewai", "gemini", "a2a", "a2a-gateway", "a2a-gateway-demo", "acp", "slack", "bridge", "bridge-agentcore", "agentcore-runtime", "google-adk", "agno", "dev", "dev-crewai"]
 
 [[package]]
 name = "bcrypt"
@@ -2104,6 +2110,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "github-copilot-sdk"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/c7/152a5e87528a3960886bf8d6af8cd1c32437367d2c40725b51da428fdaca/github_copilot_sdk-1.0.5-py3-none-any.whl", hash = "sha256:4f4715553dfab863ffdbff250fc245fb484577e2a16c9cbaab3cf43bb69c4ca7", size = 375876, upload-time = "2026-07-01T15:11:57.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a `copilot_sdk` framework adapter + history converter connecting Band agents to the **GitHub Copilot SDK** (`github-copilot-sdk`, imported as `copilot`). The SDK manages the Copilot CLI runtime subprocess internally; the adapter maps each Band room to its own Copilot session on a single shared client, with cross-restart rehydration, native tool bridging, BYOK support, and **room-routed human-in-the-loop `ask_user`**. The branch also hardens the shared runtime with a **single-instance guard** (one process per agent id per host). Multiple review rounds were run on the branch (high-effort code reviews, a documentation fact-check audit, a subprocess-lifecycle review, and a final 10-angle review + sweep over the ask_user/guard work); all findings fixed — several validated empirically against the live runtime before acting.

## Changes

### Core (`src/band/`)
- **`adapters/copilot_sdk.py`** — `CopilotSDKAdapter` + frozen `CopilotSDKAdapterConfig`:
  - session-per-room with deterministic ids `band-{band_agent_id}-{room_id}` (immutable agent id from the runtime, so agents sharing a host/client/room never resume each other's state; explicit `session_id_prefix` overrides)
  - resume via the persisted session-id task event (marked persisted only on successful send, so transient failures retry); text-injection fallback when resume misses — the injected history **includes the agent's own replies**
  - Band platform + custom tools bridged as native `copilot.Tool` handlers; built-in shell/file tools disabled via the `available_tools` allowlist — the coupling that makes `approve_all` safe
  - `Emit.EXECUTION`/`THOUGHTS` events (off by default); `Capability.MEMORY`/`CONTACTS` gate the band_* tool groups
  - **BYOK**: typed `ProviderConfig` passthrough (OpenAI/Azure/Anthropic; `base_url` required by the runtime)
  - **One client, many sessions**: `client=` shares a caller-owned `CopilotClient` across adapters (borrowed clients are never stopped); `client_factory=` stays the adapter-owned/test seam
  - lifecycle: eager start + fail-fast auth probe with rollback in `on_started`; failed/timed-out turns abort + evict the session; **a crashed CLI heals on the next message** (no cached liveness — `ensure_started` delegates to the client, verified by killing the subprocess live)

### Human-in-the-loop: `ask_user` (`config.ask_user = "room" | <handler> | None`)
- **Room mode (`"room"`, the Band-native path)** — Copilot's built-in `ask_user` tool routes to the people in the room via **turn-splitting**: the question posts as a room message (choices numbered, mentioning the turn's sender), the tool call resolves immediately with an ack that **echoes the rendered question** (so a bare "2" maps unambiguously to choice 2), the turn ends, and the answer arrives as the next room message on the same persisted session. Blocking the turn can never work: Band delivers a room's messages strictly serially (the answer would deadlock behind the very turn awaiting it) and Copilot keeps an unanswered ask pending forever (no timeout, no cancellation, not replayed on resume — verified against SDK source + docs + issue tracker). The turn-split contract is injected as its own system-prompt section via the new `render_system_prompt(extra_sections=…)` — SDK contract text, not developer text. (`integrations/copilot_sdk/room_ask_user.py`)
- **Handler mode (callable)** — answers from outside the room (terminal operator, approval service). `integrations/copilot_sdk/operator_console.py` ships a hardened terminal handler (`OperatorConsole`): refcounted log gating (auto-engages on first question), per-question deadline with graceful no-answer/EOF fallbacks, answer validation honoring `choices`/`allowFreeform` (numeric labels still match by text; out-of-range numbers re-prompt), and a single persistent stdin reader that survives event-loop restarts. Defaults are safe out of the box (answer window < turn timeout).

### Runtime: single-instance guard (`runtime/single_instance.py`)
- Two processes running one agent id corrupt each other (both claim in-flight room messages; stateful adapters resume the same on-disk sessions). `Agent.start()` now claims a per-agent-id `flock` **before the adapter boots anything**, releases on stop/failed start, and the OS drops it on crash. Only `BlockingIOError` maps to "already running"; open/flock failures get distinct actionable messages. **Opt out with `AgentConfig(single_instance=False)`** — this is a deliberate behavior change for anyone intentionally running same-host duplicates. Scope is stated honestly (same temp dir; oneshot relies on server-arbitrated claiming instead).
- `agent.py` gains a weak registry of running agents (`running_agents()`) so harnesses whose failure paths skip unwinding (e.g. pytest-timeout signal kills) can find and stop leaked agents instead of leaving zombies.

### Shared fixes riding along
- `Agent.start()` rolls back adapter resources if the runtime fails to start; `Agent.stop()` invokes the adapter's `cleanup_all()` in a `finally` (fixes the same subprocess leak for claude_sdk)
- Shared helpers extracted: `SELF_REPORTING_TOOL_NAMES` and `format_validation_error` (fixes codex's latent `loc[0]` IndexError)
- Mentions deprecation warning now exempts id-bearing dicts (adapter-supplied ground truth; the deprecation targets LLM-guessed handles)
- pytest collection fix: exact `integration` path-segment match (`tests/integrations/` was silently dropped from CI runs); e2e-marked tests outside `tests/e2e` gated on `E2E_TESTS_ENABLED`

### Tests
- **Unit (107 across the copilot + runtime-guard suites; full suite 3,542)**: fake Copilot client at the `client_factory` seam — reply/tools/resume/eviction/crash-recovery/persist-retry, per-room + per-agent isolation, shared-client ownership, startup-failure rollback, ask_user room bridge (delivery, ack echo, failure degradation, orphaned-dispatch safety), OperatorConsole (matching, timeouts, EOF, log gating, loop restart, shared gates), single-instance guard (contention, release, reap) and its PlatformRuntime wiring. The fake session now **raises on session errors like the real SDK** — which exposed and removed a production-unreachable error branch.
- **Conformance** registered; config-drift green
- **E2E (live, all passing)**: 5 parametrized cells via the shared registry (smoke, tool execution, rejoin rehydration, noisy-room recall, room isolation) on **BYOK Anthropic**, plus four dedicated tests — shared-client lifecycles, resume-miss rehydration, and **both ask_user modes**: `test_copilot_sdk_ask_user.py` (programmatic operator answers with a secret token; reply must relay it) and `test_copilot_sdk_ask_user_room.py` (question posts to the room, the user's next message answers with a secret token, the reply relays it — the full room round trip). E2E infra: leaked-agent reaper (pytest-timeout signal kills skip async unwinding), anchored rerun-except patterns, 240s budgets for multi-boot copilot tests.

### Docs & examples
- `examples/copilot_sdk/`: basic, BYOK Anthropic, Tom & Jerry, memory+contacts, and **`06_ask_user.py`** (room-routed human-in-the-loop); README covers auth resolution, feature flags, both `ask_user` modes with the timeout-pairing rules, the one-process-per-agent guard, models, troubleshooting
- The adapter-building process was distilled into a reusable plan-template + execution playbook (kept as a local skill, not in-repo); ask_user lifecycle lessons folded back into it

## Verification

- ruff / pyrefly clean; full unit suite green (3,542 collected)
- Live-validated against the real Copilot runtime: reply+mention, bridged tool execution with fallback suppression, cross-process resume/recall, resume-miss injection, subprocess-crash recovery, fail-fast auth, Anthropic + OpenAI BYOK, and **both ask_user round trips** (room mode: question → user answer → relayed token; handler mode: operator token relayed)
- Live E2E prereqs: `GITHUB_TOKEN` (Copilot-entitled) + `ANTHROPIC_API_KEY` in `.env.test`; pre-fetch via `python -m copilot download-runtime`

## Update — per-turn token usage (`Emit.USAGE`) + `core` CI lane

Follow-up commits on this branch bring `copilot_sdk` to parity with every other tool-loop adapter and simplify its CI placement.

- **`Emit.USAGE` seam** — copilot was the only tool-loop adapter still missing the per-turn token-usage capture from the `Emit.USAGE` rollout. Copilot streams usage as **per-API-call** `assistant.usage` events, so the adapter sums them across the turn (`TurnState.usage`) and emits one record from `on_message`'s `finally` (fires on **both** success and failure paths). `reasoning_tokens` is **not** folded into `output_tokens` — the providers Copilot relays (OpenAI/Anthropic) already count reasoning inside output, so folding would double-count. `SUPPORTED_EMIT` now advertises `Emit.USAGE`. Adds 5 unit tests: mapper + no-fold regression guard, cross-call summing, feature-off no-op, failure-path emission (usage still emitted when the turn raises), and empty-turn skip.
- **`core` CI lane** — drops the dedicated `copilot` lane; `Dep.COPILOT_GITHUB_TOKEN` now defaults to `Lane.CORE`, and the `copilot` entry is removed from the workflow dropdown, the lane comment, `AGENTS.md`, and the baseline README's CI-lanes table. Trade-off accepted (documented): `core`'s green signal now depends on the Copilot entitlement (`E2E_GITHUB_TOKEN`) and the CLI self-download.
- **Naming** — `_TurnState` → `TurnState`, `_RoomSessionIds` → `RoomSessionIds` (module-private dataclasses read cleaner without the leading underscore; the private `self._turn_state` / `self._session_ids` instance attributes keep theirs).

### Verification (usage work)

- Full unit suite green; ruff / pyrefly clean.
- **Live E2E**: no new test file — the registry-derived usage-smoke fan now exercises copilot automatically the moment the adapter declares `Emit.USAGE`. `test_usage_recorded_for_a_turn[copilot_sdk]` and `test_usage_not_cumulative_across_turns[copilot_sdk]` both **pass live** on BYOK Anthropic, proving `assistant.usage` fires and the per-turn record is non-cumulative across turns.
- Reviewed by a multi-role pass (elegance / integration / logic) plus a high-effort code-review sweep; the one factual nit it found (a docstring citing a sibling SDK usage type) is fixed.

## Related Issues

Fixes INT-921

🤖 Generated with [Claude Code](https://claude.com/claude-code)

