### PR TITLE
feat: baseline scorecard — N/A reasons on exclude + CI artifact …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,3 +191,29 @@ jobs:
         from band.config import load_agent_config
         print('All imports successful')
         "
+
+
+  # Single aggregate gate for branch protection. Branch rulesets require exactly
+  # this one context: `needs` a matrix job is green only when every one of its
+  # OS/Python cells passed, so requiring `ci-required` covers the whole matrix and
+  # survives future matrix changes without re-editing the ruleset. `if: always()`
+  # runs it even when a dependency failed (a skipped/failed dep would otherwise
+  # skip this job and report nothing, leaving the required check stuck "Expected").
+  ci-required:
+    name: ci-required
+    needs: [lint, test, test-crewai, packaging]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fail unless every required job succeeded
+      env:
+        RESULTS: ${{ needs.lint.result }} ${{ needs.test.result }} ${{ needs.test-crewai.result }} ${{ needs.packaging.result }}
+      run: |
+        echo "dependency results: ${RESULTS}"
+        for result in ${RESULTS}; do
+          if [ "${result}" != "success" ]; then
+            echo "::error::A required CI job did not succeed (results: ${RESULTS})."
+            exit 1
+          fi
+        done
+        echo "All required CI jobs succeeded."

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -204,6 +204,10 @@ jobs:
       # entitlement). The copilot_sdk adapter (in the `core` lane) needs it;
       # exposed to every lane's job env so `core` picks it up.
       GITHUB_TOKEN: ${{ secrets.E2E_GITHUB_TOKEN }}
+      # Per-lane scorecard: each lane writes its own adapter×test slice (pass/fail for
+      # its cells, skip for out-of-lane cells, N/A + reason for exclusions). The final
+      # `scorecard` job merges them. See tests/e2e/baseline/scorecard.py.
+      BAND_E2E_SCORECARD_JSON: artifacts/scorecard-${{ matrix.lane }}-${{ matrix.os }}.json
 
     steps:
     - name: Checkout code
@@ -270,3 +274,62 @@ jobs:
     - name: Stop the Letta server (letta)
       if: always() && matrix.lane == 'letta'
       run: docker rm -f letta-server || true
+
+    # Emitted even when tests fail (session end still runs), so a red lane still
+    # contributes its pass/fail rows to the merged scorecard.
+    - name: Upload lane scorecard
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: scorecard-${{ matrix.lane }}-${{ matrix.os }}
+        path: artifacts/scorecard-*.json
+        if-no-files-found: ignore
+
+  # Fold the per-lane scorecards into one adapter×test grid (pass / fail / skip / N-A).
+  # `if: always()` so a failed lane still yields a scorecard; this job reports the
+  # matrix, it does not gate on it (gating policy is tracked separately).
+  scorecard:
+    name: scorecard (merge lanes)
+    needs: e2e
+    if: always()
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up E2E environment
+      uses: ./.github/actions/setup-e2e
+
+    - name: Install dependencies
+      run: uv sync --extra dev
+
+    - name: Download lane scorecards
+      uses: actions/download-artifact@v4
+      with:
+        pattern: scorecard-*
+        path: artifacts
+        merge-multiple: true
+
+    - name: Merge into one scorecard
+      run: |
+        shopt -s nullglob
+        files=(artifacts/scorecard-*.json)
+        if [ ${#files[@]} -eq 0 ]; then
+          echo "no lane scorecards to merge (all lanes failed before session end)"
+          exit 0
+        fi
+        uv run python -m tests.e2e.baseline.scorecard merge "${files[@]}" \
+          --out artifacts/scorecard.json --markdown artifacts/scorecard.md
+
+    - name: Upload scorecard
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: scorecard
+        path: |
+          artifacts/scorecard.json
+          artifacts/scorecard.md
+        if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,6 +450,7 @@ Baseline provisioning/cleanup policy (see `tests/e2e/baseline/README.md`):
 - `BAND_E2E_AUTOCLEAN`: Reap provisioned agents + rooms on teardown (default: `true`; set `false` to keep resources for debugging a failing run)
 - `BAND_E2E_ORPHAN_SWEEP`: Sweep leftover agents from crashed prior runs at session start (default: `true`)
 - `BAND_E2E_ORPHAN_MAX_AGE_MINUTES`: Only sweep agents older than this, so a concurrent run is never reaped mid-flight (default: `120`)
+- `BAND_E2E_SCORECARD_JSON`: Write this run's adapter×test scorecard (pass/fail/skip + N/A reasons) as JSON to this path at session end (default: empty = don't emit). CI sets one path per lane; a final job merges them (see `tests/e2e/baseline/scorecard.py` and the Scorecard section of the baseline README)
 
 ## Adding a New Framework Integration
 

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -803,65 +803,120 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
 
         return agent_id
 
-    async def _attach_mcp_tools(self, agent_id: str) -> None:
-        """Attach all discovered MCP tools to a Letta agent."""
-        for tool_id in self._mcp.tool_ids:
+    @staticmethod
+    def _is_stale_tool_error(error: Exception) -> bool:
+        """Whether an attach failure means the tool id is gone from the org.
+
+        A 404 "tool not found in organization" says the cached id died with its
+        registration's tool rows (deleted out from under us) — recoverable by
+        re-registering.  Other errors (transient network, auth) are not.
+        """
+        if getattr(error, "status_code", None) == 404:
+            return True
+        return "not found in organization" in str(error)
+
+    async def _attach_tools(self, agent_id: str, tool_ids: list[str]) -> bool:
+        """Attach each tool id to the agent.
+
+        Returns False if an attach failed because the id is stale (a 404) — the
+        caller should re-register and retry, since the remaining ids share the
+        same dead registration.  Other failures are logged and tolerated.
+        """
+        for tool_id in tool_ids:
             try:
                 await self._client.agents.tools.attach(
-                    agent_id=agent_id,
-                    tool_id=tool_id,
+                    agent_id=agent_id, tool_id=tool_id
                 )
             except Exception as e:
+                if self._is_stale_tool_error(e):
+                    logger.warning(
+                        "Agent %s: MCP tool %s is gone from the org "
+                        "(registration's tool rows deleted)",
+                        agent_id,
+                        tool_id,
+                    )
+                    return False
                 logger.warning(
                     "Failed to attach MCP tool %s to agent %s: %s",
                     tool_id,
                     agent_id,
                     e,
                 )
+        return True
+
+    async def _reregister_and_mark_stale(self, *, wired_agent_id: str) -> None:
+        """Re-register the MCP path and flag other rooms to re-sync their tools.
+
+        Re-registration can mint new tool ids; any other room whose agent was
+        wired to the now-dead ids must re-verify attachment on its next turn
+        (its early-return fast path would otherwise run with dead tools).
+        ``wired_agent_id`` is the agent the caller re-attaches inline, so it is
+        left unmarked.
+        """
+        await self._mcp.reregister(self._client)
+        for room_ctx in self._rooms.values():
+            if room_ctx.agent_id != wired_agent_id:
+                room_ctx.stale_tools = True
+
+    async def _attach_mcp_tools(self, agent_id: str) -> None:
+        """Attach all discovered MCP tools to a Letta agent.
+
+        Self-heals once from stale ids: a 404 means the cached ids died in the
+        org, so re-register to re-sync fresh ones and retry.
+        """
+        if not await self._attach_tools(agent_id, self._mcp.tool_ids):
+            logger.warning(
+                "Agent %s: MCP tool ids stale; re-registering the Band MCP path",
+                agent_id,
+            )
+            await self._reregister_and_mark_stale(wired_agent_id=agent_id)
+            await self._attach_tools(agent_id, self._mcp.tool_ids)
         logger.debug(
             "Attached %d MCP tools to agent %s",
             len(self._mcp.tool_ids),
             agent_id,
         )
 
+    async def _list_attached_tool_ids(self, agent_id: str) -> set[str]:
+        """The ids of tools currently attached to a Letta agent."""
+        result = await self._client.agents.tools.list(agent_id=agent_id)
+        if isinstance(result, list):
+            tools = result
+        elif hasattr(result, "items"):
+            tools = list(result.items)
+        else:
+            tools = [t async for t in result]
+        return {t.id for t in tools if getattr(t, "id", None)}
+
     async def _verify_mcp_tools_attached(self, agent_id: str) -> bool:
         """Verify MCP tools are attached to an existing agent, re-attach if needed.
 
         Best-effort: failures are logged, not raised.  Returns False when the
         agent may still be missing tools, so callers tracking staleness can
-        retry on the next turn instead of considering the agent synced.
+        retry on the next turn instead of considering the agent synced.  Recovers
+        once from stale ids (a 404) by re-registering and re-attaching the fresh
+        set — mirrors ``_attach_mcp_tools``.
         """
         try:
-            agent_tools_result = await self._client.agents.tools.list(agent_id=agent_id)
-            if isinstance(agent_tools_result, list):
-                agent_tools = agent_tools_result
-            elif hasattr(agent_tools_result, "items"):
-                agent_tools = list(agent_tools_result.items)
-            else:
-                agent_tools = [t async for t in agent_tools_result]
-
-            attached_ids = {t.id for t in agent_tools if getattr(t, "id", None)}
-            missing = [tid for tid in self._mcp.tool_ids if tid not in attached_ids]
-            complete = True
-            if missing:
-                logger.info(
-                    "Agent %s missing %d MCP tools, re-attaching",
-                    agent_id,
-                    len(missing),
-                )
-                for tool_id in missing:
-                    try:
-                        await self._client.agents.tools.attach(
-                            agent_id=agent_id,
-                            tool_id=tool_id,
-                        )
-                    except Exception as e:
-                        logger.warning("Failed to re-attach tool %s: %s", tool_id, e)
-                        complete = False
-            return complete
+            attached_ids = await self._list_attached_tool_ids(agent_id)
         except Exception as e:
             logger.warning("Failed to verify MCP tools for agent %s: %s", agent_id, e)
             return False
+
+        missing = [tid for tid in self._mcp.tool_ids if tid not in attached_ids]
+        if not missing:
+            return True
+        logger.info(
+            "Agent %s missing %d MCP tools, re-attaching", agent_id, len(missing)
+        )
+        if await self._attach_tools(agent_id, missing):
+            return True
+        # Stale ids — re-register for a fresh set, then re-attach all of them.
+        logger.warning(
+            "Agent %s: MCP tool ids stale during verify; re-registering", agent_id
+        )
+        await self._reregister_and_mark_stale(wired_agent_id=agent_id)
+        return await self._attach_tools(agent_id, self._mcp.tool_ids)
 
     # Labels tried (in order) when injecting the system prompt into a
     # pre-existing agent's memory.  "persona" is the Letta default; others
@@ -985,15 +1040,13 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
     async def cleanup_all(self) -> None:
         """Release the MCP tool path on agent shutdown.
 
-        See ``LettaMCPBridge.release`` for the three registration ownership
-        tiers (external / fixed self-host / ephemeral self-host).  Retained
-        rooms are marked ``stale_tools`` only when ``release`` deregisters
-        from Letta — ephemeral self-host — because that rotation mints new
-        tool ids that existing agents must re-attach.
+        ``release`` keeps the Letta registration alive (see
+        ``LettaMCPBridge.release``): the org shares MCP tool rows by name, so
+        deregistering would strip tools from sibling agents.  Nothing rotates,
+        so retained rooms keep their valid tool attachments — no ``stale_tools``
+        marking needed here.  (A runtime re-registration triggered by a stale
+        404 is what marks rooms stale; see ``_reregister_and_mark_stale``.)
         """
-        if self._mcp.registration_rotates_on_release and self._mcp.server_id:
-            for room_ctx in self._rooms.values():
-                room_ctx.stale_tools = True
         await self._mcp.release(self._client)
 
     async def _delete_agent(self, agent_id: str, room_id: str) -> None:

--- a/src/band/integrations/letta/mcp.py
+++ b/src/band/integrations/letta/mcp.py
@@ -200,51 +200,46 @@ class LettaMCPBridge:
                 f"is reachable by Letta at {server_url}: {e}"
             ) from e
 
