### PR TITLE
fix: pair permissions and hide self-reporting ACP tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,29 +191,3 @@ jobs:
         from band.config import load_agent_config
         print('All imports successful')
         "
-
-
-  # Single aggregate gate for branch protection. Branch rulesets require exactly
-  # this one context: `needs` a matrix job is green only when every one of its
-  # OS/Python cells passed, so requiring `ci-required` covers the whole matrix and
-  # survives future matrix changes without re-editing the ruleset. `if: always()`
-  # runs it even when a dependency failed (a skipped/failed dep would otherwise
-  # skip this job and report nothing, leaving the required check stuck "Expected").
-  ci-required:
-    name: ci-required
-    needs: [lint, test, test-crewai, packaging]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-    - name: Fail unless every required job succeeded
-      env:
-        RESULTS: ${{ needs.lint.result }} ${{ needs.test.result }} ${{ needs.test-crewai.result }} ${{ needs.packaging.result }}
-      run: |
-        echo "dependency results: ${RESULTS}"
-        for result in ${RESULTS}; do
-          if [ "${result}" != "success" ]; then
-            echo "::error::A required CI job did not succeed (results: ${RESULTS})."
-            exit 1
-          fi
-        done
-        echo "All required CI jobs succeeded."

--- a/src/band/integrations/acp/client_adapter.py
+++ b/src/band/integrations/acp/client_adapter.py
@@ -34,10 +34,13 @@ from band.integrations.mcp.backends import (
     BandMCPBackend,
     create_band_mcp_backend,
 )
-from band.integrations.acp.types import CollectedChunk
+from band.integrations.acp.types import CollectedChunk, PermissionOutcome
 from band.runtime.custom_tools import CustomToolDef
 from band.runtime.mcp_server import LocalMCPServer
-from band.runtime.tools import is_room_posting_tool, iter_tool_definitions
+from band.runtime.tools import (
+    is_room_posting_tool,
+    iter_tool_definitions,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -200,6 +203,8 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
             # Streaming text/thought deltas are coalesced into one chunk per run by
             # ACPCollectingClient, so one chunk here == one logical message/event.
             for chunk in chunks:
+                if chunk.metadata.get("self_reporting"):
+                    continue
                 match chunk.chunk_type:
                     case "text":
                         if chunk.content and not replied_in_room:
@@ -310,21 +315,35 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
                 option_id,
             )
 
+            permission_metadata = {
+                "permission_request": True,
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "acp_session_id": session_id,
+                "auto_allowed": option_id is not None,
+            }
             await tools.send_event(
                 content=f"Permission requested: {tool_name}",
                 message_type="tool_call",
-                metadata={
-                    "permission_request": True,
-                    "tool_name": tool_name,
-                    "tool_call_id": tool_call_id,
-                    "acp_session_id": session_id,
-                    "auto_allowed": option_id is not None,
-                },
+                metadata=permission_metadata,
             )
 
             if option_id is None:
-                return cancel_permission()
-            return allow_permission(option_id)
+                permission_outcome = PermissionOutcome.CANCELLED
+                response = cancel_permission()
+            else:
+                permission_outcome = PermissionOutcome.APPROVED
+                response = allow_permission(option_id)
+
+            await tools.send_event(
+                content=f"Permission {permission_outcome.value}",
+                message_type="tool_result",
+                metadata={
+                    **permission_metadata,
+                    "permission_outcome": permission_outcome.value,
+                },
+            )
+            return response
 
         return handler
 

--- a/src/band/integrations/acp/client_runtime.py
+++ b/src/band/integrations/acp/client_runtime.py
@@ -17,6 +17,7 @@ from band.integrations.acp.client_profiles import (
     NoopACPClientProfile,
 )
 from band.integrations.acp.types import CollectedChunk
+from band.runtime.tools import is_self_reporting_tool
 
 logger = logging.getLogger(__name__)
 
@@ -164,58 +165,86 @@ class ACPCollectingClient(Client):  # type: ignore[misc]  # ACP Client has optio
         self._profile = profile or NoopACPClientProfile()
         self._session_chunks: dict[str, list[CollectedChunk]] = {}
         self._permission_handlers: dict[str, PermissionHandler] = {}
+        self._self_reporting_call_ids: dict[str, set[str]] = {}
 
     async def session_update(
         self, session_id: str, update: object, **kwargs: object
     ) -> None:
         del kwargs
