### PR TITLE
docs: confirm fern changelog path and Linear team key

### DIFF
--- a/.band/changelog.yml
+++ b/.band/changelog.yml
@@ -7,11 +7,11 @@
 fern_repo: band-ai/fern
 # Path within the Fern repo where changelog entries live. Match the layout of the
 # newest existing entry in that repo.
-fern_changelog_path: fern/pages/changelog # TODO: confirm against band-ai/fern
+fern_changelog_path: fern/changelog/sdks
 
 # Linear: how to find the issues that belong to this SDK's releases. The skill
 # queries the Linear GraphQL API and also matches issue identifiers (e.g. SDK-123)
 # found in the release's merged PRs. Set at least the team key.
 linear:
-  team_key: SDK # TODO: confirm this repo's Linear team key
+  team_key: INT
   # project: "Python SDK"  # optional: narrow further by project name


### PR DESCRIPTION
## Summary
- Resolves the two TODOs left in `.band/changelog.yml` from #416
- `fern_changelog_path` -> `fern/changelog/sdks` (matches current layout in the Fern docs repo)
- `linear.team_key` -> `INT` (this repo's actual Linear team key)

## Test plan
- [ ] Config-only change; no tests to run