### PR TITLE
feat(e2e): upstream add-band baseline toolkit primitives (INT-1007)

### DIFF
--- a/tests/e2e/baseline/README.md
+++ b/tests/e2e/baseline/README.md
@@ -12,8 +12,12 @@ quality. They are deterministic by design (no `sleep`, no silence windows).
 | Path | What it is |
 |------|------------|
 | `toolkit/provisioning.py` | `ResourceManager` (provision/reap agents + rooms, orphan sweep), `running_provisioned_agent`, `ProvisionedAgent` |
-| `toolkit/user_ops.py` | `UserOps`: act as the test user (send message, create/delete room, add/remove/list participants, list messages/events) |
+| `toolkit/user_ops.py` | `UserOps`: act as the test user (send message, `send_structured_mentions` / `send_mentioning_all`, create/delete room, add/remove/list participants, list messages/events) |
 | `toolkit/capture.py` | `ReplyCapture` (subscribe-before-send), `reply_capture` ctx, `wait_for_processed` (delivery-status barrier), `tool_calls()`/`thoughts()`/`errors()`/`tasks()`/`events()`/`memory(agent)` |
+| `toolkit/waits.py` | reply-presence waits without PROCESSED delivery status: `wait_for_reply_from`, `wait_for_replies_from`, `said_by` |
+| `toolkit/exchange.py` | run-scoped `marker()`, bounded `run_exchange`, ordered `MentionChainStep` / `MentionChainOutcome` |
+| `toolkit/visibility.py` | history visibility outcome types (`Seed`, `VisibilityOutcome`) for mention-scoped context probes |
+| `toolkit/discovery.py` | `owner_hub_room_ids` — rooms whose participants are exactly owner + agent |
 | `toolkit/judge.py` | `judge()` LLM-as-judge, `Verdict`, `format_transcript` |
 | `toolkit/assertions.py` | tolerant assertions: `assert_present`, `assert_at_least`, `assert_contains_any`, `assert_mentions` |
 | `toolkit/observations/` | list subclasses that own their assertions: `Replies` (replies), `ToolCalls`/`ToolCall` + `MemoryToolCalls` (tool calls; memory excluded by default), `Events`→`Thoughts`/`Errors`/`Tasks` (emitted events), `Memories`/`MemoryObservation` (stored memory, both layers); shared `tolerant_match` + `ContentAssertions` |