-    @property
-    def registration_rotates_on_release(self) -> bool:
-        """Whether ``release`` deregisters from Letta and mints new tool ids.
-
-        True only for self-host mode with an auto-generated registration name
-        (``server_name`` unset).  Fixed names and external mode keep the Letta
-        row across adapter restarts, so tool ids stay stable.
-        """
-        return self._config.mode == "self_host" and self._config.server_name is None
-
     async def release(self, client: Any) -> None:
-        """Release the local MCP tool-path cache; deregister only when safe.
+        """Relinquish the local tool-path cache without deregistering from Letta.
 
         **External mode** — no-op.  The registration names a long-lived server
         this process does not own (often the shared default ``"band"``).
-        Deleting it would strip tools from other live agents; clearing cached
-        ids would force pointless re-discovery on restart.
 
-        **Self-host, fixed ``server_name``** — clear ``server_id`` / ``tool_ids``
-        only.  The Letta row is kept: deregistering a fixed name soft-deletes
-        it permanently.  The next ``ensure_ready`` re-adopts by name after
-        verifying the URL.  Because the in-process server uses an OS-assigned
-        port, a process restart usually changes the URL — see
-        ``LettaMCPConfig.server_name``.
+        **Self-host** (fixed or ephemeral name) — clear ``server_id`` /
+        ``tool_ids`` only; never delete the Letta row.  Letta stores MCP tools
+        keyed by tool *name* at organization scope, so every adapter registered
+        against the same org shares the same tool rows regardless of its
+        registration name.  Deregistering cascade-deletes those shared rows and
+        strips the tools from sibling agents still running in the org — the
+        failure this method used to cause.  Keeping the row is safe: the tools
+        stay valid, the next ``ensure_ready`` re-adopts (fixed name) or
+        registers a fresh ``band-{suffix}`` against the still-running in-process
+        server (ephemeral), and a row orphaned by a changed port is inert (see
+        ``LettaMCPConfig.server_name``).  State is cleared before any await so a
+        concurrent message can re-register.
 