-        discriminator = getattr(update, "session_update", None)
-        chunk: CollectedChunk | None = None
+        chunk = self._chunk_from_update(session_id, update)
+        if chunk is not None:
+            self._append_chunk(session_id, chunk)
 
-        match discriminator:
+    def _chunk_from_update(
+        self, session_id: str, update: object
+    ) -> CollectedChunk | None:
+        """Parse one ACP session update without mutating the chunk buffer."""
+        match getattr(update, "session_update", None):
             case "agent_message_chunk":
-                text = self._extract_text_from_content(update)
-                chunk = CollectedChunk(chunk_type="text", content=text)
+                return self._text_chunk(update, "text")
             case "agent_thought_chunk":
-                text = self._extract_text_from_content(update)
-                chunk = CollectedChunk(chunk_type="thought", content=text)
+                return self._text_chunk(update, "thought")
             case "tool_call":
-                tool_call_id = getattr(update, "tool_call_id", "")
-                title = getattr(update, "title", "")
-                raw_input = getattr(update, "raw_input", None)
-                chunk = CollectedChunk(
-                    chunk_type="tool_call",
-                    content=title,
-                    metadata={
-                        "tool_call_id": tool_call_id,
-                        "raw_input": raw_input,
-                        "status": getattr(update, "status", "in_progress"),
-                    },
-                )
+                return self._tool_call_chunk(session_id, update)
             case "tool_call_update":
-                tool_call_id = getattr(update, "tool_call_id", "")
-                raw_output = getattr(update, "raw_output", "")
-                chunk = CollectedChunk(
-                    chunk_type="tool_result",
-                    content=str(raw_output) if raw_output else "",
-                    metadata={
-                        "tool_call_id": tool_call_id,
-                        "status": getattr(update, "status", "completed"),
-                    },
-                )
+                return self._tool_result_chunk(session_id, update)
             case "plan":
                 entries = getattr(update, "entries", [])
                 plan_text = "\n".join(
                     getattr(entry, "content", str(entry)) for entry in entries
                 )
-                chunk = CollectedChunk(chunk_type="plan", content=plan_text)
+                return CollectedChunk(chunk_type="plan", content=plan_text)
             case _:
                 text = self._extract_text_from_content(update)
-                if text:
-                    chunk = CollectedChunk(chunk_type="text", content=text)
+                return CollectedChunk(chunk_type="text", content=text) if text else None
 
-        if chunk is not None:
-            self._append_chunk(session_id, chunk)
+    def _text_chunk(self, update: object, chunk_type: str) -> CollectedChunk:
+        return CollectedChunk(
+            chunk_type=chunk_type,
+            content=self._extract_text_from_content(update),
+        )
+
+    def _tool_call_chunk(self, session_id: str, update: object) -> CollectedChunk:
+        tool_call_id = getattr(update, "tool_call_id", "")
+        title = getattr(update, "title", "")
+        self_reporting = is_self_reporting_tool(title)
+        metadata = {
+            "tool_call_id": tool_call_id,
+            "raw_input": getattr(update, "raw_input", None),
+            "status": getattr(update, "status", "in_progress"),
+        }
+        if self_reporting:
+            metadata["self_reporting"] = True
+            if tool_call_id:
+                self._self_reporting_call_ids.setdefault(session_id, set()).add(
+                    tool_call_id
+                )
+        return CollectedChunk(
+            chunk_type="tool_call",
+            content=title,
+            metadata=metadata,
+        )
+
+    def _tool_result_chunk(self, session_id: str, update: object) -> CollectedChunk:
+        tool_call_id = getattr(update, "tool_call_id", "")
+        status = getattr(update, "status", "completed")
+        self_reporting = tool_call_id in self._self_reporting_call_ids.get(
+            session_id, set()
+        )
+        metadata = {
+            "tool_call_id": tool_call_id,
+            "status": status,
+        }
+        if self_reporting:
+            metadata["self_reporting"] = True
+            if status in ("completed", "failed"):
+                self._self_reporting_call_ids[session_id].discard(tool_call_id)
+        raw_output = getattr(update, "raw_output", "")
+        return CollectedChunk(
+            chunk_type="tool_result",
+            content=str(raw_output) if raw_output else "",
+            metadata=metadata,
+        )
 
     # Chunk kinds that arrive as a stream of deltas for one logical message, so a
     # run of them is coalesced into a single chunk (agents emit one delta per token