--- a/tests/e2e/baseline/toolkit/discovery.py
+++ b/tests/e2e/baseline/toolkit/discovery.py
@@ -1,0 +1,39 @@
+"""Band-side room-shape discovery helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Protocol
+
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+
+class DiscoverableAgent(Protocol):
+    """Minimal agent identity for participant-set matching."""
+
+    id: str
+
+
+async def owner_hub_room_ids(
+    *,
+    user_ops: UserOps,
+    agent: DiscoverableAgent,
+    owner_id: str,
+    candidate_room_ids: Iterable[str],
+) -> set[str]:
+    """Return candidate rooms whose active participants are exactly the owner
+    and ``agent``.
+
+    The platform does not label a room as a hub; the shared observable shape is
+    a room the agent participates in whose participants are exactly the agent
+    and its owner.
+    """
+    expected_participants = {owner_id, agent.id}
+    hub_ids: set[str] = set()
+
+    for room_id in candidate_room_ids:
+        participant_ids = set(await user_ops.list_participant_ids(room_id))
+        if participant_ids == expected_participants:
+            hub_ids.add(room_id)
+
+    return hub_ids

--- a/tests/e2e/baseline/toolkit/exchange.py
+++ b/tests/e2e/baseline/toolkit/exchange.py
@@ -1,0 +1,182 @@
+"""Bounded inter-agent ask-and-relay exchange.
+
+The driver seeds one message in a shared room, @mentioning only the asker.
+Band only delivers messages to mentioned agents, so the marker inside that
+seed is invisible to the responder. An ordered chain of marker-bearing
+replies then proves the hand-off occurred. Handoff replies must carry Band's
+structured mention metadata; text that merely looks like ``@someone`` is not
+enough to prove target routing.
+
+Bounds, whichever hits first (the wait stops immediately on success):
+  - a wall-clock deadline (~90s)
+  - a turn cap (6 agent messages, never open-ended) — enforced inside the
+    wait predicate, so a chatty runaway fails fast instead of timing out.
+
+The marker embeds the run id, so a stale message from any earlier run can
+never satisfy the predicate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from tests.e2e.baseline.toolkit.capture import ReplyCapture
+from tests.e2e.baseline.toolkit.observations import Replies
+from tests.e2e.baseline.toolkit.user_ops import UserOps
+
+MAX_AGENT_MESSAGES = 6
+DEADLINE_S = 90.0
+
+_SEED = (
+    "Ask @{responder_handle} to reply in this room with the agreed marker "
+    "{token}. Once they reply, relay that marker back to this room in one final "
+    "message, then stop. Do not answer on their behalf."
+)
+
+
+class ExchangeAgent(Protocol):
+    """Minimal agent identity for exchange steps."""
+
+    id: str
+    name: str
+
+
+def marker(run_id: str, *, prefix: str = "E2E-MARK") -> str:
+    """A deterministic, run-scoped token: stale messages from earlier runs
+    can never satisfy a predicate looking for it."""
+    return f"{prefix}-{run_id.upper()}"
+
+
+def _said(message, sender_id: str, token: str) -> bool:
+    return message.sender_id == sender_id and token.lower() in (
+        message.content or ""
+    ).lower()
+
+
+@dataclass(frozen=True)
+class MentionChainStep:
+    """One required message in an ordered inter-agent exchange.
+
+    A recipient means the sender must use that participant's structured Band
+    mention. A recipient-less step is a response or relay, where authorship,
+    ordering, and the run-scoped marker are the observable proof.
+    """
+
+    sender: ExchangeAgent
+    recipient: ExchangeAgent | None = None
+    recipient_handle: str | None = None
+
+    def matches(self, message, token: str) -> bool:
+        if not _said(message, self.sender.id, token):
+            return False
+        if self.recipient is None:
+            return True
+        metadata = message.metadata
+        return bool(
+            metadata
+            and any(mention.id == self.recipient.id for mention in metadata.mentions)
+        )
+
+    def describe(self, token: str) -> str:
+        target = (
+            f" mentioning @{self.recipient_handle}"
+            if self.recipient is not None
+            else ""
+        )
+        return f"a reply from {self.sender.name}{target} containing {token}"
+
+
+def chain_completed(
+    steps: tuple[MentionChainStep, ...], token: str, messages: list
+) -> bool:
+    """Whether ``messages`` contain the steps as an ordered subsequence: each
+    step matched at or after the previous match, gaps allowed. The wait
+    predicate and the outcome share this one definition of "done"."""
+    cursor = 0
+    for step in steps:
+        index = next(
+            (
+                index
+                for index, message in enumerate(messages[cursor:], cursor)
+                if step.matches(message, token)
+            ),
+            None,
+        )
+        if index is None:
+            return False
+        cursor = index + 1
+    return True
+
+
+@dataclass(frozen=True)
+class MentionChainOutcome:
+    """Captured transcript evaluated against a declarative mention chain."""
+
+    token: str
+    steps: tuple[MentionChainStep, ...]
+    transcript: Replies
+    max_messages: int
+
+    def is_completed(self, messages: list) -> bool:
+        return chain_completed(self.steps, self.token, messages)
+
+    def assert_completed(self) -> None:
+        expected = " → ".join(step.describe(self.token) for step in self.steps)
+        assert self.is_completed(self.transcript), (
+            f"expected ordered chain: {expected}; "
+            f"captured {len(self.transcript)} agent message(s)"
+        )
+
+    def assert_bounded(self) -> None:
+        assert len(self.transcript) <= self.max_messages, (
+            f"expected at most {self.max_messages} agent messages, "
+            f"got {len(self.transcript)} — a runaway exchange"
+        )
+
+
+async def run_exchange(
+    *,
+    capture: ReplyCapture,
+    user_ops: UserOps,
+    room_id: str,
+    asker: ExchangeAgent,
+    asker_mention_name: str,
+    responder: ExchangeAgent,
+    responder_handle: str,
+    token: str,
+    deadline_s: float = DEADLINE_S,
+) -> MentionChainOutcome:
+    """Seed the exchange and wait until it succeeds or hits a bound.
+
+    Returns a ``MentionChainOutcome`` either way — asserting is the test's job.
+    The capture must already be open on ``room_id`` (subscribe-before-send).
+    """
+    steps = (
+        MentionChainStep(asker, responder, responder_handle),
+        MentionChainStep(responder),
+        MentionChainStep(asker),
+    )
+
+    await user_ops.send_message(
+        room_id,
+        _SEED.format(responder_handle=responder_handle, token=token),
+        mention_id=asker.id,
+        mention_name=asker_mention_name,
+    )
+
+    try:
+        await capture.wait_until(
+            lambda messages: chain_completed(steps, token, messages)
+            or len(messages) >= MAX_AGENT_MESSAGES,
+            deadline_s=deadline_s,
+        )
+    except TimeoutError:
+        pass  # whatever was captured is returned; asserting is the test's job
+
+    return MentionChainOutcome(
+        token=token,
+        steps=steps,
+        transcript=Replies(capture.messages),
+        max_messages=MAX_AGENT_MESSAGES,
+    )