-        **Self-host, ephemeral name** (``server_name`` unset) — deregister the
-        Letta row, then clear cache.  The in-process server keeps running until
-        process exit (Letta closes its MCP session asynchronously after delete;
-        stopping the server around that close wedges Letta's serial sync worker).
-        The next ``ensure_ready`` registers under a fresh ``band-{suffix}`` name.
-        State is cleared before any await so a concurrent message can re-register.
+        ``client`` is accepted for signature stability with the deregistering
+        past; it is unused now that release never calls the server.
         """
+        del client  # no server call — see docstring
         if self._config.mode == "external":
             return
-        server_id = self.server_id
         self.server_id = None
         self.tool_ids = []
-        if client and server_id and self.registration_rotates_on_release:
-            ok = await bounded_teardown(
-                client.mcp_servers.delete(server_id),
-                timeout_s=self._teardown_timeout_s,
-                action=f"deregister MCP server {server_id}",
-            )
-            if ok:
-                logger.debug("Deregistered MCP server %s from Letta", server_id)
+
+    async def reregister(self, client: Any) -> None:
+        """Re-register from scratch to recover tool ids that died in the org.
+
+        On a stale-tool 404 (the registration's org tool rows were deleted out
+        from under us — e.g. by an external sweep), re-listing the existing
+        server yields nothing; only a fresh registration re-syncs attachable
+        tools.  Drops the cache and runs ``ensure_ready``, which registers a new
+        server against the still-running backend and rediscovers its tools.
+        """
+        self.server_id = None
+        self.tool_ids = []
+        await self.ensure_ready(client)
 
     def resolve_send_tools(self, tool_names: list[str]) -> None:
         """Derive the send/event tool names from the server's discovered tools.

--- a/tests/adapters/test_letta_mcp.py
+++ b/tests/adapters/test_letta_mcp.py
@@ -9,7 +9,6 @@ and agent lifecycle — so each file stays focused on one concern.
 
 from __future__ import annotations
 
-import asyncio
 import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -33,6 +32,15 @@ from tests.adapters.lettakit import (
     make_mock_tool_page,
     make_platform_message,
 )
+
+
+def _stale_tool_error(message: str) -> Exception:
+    """A 404 ApiError-shaped exception, as letta-client raises when a tool id
+    no longer exists in the organization."""
+    err = Exception(message)
+    err.status_code = 404  # type: ignore[attr-defined]
+    return err
+
 
 # ──────────────────────────────────────────────────────────────────────
 # on_started
@@ -312,26 +320,20 @@ class TestSelfHostedMCPLifecycle:
         assert adapter._mcp.tool_ids == ["t9"]
 
     @pytest.mark.asyncio
-    async def test_message_after_stop_resyncs_retained_room_tools(self) -> None:
-        """A room retained across cleanup_all keeps its Letta agent, but the
-        re-registration mints new tool ids — the agent must be re-attached to
-        them, or its platform tool calls die with the old registration."""
+    async def test_stale_room_resyncs_tools_on_next_message(self) -> None:
+        """A room flagged stale by a runtime re-register keeps its Letta agent
+        but re-attaches to the new tool ids on its next message — otherwise its
+        platform tool calls die with the old registration's ids."""
         adapter = LettaAdapter()
         mock_client = AsyncMock()
         adapter._client = mock_client
         adapter._system_prompt = "Test"
-        adapter._mcp.server_id = "mcp-old"
-        adapter._mcp.tool_ids = ["t-old"]
+        # A re-register already minted fresh ids and flagged the room stale.
+        adapter._mcp.server_id = "mcp-new"
+        adapter._mcp.tool_ids = ["t-new"]
         adapter._mcp.backend = make_fake_mcp_backend()
-        adapter._rooms["room-1"] = _RoomContext(agent_id="agent-1")
+        adapter._rooms["room-1"] = _RoomContext(agent_id="agent-1", stale_tools=True)
 
-        await adapter.cleanup_all()
-
-        mock_client.mcp_servers.list.return_value = []
-        mock_client.mcp_servers.create.return_value = make_mock_mcp_server("mcp-new")
-        mock_client.mcp_servers.tools.list.return_value = [
-            make_mock_mcp_tool("t-new", "band_send_message"),
-        ]
         # The agent still carries only the old registration's (dead) tool.
         mock_client.agents.tools.list.return_value = make_mock_tool_page(
             make_mock_mcp_tool("t-old", "band_send_message")
@@ -490,20 +492,6 @@ class TestSelfHostedMCPLifecycle:
         assert create_name != "band-deadname"
         assert adapter._mcp.server_id == "mcp-fresh"
 
-    def test_registration_rotates_on_release(self) -> None:
-        external = LettaAdapter(
-            config=LettaAdapterConfig(
-                mcp=LettaMCPConfig(mode="external", server_url="http://mcp/sse")
-            )
-        )
-        ephemeral = LettaAdapter()
-        fixed = LettaAdapter(
-            config=LettaAdapterConfig(mcp=LettaMCPConfig(server_name="band-compose"))
-        )
-        assert external._mcp.registration_rotates_on_release is False
-        assert ephemeral._mcp.registration_rotates_on_release is True
-        assert fixed._mcp.registration_rotates_on_release is False
-
     def test_advertised_url_loopback_when_bind_all_interfaces(self) -> None:
         adapter = LettaAdapter(
             config=LettaAdapterConfig(
@@ -521,47 +509,93 @@ class TestSelfHostedMCPLifecycle:
         assert adapter._get_room_tools("other") is None
 
     @pytest.mark.asyncio
-    async def test_cleanup_all_deregisters_but_keeps_server_running(self) -> None:
-        """Agent shutdown releases the Letta registration (it would otherwise
-        leak and poison later syncs) but leaves the server serving: Letta
-        closes its cached session asynchronously after the delete, and a
-        server that dies around that close wedges Letta's sync worker."""
+    async def test_cleanup_all_selfhost_keeps_registration(self) -> None:
+        """Ephemeral self-host cleanup must NOT deregister the Letta row.
+
+        Letta shares MCP tool rows by name across the org, so deregistering one
+        adapter's server cascade-deletes tools out from under sibling agents
+        still running in the same org (the silent-turn failure this guards).
+        cleanup_all clears only the local cache; the row and its tools survive.
+        """
         adapter = LettaAdapter()
         mock_client = AsyncMock()
         adapter._client = mock_client
         adapter._mcp.server_id = "mcp-server-1"
+        adapter._mcp.tool_ids = ["t1"]
         fake_backend = make_fake_mcp_backend()
         adapter._mcp.backend = fake_backend
         adapter._rooms["room-1"] = _RoomContext(agent_id="agent-1")
 
         await adapter.cleanup_all()
 
-        mock_client.mcp_servers.delete.assert_awaited_once_with("mcp-server-1")
+        mock_client.mcp_servers.delete.assert_not_called()
         fake_backend.stop.assert_not_awaited()
         assert adapter._mcp.backend is fake_backend
         assert adapter._mcp.server_id is None
         assert adapter._mcp.tool_ids == []
-        assert adapter._rooms["room-1"].stale_tools is True
+        # Nothing rotated, so the retained room's attachments stay valid.
+        assert adapter._rooms["room-1"].stale_tools is False
 
     @pytest.mark.asyncio
-    async def test_cleanup_all_timeout_warns_and_continues(self, caplog) -> None:
-        async def stalled_delete(_server_id: str) -> None:
-            await asyncio.sleep(1)
-
-        adapter = LettaAdapter(config=LettaAdapterConfig(teardown_timeout_s=0.01))
+    async def test_attach_recovers_from_stale_tool_404(self) -> None:
+        """A 404 on attach (tool ids died in the org) triggers one re-register
+        against a fresh server, then re-attaches the new ids."""
+        adapter = LettaAdapter()
         mock_client = AsyncMock()
-        mock_client.mcp_servers.delete.side_effect = stalled_delete
         adapter._client = mock_client
-        adapter._mcp.server_id = "mcp-server-1"
+        adapter._system_prompt = "Test"
+        adapter._mcp.backend = make_fake_mcp_backend(port=55001)
+        adapter._mcp.server_id = "mcp-dead"
+        adapter._mcp.tool_ids = ["t-dead"]
 
-        with caplog.at_level("WARNING", logger="band.adapters.letta"):
-            await adapter.cleanup_all()
+        # First attach 404s (stale); after re-register it succeeds.
+        stale = _stale_tool_error("Tool with id=t-dead not found in organization")
+        mock_client.agents.tools.attach.side_effect = [stale, None]
+        mock_client.agents.create.return_value = make_mock_agent("agent-1")
+        # Re-registration mints a fresh server exposing a live tool id.
+        mock_client.mcp_servers.list.return_value = []
+        mock_client.mcp_servers.create.return_value = make_mock_mcp_server("mcp-fresh")
+        mock_client.mcp_servers.tools.list.return_value = [
+            make_mock_mcp_tool("t-live", "band_send_message"),
+        ]
 
-        mock_client.mcp_servers.delete.assert_awaited_once_with("mcp-server-1")
-        assert adapter._mcp.server_id is None
-        assert (
-            "Timed out after 0.01s while trying to deregister MCP server" in caplog.text
-        )
+        agent_id = await adapter._create_agent()
+
+        assert agent_id == "agent-1"
+        assert adapter._mcp.server_id == "mcp-fresh"
+        assert adapter._mcp.tool_ids == ["t-live"]
+        # Attached the dead id (fails), then the live id after re-register.
+        attached = [
+            c.kwargs["tool_id"] for c in mock_client.agents.tools.attach.call_args_list
+        ]
+        assert attached == ["t-dead", "t-live"]
+
+    @pytest.mark.asyncio
+    async def test_reregister_marks_other_rooms_stale(self) -> None:
+        """When a re-register mints new tool ids, other rooms' agents must be
+        flagged to re-verify — their fast path would otherwise run dead tools."""
+        adapter = LettaAdapter()
+        mock_client = AsyncMock()
+        adapter._client = mock_client
+        adapter._system_prompt = "Test"
+        adapter._mcp.backend = make_fake_mcp_backend(port=55002)
+        adapter._mcp.server_id = "mcp-dead"
+        adapter._mcp.tool_ids = ["t-dead"]
+        # A sibling room, live before the recovery, wired to the old ids.
+        adapter._rooms["other"] = _RoomContext(agent_id="agent-other")
+
+        stale = _stale_tool_error("Tool with id=t-dead not found in organization")
+        mock_client.agents.tools.attach.side_effect = [stale, None]
+        mock_client.agents.create.return_value = make_mock_agent("agent-new")
+        mock_client.mcp_servers.list.return_value = []
+        mock_client.mcp_servers.create.return_value = make_mock_mcp_server("mcp-fresh")
+        mock_client.mcp_servers.tools.list.return_value = [
+            make_mock_mcp_tool("t-live", "band_send_message"),
+        ]
+
+        await adapter._create_agent()
+
+        assert adapter._rooms["other"].stale_tools is True
 
     @pytest.mark.asyncio
     async def test_create_conflict_recovers_committed_registration(self) -> None:

--- a/tests/e2e/baseline/README.md
+++ b/tests/e2e/baseline/README.md
@@ -102,9 +102,9 @@ room). What they *share* — `@requires` gating, `AdapterCell` construction, and
 | several named adapters in one room | `@with_adapters(Adapter.LANGGRAPH, Adapter.ANTHROPIC)` | `agents` — list; `a, b = agents` |
 | two of the **same** adapter | `@with_adapters(Adapter.ANTHROPIC, Adapter.ANTHROPIC)` | `agents` |
 | the **same scenario across every adapter** | `@per_adapter()` (the full matrix, explicitly) | `agent` (id via `agent.adapter_id`) |
-| a **subset** of adapters | `@per_adapter(Adapter.X, Adapter.Y)` (positional = include) / `@per_adapter(exclude={...} / supports={Capability.MEMORY} / without={Capability.MEMORY} / runs_tool_loop=True)` | `agent` |
+| a **subset** of adapters | `@per_adapter(Adapter.X, Adapter.Y)` (positional = include) / `@per_adapter(exclude=[ExcludedAdapter(Adapter.X, "reason")] / supports={Capability.MEMORY} / without={Capability.MEMORY} / runs_tool_loop=True)` | `agent` |
 | to **drive the lifecycle yourself** (build-only, reboot, rehydration) | `@per_adapter()` | `cell` — an `AdapterCell` (see **AdapterCell** below) |
-| a **fanned cell A + one different-framework peer B** (cross-framework) | `@per_adapter(exclude={Adapter.X}, peer=Adapter.X)` | `cell` (A) + `peer` (B, an `AdapterCell` you drive); peer deps fold into the cell's `@requires` |
+| a **fanned cell A + one different-framework peer B** (cross-framework) | `@per_adapter(exclude=[ExcludedAdapter(Adapter.X, "it is the peer")], peer=Adapter.X)` | `cell` (A) + `peer` (B, an `AdapterCell` you drive); peer deps fold into the cell's `@requires` |
 | custom tools (any tool-capable framework) | `@with_adapters(Adapter.X, tools=[LOOKUP_TOOL], **EXECUTION_REPORTING)` — one `ToolSpec`, translated per framework (anthropic-family, pydantic-ai, agno) | `agent` |
 | custom tools across the matrix | `@per_adapter(Adapter.ANTHROPIC, Adapter.PYDANTIC_AI, Adapter.AGNO, tools=[LOOKUP_TOOL], **EXECUTION_REPORTING)` | `agent` |
 
@@ -122,7 +122,7 @@ room). What they *share* — `@requires` gating, `AdapterCell` construction, and
   `RunContext` callable, an agno tool). Add `**EXECUTION_REPORTING` to observe the
   calls via `capture.tool_calls`. Only letta can't accept a local tool (MCP) and
   **rejects** `tools` with a clear error rather than silently dropping it.
-- **Cross-framework peer:** `@per_adapter(exclude={Adapter.X}, peer=Adapter.X)` fans A
+- **Cross-framework peer:** `@per_adapter(exclude=[ExcludedAdapter(Adapter.X, "reason")], peer=Adapter.X)` fans A
   across the matrix and hands each cell a *different-framework* peer B via the `peer`
   fixture (an `AdapterCell` the test drives — provision + `run_as`). The peer's
   `@requires` fold into the cell's single gate mark, and the peer is visible to lane
@@ -328,7 +328,11 @@ peer **B** (via the `peer` fixture) in the same room; `.mentioning()` filters a 
 to replies that mention a participant. See `smoke/matrix/test_rehydration_cross_framework.py`:
 
 ```python notest
-@per_adapter(exclude={Adapter.LANGGRAPH}, peer=Adapter.LANGGRAPH, prompt=REPLY_PROMPT)
+@per_adapter(
+    exclude=[ExcludedAdapter(Adapter.LANGGRAPH, "it is the fixed peer here")],
+    peer=Adapter.LANGGRAPH,
+    prompt=REPLY_PROMPT,
+)
 async def test_foreign_peer(cell, peer, resource_manager, user_ops, reply_capture):
     marker = unique_marker("note")
     a = await cell.provision(f"a-{cell.adapter_id}")          # A (fanned)
@@ -629,6 +633,34 @@ Lanes live in the registry, not the workflow YAML. To add one:
    that's missing the new lane (or still lists a removed one), fails loudly in the
    guard suite on every PR rather than silently never running / never being
    selectable.
+
+## Scorecard (the adapter×test artifact)
+
+One place to see **adapter × test → pass / fail / skip / N-A (+ reason)**. An excluded
+adapter would otherwise vanish from the results (`specs()` omits it, no test node) with
+its reason buried in a comment; the scorecard makes the full grid observable and gives
+CI a queryable N-A instead of a silent gap.
+
+- **Reasons live at the call site.** `@per_adapter(exclude=…)` takes
+  `ExcludedAdapter(adapter, reason)` records — a non-empty reason is required at
+  decoration time (`ExcludedAdapter.__post_init__`), so an adapter can never be excluded
+  without saying why. The records ride the `PerAdapter` marker, so collection can read
+  them back.
+- **Emission is settings-driven.** Set `BAND_E2E_SCORECARD_JSON=<path>` and the session
+  writes that run's rows at the end — collected cells' pass/fail (read from each test
+  report, keyed by exact nodeid — no junit scraping), out-of-lane cells as `skip`, and
+  the `@per_adapter` exclusions as `na` with their reasons. Empty (the local default)
+  emits nothing.
+- **CI folds the lanes together.** Each `e2e` lane writes its own slice to
+  `artifacts/scorecard-<lane>-<os>.json` and uploads it; the final `scorecard` job merges
+  them (`python -m tests.e2e.baseline.scorecard merge … --out … --markdown …`) into one
+  `artifacts/scorecard.json` (+ a markdown grid). A cell runs in exactly one lane, so the
+  union keeps its real outcome over the `skip`s and never clobbers an `na`. The job
+  *reports* the matrix; it does not gate on it.
+
+The logic (`na_rows` / `outcome_row` / `merge`) lives in `scorecard.py` as pure functions
+(unit-tested in `tests/framework_conformance/test_scorecard.py`); the conftest is a thin
+`pytest_runtest_logreport` / `pytest_sessionfinish` delegate.
 
 ## Letta lane
 

--- a/tests/e2e/baseline/agents.py
+++ b/tests/e2e/baseline/agents.py
@@ -49,6 +49,7 @@ __all__ = [
     "LANE_MARKER",
     "Adapter",
     "Lane",
+    "ExcludedAdapter",
     "WithAdapters",
     "PerAdapter",
     "adapter_params",
@@ -121,8 +122,37 @@ class WithAdapters(MarkerPayload):
 
 
 @dataclass(frozen=True)
+class ExcludedAdapter:
+    """An adapter a ``@per_adapter`` test deliberately does not run, and why.
+
+    The reason lives at the call site (the test file that decides the exclusion) so
+    the scorecard renders an ``N/A`` cell with a human explanation instead of the
+    adapter silently vanishing from the matrix. Mirrors ``AdapterSpec.e2e_pending``:
+    a plain-language reason string, not a code. It is constructed inline in the
+    decorator call, so the empty-reason guard fires at import time (decoration),
+    never at runtime.
+    """
+
+    adapter: Adapter
+    reason: str
+
+    def __post_init__(self) -> None:
+        if not self.reason.strip():
+            raise ValueError(
+                f"@per_adapter exclude of {self.adapter} needs a non-empty reason "
+                "(why is this adapter N/A for this test?)"
+            )
+
+
+@dataclass(frozen=True)
 class PerAdapter(MarkerPayload):
-    """Per-cell construction steering for ``@per_adapter`` (carried on its marker)."""
+    """Per-cell construction steering for ``@per_adapter`` (carried on its marker).
+
+    ``exclude`` records the adapters this test opts out of, each with its reason. They
+    produce no test node (``specs()`` omits them), so they exist only here — this is
+    what lets the scorecard surface an excluded cell as ``N/A`` (+ reason) rather than
+    letting it disappear without a trace.
+    """
 
     MARKER: ClassVar[str] = PER_ADAPTER_MARKER
 
@@ -130,6 +160,7 @@ class PerAdapter(MarkerPayload):
     features: AdapterFeatures | None
     tools: list[ToolSpec] | None
     peer: Adapter | None = None
+    exclude: tuple[ExcludedAdapter, ...] = ()
 
 
 def with_adapters(
@@ -203,7 +234,7 @@ def adapter_params(
 
 def per_adapter(
     *adapters: Adapter,
-    exclude: Collection[Adapter] | None = None,
+    exclude: Collection[ExcludedAdapter] | None = None,
     supports: Collection[Capability] | None = None,
     without: Collection[Capability] | None = None,
     runs_tool_loop: bool | None = None,
@@ -222,7 +253,7 @@ def per_adapter(
     ``peer`` fixtures carry these as defaults::
 
         @per_adapter()                                   # full matrix
-        @per_adapter(exclude={Adapter.CREWAI})           # all but crewai
+        @per_adapter(exclude=[ExcludedAdapter(Adapter.CREWAI, "no per-turn usage")])
         @per_adapter(Adapter.ANTHROPIC, Adapter.AGNO)    # only these
         @per_adapter(supports={Capability.MEMORY})       # by capability
         @per_adapter(lane=Lane.CORE, peer=Adapter.LANGGRAPH)  # each cell + a foreign peer
@@ -234,8 +265,17 @@ def per_adapter(
     the parameters.
     """
     include = frozenset(adapters) or None
+    excluded = tuple(exclude or ())
+    exclude_ids = frozenset(e.adapter for e in excluded)
+    registered = {s.id for s in specs(include_pending=True)}
+    unknown = exclude_ids - registered
+    if unknown:
+        # A typo'd or stale exclusion would otherwise silently no-op (nothing to drop).
+        raise ValueError(
+            f"@per_adapter(exclude=...) names unregistered adapters: {sorted(unknown)}"
+        )
     if peer is not None:
-        if peer not in {s.id for s in specs(include_pending=True)}:
+        if peer not in registered:
             raise ValueError(f"@per_adapter(peer={peer!r}) is not a registered adapter")
         if peer not in {s.id for s in specs()}:
             # A pending adapter defines a lane but runs no cells (no builder-backed cell),
@@ -246,7 +286,7 @@ def per_adapter(
             )
     params = adapter_params(
         include=include,
-        exclude=exclude,
+        exclude=exclude_ids or None,
         supports=supports,
         without=without,
         runs_tool_loop=runs_tool_loop,
@@ -259,11 +299,13 @@ def per_adapter(
         raise ValueError(
             "@per_adapter selected no adapters "
             f"(include={sorted(map(str, include)) if include else None}, "
-            f"exclude={exclude}, supports={supports}, without={without}, "
-            f"runs_tool_loop={runs_tool_loop}, lane={lane}); widen the filter or fix "
-            "the registry drift"
+            f"exclude={sorted(map(str, exclude_ids)) or None}, supports={supports}, "
+            f"without={without}, runs_tool_loop={runs_tool_loop}, lane={lane}); widen "
+            "the filter or fix the registry drift"
         )
-    build = PerAdapter(prompt=prompt, features=features, tools=tools, peer=peer)
+    build = PerAdapter(
+        prompt=prompt, features=features, tools=tools, peer=peer, exclude=excluded
+    )
 
     def decorate(fn: Callable[..., object]) -> Callable[..., object]:
         fn = pytest.mark.parametrize("adapter_id", params, indirect=True)(fn)

--- a/tests/e2e/baseline/conftest.py
+++ b/tests/e2e/baseline/conftest.py
@@ -44,7 +44,7 @@ from tests.e2e.baseline.lane_selection import (
     assert_every_item_is_schedulable,
 )
 from tests.e2e.baseline.requires import MARKER, require_dep
-from tests.e2e.baseline.scorecard import ScorecardCollector, write_json
+from tests.e2e.baseline.scorecard import ScorecardCollector
 from tests.e2e.baseline.settings import BaselineSettings
 from tests.toolkit.timeouts import effective_timeout
 
@@ -68,15 +68,14 @@ __all__ = [
 ]
 
 
-# Session-scoped scorecard accumulator; the hooks below delegate to it. The path it
-# writes to is read once at configure (empty = don't emit — the local default).
-_scorecard = ScorecardCollector()
-_scorecard_path = ""
-
-
 def pytest_configure(config: pytest.Config) -> None:
-    global _scorecard_path
-    _scorecard_path = BaselineSettings().run.scorecard_json
+    # Register the scorecard plugin only when a path is set (empty = don't emit, the
+    # local default), so its hooks own their state instead of module globals.
+    scorecard_json = BaselineSettings().run.scorecard_json
+    if scorecard_json:
+        config.pluginmanager.register(
+            ScorecardCollector(scorecard_json), name="baseline-scorecard"
+        )
     config.addinivalue_line(
         "markers",
         f"{MARKER}(deps): declare a baseline test's optional dependencies; the "
@@ -164,15 +163,3 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         timeout = effective_timeout(item, base)
         if timeout is not None:
             item.add_marker(pytest.mark.timeout(timeout), append=False)
-
-
-def pytest_runtest_logreport(report: pytest.TestReport) -> None:
-    """Feed each cell's outcome to the scorecard (no-op unless emission is enabled)."""
-    if _scorecard_path:
-        _scorecard.on_report(report)
-
-
-def pytest_sessionfinish(session: pytest.Session) -> None:
-    """Write this run's scorecard — collected outcomes plus the N/A exclusions."""
-    if _scorecard_path:
-        write_json(_scorecard.scorecard(session.items), _scorecard_path)

--- a/tests/e2e/baseline/conftest.py
+++ b/tests/e2e/baseline/conftest.py
@@ -44,6 +44,7 @@ from tests.e2e.baseline.lane_selection import (
     assert_every_item_is_schedulable,
 )
 from tests.e2e.baseline.requires import MARKER, require_dep
+from tests.e2e.baseline.scorecard import ScorecardCollector, write_json
 from tests.e2e.baseline.settings import BaselineSettings
 from tests.toolkit.timeouts import effective_timeout
 
@@ -67,7 +68,15 @@ __all__ = [
 ]
 
 
+# Session-scoped scorecard accumulator; the hooks below delegate to it. The path it
+# writes to is read once at configure (empty = don't emit — the local default).
+_scorecard = ScorecardCollector()
+_scorecard_path = ""
+
+
 def pytest_configure(config: pytest.Config) -> None:
+    global _scorecard_path
+    _scorecard_path = BaselineSettings().run.scorecard_json
     config.addinivalue_line(
         "markers",
         f"{MARKER}(deps): declare a baseline test's optional dependencies; the "
@@ -155,3 +164,15 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         timeout = effective_timeout(item, base)
         if timeout is not None:
             item.add_marker(pytest.mark.timeout(timeout), append=False)
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Feed each cell's outcome to the scorecard (no-op unless emission is enabled)."""
+    if _scorecard_path:
+        _scorecard.on_report(report)
+
+
+def pytest_sessionfinish(session: pytest.Session) -> None:
+    """Write this run's scorecard — collected outcomes plus the N/A exclusions."""
+    if _scorecard_path:
+        write_json(_scorecard.scorecard(session.items), _scorecard_path)

--- a/tests/e2e/baseline/scorecard.py
+++ b/tests/e2e/baseline/scorecard.py
@@ -127,17 +127,20 @@ def outcome_row(
 
 
 class ScorecardCollector:
-    """Accumulates cell outcomes across a run, then folds in the ``N/A`` markers.
+    """A pytest plugin that records cell outcomes and writes the run's scorecard.
 
-    Held as a single instance by the conftest; its hooks delegate ``on_report`` per test
-    and ``scorecard`` at session end. Kept here (not in the conftest) so the logic is
-    unit-testable and the conftest stays a thin delegate — mirroring ``lane_selection``.
+    The conftest registers one instance — only when emission is enabled (a path is set),
+    so its hooks are unconditional once active — instead of routing session-wide hooks
+    through module globals. It owns its state and its output path; the row-building stays
+    in the module-level pure functions (``outcome_row`` / ``na_rows``), so ``scorecard``
+    is unit-testable without a running session.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, path: str | Path) -> None:
+        self._path = path
         self._outcomes: dict[tuple[str, str], ScorecardRow] = {}
 
-    def on_report(self, report: pytest.TestReport) -> None:
+    def pytest_runtest_logreport(self, report: pytest.TestReport) -> None:
         row = outcome_row(report)
         if row is not None:
             # Last write wins — a flaky rerun's final report is the cell's real outcome.
@@ -152,6 +155,9 @@ class ScorecardCollector:
         rows = dict(self._outcomes)
         rows.update(na_rows(items))
         return sorted(rows.values(), key=lambda row: (row.test, row.adapter))
+
+    def pytest_sessionfinish(self, session: pytest.Session) -> None:
+        write_json(self.scorecard(session.items), self._path)
 
 
 def merge(scorecards: Iterable[list[ScorecardRow]]) -> list[ScorecardRow]:

--- a/tests/e2e/baseline/scorecard.py
+++ b/tests/e2e/baseline/scorecard.py
@@ -1,0 +1,231 @@
+"""The adapter×test scorecard: pass / fail / skip / N-A (+ reason) in one artifact.
+
+Excluded adapters produce no test node (``specs()`` omits them), so a matrix cell an
+adapter opts out of would otherwise vanish from the results with its reason buried in a
+code comment. This module makes the full grid observable:
+
+* :func:`na_rows` reads each ``@per_adapter`` marker's ``exclude`` records (the reasons
+  live on the marker — see ``agents.PerAdapter``) and emits an ``N/A`` row per excluded
+  cell, so no cell disappears without a trace.
+* :class:`ScorecardCollector` records the run outcome (pass / fail / skip) of every
+  collected cell from its test report — exact ``nodeid`` keys, no junit-name scraping.
+* :func:`merge` unions the per-lane scorecards CI emits (each lane runs only its own
+  cells; the rest are ``skip``) into one grid.
+
+The pieces are pure functions so they unit-test without a live platform; the conftest is
+a thin hook delegate, and ``python -m tests.e2e.baseline.scorecard merge`` is the
+post-run CI step that folds the lanes together.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from tests.e2e.baseline.agents import PER_ADAPTER_MARKER, PerAdapter
+
+logger = logging.getLogger(__name__)
+
+# ``na`` = deliberately excluded (with a reason); ``skip`` = collected but not run in this
+# lane (lane scoping / E2E disabled). Ranked so a real outcome beats ``skip`` when the
+# per-lane scorecards are unioned, and an ``N/A`` is never overwritten by a ``skip``.
+Status = Literal["pass", "fail", "skip", "na"]
+_RANK: dict[Status, int] = {"skip": 0, "na": 1, "pass": 2, "fail": 3}
+
+
+@dataclass(frozen=True)
+class ScorecardRow:
+    """One adapter×test cell: its outcome, and the reason when it is ``N/A``/``skip``."""
+
+    test: str  # nodeid without the ``[adapter]`` param — the test function
+    adapter: str
+    status: Status
+    reason: str | None = None
+
+
+def _test_id(nodeid: str) -> str:
+    """The test-function nodeid — the cell's ``[adapter]`` param stripped off."""
+    return nodeid.split("[", 1)[0]
+
+
+def na_rows(items: Iterable[pytest.Item]) -> dict[tuple[str, str], ScorecardRow]:
+    """The ``N/A`` cells the matrix defines: every ``@per_adapter`` exclusion, with reason.
+
+    Excluded adapters have no test node, so their reasons exist only on the marker (shared
+    by every surviving cell of the test — reading it off any one is enough). Keyed by
+    ``(test, adapter)`` for a disjoint merge with the run outcomes.
+    """
+    rows: dict[tuple[str, str], ScorecardRow] = {}
+    for item in items:
+        marker = item.get_closest_marker(PER_ADAPTER_MARKER)
+        if marker is None or not marker.args:
+            continue
+        build = marker.args[0]
+        if not isinstance(build, PerAdapter):
+            continue
+        test = _test_id(item.nodeid)
+        for excluded in build.exclude:
+            adapter = str(excluded.adapter)
+            rows[(test, adapter)] = ScorecardRow(test, adapter, "na", excluded.reason)
+    return rows
+
+
+def _skip_reason(report: pytest.TestReport) -> str | None:
+    """The human reason from a skip report's ``longrepr`` (``(path, line, msg)``)."""
+    longrepr = report.longrepr
+    if isinstance(longrepr, tuple) and len(longrepr) == 3:
+        return longrepr[2].removeprefix("Skipped: ").strip() or None
+    return None
+
+
+def outcome_row(
+    report: pytest.TestReport,
+) -> tuple[tuple[str, str], ScorecardRow] | None:
+    """A pass / fail / skip row for one matrix cell, keyed by ``(test, adapter)``.
+
+    Only parametrized matrix cells carry an ``[adapter]`` in their nodeid; other tests
+    (provisioning, user-ops, the registry guards) are not part of the grid and return
+    ``None``. The verdict comes from the setup and call phases: a skip (lane scoping,
+    E2E disabled, or an in-body ``pytest.skip``) is ``skip``; a setup *error* (a failed
+    fixture) or a call failure is ``fail``; a passing call is ``pass``. Teardown reports
+    and passing setups carry no verdict and are ignored — so the accumulator's
+    last-write-wins keeps the call outcome, not a trailing teardown.
+    """
+    if "[" not in report.nodeid:
+        return None
+    if report.when not in ("setup", "call"):
+        return None
+    if report.skipped:
+        status: Status = "skip"
+        reason = _skip_reason(report)
+    elif report.failed:
+        status = "fail"
+        reason = None
+    elif report.when == "call":
+        status = "pass"
+        reason = None
+    else:
+        return None  # a passing setup carries no verdict — wait for the call phase
+    test, _, rest = report.nodeid.partition("[")
+    adapter = rest.rstrip("]")
+    return (test, adapter), ScorecardRow(test, adapter, status, reason)
+
+
+class ScorecardCollector:
+    """Accumulates cell outcomes across a run, then folds in the ``N/A`` markers.
+
+    Held as a single instance by the conftest; its hooks delegate ``on_report`` per test
+    and ``scorecard`` at session end. Kept here (not in the conftest) so the logic is
+    unit-testable and the conftest stays a thin delegate — mirroring ``lane_selection``.
+    """
+
+    def __init__(self) -> None:
+        self._outcomes: dict[tuple[str, str], ScorecardRow] = {}
+
+    def on_report(self, report: pytest.TestReport) -> None:
+        row = outcome_row(report)
+        if row is not None:
+            # Last write wins — a flaky rerun's final report is the cell's real outcome.
+            self._outcomes[row[0]] = row[1]
+
+    def scorecard(self, items: Iterable[pytest.Item]) -> list[ScorecardRow]:
+        """This run's rows: the collected cells' outcomes plus the ``N/A`` exclusions.
+
+        The two sets are disjoint (an excluded adapter has no node, so no outcome), but
+        ``N/A`` is applied last so a marker reason is authoritative if they ever overlap.
+        """
+        rows = dict(self._outcomes)
+        rows.update(na_rows(items))
+        return sorted(rows.values(), key=lambda row: (row.test, row.adapter))
+
+
+def merge(scorecards: Iterable[list[ScorecardRow]]) -> list[ScorecardRow]:
+    """Union per-lane scorecards into one grid.
+
+    A cell runs in exactly one lane, so across lanes only one scorecard has a real
+    outcome for it and the rest are ``skip``; ``N/A`` is ``N/A`` everywhere. Keeping the
+    highest-ranked row per cell surfaces the real result and never lets a ``skip`` hide an
+    ``N/A`` — a cell that ran nowhere (its lane never reported) stays ``skip``, visible
+    rather than silently dropped.
+    """
+    best: dict[tuple[str, str], ScorecardRow] = {}
+    for card in scorecards:
+        for row in card:
+            key = (row.test, row.adapter)
+            if key not in best or _RANK[row.status] > _RANK[best[key].status]:
+                best[key] = row
+    return sorted(best.values(), key=lambda row: (row.test, row.adapter))
+
+
+def write_json(rows: list[ScorecardRow], path: str | Path) -> None:
+    """Write ``rows`` as a JSON array to ``path`` (creating parent dirs)."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps([asdict(row) for row in rows], indent=2) + "\n")
+
+
+def _load(path: str | Path) -> list[ScorecardRow]:
+    return [ScorecardRow(**row) for row in json.loads(Path(path).read_text())]
+
+
+def to_markdown(rows: list[ScorecardRow]) -> str:
+    """A pivot grid (tests × adapters) plus the ``N/A`` reasons — the one-look view."""
+    symbol: dict[Status, str] = {"pass": "✅", "fail": "❌", "skip": "⏭️", "na": "N/A"}
+    tests = sorted({row.test.rsplit("::", 1)[-1] for row in rows})
+    adapters = sorted({row.adapter for row in rows})
+    cell = {(row.test.rsplit("::", 1)[-1], row.adapter): row.status for row in rows}
+
+    header = "| test | " + " | ".join(adapters) + " |"
+    divider = "| --- " * (len(adapters) + 1) + "|"
+    body = [
+        "| "
+        + test
+        + " | "
+        + " | ".join(symbol.get(cell.get((test, a), "skip"), "·") for a in adapters)
+        + " |"
+        for test in tests
+    ]
+    lines = [header, divider, *body]
+
+    na = [row for row in rows if row.status == "na"]
+    if na:
+        lines += ["", "**N/A reasons**", ""]
+        lines += [
+            f"- `{row.test.rsplit('::', 1)[-1]}` / `{row.adapter}` — {row.reason}"
+            for row in sorted(na, key=lambda r: (r.test, r.adapter))
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI: ``merge`` the per-lane scorecards CI uploads into one artifact."""
+    parser = argparse.ArgumentParser(prog="scorecard")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    merge_cmd = sub.add_parser("merge", help="union per-lane scorecards into one grid")
+    merge_cmd.add_argument("inputs", nargs="+", help="per-lane scorecard JSON files")
+    merge_cmd.add_argument("--out", required=True, help="combined scorecard.json path")
+    merge_cmd.add_argument("--markdown", help="also write a markdown grid to this path")
+    args = parser.parse_args(argv)
+
+    rows = merge(_load(path) for path in args.inputs)
+    write_json(rows, args.out)
+    if args.markdown:
+        Path(args.markdown).write_text(to_markdown(rows))
+    logger.info(
+        "scorecard: %d cells from %d lane file(s) -> %s",
+        len(rows),
+        len(args.inputs),
+        args.out,
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    main()

--- a/tests/e2e/baseline/scorecard.py
+++ b/tests/e2e/baseline/scorecard.py
@@ -29,9 +29,14 @@ from typing import Literal
 
 import pytest
 
-from tests.e2e.baseline.agents import PER_ADAPTER_MARKER, PerAdapter
+from tests.e2e.baseline.agents import PER_ADAPTER_MARKER, Adapter, PerAdapter
 
 logger = logging.getLogger(__name__)
+
+# Only a registered adapter id names a matrix cell. Other parametrized tests carry
+# unrelated params in their nodeid (e.g. ``test_send_event[thought]``), which must not
+# be mistaken for adapters when reading outcomes off a report.
+_ADAPTER_IDS: frozenset[str] = frozenset(str(adapter) for adapter in Adapter)
 
 # ``na`` = deliberately excluded (with a reason); ``skip`` = collected but not run in this
 # lane (lane scoping / E2E disabled). Ranked so a real outcome beats ``skip`` when the
@@ -90,18 +95,23 @@ def outcome_row(
 ) -> tuple[tuple[str, str], ScorecardRow] | None:
     """A pass / fail / skip row for one matrix cell, keyed by ``(test, adapter)``.
 
-    Only parametrized matrix cells carry an ``[adapter]`` in their nodeid; other tests
-    (provisioning, user-ops, the registry guards) are not part of the grid and return
-    ``None``. The verdict comes from the setup and call phases: a skip (lane scoping,
-    E2E disabled, or an in-body ``pytest.skip``) is ``skip``; a setup *error* (a failed
-    fixture) or a call failure is ``fail``; a passing call is ``pass``. Teardown reports
-    and passing setups carry no verdict and are ignored — so the accumulator's
-    last-write-wins keeps the call outcome, not a trailing teardown.
+    Only matrix cells count: a cell's ``[…]`` param is a registered adapter id, so a
+    parametrized test carrying anything else (``test_send_event[thought]``) and the
+    unparametrized tests (provisioning, user-ops, the registry guards) return ``None``.
+    The verdict comes from the setup and call phases: a skip (lane scoping, E2E disabled,
+    or an in-body ``pytest.skip``) is ``skip``; a setup *error* (a failed fixture) or a
+    call failure is ``fail``; a passing call is ``pass``. Teardown reports and passing
+    setups carry no verdict and are ignored — so the accumulator's last-write-wins keeps
+    the call outcome, not a trailing teardown.
     """
-    if "[" not in report.nodeid:
-        return None
     if report.when not in ("setup", "call"):
         return None
+    test, sep, rest = report.nodeid.partition("[")
+    if not sep:
+        return None  # unparametrized — not a matrix cell
+    adapter = rest.rstrip("]")
+    if adapter not in _ADAPTER_IDS:
+        return None  # a non-adapter parametrization (e.g. an event type)
     if report.skipped:
         status: Status = "skip"
         reason = _skip_reason(report)
@@ -113,8 +123,6 @@ def outcome_row(
         reason = None
     else:
         return None  # a passing setup carries no verdict — wait for the call phase
-    test, _, rest = report.nodeid.partition("[")
-    adapter = rest.rstrip("]")
     return (test, adapter), ScorecardRow(test, adapter, status, reason)
 
 

--- a/tests/e2e/baseline/settings.py
+++ b/tests/e2e/baseline/settings.py
@@ -80,6 +80,10 @@ class BaselineRun(BaseSettings):
     # Safety guard: the sweep only reaps agents older than this, so a
     # concurrent run on the same shared platform is never deleted mid-flight.
     orphan_max_age_minutes: int = 120  # BAND_E2E_ORPHAN_MAX_AGE_MINUTES
+    # Write this run's adapter×test scorecard (pass/fail/skip + N/A reasons) as JSON
+    # to this path at session end. Empty = don't emit (the local default). CI sets one
+    # path per lane; a final job merges them (see scorecard.py).
+    scorecard_json: str = ""  # BAND_E2E_SCORECARD_JSON
 
 
 class LLMCredentials(BaseSettings):

--- a/tests/e2e/baseline/smoke/inspection/test_usage.py
+++ b/tests/e2e/baseline/smoke/inspection/test_usage.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 import pytest
 
-from tests.e2e.baseline.agents import Adapter, per_adapter
+from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import (
     COST_AGENT,
     COST_MULTI_TURN_AGENT,
@@ -48,11 +48,19 @@ from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceMa
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
 
-# Adapters that don't emit usage: crewai_flow (usage in user-supplied flow
-# internals) and crewai (deferred — cumulative-lifetime counter, not per-turn).
-# Every other registered adapter must emit usage (letta does, via Emit.USAGE
-# from the per-room LettaResponse.usage).
-@per_adapter(exclude={Adapter.CREWAI_FLOW, Adapter.CREWAI}, **COST_AGENT)
+# Every registered adapter must emit usage (letta does, via Emit.USAGE from the
+# per-room LettaResponse.usage) except the crewai pair excluded below.
+@per_adapter(
+    exclude=[
+        ExcludedAdapter(
+            Adapter.CREWAI_FLOW, "usage lives in user-supplied flow internals"
+        ),
+        ExcludedAdapter(
+            Adapter.CREWAI, "deferred: cumulative-lifetime counter, not per-turn"
+        ),
+    ],
+    **COST_AGENT,
+)
 @pytest.mark.asyncio(loop_scope="session")
 async def test_usage_recorded_for_a_turn(
     agent: ProvisionedAgent,
@@ -126,11 +134,20 @@ async def test_usage_recorded_for_a_turn(
     )
 
 
-# Same fan and exclusions as the single-turn smoke: every usage-emitting adapter,
-# minus the crewai pair (crewai_flow N-A; crewai deferred). The prompt lets the
-# user dictate length so the test can drive one LONG turn then one TINY turn
-# (see COST_MULTI_TURN_AGENT).
-@per_adapter(exclude={Adapter.CREWAI_FLOW, Adapter.CREWAI}, **COST_MULTI_TURN_AGENT)
+# Same fan and exclusions as the single-turn smoke. The prompt lets the user dictate
+# length so the test can drive one LONG turn then one TINY turn (see
+# COST_MULTI_TURN_AGENT).
+@per_adapter(
+    exclude=[
+        ExcludedAdapter(
+            Adapter.CREWAI_FLOW, "usage lives in user-supplied flow internals"
+        ),
+        ExcludedAdapter(
+            Adapter.CREWAI, "deferred: cumulative-lifetime counter, not per-turn"
+        ),
+    ],
+    **COST_MULTI_TURN_AGENT,
+)
 # Two turns, and the first drives a long multi-paragraph generation — so this test
 # legitimately needs roughly a second turn's budget on top of the per-turn default.
 @pytest.mark.timeout(extra=120)

--- a/tests/e2e/baseline/smoke/matrix/test_burst_recall.py
+++ b/tests/e2e/baseline/smoke/matrix/test_burst_recall.py
@@ -27,7 +27,7 @@ from tests.e2e.baseline.flaky import flaky_model
 
 from band.client.streaming import DeliveryStatus
 
-from tests.e2e.baseline.agents import Adapter, per_adapter
+from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
 from tests.e2e.baseline.settings import BaselineSettings
 from tests.e2e.baseline.smoke.samples.sample_agents import (
     RECALL_ALL_FACTS,
@@ -43,7 +43,15 @@ from tests.e2e.baseline.toolkit.user_ops import UserOps
 BURST_SIZE = 6
 
 
-@per_adapter(exclude={Adapter.CREWAI_FLOW}, prompt=REPLY_PROMPT)
+@per_adapter(
+    exclude=[
+        ExcludedAdapter(
+            Adapter.CREWAI_FLOW,
+            "terminal echo flow with no memory — cannot span-recall an early fact",
+        )
+    ],
+    prompt=REPLY_PROMPT,
+)
 @flaky_model("spanning recall is model-driven")
 @pytest.mark.timeout(
     extra=780

--- a/tests/e2e/baseline/smoke/matrix/test_concurrent_instances.py
+++ b/tests/e2e/baseline/smoke/matrix/test_concurrent_instances.py
@@ -32,7 +32,7 @@ import asyncio
 import pytest
 from tests.e2e.baseline.flaky import flaky_infra
 
-from tests.e2e.baseline.agents import Adapter, per_adapter
+from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import liveness_probe, unique_marker
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
 from tests.e2e.baseline.toolkit.provisioning import AdapterCell, ResourceManager
@@ -42,8 +42,14 @@ INSTANCES = 3  # the spec's Test Agent + Calc + Greeter trio
 
 
 @per_adapter(
-    exclude={Adapter.LETTA}
-)  # Letta: global-by-name MCP tools (see module doc)
+    exclude=[
+        ExcludedAdapter(
+            Adapter.LETTA,
+            "global-by-name MCP tools collide across concurrent same-adapter "
+            "instances (see module docstring)",
+        )
+    ]
+)
 @flaky_infra("only transient reruns")
 @pytest.mark.timeout(extra=300)  # three concurrent boots + three turns
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/e2e/baseline/smoke/matrix/test_context_recall.py
+++ b/tests/e2e/baseline/smoke/matrix/test_context_recall.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import pytest
 from tests.e2e.baseline.flaky import flaky_infra, model_turn_retrying
 
-from tests.e2e.baseline.agents import Adapter, per_adapter
+from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import (
     RECALL,
     REMEMBER,
@@ -48,9 +48,16 @@ from tests.e2e.baseline.toolkit.provisioning import (
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
 
-# CREWAI_FLOW is a terminal echo flow with no memory (like codex/opencode), so it
-# cannot recall a note stated on an earlier turn — exclude it from recall scenarios.
-@per_adapter(exclude={Adapter.CREWAI_FLOW}, prompt=REPLY_PROMPT)
+@per_adapter(
+    exclude=[
+        ExcludedAdapter(
+            Adapter.CREWAI_FLOW,
+            "terminal echo flow with no memory — cannot recall a note from an "
+            "earlier turn",
+        )
+    ],
+    prompt=REPLY_PROMPT,
+)
 @flaky_infra("only transient failures")
 @pytest.mark.timeout(extra=120)  # two turns (state, then recall)
 @pytest.mark.asyncio(loop_scope="session")
@@ -86,7 +93,23 @@ async def test_recalls_within_session(
 
 
 @per_adapter(
-    exclude={Adapter.CODEX, Adapter.OPENCODE, Adapter.CREWAI_FLOW}, prompt=REPLY_PROMPT
+    exclude=[
+        ExcludedAdapter(
+            Adapter.CODEX,
+            "recovers context by resuming its own backend session, not via platform "
+            "/context — a pass would not validate this rehydration",
+        ),
+        ExcludedAdapter(
+            Adapter.OPENCODE,
+            "recovers context by resuming its own backend session, not via platform "
+            "/context — a pass would not validate this rehydration",
+        ),
+        ExcludedAdapter(
+            Adapter.CREWAI_FLOW,
+            "terminal echo flow with no memory — cannot recall across a rejoin",
+        ),
+    ],
+    prompt=REPLY_PROMPT,
 )
 # The recall turn's model non-determinism is absorbed per-turn (model_turn_retrying)
 # rather than by re-running the whole two-boot test; this decorator only covers a

--- a/tests/e2e/baseline/smoke/matrix/test_noisy_room.py
+++ b/tests/e2e/baseline/smoke/matrix/test_noisy_room.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import pytest
 from tests.e2e.baseline.flaky import flaky_infra
 
-from tests.e2e.baseline.agents import Adapter, per_adapter
+from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
 from tests.e2e.baseline.settings import BaselineSettings
 from tests.e2e.baseline.smoke.samples.sample_agents import liveness_probe, unique_marker
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
@@ -38,9 +38,14 @@ from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceMa
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
 
-# CREWAI_FLOW is a terminal echo flow with no memory (like codex/opencode), so it
-# cannot recall a seeded fact — exclude it from recall scenarios.
-@per_adapter(exclude={Adapter.CREWAI_FLOW})
+@per_adapter(
+    exclude=[
+        ExcludedAdapter(
+            Adapter.CREWAI_FLOW,
+            "terminal echo flow with no memory — cannot recall a seeded fact",
+        )
+    ]
+)
 @flaky_infra("only transient failures")
 @pytest.mark.timeout(extra=300)  # seed + several noise inferences + probe + recall
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/e2e/baseline/smoke/matrix/test_rehydration_cross_framework.py
+++ b/tests/e2e/baseline/smoke/matrix/test_rehydration_cross_framework.py
@@ -31,7 +31,7 @@ rehydration bug.
 Lifecycle: A's identity via ``cell`` (owns its boot); B's via the ``peer`` fixture (a
 different-framework cell the test drives). The two runs are strictly sequential — B's
 run fully exits before A boots — so ``track_running`` never sees overlapping runs of one
-identity. ``lane=Lane.CORE`` + ``exclude={LANGGRAPH}`` keeps A and B both in the core
+identity. ``lane=Lane.CORE`` + excluding ``LANGGRAPH`` keeps A and B both in the core
 lane (schedulable, no cross-lane) and guarantees A is never langgraph (so A ≠ B).
 """
 
@@ -40,7 +40,7 @@ from __future__ import annotations
 import pytest
 from tests.e2e.baseline.flaky import flaky_infra
 
-from tests.e2e.baseline.agents import Adapter, Lane, per_adapter
+from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, Lane, per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import REPLY_PROMPT, unique_marker
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
 from tests.e2e.baseline.toolkit.provisioning import (
@@ -62,7 +62,12 @@ def _relay_prompt(target: ProvisionedAgent, marker: str) -> str:
 
 @per_adapter(
     lane=Lane.CORE,
-    exclude={Adapter.LANGGRAPH},
+    exclude=[
+        ExcludedAdapter(
+            Adapter.LANGGRAPH,
+            "the fixed foreign peer here, so it can't also be the fanned cell",
+        )
+    ],
     peer=Adapter.LANGGRAPH,
     prompt=REPLY_PROMPT,
 )

--- a/tests/e2e/baseline/smoke/matrix/test_rehydration_idempotency.py
+++ b/tests/e2e/baseline/smoke/matrix/test_rehydration_idempotency.py
@@ -36,7 +36,7 @@ from tests.e2e.baseline.flaky import flaky_infra, flaky_model
 
 from band.client.streaming import DeliveryStatus
 
-from tests.e2e.baseline.agents import Adapter, per_adapter
+from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import (
     RECALL,
     REMEMBER,
@@ -142,7 +142,12 @@ async def test_handled_work_not_redrained_on_restart(
 
 @per_adapter(
     runs_tool_loop=True,
-    exclude={Adapter.CREWAI},  # cumulative usage → the per-turn token gate is N-A
+    exclude=[
+        ExcludedAdapter(
+            Adapter.CREWAI,
+            "cumulative-lifetime usage counter — the per-turn token gate is N/A",
+        )
+    ],
     prompt=REPLY_PROMPT,
     features=usage_features(),
 )

--- a/tests/e2e/baseline/smoke/matrix/test_rehydration_offline.py
+++ b/tests/e2e/baseline/smoke/matrix/test_rehydration_offline.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import pytest
 from tests.e2e.baseline.flaky import flaky_model
 
-from tests.e2e.baseline.agents import Adapter, per_adapter
+from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import (
     RECALL,
     REMEMBER,
@@ -45,7 +45,21 @@ from tests.e2e.baseline.toolkit.provisioning import (
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
 
-@per_adapter(exclude={Adapter.CODEX, Adapter.OPENCODE}, prompt=REPLY_PROMPT)
+@per_adapter(
+    exclude=[
+        ExcludedAdapter(
+            Adapter.CODEX,
+            "recovers context by resuming its own backend session, not via platform "
+            "/context — a pass would not validate this rehydration",
+        ),
+        ExcludedAdapter(
+            Adapter.OPENCODE,
+            "recovers context by resuming its own backend session, not via platform "
+            "/context — a pass would not validate this rehydration",
+        ),
+    ],
+    prompt=REPLY_PROMPT,
+)
 @flaky_model(
     "cold-boot recall is model-non-deterministic — the model occasionally denies "
     "having the note despite it being in the rehydrated context"

--- a/tests/e2e/baseline/smoke/matrix/test_rehydration_partial.py
+++ b/tests/e2e/baseline/smoke/matrix/test_rehydration_partial.py
@@ -37,6 +37,15 @@ rehydration itself works — the gap is specific to replying after a reboot in a
 live multi-agent room). Tracked as a langgraph-adapter behaviour to investigate;
 excluded here so the scenario stays green for the adapters that support it.
 
+Excludes ``letta`` for a different reason confirmed live: the self-hosted Letta
+adapter registers its Band MCP tool server per instance, but Letta stores MCP tools
+by name at organization scope and re-points the shared ``band_send_message`` row to
+whichever instance registered most recently. With two Letta agents live in one org,
+the rebooted agent *does* answer, but its send routes through the peer's MCP server
+and posts under the peer's identity, so the stayer-scoped reply is never observed.
+Fixing it needs per-instance tool-name isolation (or per-agent Letta project/org
+scoping); until then two Letta agents cannot keep separate identities in one org.
+
 Wording note: a neutral "note", not a "secret code" (models refuse to echo a
 credential-shaped value — an unrelated false failure).
 """
@@ -77,6 +86,14 @@ from tests.e2e.baseline.toolkit.user_ops import UserOps
             Adapter.LANGGRAPH,
             "emits no chat reply after a reboot in a live multi-agent room "
             "(langgraph-adapter behaviour under investigation)",
+        ),
+        ExcludedAdapter(
+            Adapter.LETTA,
+            "self-hosted Letta shares one org-wide send-message tool across "
+            "co-located agents, so a second live agent's reply routes through the "
+            "most-recently-registered adapter's MCP server and posts under the "
+            "wrong identity — the stayer-scoped reply is never observed. Needs "
+            "per-instance tool-name isolation to run two Letta agents in one org",
         ),
         ExcludedAdapter(
             Adapter.CREWAI_FLOW,

--- a/tests/e2e/baseline/smoke/matrix/test_rehydration_partial.py
+++ b/tests/e2e/baseline/smoke/matrix/test_rehydration_partial.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 import pytest
 from tests.e2e.baseline.flaky import flaky_infra
 
-from tests.e2e.baseline.agents import Adapter, per_adapter
+from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import (
     RECALL,
     REMEMBER,
@@ -62,7 +62,28 @@ from tests.e2e.baseline.toolkit.user_ops import UserOps
 
 
 @per_adapter(
-    exclude={Adapter.CODEX, Adapter.OPENCODE, Adapter.LANGGRAPH, Adapter.CREWAI_FLOW},
+    exclude=[
+        ExcludedAdapter(
+            Adapter.CODEX,
+            "recovers context by resuming its own backend session, not via platform "
+            "/context — a pass would not validate this rehydration",
+        ),
+        ExcludedAdapter(
+            Adapter.OPENCODE,
+            "recovers context by resuming its own backend session, not via platform "
+            "/context — a pass would not validate this rehydration",
+        ),
+        ExcludedAdapter(
+            Adapter.LANGGRAPH,
+            "emits no chat reply after a reboot in a live multi-agent room "
+            "(langgraph-adapter behaviour under investigation)",
+        ),
+        ExcludedAdapter(
+            Adapter.CREWAI_FLOW,
+            "terminal echo flow with no memory — cannot rehydrate context across a "
+            "reboot",
+        ),
+    ],
     prompt=REPLY_PROMPT,
 )
 @flaky_infra("only transient failures")

--- a/tests/e2e/baseline/smoke/matrix/test_room_isolation.py
+++ b/tests/e2e/baseline/smoke/matrix/test_room_isolation.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import pytest
 from tests.e2e.baseline.flaky import flaky_model
 
-from tests.e2e.baseline.agents import Adapter, per_adapter
+from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import (
     RECALL,
     REPLY_PROMPT,
@@ -32,9 +32,15 @@ from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceMa
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
 
-# CREWAI_FLOW is a terminal echo flow with no memory (like codex/opencode), so it
-# cannot recall a per-room note — exclude it from recall scenarios.
-@per_adapter(exclude={Adapter.CREWAI_FLOW}, prompt=REPLY_PROMPT)
+@per_adapter(
+    exclude=[
+        ExcludedAdapter(
+            Adapter.CREWAI_FLOW,
+            "terminal echo flow with no memory — cannot recall a per-room note",
+        )
+    ],
+    prompt=REPLY_PROMPT,
+)
 @flaky_model(
     "recall on a live model is non-deterministic — the model occasionally denies "
     "having the note despite it being in context"

--- a/tests/framework_conformance/test_scorecard.py
+++ b/tests/framework_conformance/test_scorecard.py
@@ -1,0 +1,218 @@
+"""Unit guards for the adapter×test scorecard (``ExcludedAdapter`` + ``scorecard``).
+
+Pure-function tests (no live platform), so they run in the ordinary unit suite on every
+PR rather than only in the manually-triggered E2E job — the scorecard is what keeps an
+excluded adapter from vanishing from the matrix, and its reasons feed CI gating, so a
+regression here silently drops rows or loses the N/A explanations.
+
+Covered:
+* ``ExcludedAdapter`` requires a non-empty reason at construction (so ``@per_adapter``
+  cannot exclude an adapter without saying why);
+* ``@per_adapter`` drops the excluded adapters from the fanned cells yet carries their
+  reasons on the ``PerAdapter`` marker, and rejects an unregistered exclusion;
+* ``na_rows`` turns those marker records into N/A rows; ``outcome_row`` maps a test
+  report to pass / fail / skip; ``merge`` unions per-lane cards (a real outcome beats a
+  skip, an N/A is never clobbered).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.e2e.baseline.agents import (
+    PER_ADAPTER_MARKER,
+    Adapter,
+    ExcludedAdapter,
+    PerAdapter,
+    per_adapter,
+)
+from tests.e2e.baseline.scorecard import (
+    ScorecardCollector,
+    ScorecardRow,
+    merge,
+    na_rows,
+    outcome_row,
+    to_markdown,
+)
+
+
+# --- ExcludedAdapter: a reason is mandatory -----------------------------------------
+
+
+def test_excluded_adapter_keeps_adapter_and_reason() -> None:
+    excluded = ExcludedAdapter(Adapter.CREWAI, "no per-turn usage")
+    assert excluded.adapter is Adapter.CREWAI
+    assert excluded.reason == "no per-turn usage"
+
+
+@pytest.mark.parametrize("reason", ["", "   ", "\n\t"])
+def test_excluded_adapter_rejects_empty_reason(reason: str) -> None:
+    with pytest.raises(ValueError, match="non-empty reason"):
+        ExcludedAdapter(Adapter.CREWAI, reason)
+
+
+# --- @per_adapter: excluded cells drop out, but their reasons ride the marker --------
+
+
+def _per_adapter_marker(fn: object) -> PerAdapter:
+    """The ``PerAdapter`` payload a decorated function carries."""
+    for mark in fn.pytestmark:  # type: ignore[attr-defined]
+        if mark.name == PER_ADAPTER_MARKER:
+            return mark.args[0]
+    raise AssertionError("no per_adapter marker on the decorated function")
+
+
+def _parametrized_adapter_ids(fn: object) -> list[str]:
+    for mark in fn.pytestmark:  # type: ignore[attr-defined]
+        if mark.name == "parametrize":
+            return [param.id for param in mark.args[1]]
+    raise AssertionError("no parametrize marker on the decorated function")
+
+
+def test_per_adapter_excludes_cell_but_carries_reason() -> None:
+    @per_adapter(exclude=[ExcludedAdapter(Adapter.CREWAI, "cumulative usage")])
+    def fn() -> None: ...
+
+    assert str(Adapter.CREWAI) not in _parametrized_adapter_ids(fn)
+    payload = _per_adapter_marker(fn)
+    assert payload.exclude == (ExcludedAdapter(Adapter.CREWAI, "cumulative usage"),)
+
+
+def test_per_adapter_rejects_unregistered_exclusion() -> None:
+    # Adapter is a StrEnum, so a plain unregistered string is an unknown id.
+    with pytest.raises(ValueError, match="unregistered adapters"):
+        per_adapter(exclude=[ExcludedAdapter("no-such-adapter", "typo")])(lambda: None)  # type: ignore[arg-type]
+
+
+# --- na_rows: marker exclusions become N/A rows -------------------------------------
+
+
+class _FakeItem:
+    """A ``pytest.Item`` stand-in exposing only what ``na_rows`` reads."""
+
+    def __init__(self, nodeid: str, exclude: tuple[ExcludedAdapter, ...] = ()) -> None:
+        self.nodeid = nodeid
+        build = PerAdapter(prompt=None, features=None, tools=None, exclude=exclude)
+        self._marker = SimpleNamespace(args=(build,))
+
+    def get_closest_marker(self, name: str) -> object | None:
+        return self._marker if name == PER_ADAPTER_MARKER else None
+
+
+def test_na_rows_from_marker_exclusions() -> None:
+    exclude = (
+        ExcludedAdapter(Adapter.CREWAI, "cumulative usage"),
+        ExcludedAdapter(Adapter.CREWAI_FLOW, "flow internals"),
+    )
+    # Two collected cells of the same test share the marker; the reasons dedupe by key.
+    items = [
+        _FakeItem("m.py::test_x[anthropic]", exclude),
+        _FakeItem("m.py::test_x[agno]", exclude),
+    ]
+    rows = na_rows(items)
+    assert rows[("m.py::test_x", "crewai")] == ScorecardRow(
+        "m.py::test_x", "crewai", "na", "cumulative usage"
+    )
+    assert rows[("m.py::test_x", "crewai_flow")].reason == "flow internals"
+    assert len(rows) == 2
+
+
+def test_na_rows_ignores_items_without_per_adapter_marker() -> None:
+    class _Bare:
+        nodeid = "p.py::test_provisioning"
+
+        def get_closest_marker(self, name: str) -> None:
+            return None
+
+    assert na_rows([_Bare()]) == {}
+
+
+# --- outcome_row: a test report -> a cell verdict -----------------------------------
+
+
+def _report(
+    nodeid: str, when: str, *, outcome: str, reason: str | None = None
+) -> object:
+    longrepr = ("m.py", 1, f"Skipped: {reason}") if reason is not None else None
+    return SimpleNamespace(
+        nodeid=nodeid,
+        when=when,
+        skipped=outcome == "skipped",
+        failed=outcome == "failed",
+        passed=outcome == "passed",
+        longrepr=longrepr,
+    )
+
+
+def test_outcome_row_call_pass_and_fail() -> None:
+    key, row = outcome_row(_report("m.py::t[anthropic]", "call", outcome="passed"))
+    assert (key, row.status) == (("m.py::t", "anthropic"), "pass")
+    _, fail = outcome_row(_report("m.py::t[crewai]", "call", outcome="failed"))
+    assert fail.status == "fail"
+
+
+def test_outcome_row_setup_skip_captures_reason() -> None:
+    _, row = outcome_row(
+        _report("m.py::t[agno]", "setup", outcome="skipped", reason="lane 'core'")
+    )
+    assert (row.status, row.reason) == ("skip", "lane 'core'")
+
+
+def test_outcome_row_setup_error_is_a_fail() -> None:
+    _, row = outcome_row(_report("m.py::t[agno]", "setup", outcome="failed"))
+    assert row.status == "fail"
+
+
+def test_outcome_row_ignores_non_matrix_and_passing_setup() -> None:
+    assert outcome_row(_report("p.py::test_no_param", "call", outcome="passed")) is None
+    assert outcome_row(_report("m.py::t[agno]", "setup", outcome="passed")) is None
+    assert outcome_row(_report("m.py::t[agno]", "teardown", outcome="passed")) is None
+
+
+# --- collector + merge: a run's rows, then the cross-lane union ----------------------
+
+
+def test_collector_combines_outcomes_and_na() -> None:
+    collector = ScorecardCollector()
+    collector.on_report(_report("m.py::t[anthropic]", "call", outcome="passed"))
+    item = _FakeItem(
+        "m.py::t[anthropic]", (ExcludedAdapter(Adapter.CREWAI, "no usage"),)
+    )
+    rows = {(r.test, r.adapter): r for r in collector.scorecard([item])}
+    assert rows[("m.py::t", "anthropic")].status == "pass"
+    assert rows[("m.py::t", "crewai")].status == "na"
+
+
+def test_merge_prefers_real_outcome_over_skip_and_keeps_na() -> None:
+    lane_a = [
+        ScorecardRow("t", "anthropic", "pass"),
+        ScorecardRow("t", "crewai", "skip", "lane"),
+        ScorecardRow("t", "crewai_flow", "na", "no usage"),
+    ]
+    lane_b = [
+        ScorecardRow("t", "anthropic", "skip", "lane"),
+        ScorecardRow("t", "crewai", "fail"),
+        ScorecardRow("t", "crewai_flow", "na", "no usage"),
+    ]
+    merged = {(r.test, r.adapter): r for r in merge([lane_a, lane_b])}
+    assert merged[("t", "anthropic")].status == "pass"
+    assert merged[("t", "crewai")].status == "fail"
+    assert merged[("t", "crewai_flow")].status == "na"
+
+
+def test_merge_leaves_a_never_run_cell_visible_as_skip() -> None:
+    merged = merge([[ScorecardRow("t", "letta", "skip", "lane")]])
+    assert merged[0].status == "skip"
+
+
+def test_to_markdown_renders_grid_and_na_reasons() -> None:
+    md = to_markdown(
+        [
+            ScorecardRow("m.py::test_x", "anthropic", "pass"),
+            ScorecardRow("m.py::test_x", "crewai", "na", "no per-turn usage"),
+        ]
+    )
+    assert "| test | anthropic | crewai |" in md
+    assert "no per-turn usage" in md

--- a/tests/framework_conformance/test_scorecard.py
+++ b/tests/framework_conformance/test_scorecard.py
@@ -184,8 +184,10 @@ def test_outcome_row_ignores_non_adapter_parametrization() -> None:
 
 
 def test_collector_combines_outcomes_and_na() -> None:
-    collector = ScorecardCollector()
-    collector.on_report(_report("m.py::t[anthropic]", "call", outcome="passed"))
+    collector = ScorecardCollector(path="unused")
+    collector.pytest_runtest_logreport(
+        _report("m.py::t[anthropic]", "call", outcome="passed")
+    )
     item = _FakeItem(
         "m.py::t[anthropic]", (ExcludedAdapter(Adapter.CREWAI, "no usage"),)
     )

--- a/tests/framework_conformance/test_scorecard.py
+++ b/tests/framework_conformance/test_scorecard.py
@@ -171,6 +171,15 @@ def test_outcome_row_ignores_non_matrix_and_passing_setup() -> None:
     assert outcome_row(_report("m.py::t[agno]", "teardown", outcome="passed")) is None
 
 
+def test_outcome_row_ignores_non_adapter_parametrization() -> None:
+    # A parametrized test whose param is not a registered adapter (an event type, not a
+    # matrix cell) must not pollute the grid with a phantom "adapter".
+    assert (
+        outcome_row(_report("e.py::test_send_event[thought]", "call", outcome="passed"))
+        is None
+    )
+
+
 # --- collector + merge: a run's rows, then the cross-lane union ----------------------
 
 


### PR DESCRIPTION
## Summary

Baseline E2E scorecard: N/A reasons on exclusions + a merged CI artifact. Plus the `ci-required` aggregate gate that makes the unit/conformance CI a requireable single context (INT-975).

Linear: [INT-820](https://linear.app/thenvoi/issue/INT-820) · [INT-985](https://linear.app/thenvoi/issue/INT-985) · [INT-975](https://linear.app/thenvoi/issue/INT-975)

> **Stacked on #415** for its Windows single-instance guard fix (`msvcrt`) — without it `test (windows-latest, *)` is red. Auto-retargets to `dev` after #415 merges.

## Changes

- **Scorecard** — per-adapter×test grid with N/A + reason on exclusions; per-lane JSON merged into one artifact at session end.
- **`ci-required`** (`ci.yml`) — `needs: [lint, test, test-crewai, packaging]`, `if: always()`, fails unless all succeed. One stable context covering the whole matrix, for branch protection.

## Follow-up (repo-admin, after this reaches `dev`/`main`)

Point both rulesets at `ci-required`: add it on `dev`; on `main` replace the broken `test (3.11)`/`test (3.12)`. Keep `lint`, `packaging`, `Validate PR Title`.