### PR TITLE
ci: make unit/conformance CI a mandatory gate via ci-required [INT-975]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,3 +191,29 @@ jobs:
         from band.config import load_agent_config
         print('All imports successful')
         "
+
+
+  # Single aggregate gate for branch protection. Branch rulesets require exactly
+  # this one context: `needs` a matrix job is green only when every one of its
+  # OS/Python cells passed, so requiring `ci-required` covers the whole matrix and
+  # survives future matrix changes without re-editing the ruleset. `if: always()`
+  # runs it even when a dependency failed (a skipped/failed dep would otherwise
+  # skip this job and report nothing, leaving the required check stuck "Expected").
+  ci-required:
+    name: ci-required
+    needs: [lint, test, test-crewai, packaging]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fail unless every required job succeeded
+      env:
+        RESULTS: ${{ needs.lint.result }} ${{ needs.test.result }} ${{ needs.test-crewai.result }} ${{ needs.packaging.result }}
+      run: |
+        echo "dependency results: ${RESULTS}"
+        for result in ${RESULTS}; do
+          if [ "${result}" != "success" ]; then
+            echo "::error::A required CI job did not succeed (results: ${RESULTS})."
+            exit 1
+          fi
+        done
+        echo "All required CI jobs succeeded."


### PR DESCRIPTION
## Summary

Adds a single aggregate **`ci-required`** job to `ci.yml` so branch protection can require *one stable context* that actually reports — instead of the matrix per-cell names (`test (ubuntu-latest, 3.11)`, …) or the bare `test (3.11)`/`test (3.12)` that never report and sit "Expected — Waiting" forever.

`ci-required` `needs: [lint, test, test-crewai, packaging]`, runs `if: always()`, and fails unless every dependency resolved to `success`. A matrix `needs:` is green only when all its cells passed, so this one context covers the whole OS/Python matrix and survives future matrix changes with no further ruleset edits.

Linear: https://linear.app/thenvoi/issue/INT-975/make-ci-checks-mandatory-reconcile-required-status-contexts-with (Implements INT-975)

> **Stacked on #415** (`int-945`) for its Windows single-instance guard fix (`msvcrt` locking). Without it, `test (windows-latest, *)` is red — the guard was `fcntl`-only and inert on Windows — so a mandatory gate would block every PR. Rebase onto `dev` after #415 merges.

## Changes

- **`ci.yml`** — new `ci-required` aggregate gate job (the only net change on this branch; everything else is inherited from #415).

## Follow-up (needs repo-admin, done separately, after this lands on `dev`/`main`)

Point both rulesets at `ci-required`:
- `dev-branch-protection`: add `ci-required` (dev requires no test context today).
- `main-branch-protection`: replace the broken `test (3.11)`/`test (3.12)` with `ci-required`; keep `lint`, `packaging`, `Validate PR Title`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)