--- a/tests/e2e/baseline/toolkit/user_ops.py
+++ b/tests/e2e/baseline/toolkit/user_ops.py
@@ -8,7 +8,9 @@ method yet, so it uses a direct REST call (see ``delete_room``).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
+from typing import Protocol
 
 import httpx
 from band_rest import (
@@ -21,6 +23,13 @@ from band_rest import (
 )
 
 from band.core.types import MessageType
+
+
+class MentionTarget(Protocol):
+    """Anything with the id/name pair Band needs for structured mentions."""
+
+    id: str
+    name: str
 
 
 class UserOps:
@@ -54,6 +63,49 @@ class UserOps:
             ),
         )
         return response.data.id
+
+    async def send_structured_mentions(
+        self,
+        room_id: str,
+        content: str,
+        *,
+        mentions: Sequence[MentionTarget],
+    ) -> str:
+        """Send ``content`` with delivery mentions, without rewriting its text.
+
+        Band routes agent delivery from the structured ``mentions`` metadata.
+        Keeping ``content`` untouched lets scenarios distinguish platform
+        routing from a harness's optional textual-address parsing.
+        """
+        response = await self._client.human_api_messages.send_my_chat_message(
+            room_id,
+            message=ChatMessageRequest(
+                content=content,
+                mentions=[
+                    ChatMessageRequestMentionsItem(id=agent.id, name=agent.name)
+                    for agent in mentions
+                ],
+            ),
+        )
+        return response.data.id
+
+    async def send_mentioning_all(
+        self,
+        room_id: str,
+        content: str,
+        *,
+        mentions: Sequence[MentionTarget],
+    ) -> str:
+        """Send one user message @mentioning every agent in ``mentions``;
+        return the message id. Band delivers the message to each mentioned
+        agent. Mirrors ``send_message``'s convention (``@Name`` text prefixes
+        matching the structured mentions)."""
+        prefix = " ".join(f"@{agent.name}" for agent in mentions)
+        return await self.send_structured_mentions(
+            room_id,
+            f"{prefix} {content}",
+            mentions=mentions,
+        )
 
     async def add_participant(
         self, room_id: str, participant_id: str, *, role: str = "member"

--- a/tests/e2e/baseline/toolkit/visibility.py
+++ b/tests/e2e/baseline/toolkit/visibility.py
@@ -1,0 +1,91 @@
+"""History visibility outcome types for mention-scoped context probes.
+
+Band scopes an agent's context to its own conversation: delivery is
+mention-only, and the context endpoint rehydrates only what the agent said
+or what was said to it — the designed privacy boundary. Turns between the
+user and other agents are outside that scope. Probes that plant an
+unaddressed seed and ask the reader to echo a token or declare blindness use
+these outcome types; the full choreography lives in the test (or a harness-
+specific driver) that owns attach timing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from tests.e2e.baseline.toolkit.observations import Replies
+
+
+class SeedAuthor(Enum):
+    """Who authors the token turn: the driver user (addressed to the peer,
+    ambient to the reader) or the peer agent itself."""
+
+    USER = "user"
+    PEER = "peer"
+
+
+class Timing(Enum):
+    """When the seed lands relative to the reader's attach."""
+
+    LIVE = "live"  # the reader was already attached — an ambient turn
+    PRE_ATTACH = "pre-attach"  # before attach — visible only via rehydration
+
+
+@dataclass(frozen=True)
+class Seed:
+    """One declared cell of a visibility matrix."""
+
+    author: SeedAuthor
+    planted: Timing
+
+    def __str__(self) -> str:
+        return f"{self.author.value}-{self.planted.value}"
+
+
+@dataclass(frozen=True)
+class VisibilityOutcome:
+    """The reader's own account of what it can see, plus the transcript.
+
+    Exactly one of the three predicates holds for a completed probe:
+    ``saw_seed`` (the unaddressed turn leaked into the reader's context),
+    ``declared_blind`` (the reader processed the probe and the boundary held),
+    or neither (silence or an off-script reply — a delivery or
+    prompt-compliance problem, which is not a visibility verdict).
+    """
+
+    seed: Seed
+    reader_name: str
+    token: str
+    escape: str
+    replies: Replies
+
+    @property
+    def saw_seed(self) -> bool:
+        return any(self.token in (m.content or "") for m in self.replies)
+
+    @property
+    def declared_blind(self) -> bool:
+        return not self.saw_seed and any(
+            self.escape in (m.content or "") for m in self.replies
+        )
+
+    def assert_seed_invisible(self) -> None:
+        """The mention-scoped context boundary held: the reader processed the
+        probe and declared blindness. A token echo is a leak; a missing or
+        off-script reply proves nothing and fails as no-verdict."""
+        cell = f"{self.seed} seed for reader {self.reader_name}"
+        if self.saw_seed:
+            raise AssertionError(
+                f"{cell}: the reader echoed the token from a turn that was "
+                f"never addressed to it — the mention-scoped context boundary "
+                f"leaked; it said: "
+                + " | ".join((m.content or "")[:120] for m in self.replies)
+            )
+        if not self.replies:
+            raise AssertionError(f"{cell}: the reader never replied to the probe")
+        assert self.declared_blind, (
+            f"{cell}: the reader replied without the token or the escape "
+            f"marker — no visibility verdict; it said: "
+            + " | ".join((m.content or "")[:120] for m in self.replies)
+        )

--- a/tests/e2e/baseline/toolkit/waits.py
+++ b/tests/e2e/baseline/toolkit/waits.py
@@ -1,0 +1,136 @@
+"""Reply-presence waits on top of ``ReplyCapture``.
+
+``ReplyCapture.wait_for_reply`` barriers on the platform's PROCESSED delivery
+status before looking at reply frames. Not every Band client reports that
+status (live-observed: some harnesses leave delivery at ``none`` even after
+they visibly reply). These waits are reply-presence-based and harness-neutral
+— still event-driven over the WS capture, no polling.
+
+Both waits are best-effort: on the deadline they return whatever matched
+rather than raising, so the caller's declarative assertion (``assert_present`` /
+``assert_contains_any``) is what fails — naming the missing behavior — instead
+of a bare ``TimeoutError`` from deep in the capture.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from tests.e2e.baseline.toolkit.capture import ReplyCapture
+from tests.e2e.baseline.toolkit.observations import Replies
+
+
+def _authored(
+    message, sender_id: str, containing: str | tuple[str, ...] | None
+) -> bool:
+    if message.sender_id != sender_id:
+        return False
+    if containing is None:
+        return True
+    tokens = (containing,) if isinstance(containing, str) else containing
+    content = (message.content or "").lower()
+    return any(token.lower() in content for token in tokens)
+
+
+async def wait_for_reply_from(
+    capture: ReplyCapture,
+    sender_id: str,
+    *,
+    since: int = 0,
+    containing: str | tuple[str, ...] | None = None,
+    deadline_s: float | None = None,
+) -> Replies:
+    """Wait for a message authored by ``sender_id`` (optionally carrying
+    ``containing`` — a tuple means any of its tokens settles the wait) at
+    buffer index ``since`` or later; return that sender's replies from the
+    window.
+
+    ``since`` scopes the wait to the current turn of a multi-turn test — mark
+    ``len(capture.messages)`` once the previous turn has settled — so an earlier
+    turn's reply can never satisfy a later turn's wait. ``containing`` waits for
+    the message that proves the behavior, not merely the first one: a sender's
+    first message is not always the answer (live-observed, some agents post an
+    interim notice before replying).
+
+    ``containing`` gates only the WAIT; the returned window is the sender's full
+    message set from ``since``, unfiltered — so assertions can inspect interim
+    messages too (e.g. catch a leak in any of them). Contrast
+    ``wait_for_replies_from``, which filters what it returns."""
+    try:
+        await capture.wait_until(
+            lambda msgs: any(
+                _authored(m, sender_id, containing) for m in msgs[since:]
+            ),
+            deadline_s=deadline_s,
+        )
+    except TimeoutError:
+        pass  # best-effort: the caller's assertion reports the miss
+    return Replies(m for m in capture.messages[since:] if m.sender_id == sender_id)
+
+
+async def wait_for_replies_from(
+    capture: ReplyCapture,
+    sender_ids: Sequence[str],
+    *,
+    since: int = 0,
+    containing: str | None = None,
+    deadline_s: float | None = None,
+) -> dict[str, Replies]:
+    """Wait until every sender in ``sender_ids`` has authored a matching message
+    at buffer index ``since`` or later (the fan-out settling condition); return
+    the matching replies keyed by sender id. With ``containing``, a sender only
+    counts once it produces a reply carrying that token, so an interim/non-
+    answer message does not satisfy the wait and the empty entry names the
+    silent sender.
+
+    ``since`` scopes the wait and returned replies to the current round of a
+    multi-round test, preventing an earlier fan-out reply from satisfying a
+    later one.
+
+    Unlike ``wait_for_reply_from``, here ``containing`` also FILTERS the returned
+    per-sender ``Replies`` — each entry holds only the matching messages, so a
+    fan-out assertion sees exactly the proving replies."""
+    pending = list(sender_ids)
+    try:
+        await capture.wait_until(
+            lambda msgs: all(
+                any(_authored(m, sender, containing) for m in msgs[since:])
+                for sender in pending
+            ),
+            deadline_s=deadline_s,
+        )
+    except TimeoutError:
+        pass  # best-effort: per-sender assertions report which stayed silent
+    return {
+        sender: Replies(
+            m
+            for m in capture.messages[since:]
+            if _authored(m, sender, containing)
+        )
+        for sender in pending
+    }
+
+
+def said_by(
+    capture: ReplyCapture,
+    sender_id: str,
+    token: str,
+    *,
+    since: int = 0,
+    excluding: str | None = None,
+) -> Replies:
+    """Messages authored by ``sender_id`` carrying ``token`` — built for absence
+    assertions (``assert not said_by(...)``) as much as presence. ``excluding``
+    drops messages that also carry that other token, so a reply that merely
+    quotes earlier context alongside its own answer does not count.
+    Pure observation over the already-captured buffer; nothing is awaited —
+    the caller settles the window first (e.g. via a control turn)."""
+
+    def matches(message) -> bool:
+        if not _authored(message, sender_id, token):
+            return False
+        if excluding is None:
+            return True
+        return excluding.lower() not in (message.content or "").lower()
+
+    return Replies(m for m in capture.messages[since:] if matches(m))

--- a/tests/framework_conformance/test_baseline_toolkit_helpers.py
+++ b/tests/framework_conformance/test_baseline_toolkit_helpers.py
@@ -1,0 +1,90 @@
+"""PR-run unit tests for baseline-toolkit helpers ported from add-band.
+
+Pure logic that would otherwise be skipped under ``tests/e2e/**`` (E2E-gated),
+so it lives here to run on every PR — no platform, no keys.
+"""
+
+from __future__ import annotations
+
+import pytest
+from band.client.streaming import MessageCreatedPayload
+
+from tests.e2e.baseline.toolkit.exchange import (
+    MentionChainStep,
+    chain_completed,
+    marker,
+)
+from tests.e2e.baseline.toolkit.observations import Replies
+from tests.e2e.baseline.toolkit.visibility import (
+    Seed,
+    SeedAuthor,
+    Timing,
+    VisibilityOutcome,
+)
+
+
+def _reply(sender_id: str, content: str) -> MessageCreatedPayload:
+    now = "2026-01-01T00:00:00Z"
+    return MessageCreatedPayload(
+        id="m",
+        content=content,
+        message_type="text",
+        sender_id=sender_id,
+        sender_type="Agent",
+        inserted_at=now,
+        updated_at=now,
+    )
+
+
+class _Agent:
+    def __init__(self, agent_id: str, name: str) -> None:
+        self.id = agent_id
+        self.name = name
+
+
+def test_marker_is_run_scoped() -> None:
+    assert marker("abc") == "E2E-MARK-ABC"
+    assert marker("abc", prefix="PA-MARK") == "PA-MARK-ABC"
+
+
+def test_chain_completed_requires_all_steps() -> None:
+    token = marker("run-1")
+    asker = _Agent("a", "Asker")
+    responder = _Agent("b", "Responder")
+    steps = (
+        MentionChainStep(asker),
+        MentionChainStep(responder),
+        MentionChainStep(asker),
+    )
+    incomplete = [
+        _reply("a", f"ask {token}"),
+        _reply("b", f"answer {token}"),
+    ]
+    complete = incomplete + [_reply("a", f"relay {token}")]
+    assert chain_completed(steps, token, incomplete) is False
+    assert chain_completed(steps, token, complete) is True
+
+
+def test_visibility_outcome_declared_blind() -> None:
+    outcome = VisibilityOutcome(
+        seed=Seed(SeedAuthor.USER, Timing.LIVE),
+        reader_name="reader",
+        token="PA-VIS-TOKEN",
+        escape="UNKNOWN-ABC",
+        replies=Replies([_reply("reader", "UNKNOWN-ABC")]),
+    )
+    assert outcome.saw_seed is False
+    assert outcome.declared_blind is True
+    outcome.assert_seed_invisible()
+
+
+def test_visibility_outcome_seed_echo_is_leak() -> None:
+    outcome = VisibilityOutcome(
+        seed=Seed(SeedAuthor.PEER, Timing.PRE_ATTACH),
+        reader_name="reader",
+        token="PA-VIS-TOKEN",
+        escape="UNKNOWN-ABC",
+        replies=Replies([_reply("reader", "PA-VIS-TOKEN leaked")]),
+    )
+    with pytest.raises(AssertionError, match="leaked"):
+        outcome.assert_seed_invisible()


### PR DESCRIPTION
## Summary

Ports Tier 1 pytest-free Band-driving helpers from `add-band/pa-conformance/driver/` into the baseline E2E toolkit so adapter tests and PA conformance share one implementation ([INT-1007](https://linear.app/thenvoi/issue/INT-1007)).

- `toolkit/waits.py` — reply-presence waits (`wait_for_reply_from`, `wait_for_replies_from`, `said_by`) without requiring PROCESSED delivery status
- `toolkit/user_ops.py` — `send_structured_mentions`, `send_mentioning_all` for multi-agent fan-out
- `toolkit/exchange.py` — run-scoped `marker()`, bounded `run_exchange`, ordered mention-chain assertions
- `toolkit/visibility.py` — `Seed` / `VisibilityOutcome` types for history visibility probes
- `toolkit/discovery.py` — `owner_hub_room_ids` for owner+agent-only rooms
- `tests/framework_conformance/test_baseline_toolkit_helpers.py` — PR-run guards for pure logic

**Follow-up (separate PR on [add-band#29](https://github.com/band-ai/add-band/pull/29)):** thin local `pa-conformance/driver/` copies to SDK re-exports once this lands and `uv.lock` picks up the new commit.

## Test plan

- [x] `uv run pytest tests/framework_conformance/test_baseline_toolkit_helpers.py -q` — 4 passed
- [ ] add-band follow-up: re-export from SDK bridge and remove duplicated driver modules
- [ ] Targeted PA conformance run after add-band pins the new SDK ref


Made with [Cursor](https://cursor.com)