@@ -265,6 +294,7 @@ class ACPCollectingClient(Client):  # type: ignore[misc]  # ACP Client has optio
     def reset_session(self, session_id: str) -> None:
         self._session_chunks.pop(session_id, None)
         self._permission_handlers.pop(session_id, None)
+        self._self_reporting_call_ids.pop(session_id, None)
 
     def get_collected_text(self, session_id: str | None = None) -> str:
         if session_id is not None:

--- a/src/band/integrations/acp/types.py
+++ b/src/band/integrations/acp/types.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Any
+
+
+class PermissionOutcome(StrEnum):
+    """User-visible outcome recorded for an ACP permission request."""
+
+    APPROVED = "approved"
+    CANCELLED = "cancelled"
 
 
 @dataclass

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -688,6 +688,13 @@ ROOM_POSTING_TOOL_NAMES: frozenset[str] = frozenset(
 )
 
 
+def _matches_tool_name(tool_name: str, names: frozenset[str]) -> bool:
+    """Match a native tool name or the ``<server>-<tool>`` MCP spelling."""
+    if tool_name in names:
+        return True
+    return tool_name.endswith(tuple(f"-{name}" for name in names))
+
+
 def is_room_posting_tool(tool_name: str) -> bool:
     """True when a successful call of ``tool_name`` posts a message to the room.
 
@@ -697,9 +704,7 @@ def is_room_posting_tool(tool_name: str) -> bool:
     uses them, and a miss only costs a duplicate reply (the pre-suppression
     behavior), never a wrong post. Extend here when such a backend is added.
     """
-    if tool_name in ROOM_POSTING_TOOL_NAMES:
-        return True
-    return tool_name.endswith(tuple(f"-{name}" for name in ROOM_POSTING_TOOL_NAMES))
+    return _matches_tool_name(tool_name, ROOM_POSTING_TOOL_NAMES)
 
 
 # Registry mapping tool names to their schemas and bound AgentTools methods.
@@ -1149,8 +1154,18 @@ def get_band_tool_category(name: str) -> str | None:
 # messages/events themselves), so adapters must not also report them as
 # tool_call/tool_result events. Adapters may extend this with local names.
 SELF_REPORTING_TOOL_NAMES: frozenset[str] = frozenset(
-    {"band_send_message", "band_send_event"}
+    {"band_send_message", "band_send_event", "create_agent_chat_message"}
 )
+
+
+def is_self_reporting_tool(tool_name: str) -> bool:
+    """True when executing ``tool_name`` already creates visible room output.
+
+    ACP and other MCP clients may prefix a server name (for example,
+    ``band-band_send_message``), so matching follows the same convention as
+    :func:`is_room_posting_tool`.
+    """
+    return _matches_tool_name(tool_name, SELF_REPORTING_TOOL_NAMES)
 
 
 def mcp_tool_names(names: frozenset[str]) -> list[str]:

--- a/tests/e2e/baseline/smoke/adapters/test_copilot_acp.py
+++ b/tests/e2e/baseline/smoke/adapters/test_copilot_acp.py
@@ -1,0 +1,56 @@
+"""Live smoke coverage for the outbound ACP room-visible tool contract.
+
+The scenario is intentionally backend-neutral: it asks the ACP agent to emit one
+Band event, then checks the persisted room event and confirms that the same
+self-reporting tool was not duplicated as ACP tool narration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from band.core.types import MessageType
+
+from tests.e2e.baseline.agents import Adapter, with_adapters
+from tests.e2e.baseline.flaky import flaky_model
+from tests.e2e.baseline.smoke.samples.sample_agents import (
+    TOOL_AGENT,
+    emit_event_instruction,
+    unique_marker,
+)
+from tests.e2e.baseline.toolkit.capture import CaptureFactory
+from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceManager
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+
+@with_adapters(Adapter.COPILOT_ACP, **TOOL_AGENT)
+@flaky_model("the ACP agent may occasionally miss the explicit tool-only request")
+@pytest.mark.timeout(extra=180)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_acp_self_reporting_event_is_not_duplicated(
+    agent: ProvisionedAgent,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """A Band event is persisted once, without redundant ACP tool narration."""
+    marker = unique_marker("acp-event")
+    room_id = await resource_manager.provision_room(
+        title="e2e-acp-self-reporting", participants=[agent.id]
+    )
+
+    async with reply_capture(room_id) as capture:
+        mid = await user_ops.send_message(
+            room_id,
+            emit_event_instruction(MessageType.THOUGHT, marker),
+            mention_id=agent.id,
+            mention_name=agent.name,
+        )
+        await capture.wait_for_processed(mid, agent.id)
+        thoughts = await capture.thoughts(sender_id=agent.id)
+        calls = await capture.tool_calls(sender_id=agent.id)
+
+    thoughts.assert_contains_any([marker])
+    assert not calls.fired("band_send_event"), (
+        "self-reporting Band events must not be replayed as ACP tool calls"
+    )

--- a/tests/integrations/acp/acp_toolkit.py
+++ b/tests/integrations/acp/acp_toolkit.py
@@ -29,7 +29,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -52,6 +52,8 @@ from acp.schema import (
     PromptResponse,
     ToolCallUpdate,
 )
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
 
 from band.core.types import PlatformMessage
 from band.integrations.acp.client_adapter import ACPClientAdapter
@@ -60,6 +62,48 @@ from band.testing import FakeAgentTools
 
 PromptHandler = Callable[["FakeACPAgent", str], Awaitable[None]]
 _SESSION_EVENT_MARKER = "acp_client_session_id"  # the adapter's trailing task event
+
+
+@dataclass(frozen=True)
+class RoomActivity:
+    """One room write, retained in the order the adapter made it."""
+
+    kind: Literal["message", "event"]
+    content: str
+    message_type: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class TranscriptTools(FakeAgentTools):
+    """Fake tools that retain the complete order of room writes."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.transcript: list[RoomActivity] = []
+
+    async def send_message(
+        self, content: str, mentions: list[str] | list[dict[str, str]] | None = None
+    ) -> dict[str, Any]:
+        message = await super().send_message(content, mentions)
+        self.transcript.append(RoomActivity(kind="message", content=content))
+        return message
+
+    async def send_event(
+        self,
+        content: str,
+        message_type: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        event = await super().send_event(content, message_type, metadata)
+        self.transcript.append(
+            RoomActivity(
+                kind="event",
+                content=content,
+                message_type=message_type,
+                metadata=dict(metadata or {}),
+            )
+        )
+        return event
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +173,7 @@ class FakeACPAgent:
         self._custom: PromptHandler | None = None
         # Observability for assertions:
         self.sessions: list[dict[str, Any]] = []
+        self._mcp_servers_by_session: dict[str, list[Any]] = {}
         self.prompts: list[dict[str, Any]] = []
         self.permission_responses: list[Any] = []
         self.approved: bool | None = None
@@ -182,6 +227,31 @@ class FakeACPAgent:
         self._script.append(_action)
         return self
 
+    def will_call_mcp_tool(
+        self,
+        tool_call_id: str,
+        tool_name: str,
+        *,
+        arguments: dict[str, Any],
+        server: str = "band",
+    ) -> FakeACPAgent:
+        """Call an advertised MCP tool between ACP call and result updates."""
+
+        async def _action(a: FakeACPAgent, sid: str) -> None:
+            await a.emit(
+                sid, start_tool_call(tool_call_id, tool_name, raw_input=arguments)
+            )
+            result = await a.call_mcp_tool(
+                session_id=sid,
+                server=server,
+                tool_name=tool_name,
+                arguments=arguments,
+            )
+            await a.emit(sid, update_tool_call(tool_call_id, raw_output=result))
+
+        self._script.append(_action)
+        return self
+
     def will_plan(self, *steps: str) -> FakeACPAgent:
         self._script.append(
             lambda a, sid: a.emit(sid, update_plan([plan_entry(s) for s in steps]))
@@ -189,12 +259,16 @@ class FakeACPAgent:
         return self
 
     def will_ask_permission(
-        self, *, tool_call_id: str = "tc-1", allow_option_id: str = "allow-1"
+        self,
+        *,
+        tool_call_id: str = "tc-1",
+        title: str | None = None,
+        allow_option_id: str = "allow-1",
     ) -> FakeACPAgent:
         async def _action(a: FakeACPAgent, sid: str) -> None:
             resp = await a.ask_permission(
                 sid,
-                ToolCallUpdate(tool_call_id=tool_call_id),
+                ToolCallUpdate(tool_call_id=tool_call_id, title=title),
                 [
                     PermissionOption(
                         kind="allow_once", name="Allow", optionId=allow_option_id
@@ -228,6 +302,41 @@ class FakeACPAgent:
         self.permission_responses.append(resp)
         return resp
 
+    async def call_mcp_tool(
+        self,
+        *,
+        session_id: str,
+        server: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> Any:
+        """Call a named streamable-HTTP MCP server advertised for this session."""
+        server_config = next(
+            (
+                config
+                for config in self._mcp_servers_by_session[session_id]
+                if getattr(config, "name", None) == server
+            ),
+            None,
+        )
+        if server_config is None:
+            raise ValueError(f"MCP server {server!r} was not advertised")
+        if getattr(server_config, "type", None) != "http":
+            raise ValueError(f"MCP server {server!r} does not use streamable HTTP")
+
+        async with streamable_http_client(server_config.url) as (
+            read_stream,
+            write_stream,
+            _,
+        ):
+            async with ClientSession(read_stream, write_stream) as client:
+                await client.initialize()
+                result = await client.call_tool(tool_name, arguments)
+
+        if result.isError:
+            raise RuntimeError(f"MCP tool {tool_name!r} failed: {result.content}")
+        return result.structuredContent or result.content
+
     # -- acp.Agent protocol ------------------------------------------------------
 
     def on_connect(self, conn: AgentSideConnection) -> None:
@@ -252,6 +361,7 @@ class FakeACPAgent:
         self.sessions.append(
             {"session_id": sid, "cwd": cwd, "mcp_servers": list(mcp_servers or [])}
         )
+        self._mcp_servers_by_session[sid] = list(mcp_servers or [])
         return NewSessionResponse(session_id=sid)
 
     async def prompt(
@@ -273,6 +383,7 @@ class Reply:
 
     messages: list[dict[str, Any]] = field(default_factory=list)
     events: list[dict[str, Any]] = field(default_factory=list)
+    transcript: list[RoomActivity] = field(default_factory=list)
 
     def _events_of(self, message_type: str) -> list[dict[str, Any]]:
         return [e for e in self.events if e.get("message_type") == message_type]
@@ -324,7 +435,7 @@ class AcpSession:
 
     async def send(self, content: str, *, room: str = "room-1") -> Reply:
         """Deliver ``content`` to ``room`` and return what the adapter posted back."""
-        tools = FakeAgentTools()
+        tools = TranscriptTools()
         await self.adapter.on_message(
             _message(content, room),
             tools,
@@ -334,7 +445,11 @@ class AcpSession:
             is_session_bootstrap=False,
             room_id=room,
         )
-        return Reply(messages=tools.messages_sent, events=tools.events_sent)
+        return Reply(
+            messages=tools.messages_sent,
+            events=tools.events_sent,
+            transcript=tools.transcript,
+        )
 
     def session_id(self, room: str) -> str:
         return self.adapter._room_to_session[room]

--- a/tests/integrations/acp/test_client_adapter.py
+++ b/tests/integrations/acp/test_client_adapter.py
@@ -753,10 +753,10 @@ class TestACPClientAdapterPermissionHandler:
         assert len(adapter_with_mocks._runtime._client._permission_handlers) > 0
 
     @pytest.mark.asyncio
-    async def test_permission_handler_posts_event(
+    async def test_permission_handler_posts_paired_events(
         self, adapter_with_mocks: ACPClientAdapter
     ) -> None:
-        """Should post permission request event to platform."""
+        """Should render an approved permission request as a matched event pair."""
         tools = FakeAgentTools()
         msg = make_platform_message("Hello", room_id="room-123")
 
@@ -790,16 +790,24 @@ class TestACPClientAdapterPermissionHandler:
             room_id="room-123",
         )
 
-        # Should have posted a permission event
+        # A permission request is a tool interaction, so its transcript entry must
+        # be closed by a result carrying the same tool call id.
         perm_events = [
             e
             for e in tools.events_sent
             if e.get("metadata", {}).get("permission_request")
         ]
-        assert len(perm_events) == 1
+        assert [event["message_type"] for event in perm_events] == [
+            "tool_call",
+            "tool_result",
+        ]
+        assert all(
+            event["metadata"]["tool_call_id"] == "tc-perm-1" for event in perm_events
+        )
         assert perm_events[0]["metadata"]["tool_name"] == "write_file"
         assert perm_events[0]["metadata"]["auto_allowed"] is True
-        assert perm_events[0]["message_type"] == "tool_call"
+        assert perm_events[1]["content"] == "Permission approved"
+        assert perm_events[1]["metadata"]["permission_outcome"] == "approved"
 
     @pytest.mark.asyncio
     async def test_permission_handler_selects_allow_option(
@@ -879,6 +887,20 @@ class TestACPClientAdapterPermissionHandler:
         )
 
         assert captured_result == {"outcome": {"outcome": "cancelled"}}
+        perm_events = [
+            event
+            for event in tools.events_sent
+            if event.get("metadata", {}).get("permission_request")
+        ]
+        assert [event["message_type"] for event in perm_events] == [
+            "tool_call",
+            "tool_result",
+        ]
+        assert all(
+            event["metadata"]["tool_call_id"] == "tc-danger" for event in perm_events
+        )
+        assert perm_events[1]["content"] == "Permission cancelled"
+        assert perm_events[1]["metadata"]["permission_outcome"] == "cancelled"
 
     @pytest.mark.asyncio
     async def test_permission_handler_uses_name_fallback(
@@ -916,8 +938,11 @@ class TestACPClientAdapterPermissionHandler:
             for e in tools.events_sent
             if e.get("metadata", {}).get("permission_request")
         ]
-        assert len(perm_events) == 1
-        assert perm_events[0]["metadata"]["tool_name"] == "bash"
+        assert [event["message_type"] for event in perm_events] == [
+            "tool_call",
+            "tool_result",
+        ]
+        assert all(event["metadata"]["tool_name"] == "bash" for event in perm_events)
 
 
 class TestACPClientAdapterCleanup:

--- a/tests/integrations/acp/test_client_adapter_behavior.py
+++ b/tests/integrations/acp/test_client_adapter_behavior.py
@@ -52,7 +52,8 @@ async def test_text_suppressed_when_turn_posted_via_band_tool(fake_agent) -> Non
         reply = await session.send("question?")
 
     assert reply.texts == []
-    assert len(reply.tool_calls) == 1
+    assert reply.tool_calls == []
+    assert reply.tool_results == []
 
 
 @pytest.mark.asyncio
@@ -67,6 +68,8 @@ async def test_text_suppressed_for_prefixed_remote_band_mcp_tool(fake_agent) -> 
         reply = await session.send("question?")
 
     assert reply.texts == []
+    assert reply.tool_calls == []
+    assert reply.tool_results == []
 
 
 @pytest.mark.asyncio
@@ -135,6 +138,95 @@ async def test_permission_request_auto_approved(fake_agent) -> None:
     assert len(reply.permissions) == 1
     assert reply.permissions[0]["metadata"]["auto_allowed"] is True
     assert "done" in reply.texts  # the turn proceeded after approval
+
+
+@pytest.mark.asyncio
+async def test_band_mcp_reply_is_not_replayed_as_acp_tool_events(fake_agent) -> None:
+    """A room-visible Band message must not receive redundant ACP narration."""
+    fake_agent.will_call_mcp_tool(
+        "tc-message",
+        "band_send_message",
+        arguments={
+            "room_id": "room-1",
+            "content": "Reply from the agent",
+            "mentions": ["@pat"],
+        },
+    )
+
+    async with acp_adapter(fake_agent, inject_band_tools=True) as session:
+        reply = await session.send("send the reply", room="room-1")
+
+    assert [
+        (activity.kind, activity.message_type) for activity in reply.transcript
+    ] == [
+        ("message", None),
+        ("event", "task"),
+    ]
+    assert reply.transcript[0].content == "Reply from the agent"
+    assert reply.tool_calls == []
+    assert reply.tool_results == []
+
+
+@pytest.mark.asyncio
+async def test_band_mcp_event_is_not_replayed_as_acp_tool_events(fake_agent) -> None:
+    """A room-visible Band event must not receive redundant ACP narration."""
+    fake_agent.will_call_mcp_tool(
+        "tc-event",
+        "band_send_event",
+        arguments={
+            "room_id": "room-1",
+            "content": "Working on it",
+            "message_type": "thought",
+        },
+    )
+
+    async with acp_adapter(fake_agent, inject_band_tools=True) as session:
+        reply = await session.send("do the work", room="room-1")
+
+    assert [
+        (activity.kind, activity.message_type) for activity in reply.transcript
+    ] == [
+        ("event", "thought"),
+        ("event", "task"),
+    ]
+    assert reply.thoughts == ["Working on it"]
+    assert reply.tool_calls == []
+    assert reply.tool_results == []
+
+
+@pytest.mark.asyncio
+async def test_permissioned_band_mcp_turn_has_one_causal_transcript(fake_agent) -> None:
+    """Permission, tool execution, and visible reply must retain causal order."""
+    fake_agent.will_ask_permission(
+        tool_call_id="tc-message",
+        title="band_send_message",
+    ).will_call_mcp_tool(
+        "tc-message",
+        "band_send_message",
+        arguments={
+            "room_id": "room-1",
+            "content": "Reply from the agent",
+            "mentions": ["@pat"],
+        },
+    )
+
+    async with acp_adapter(fake_agent, inject_band_tools=True) as session:
+        reply = await session.send("send the reply", room="room-1")
+
+    assert [
+        (activity.kind, activity.message_type) for activity in reply.transcript
+    ] == [
+        ("event", "tool_call"),
+        ("event", "tool_result"),
+        ("message", None),
+        ("event", "task"),
+    ]
+    assert reply.transcript[0].metadata["permission_request"] is True
+    assert reply.transcript[0].metadata["tool_call_id"] == "tc-message"
+    assert reply.transcript[1].metadata["permission_request"] is True
+    assert reply.transcript[1].metadata["permission_outcome"] == "approved"
+    assert reply.transcript[1].metadata["tool_call_id"] == "tc-message"
+    assert reply.transcript[2].content == "Reply from the agent"
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/acp/test_client_runtime.py
+++ b/tests/integrations/acp/test_client_runtime.py
@@ -127,6 +127,34 @@ class TestACPCollectingClientCoalescing:
             "text",
         ]  # runs on either side stay distinct
 
+    @pytest.mark.asyncio
+    async def test_self_reporting_tool_result_keeps_render_suppression_metadata(
+        self,
+    ) -> None:
+        client = ACPCollectingClient()
+        tool_call = MagicMock(
+            session_update="tool_call",
+            tool_call_id="tc-message",
+            title="band_send_message",
+            raw_input={"content": "hello"},
+            status="in_progress",
+        )
+        tool_result = MagicMock(
+            session_update="tool_call_update",
+            tool_call_id="tc-message",
+            raw_output={"id": "msg-1"},
+            status="completed",
+        )
+
+        await client.session_update("s1", tool_call)
+        await client.session_update("s1", tool_result)
+
+        chunks = client.get_collected_chunks("s1")
+        assert [chunk.metadata.get("self_reporting") for chunk in chunks] == [
+            True,
+            True,
+        ]
+
 
 class TestACPRuntime:
     """Tests for ACP runtime subprocess orchestration."""

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -22,6 +22,7 @@ from band.runtime.tools import (
     append_mention_handles_hint,
     available_mention_handles,
     is_room_posting_tool,
+    is_self_reporting_tool,
 )
 
 
@@ -1393,3 +1394,28 @@ class TestIsRoomPostingTool:
     def test_no_substring_false_positive(self):
         """Only an exact or server-prefixed match counts, not any substring."""
         assert is_room_posting_tool("band_send_message_draft") is False
+
+
+class TestIsSelfReportingTool:
+    """Tools whose execution already creates visible room output."""
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "band_send_message",
+            "band_send_event",
+            "create_agent_chat_message",
+            "band-band_send_message",
+            "band-band_send_event",
+            "band-create_agent_chat_message",
+        ],
+    )
+    def test_self_reporting_names(self, tool_name: str) -> None:
+        assert is_self_reporting_tool(tool_name) is True
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        ["band_lookup_peers", "get_weather", "band_send_message_draft"],
+    )
+    def test_non_self_reporting_names(self, tool_name: str) -> None:
+        assert is_self_reporting_tool(tool_name) is False


### PR DESCRIPTION
## Summary

Fixes ACP room transcript handling for permission requests and self-reporting Band tools.

- Permission requests now emit matched tool_call and tool_result events with a shared call ID and explicit outcome.
- ACP narration for self-reporting Band tools (band_send_message, band_send_event, and standalone MCP message names) is suppressed so visible room output is not duplicated or ordered after its own reply.
- Adds shared name matching and deterministic ACP/MCP behavior coverage.

## Validation

- Ruff check: passed
- Pyrefly check: 0 errors
- ACP and runtime-focused tests: 350 passed
- Full unit suite (rebased onto current dev): 3811 passed