### PR TITLE
fix: settle freshly-joined peer before first gateway message [INT-969]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,15 @@ from band.adapters.a2a_gateway import A2AGatewayAdapter, GatewayServer
 adapter = A2AGatewayAdapter(port=10000)
 ```
 
+`new_participant_settle_seconds` (default `3.0`) pauses after a peer is freshly
+added to a room and before the first message is posted, giving the peer's
+execution context time to subscribe to the room. This narrows the window in
+which a slow or restarting peer can discover that first message through both its
+catch-up poll and its live feed and answer it more than once. Only the first
+message to a freshly-joined peer waits; warm rooms are unaffected. Set to `0` to
+disable. This is a mitigation, not a correctness guarantee; the durable fix is
+an exclusive server-side claim so an in-flight message can't be re-served.
+
 ### Key files
 
 | Purpose | Path |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -615,6 +615,11 @@ test, where the markdown-docs run actually executes it.
   constant) or otherwise cannot fail for a real reason; they add maintenance
   cost without protection.
 - Comments should describe the code as it is, not narrate what changed between versions.
+- Before adding a third-party dependency, prefer the stdlib or an existing
+  in-repo idiom (grep first) — don't take on a package to replace a few lines.
+  If a dependency is still warranted, vet it first: permissive license
+  (MIT/BSD/Apache-2.0), real adoption (stars + dependent packages/repos), and
+  active maintenance (release history, not a brand-new bus-factor-1 project).
 
 ## Pre-Commit Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,10 +206,14 @@ adapter = A2AGatewayAdapter(port=10000)
 added to a room and before the first message is posted, giving the peer's
 execution context time to subscribe to the room. This narrows the window in
 which a slow or restarting peer can discover that first message through both its
-catch-up poll and its live feed and answer it more than once. Only the first
-message to a freshly-joined peer waits; warm rooms are unaffected. Set to `0` to
-disable. This is a mitigation, not a correctness guarantee; the durable fix is
-an exclusive server-side claim so an in-flight message can't be re-served.
+catch-up poll and its live feed and answer it more than once. Only a
+freshly-joined peer incurs this settle; a warm turn (the peer is already a
+participant) adds no settle of its own, though it can still wait behind an
+earlier concurrent turn in the same context, because turns within one context
+are serialized end-to-end (Band correlates a peer's reply only by room, so a
+room holds one in-flight turn at a time). Set to `0` to disable the settle. This
+is a mitigation, not a correctness guarantee; the durable fix is an exclusive
+server-side claim so an in-flight message can't be re-served.
 
 ### Key files
 

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -116,9 +116,9 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
                 execution context time to finish subscribing to the room. Only
                 the first message to a freshly-joined peer is affected; warm
                 rooms (where the peer is already a participant) never wait. This
-                shrinks the window in which the peer can discover that first
-                message through both its real-time feed and its catch-up poll
-                and reply to it more than once. Set to 0 to disable.
+                is a temporary mitigation, not an exactly-once guarantee:
+                durable prevention requires a platform-side exclusive message
+                claim. Set to 0 to disable.
         """
         super().__init__(
             history_converter=GatewayHistoryConverter(),

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import re
 from collections.abc import AsyncIterator
+from contextlib import AbstractAsyncContextManager, nullcontext
 from typing import ClassVar
 from uuid import uuid4
 
@@ -114,11 +115,12 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
             new_participant_settle_seconds: Pause after adding a peer to a room
                 and before the first message is posted, giving the peer's
                 execution context time to finish subscribing to the room. Only
-                the first message to a freshly-joined peer is affected; warm
-                rooms (where the peer is already a participant) never wait. This
-                is a temporary mitigation, not an exactly-once guarantee:
-                durable prevention requires a platform-side exclusive message
-                claim. Set to 0 to disable.
+                a freshly-joined peer incurs this settle; a warm turn (the peer
+                is already a participant) adds no settle of its own, though it
+                can still wait behind an earlier concurrent turn in the same
+                context. This is a temporary mitigation, not an exactly-once
+                guarantee: durable prevention requires a platform-side exclusive
+                message claim. Set to 0 to disable.
         """
         super().__init__(
             history_converter=GatewayHistoryConverter(),
@@ -140,9 +142,11 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         self._context_to_room: dict[str, str] = {}
         self._room_participants: dict[str, set[str]] = {}
 
-        # Serializes room resolution per context, so concurrent requests in the
-        # same conversation share one peer join + settle instead of each adding
-        # the peer and posting into the unsettled window.
+        # Serializes turns per context end-to-end: Band correlates a peer's
+        # reply only by room, so a room holds at most one in-flight turn at a
+        # time for that correlation to be unambiguous. Concurrent turns in one
+        # conversation queue here instead of racing to register competing
+        # pending tasks or posting into an unsettled window.
         self._context_locks: dict[str, asyncio.Lock] = {}
 
         # Request/response correlation
@@ -267,16 +271,13 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         if is_session_bootstrap and history:
             self._rehydrate(history)
 
-        # Find pending task for this room
+        # Correlate with the room's in-flight turn, if any, and enqueue the
+        # event. The turn (in _handle_a2a_request) owns the pending entry's
+        # lifecycle and removes it when done, so we only enqueue here.
         pending = self._pending_tasks.get(room_id)
         if pending:
-            # Convert to A2A event and push to SSE queue
             event = self._translate_to_a2a(msg, pending.task)
             await pending.sse_queue.put(event)
-
-            # Clean up on terminal state
-            if event.final:
-                del self._pending_tasks[room_id]
 
     async def on_cleanup(self, room_id: str) -> None:
         """Clean up resources for a room.
@@ -322,66 +323,69 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         Yields:
             TaskStatusUpdateEvent for SSE streaming.
         """
-        # Resolve peer from slug or UUID
         peer = self._resolve_peer(peer_id)
         if not peer:
             logger.error("Peer not found: %s", peer_id)
             return
 
-        # Use the peer's actual UUID for Band API calls
-        peer_uuid = peer.id
+        # A named context serializes all of its turns end-to-end: because Band
+        # correlates a peer's reply only by room, a room may hold exactly one
+        # in-flight turn at a time. Distinct contexts (and each None context, an
+        # unshared new conversation) run concurrently. The turn owns its pending
+        # entry and removes it on exit, whether it ends on a terminal event or is
+        # cancelled by a client disconnect.
+        async with self._turn_lock(message.context_id):
+            room_id, context_id = await self._resolve_room(message.context_id, peer.id)
 
-        # Get or create room for context
-        room_id, context_id = await self._get_or_create_room(
-            message.context_id, peer_uuid
-        )
+            sse_queue: asyncio.Queue[TaskStatusUpdateEvent] = asyncio.Queue()
+            self._pending_tasks[room_id] = PendingA2ATask(
+                task=self._create_task(context_id),
+                sse_queue=sse_queue,
+                peer_id=peer.id,
+            )
+            try:
+                # Persist the context mapping in history for later rehydration.
+                await self._emit_context_event(room_id, context_id)
+                await self._rest.agent_api_messages.create_agent_chat_message(
+                    chat_id=room_id,
+                    message=ChatMessageRequest(
+                        content=f"@{peer.name} {get_message_text(message) or ''}",
+                        mentions=[
+                            ChatMessageRequestMentionsItem(id=peer.id, name=peer.name)
+                        ],
+                    ),
+                    request_options=DEFAULT_REQUEST_OPTIONS,
+                )
+                logger.debug(
+                    "Sent message to peer %s (%s) in room %s (context=%s)",
+                    peer.name,
+                    peer.id,
+                    room_id,
+                    context_id,
+                )
 
-        # Create A2A task
-        task = self._create_task(context_id)
+                # Events are enqueued by on_message() as the peer replies.
+                while True:
+                    event = await sse_queue.get()
+                    yield event
+                    if event.final:
+                        break
+            finally:
+                self._pending_tasks.pop(room_id, None)
 
-        # Register pending task with SSE queue
-        sse_queue: asyncio.Queue[TaskStatusUpdateEvent] = asyncio.Queue()
-        self._pending_tasks[room_id] = PendingA2ATask(
-            task=task,
-            sse_queue=sse_queue,
-            peer_id=peer_uuid,
-        )
+    def _turn_lock(self, context_id: str | None) -> AbstractAsyncContextManager[None]:
+        """Serializer for a context's turns; a no-op for an unshared None context.
 
-        # Emit task event to track context mapping in history
-        await self._emit_context_event(room_id, context_id)
-
-        # Send message to Band via REST client
-        content = get_message_text(message) or ""
-
-        # Use peer name for mention
-        peer_name = peer.name
-
-        await self._rest.agent_api_messages.create_agent_chat_message(
-            chat_id=room_id,
-            message=ChatMessageRequest(
-                content=f"@{peer_name} {content}",
-                mentions=[ChatMessageRequestMentionsItem(id=peer_uuid, name=peer_name)],
-            ),
-            request_options=DEFAULT_REQUEST_OPTIONS,
-        )
-
-        logger.debug(
-            "Sent message to peer %s (%s) in room %s (context=%s)",
-            peer_name,
-            peer_uuid,
-            room_id,
-            context_id,
-        )
-
-        # Stream events from queue (populated by on_message())
-        while True:
-            event = await sse_queue.get()
-            yield event
-            if event.final:
-                break
+        A named context reuses one lock (see ``_context_lock``); a None context
+        is a brand-new conversation with its own fresh room, so it needs no
+        guard and must not share the lock keyed on ``None``.
+        """
+        if context_id is None:
+            return nullcontext()
+        return self._context_lock(context_id)
 
     def _context_lock(self, context_id: str) -> asyncio.Lock:
-        """Return the resolution lock for a context, creating it on first use.
+        """Return the turn lock for a context, creating it on first use.
 
         Same keyed-lock idiom as ``copilot_sdk``/``slack``: ``setdefault`` is
         atomic under the single-threaded event loop (no await between lookup and
@@ -391,10 +395,13 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         """
         return self._context_locks.setdefault(context_id, asyncio.Lock())
 
-    async def _get_or_create_room(
+    async def _resolve_room(
         self, context_id: str | None, target_peer_id: str
     ) -> tuple[str, str]:
-        """Get existing room for context or create a new one.
+        """Resolve the room for a context, creating it and joining the peer if new.
+
+        Callers reach this holding the context's turn lock (except for a None
+        context, which is inherently unshared).
 
         Args:
             context_id: A2A context ID (may be None for new conversations).
@@ -403,37 +410,17 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         Returns:
             Tuple of (room_id, context_id).
         """
-        # A None context is a brand-new conversation with nothing to share, so
-        # it needs no lock. A named context is serialized so concurrent requests
-        # in the same conversation resolve the room and join the peer once.
-        if context_id is None:
-            return await self._resolve_room(None, target_peer_id)
-        async with self._context_lock(context_id):
-            return await self._resolve_room(context_id, target_peer_id)
-
-    async def _resolve_room(
-        self, context_id: str | None, target_peer_id: str
-    ) -> tuple[str, str]:
-        """Resolve the room for a context, creating it and joining the peer if new.
-
-        Callers reach this holding the per-context lock (except for a None
-        context, which is inherently unshared).
-        """
-        # New or None context_id → create new room
         if context_id is None or context_id not in self._context_to_room:
-            # Create new room via REST
             response = await self._rest.agent_api_chats.create_agent_chat(
                 chat=ChatRoomRequest(),
                 request_options=DEFAULT_REQUEST_OPTIONS,
             )
             room_id = response.data.id
-
-            # Add target peer to room
-            await self._add_participant(room_id, target_peer_id)
-
             context_id = context_id or str(uuid4())
+            # Record the mapping before joining/settling so a turn cancelled
+            # mid-settle leaves a reusable room instead of an orphan.
             self._context_to_room[context_id] = room_id
-            self._room_participants[room_id] = {target_peer_id}
+            await self._add_participant(room_id, target_peer_id)
 
             logger.info(
                 "Created new room %s for context %s with peer %s",
@@ -442,13 +429,11 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
                 target_peer_id,
             )
         else:
-            # Existing context → use existing room
             room_id = self._context_to_room[context_id]
 
-            # Same context, different peer → add to room (multi-agent conversation)
+            # Same context, different peer → add to room (multi-agent conversation).
             if target_peer_id not in self._room_participants.get(room_id, set()):
                 await self._add_participant(room_id, target_peer_id)
-                self._room_participants.setdefault(room_id, set()).add(target_peer_id)
 
                 logger.info(
                     "Added peer %s to existing room %s (context=%s)",
@@ -460,23 +445,32 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         return room_id, context_id
 
     async def _add_participant(self, room_id: str, peer_id: str) -> None:
-        """Add a peer to a room, then let its execution context settle.
+        """Add a peer to a room, record membership, then let it settle.
 
-        The settle pause runs only here, on the freshly-joined-peer path, so the
-        peer has a moment to finish subscribing to the room before the caller
-        posts the first message. Warm rooms never reach this method, so they
-        never wait. See ``new_participant_settle_seconds``.
+        Membership is recorded the instant the REST add succeeds and before the
+        settle pause, so a turn cancelled during the pause does not lose the
+        join (which would otherwise make a retry re-add the peer). A warm turn
+        (peer already a participant) never calls this and so adds no settle of
+        its own, though it can still wait behind an earlier concurrent turn in
+        the same context. See ``new_participant_settle_seconds``.
         """
         await self._rest.agent_api_participants.add_agent_chat_participant(
             chat_id=room_id,
             participant=ParticipantRequest(participant_id=peer_id, role="member"),
             request_options=DEFAULT_REQUEST_OPTIONS,
         )
-        # Stopgap, not a real fix. The platform's message claim is not exclusive:
-        # a message in flight is still handed out to any poll, so a slow or
-        # restarting peer can pick up this first message more than once and reply
-        # twice. We can only narrow that window from here by pausing before the
-        # caller posts; the durable fix is an exclusive, owned claim server-side.
+        self._room_participants.setdefault(room_id, set()).add(peer_id)
+        await self._settle_new_participant()
+
+    async def _settle_new_participant(self) -> None:
+        """Pause after a fresh join so the peer can finish subscribing.
+
+        Stopgap, not a real fix. The platform's message claim is not exclusive:
+        a message in flight is still handed out to any poll, so a slow or
+        restarting peer can pick up the first message more than once and reply
+        twice. We can only narrow that window from here by pausing before the
+        caller posts; the durable fix is an exclusive, owned claim server-side.
+        """
         if self._new_participant_settle_seconds:
             await asyncio.sleep(self._new_participant_settle_seconds)
 

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -383,14 +383,13 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
     def _context_lock(self, context_id: str) -> asyncio.Lock:
         """Return the resolution lock for a context, creating it on first use.
 
-        Safe to call concurrently: there is no await between the lookup and the
-        insert, so under the single-threaded event loop it is atomic.
+        Same keyed-lock idiom as ``copilot_sdk``/``slack``: ``setdefault`` is
+        atomic under the single-threaded event loop (no await between lookup and
+        insert). No eviction is needed since contexts persist in
+        ``_context_to_room`` for the adapter's lifetime, so the lock map is
+        bounded by the same set of keys.
         """
-        lock = self._context_locks.get(context_id)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._context_locks[context_id] = lock
-        return lock
+        return self._context_locks.setdefault(context_id, asyncio.Lock())
 
     async def _get_or_create_room(
         self, context_id: str | None, target_peer_id: str

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -140,6 +140,11 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         self._context_to_room: dict[str, str] = {}
         self._room_participants: dict[str, set[str]] = {}
 
+        # Serializes room resolution per context, so concurrent requests in the
+        # same conversation share one peer join + settle instead of each adding
+        # the peer and posting into the unsettled window.
+        self._context_locks: dict[str, asyncio.Lock] = {}
+
         # Request/response correlation
         self._pending_tasks: dict[str, PendingA2ATask] = {}  # room_id → task
         self._peer_discovery_retry_delays_seconds: tuple[float, ...] = (
@@ -375,6 +380,18 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
             if event.final:
                 break
 
+    def _context_lock(self, context_id: str) -> asyncio.Lock:
+        """Return the resolution lock for a context, creating it on first use.
+
+        Safe to call concurrently: there is no await between the lookup and the
+        insert, so under the single-threaded event loop it is atomic.
+        """
+        lock = self._context_locks.get(context_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._context_locks[context_id] = lock
+        return lock
+
     async def _get_or_create_room(
         self, context_id: str | None, target_peer_id: str
     ) -> tuple[str, str]:
@@ -386,6 +403,22 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
 
         Returns:
             Tuple of (room_id, context_id).
+        """
+        # A None context is a brand-new conversation with nothing to share, so
+        # it needs no lock. A named context is serialized so concurrent requests
+        # in the same conversation resolve the room and join the peer once.
+        if context_id is None:
+            return await self._resolve_room(None, target_peer_id)
+        async with self._context_lock(context_id):
+            return await self._resolve_room(context_id, target_peer_id)
+
+    async def _resolve_room(
+        self, context_id: str | None, target_peer_id: str
+    ) -> tuple[str, str]:
+        """Resolve the room for a context, creating it and joining the peer if new.
+
+        Callers reach this holding the per-context lock (except for a None
+        context, which is inherently unshared).
         """
         # New or None context_id → create new room
         if context_id is None or context_id not in self._context_to_room:

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -102,6 +102,7 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         gateway_url: str = "http://localhost:10000",
         port: int = 10000,
         features: AdapterFeatures | None = None,
+        new_participant_settle_seconds: float = 3.0,
     ) -> None:
         """Initialize gateway adapter.
 
@@ -110,6 +111,14 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
             api_key: API key for authentication (same as Agent.create()).
             gateway_url: Base URL for A2A endpoints exposed by this gateway.
             port: Port for HTTP server to listen on.
+            new_participant_settle_seconds: Pause after adding a peer to a room
+                and before the first message is posted, giving the peer's
+                execution context time to finish subscribing to the room. Only
+                the first message to a freshly-joined peer is affected; warm
+                rooms (where the peer is already a participant) never wait. This
+                shrinks the window in which the peer can discover that first
+                message through both its real-time feed and its catch-up poll
+                and reply to it more than once. Set to 0 to disable.
         """
         super().__init__(
             history_converter=GatewayHistoryConverter(),
@@ -117,6 +126,7 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
         )
         self.gateway_url = gateway_url
         self.port = port
+        self._new_participant_settle_seconds = new_participant_settle_seconds
 
         # Direct REST client for room/message operations
         self._rest = AsyncRestClient(base_url=rest_url, api_key=api_key)
@@ -387,13 +397,7 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
             room_id = response.data.id
 
             # Add target peer to room
-            await self._rest.agent_api_participants.add_agent_chat_participant(
-                chat_id=room_id,
-                participant=ParticipantRequest(
-                    participant_id=target_peer_id, role="member"
-                ),
-                request_options=DEFAULT_REQUEST_OPTIONS,
-            )
+            await self._add_participant(room_id, target_peer_id)
 
             context_id = context_id or str(uuid4())
             self._context_to_room[context_id] = room_id
@@ -411,13 +415,7 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
 
             # Same context, different peer → add to room (multi-agent conversation)
             if target_peer_id not in self._room_participants.get(room_id, set()):
-                await self._rest.agent_api_participants.add_agent_chat_participant(
-                    chat_id=room_id,
-                    participant=ParticipantRequest(
-                        participant_id=target_peer_id, role="member"
-                    ),
-                    request_options=DEFAULT_REQUEST_OPTIONS,
-                )
+                await self._add_participant(room_id, target_peer_id)
                 self._room_participants.setdefault(room_id, set()).add(target_peer_id)
 
                 logger.info(
@@ -428,6 +426,22 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
                 )
 
         return room_id, context_id
+
+    async def _add_participant(self, room_id: str, peer_id: str) -> None:
+        """Add a peer to a room, then let its execution context settle.
+
+        The settle pause runs only here, on the freshly-joined-peer path, so the
+        peer has a moment to finish subscribing to the room before the caller
+        posts the first message. Warm rooms never reach this method, so they
+        never wait. See ``new_participant_settle_seconds``.
+        """
+        await self._rest.agent_api_participants.add_agent_chat_participant(
+            chat_id=room_id,
+            participant=ParticipantRequest(participant_id=peer_id, role="member"),
+            request_options=DEFAULT_REQUEST_OPTIONS,
+        )
+        if self._new_participant_settle_seconds:
+            await asyncio.sleep(self._new_participant_settle_seconds)
 
     def _rehydrate(self, history: GatewaySessionState) -> None:
         """Restore session state from history.

--- a/src/band/integrations/a2a/gateway/adapter.py
+++ b/src/band/integrations/a2a/gateway/adapter.py
@@ -440,6 +440,11 @@ class A2AGatewayAdapter(SimpleAdapter[GatewaySessionState]):
             participant=ParticipantRequest(participant_id=peer_id, role="member"),
             request_options=DEFAULT_REQUEST_OPTIONS,
         )
+        # Stopgap, not a real fix. The platform's message claim is not exclusive:
+        # a message in flight is still handed out to any poll, so a slow or
+        # restarting peer can pick up this first message more than once and reply
+        # twice. We can only narrow that window from here by pausing before the
+        # caller posts; the durable fix is an exclusive, owned claim server-side.
         if self._new_participant_settle_seconds:
             await asyncio.sleep(self._new_participant_settle_seconds)
 

--- a/tests/adapters/test_a2a_gateway_adapter.py
+++ b/tests/adapters/test_a2a_gateway_adapter.py
@@ -6,6 +6,7 @@ Tests the internal context mapping logic without hitting the real platform.
 from __future__ import annotations
 
 import asyncio
+from typing import Callable
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -14,24 +15,23 @@ from band.integrations.a2a.gateway import A2AGatewayAdapter
 from band_rest import Peer
 
 
-class TestA2AGatewayContextIdFlow:
-    """Unit tests for context_id persistence in A2A Gateway (mock-based)."""
+@pytest.fixture
+def make_gateway_adapter() -> Callable[..., A2AGatewayAdapter]:
+    """Factory for a gateway adapter with mocked REST calls.
 
-    @pytest.fixture
-    def gateway_adapter_with_mocks(self) -> A2AGatewayAdapter:
-        """Create gateway adapter with mocked REST client for testing."""
+    Returns a builder so each test picks its own settle window. The builder
+    stubs every REST call the room-resolution path touches, registers a
+    "weather" peer, and exposes ``_rooms_created`` (the ids handed out by
+    ``create_agent_chat``, in order) for assertions.
+    """
+
+    def build(settle_seconds: float = 0.0) -> A2AGatewayAdapter:
         adapter = A2AGatewayAdapter(
             rest_url="http://localhost:4000",
             api_key="test-key",
-            gateway_url="http://localhost:10000",
-            port=10000,
-            # These context-mapping tests don't exercise the settle window;
-            # disable it so they don't pause. The settle behaviour has its own
-            # tests below.
-            new_participant_settle_seconds=0.0,
+            new_participant_settle_seconds=settle_seconds,
         )
 
-        # Mock peer
         weather_peer = Peer(
             id="uuid-weather",
             name="Weather Agent",
@@ -43,10 +43,9 @@ class TestA2AGatewayContextIdFlow:
         adapter._peers = {"weather-agent": weather_peer}
         adapter._peers_by_uuid = {"uuid-weather": weather_peer}
 
-        # Track room creation
         rooms_created: list[str] = []
 
-        def track_room_creation(*args, **kwargs):
+        def track_room_creation(*args: object, **kwargs: object) -> MagicMock:
             room_id = f"room-{len(rooms_created) + 1}"
             rooms_created.append(room_id)
             response = MagicMock()
@@ -63,12 +62,18 @@ class TestA2AGatewayContextIdFlow:
 
         return adapter
 
+    return build
+
+
+class TestA2AGatewayContextIdFlow:
+    """Unit tests for context_id persistence in A2A Gateway (mock-based)."""
+
     @pytest.mark.asyncio
     async def test_same_context_id_twice_uses_same_room(
-        self, gateway_adapter_with_mocks: A2AGatewayAdapter
+        self, make_gateway_adapter: Callable[..., A2AGatewayAdapter]
     ) -> None:
         """Same contextId sent twice should reuse the same chat room."""
-        adapter = gateway_adapter_with_mocks
+        adapter = make_gateway_adapter()
 
         # First request with context_id="ctx-user-session"
         room_1, ctx_1 = await adapter._get_or_create_room(
@@ -88,10 +93,10 @@ class TestA2AGatewayContextIdFlow:
 
     @pytest.mark.asyncio
     async def test_different_context_ids_create_different_rooms(
-        self, gateway_adapter_with_mocks: A2AGatewayAdapter
+        self, make_gateway_adapter: Callable[..., A2AGatewayAdapter]
     ) -> None:
         """Different contextIds should create separate chat rooms."""
-        adapter = gateway_adapter_with_mocks
+        adapter = make_gateway_adapter()
 
         # First context
         room_a, ctx_a = await adapter._get_or_create_room(
@@ -111,10 +116,10 @@ class TestA2AGatewayContextIdFlow:
 
     @pytest.mark.asyncio
     async def test_same_context_different_peers_same_room_adds_peer(
-        self, gateway_adapter_with_mocks: A2AGatewayAdapter
+        self, make_gateway_adapter: Callable[..., A2AGatewayAdapter]
     ) -> None:
         """Same contextId with different peers should use same room, add peer."""
-        adapter = gateway_adapter_with_mocks
+        adapter = make_gateway_adapter()
 
         # Add second peer
         data_peer = Peer(
@@ -157,33 +162,10 @@ class TestFreshlyJoinedPeerSettle:
     never add a peer and so never wait.
     """
 
-    def _build_adapter(self, settle_seconds: float) -> A2AGatewayAdapter:
-        adapter = A2AGatewayAdapter(
-            rest_url="http://localhost:4000",
-            api_key="test-key",
-            new_participant_settle_seconds=settle_seconds,
-        )
-        peer = Peer(
-            id="uuid-weather",
-            name="Weather Agent",
-            type="Agent",
-            handle="test/weather-agent",
-            is_contact=False,
-            source="registry",
-        )
-        adapter._peers = {"weather-agent": peer}
-        adapter._peers_by_uuid = {"uuid-weather": peer}
-
-        response = MagicMock()
-        response.data = MagicMock(id="room-1")
-        adapter._rest.agent_api_chats.create_agent_chat = AsyncMock(
-            return_value=response
-        )
-        adapter._rest.agent_api_participants.add_agent_chat_participant = AsyncMock()
-        return adapter
-
     @pytest.mark.asyncio
-    async def test_first_message_waits_until_fresh_peer_subscribes(self) -> None:
+    async def test_first_message_waits_until_fresh_peer_subscribes(
+        self, make_gateway_adapter: Callable[..., A2AGatewayAdapter]
+    ) -> None:
         """A fresh join must not return until the peer has had time to subscribe.
 
         Reproduction: the peer subscribes a short while after being added. With
@@ -203,7 +185,7 @@ class TestFreshlyJoinedPeerSettle:
             asyncio.get_running_loop().create_task(subscribe())
 
         # Settle window comfortably longer than the peer's subscribe time.
-        adapter = self._build_adapter(settle_seconds=0.5)
+        adapter = make_gateway_adapter(settle_seconds=0.5)
         adapter._rest.agent_api_participants.add_agent_chat_participant = AsyncMock(
             side_effect=start_peer_subscription
         )
@@ -216,10 +198,12 @@ class TestFreshlyJoinedPeerSettle:
         )
 
     @pytest.mark.asyncio
-    async def test_warm_room_reuse_never_waits(self) -> None:
+    async def test_warm_room_reuse_never_waits(
+        self, make_gateway_adapter: Callable[..., A2AGatewayAdapter]
+    ) -> None:
         """Reusing a room where the peer is already a member must not settle."""
         # A settle this long would hang the test if the warm path waited.
-        adapter = self._build_adapter(settle_seconds=30.0)
+        adapter = make_gateway_adapter(settle_seconds=30.0)
         adapter._context_to_room["ctx-warm"] = "room-existing"
         adapter._room_participants["room-existing"] = {"uuid-weather"}
 
@@ -231,10 +215,12 @@ class TestFreshlyJoinedPeerSettle:
         adapter._rest.agent_api_participants.add_agent_chat_participant.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_zero_settle_returns_without_waiting(self) -> None:
+    async def test_zero_settle_returns_without_waiting(
+        self, make_gateway_adapter: Callable[..., A2AGatewayAdapter]
+    ) -> None:
         """A zero settle window opts out of the pause entirely."""
         # A peer that never signals readiness: proves the gateway does not wait.
-        adapter = self._build_adapter(settle_seconds=0.0)
+        adapter = make_gateway_adapter(settle_seconds=0.0)
 
         await asyncio.wait_for(
             adapter._get_or_create_room("ctx-fast", "uuid-weather"), timeout=1.0
@@ -243,7 +229,9 @@ class TestFreshlyJoinedPeerSettle:
         adapter._rest.agent_api_participants.add_agent_chat_participant.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_concurrent_requests_same_context_join_peer_once(self) -> None:
+    async def test_concurrent_requests_same_context_join_peer_once(
+        self, make_gateway_adapter: Callable[..., A2AGatewayAdapter]
+    ) -> None:
         """Concurrent requests in one conversation must join the peer only once.
 
         While the first request sits in the settle window, its peer join is not
@@ -251,7 +239,7 @@ class TestFreshlyJoinedPeerSettle:
         must wait for that join to finish rather than issue a duplicate add or
         post before the settle ends.
         """
-        adapter = self._build_adapter(settle_seconds=0.1)
+        adapter = make_gateway_adapter(settle_seconds=0.1)
         # Existing conversation whose room has no participants recorded yet.
         adapter._context_to_room["ctx"] = "room-1"
         adapter._room_participants["room-1"] = set()

--- a/tests/adapters/test_a2a_gateway_adapter.py
+++ b/tests/adapters/test_a2a_gateway_adapter.py
@@ -5,6 +5,7 @@ Tests the internal context mapping logic without hitting the real platform.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -24,6 +25,10 @@ class TestA2AGatewayContextIdFlow:
             api_key="test-key",
             gateway_url="http://localhost:10000",
             port=10000,
+            # These context-mapping tests don't exercise the settle window;
+            # disable it so they don't pause. The settle behaviour has its own
+            # tests below.
+            new_participant_settle_seconds=0.0,
         )
 
         # Mock peer
@@ -138,3 +143,101 @@ class TestA2AGatewayContextIdFlow:
             adapter._rest.agent_api_participants.add_agent_chat_participant.call_count
             == 2
         )
+
+
+class TestFreshlyJoinedPeerSettle:
+    """The gateway must let a freshly-added peer subscribe before the first message.
+
+    A peer added to a room needs a moment for its execution context to
+    subscribe to the room's real-time feed. If the gateway posts the first
+    message during that window, the peer can discover the message through both
+    its catch-up poll and its live feed and answer it more than once. The
+    gateway therefore settles after adding a peer and before returning control
+    to post the message. Warm rooms, where the peer is already a participant,
+    never add a peer and so never wait.
+    """
+
+    def _build_adapter(self, settle_seconds: float) -> A2AGatewayAdapter:
+        adapter = A2AGatewayAdapter(
+            rest_url="http://localhost:4000",
+            api_key="test-key",
+            new_participant_settle_seconds=settle_seconds,
+        )
+        peer = Peer(
+            id="uuid-weather",
+            name="Weather Agent",
+            type="Agent",
+            handle="test/weather-agent",
+            is_contact=False,
+            source="registry",
+        )
+        adapter._peers = {"weather-agent": peer}
+        adapter._peers_by_uuid = {"uuid-weather": peer}
+
+        response = MagicMock()
+        response.data = MagicMock(id="room-1")
+        adapter._rest.agent_api_chats.create_agent_chat = AsyncMock(
+            return_value=response
+        )
+        adapter._rest.agent_api_participants.add_agent_chat_participant = AsyncMock()
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_first_message_waits_until_fresh_peer_subscribes(self) -> None:
+        """A fresh join must not return until the peer has had time to subscribe.
+
+        Reproduction: the peer subscribes a short while after being added. With
+        no settle window the gateway returns immediately, while the peer is
+        still unsubscribed, which is the race that lets the first message be
+        answered multiple times. The settle window must outlast the peer's
+        subscription so the gateway only proceeds once the peer is ready.
+        """
+        # Peer's subscription completes shortly after it is added to the room.
+        peer_subscribed = asyncio.Event()
+
+        async def start_peer_subscription(*args: object, **kwargs: object) -> None:
+            async def subscribe() -> None:
+                await asyncio.sleep(0.05)
+                peer_subscribed.set()
+
+            asyncio.get_running_loop().create_task(subscribe())
+
+        # Settle window comfortably longer than the peer's subscribe time.
+        adapter = self._build_adapter(settle_seconds=0.5)
+        adapter._rest.agent_api_participants.add_agent_chat_participant = AsyncMock(
+            side_effect=start_peer_subscription
+        )
+
+        await adapter._get_or_create_room("ctx-fresh", "uuid-weather")
+
+        assert peer_subscribed.is_set(), (
+            "gateway returned before the freshly-added peer finished subscribing; "
+            "the first message would be posted into the duplicate-processing window"
+        )
+
+    @pytest.mark.asyncio
+    async def test_warm_room_reuse_never_waits(self) -> None:
+        """Reusing a room where the peer is already a member must not settle."""
+        # A settle this long would hang the test if the warm path waited.
+        adapter = self._build_adapter(settle_seconds=30.0)
+        adapter._context_to_room["ctx-warm"] = "room-existing"
+        adapter._room_participants["room-existing"] = {"uuid-weather"}
+
+        room_id, _ = await asyncio.wait_for(
+            adapter._get_or_create_room("ctx-warm", "uuid-weather"), timeout=1.0
+        )
+
+        assert room_id == "room-existing"
+        adapter._rest.agent_api_participants.add_agent_chat_participant.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_zero_settle_returns_without_waiting(self) -> None:
+        """A zero settle window opts out of the pause entirely."""
+        # A peer that never signals readiness: proves the gateway does not wait.
+        adapter = self._build_adapter(settle_seconds=0.0)
+
+        await asyncio.wait_for(
+            adapter._get_or_create_room("ctx-fast", "uuid-weather"), timeout=1.0
+        )
+
+        adapter._rest.agent_api_participants.add_agent_chat_participant.assert_called_once()

--- a/tests/adapters/test_a2a_gateway_adapter.py
+++ b/tests/adapters/test_a2a_gateway_adapter.py
@@ -241,3 +241,26 @@ class TestFreshlyJoinedPeerSettle:
         )
 
         adapter._rest.agent_api_participants.add_agent_chat_participant.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_same_context_join_peer_once(self) -> None:
+        """Concurrent requests in one conversation must join the peer only once.
+
+        While the first request sits in the settle window, its peer join is not
+        yet recorded. A second concurrent request for the same context and peer
+        must wait for that join to finish rather than issue a duplicate add or
+        post before the settle ends.
+        """
+        adapter = self._build_adapter(settle_seconds=0.1)
+        # Existing conversation whose room has no participants recorded yet.
+        adapter._context_to_room["ctx"] = "room-1"
+        adapter._room_participants["room-1"] = set()
+
+        results = await asyncio.gather(
+            adapter._get_or_create_room("ctx", "uuid-weather"),
+            adapter._get_or_create_room("ctx", "uuid-weather"),
+        )
+
+        assert results == [("room-1", "ctx"), ("room-1", "ctx")]
+        adapter._rest.agent_api_participants.add_agent_chat_participant.assert_called_once()
+        assert adapter._room_participants["room-1"] == {"uuid-weather"}

--- a/tests/adapters/test_a2a_gateway_adapter.py
+++ b/tests/adapters/test_a2a_gateway_adapter.py
@@ -10,6 +10,7 @@ from typing import Callable
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from a2a.types import Message as A2AMessage, Part, Role, TextPart
 
 from band.integrations.a2a.gateway import A2AGatewayAdapter
 from band_rest import Peer
@@ -76,14 +77,10 @@ class TestA2AGatewayContextIdFlow:
         adapter = make_gateway_adapter()
 
         # First request with context_id="ctx-user-session"
-        room_1, ctx_1 = await adapter._get_or_create_room(
-            "ctx-user-session", "uuid-weather"
-        )
+        room_1, ctx_1 = await adapter._resolve_room("ctx-user-session", "uuid-weather")
 
         # Second request with SAME context_id
-        room_2, ctx_2 = await adapter._get_or_create_room(
-            "ctx-user-session", "uuid-weather"
-        )
+        room_2, ctx_2 = await adapter._resolve_room("ctx-user-session", "uuid-weather")
 
         # Assertions
         assert room_1 == room_2, f"Expected same room, got {room_1} vs {room_2}"
@@ -99,14 +96,10 @@ class TestA2AGatewayContextIdFlow:
         adapter = make_gateway_adapter()
 
         # First context
-        room_a, ctx_a = await adapter._get_or_create_room(
-            "ctx-session-a", "uuid-weather"
-        )
+        room_a, ctx_a = await adapter._resolve_room("ctx-session-a", "uuid-weather")
 
         # Second context (different)
-        room_b, ctx_b = await adapter._get_or_create_room(
-            "ctx-session-b", "uuid-weather"
-        )
+        room_b, ctx_b = await adapter._resolve_room("ctx-session-b", "uuid-weather")
 
         # Assertions
         assert room_a != room_b, f"Expected different rooms, got same: {room_a}"
@@ -134,10 +127,10 @@ class TestA2AGatewayContextIdFlow:
         adapter._peers_by_uuid["uuid-data"] = data_peer
 
         # First peer
-        room_1, _ = await adapter._get_or_create_room("ctx-multi", "uuid-weather")
+        room_1, _ = await adapter._resolve_room("ctx-multi", "uuid-weather")
 
         # Second peer, same context
-        room_2, _ = await adapter._get_or_create_room("ctx-multi", "uuid-data")
+        room_2, _ = await adapter._resolve_room("ctx-multi", "uuid-data")
 
         # Assertions
         assert room_1 == room_2, "Same context should use same room"
@@ -158,44 +151,41 @@ class TestFreshlyJoinedPeerSettle:
     message during that window, the peer can discover the message through both
     its catch-up poll and its live feed and answer it more than once. The
     gateway therefore settles after adding a peer and before returning control
-    to post the message. Warm rooms, where the peer is already a participant,
-    never add a peer and so never wait.
+    to post the message. A warm turn, where the peer is already a participant,
+    adds no settle of its own, though it can still wait behind an earlier
+    concurrent turn in the same context.
     """
 
     @pytest.mark.asyncio
-    async def test_first_message_waits_until_fresh_peer_subscribes(
+    async def test_fresh_join_waits_for_settle(
         self, make_gateway_adapter: Callable[..., A2AGatewayAdapter]
     ) -> None:
-        """A fresh join must not return until the peer has had time to subscribe.
+        """A fresh join must not return until the settle window completes.
 
-        Reproduction: the peer subscribes a short while after being added. With
-        no settle window the gateway returns immediately, while the peer is
-        still unsubscribed, which is the race that lets the first message be
-        answered multiple times. The settle window must outlast the peer's
-        subscription so the gateway only proceeds once the peer is ready.
+        The settle is what gives a freshly-added peer time to subscribe before
+        the first message is posted. Gating the settle on an event verifies the
+        wait deterministically: room resolution stays pending until the settle
+        is released, then completes.
         """
-        # Peer's subscription completes shortly after it is added to the room.
-        peer_subscribed = asyncio.Event()
+        adapter = make_gateway_adapter()
 
-        async def start_peer_subscription(*args: object, **kwargs: object) -> None:
-            async def subscribe() -> None:
-                await asyncio.sleep(0.05)
-                peer_subscribed.set()
+        entered_settle = asyncio.Event()
+        release_settle = asyncio.Event()
 
-            asyncio.get_running_loop().create_task(subscribe())
+        async def gated_settle() -> None:
+            entered_settle.set()
+            await release_settle.wait()
 
-        # Settle window comfortably longer than the peer's subscribe time.
-        adapter = make_gateway_adapter(settle_seconds=0.5)
-        adapter._rest.agent_api_participants.add_agent_chat_participant = AsyncMock(
-            side_effect=start_peer_subscription
-        )
+        adapter._settle_new_participant = gated_settle
 
-        await adapter._get_or_create_room("ctx-fresh", "uuid-weather")
+        task = asyncio.create_task(adapter._resolve_room("ctx-fresh", "uuid-weather"))
+        await asyncio.wait_for(entered_settle.wait(), timeout=1.0)
 
-        assert peer_subscribed.is_set(), (
-            "gateway returned before the freshly-added peer finished subscribing; "
-            "the first message would be posted into the duplicate-processing window"
-        )
+        assert not task.done(), "resolve returned before the settle completed"
+
+        release_settle.set()
+        _, context_id = await asyncio.wait_for(task, timeout=1.0)
+        assert context_id == "ctx-fresh"
 
     @pytest.mark.asyncio
     async def test_warm_room_reuse_never_waits(
@@ -208,7 +198,7 @@ class TestFreshlyJoinedPeerSettle:
         adapter._room_participants["room-existing"] = {"uuid-weather"}
 
         room_id, _ = await asyncio.wait_for(
-            adapter._get_or_create_room("ctx-warm", "uuid-weather"), timeout=1.0
+            adapter._resolve_room("ctx-warm", "uuid-weather"), timeout=1.0
         )
 
         assert room_id == "room-existing"
@@ -223,32 +213,122 @@ class TestFreshlyJoinedPeerSettle:
         adapter = make_gateway_adapter(settle_seconds=0.0)
 
         await asyncio.wait_for(
-            adapter._get_or_create_room("ctx-fast", "uuid-weather"), timeout=1.0
+            adapter._resolve_room("ctx-fast", "uuid-weather"), timeout=1.0
         )
 
         adapter._rest.agent_api_participants.add_agent_chat_participant.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_concurrent_requests_same_context_join_peer_once(
+    async def test_concurrent_turns_same_context_each_get_own_reply(
         self, make_gateway_adapter: Callable[..., A2AGatewayAdapter]
     ) -> None:
-        """Concurrent requests in one conversation must join the peer only once.
+        """Overlapping turns in one context serialize; both callers get a reply.
 
-        While the first request sits in the settle window, its peer join is not
-        yet recorded. A second concurrent request for the same context and peer
-        must wait for that join to finish rather than issue a duplicate add or
-        post before the settle ends.
+        Band correlates a peer's reply only by room, so the gateway holds one
+        in-flight turn per room: the second turn does not post until the first
+        has streamed its terminal event. Regression guard for the old bug where
+        both turns registered a pending task on the same room, the second
+        overwrote the first, and the first caller's stream hung forever.
         """
-        adapter = make_gateway_adapter(settle_seconds=0.1)
-        # Existing conversation whose room has no participants recorded yet.
-        adapter._context_to_room["ctx"] = "room-1"
-        adapter._room_participants["room-1"] = set()
+        adapter = make_gateway_adapter(settle_seconds=0.0)
 
-        results = await asyncio.gather(
-            adapter._get_or_create_room("ctx", "uuid-weather"),
-            adapter._get_or_create_room("ctx", "uuid-weather"),
+        # Posting a message makes the mentioned peer reply into that room.
+        async def reply_after_post(**kwargs: object) -> MagicMock:
+            room = kwargs["chat_id"]
+
+            async def deliver() -> None:
+                # Let the turn register its pending task and start awaiting.
+                await asyncio.sleep(0)
+                reply = MagicMock()
+                reply.content = "answer"
+                reply.message_type = "text"
+                await adapter.on_message(
+                    reply,
+                    MagicMock(),
+                    None,
+                    None,
+                    None,
+                    is_session_bootstrap=False,
+                    room_id=room,
+                )
+
+            asyncio.get_running_loop().create_task(deliver())
+            return MagicMock()
+
+        adapter._rest.agent_api_messages.create_agent_chat_message = AsyncMock(
+            side_effect=reply_after_post
         )
 
-        assert results == [("room-1", "ctx"), ("room-1", "ctx")]
+        async def drive(text: str) -> list[object]:
+            message = A2AMessage(
+                role=Role.user,
+                message_id=text,
+                parts=[Part(root=TextPart(text=text))],
+                context_id="ctx-shared",
+            )
+            return [
+                event
+                async for event in adapter._handle_a2a_request("weather-agent", message)
+            ]
+
+        events_a, events_b = await asyncio.wait_for(
+            asyncio.gather(drive("first"), drive("second")), timeout=2.0
+        )
+
+        # Both callers received their own terminal event; neither hung.
+        assert events_a and events_a[-1].final
+        assert events_b and events_b[-1].final
+        # The peer was joined once and the room created once.
         adapter._rest.agent_api_participants.add_agent_chat_participant.assert_called_once()
-        assert adapter._room_participants["room-1"] == {"uuid-weather"}
+        assert len(adapter._rooms_created) == 1
+        assert (
+            adapter._rest.agent_api_messages.create_agent_chat_message.call_count == 2
+        )
+        # Each turn removed its own pending entry on completion.
+        assert adapter._pending_tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_join_recorded_before_settle_survives_cancellation(
+        self, make_gateway_adapter: Callable[..., A2AGatewayAdapter]
+    ) -> None:
+        """State recorded before the settle survives a turn cancelled mid-settle.
+
+        The context to room mapping and participant membership are recorded the
+        instant the REST calls succeed, before the settle. So a cancel during
+        the settle strands neither an orphan room nor a lost join: a later turn
+        reuses the room and does not re-add the peer.
+        """
+        adapter = make_gateway_adapter()
+
+        entered_settle = asyncio.Event()
+        release_settle = asyncio.Event()
+
+        async def gated_settle() -> None:
+            entered_settle.set()
+            await release_settle.wait()
+
+        adapter._settle_new_participant = gated_settle
+
+        task = asyncio.create_task(adapter._resolve_room("ctx", "uuid-weather"))
+        await asyncio.wait_for(entered_settle.wait(), timeout=1.0)
+
+        # Room creation + REST add have completed; state must already reflect them.
+        room_id = adapter._context_to_room["ctx"]
+        assert adapter._rooms_created == [room_id]
+        assert adapter._room_participants[room_id] == {"uuid-weather"}
+
+        # Cancel the turn while it is paused in the settle.
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Recorded state persists across the cancellation.
+        assert adapter._context_to_room["ctx"] == room_id
+        assert adapter._room_participants[room_id] == {"uuid-weather"}
+
+        # A later turn reuses the room and does not re-add the (warm) peer.
+        add_mock = adapter._rest.agent_api_participants.add_agent_chat_participant
+        calls_before = add_mock.call_count
+        resolved_room, resolved_ctx = await adapter._resolve_room("ctx", "uuid-weather")
+        assert (resolved_room, resolved_ctx) == (room_id, "ctx")
+        assert add_mock.call_count == calls_before

--- a/tests/integration/test_a2a_gateway_context.py
+++ b/tests/integration/test_a2a_gateway_context.py
@@ -62,7 +62,7 @@ class TestA2AGatewayContextIdWithPlatform:
         """Same context_id twice should route to same room with shared messages.
 
         Uses the session-scoped shared_room to avoid creating new rooms.
-        Pre-populates the adapter's context mapping so _get_or_create_room()
+        Pre-populates the adapter's context mapping so _resolve_room()
         finds the existing room instead of creating one.
         """
         # Get a peer to add to rooms
@@ -90,7 +90,7 @@ class TestA2AGatewayContextIdWithPlatform:
         adapter._room_participants[shared_room] = {peer.id}
 
         # ===== Step 1: First request with context_id =====
-        room_1, ctx_1 = await adapter._get_or_create_room(context_id, peer.id)
+        room_1, ctx_1 = await adapter._resolve_room(context_id, peer.id)
 
         await asyncio.sleep(0.5)  # Platform consistency
 
@@ -105,7 +105,7 @@ class TestA2AGatewayContextIdWithPlatform:
         msg1_id = msg1_response.data.id
 
         # ===== Step 2: Second request with SAME context_id =====
-        room_2, ctx_2 = await adapter._get_or_create_room(context_id, peer.id)
+        room_2, ctx_2 = await adapter._resolve_room(context_id, peer.id)
 
         # Verify same room
         assert room_1 == room_2, (
@@ -147,7 +147,7 @@ class TestA2AGatewayContextIdWithPlatform:
         """Same context_id with different peers should use same room, add all peers.
 
         Uses session-scoped shared_room to avoid creating new rooms.
-        Pre-populates context mapping and participant set so _get_or_create_room()
+        Pre-populates context mapping and participant set so _resolve_room()
         adds the second peer via _ensure_participant without creating a room.
         """
         # Get multiple peers
@@ -180,12 +180,12 @@ class TestA2AGatewayContextIdWithPlatform:
         adapter._room_participants[shared_room] = {peer_1.id, peer_2.id}
 
         # First peer - already mapped, should return shared_room
-        room_1, _ = await adapter._get_or_create_room(context_id, peer_1.id)
+        room_1, _ = await adapter._resolve_room(context_id, peer_1.id)
 
         await asyncio.sleep(0.3)
 
         # Second peer, same context - already in room
-        room_2, _ = await adapter._get_or_create_room(context_id, peer_2.id)
+        room_2, _ = await adapter._resolve_room(context_id, peer_2.id)
 
         # Verify same room
         assert room_1 == room_2, "Same context should use same room for different peers"

--- a/tests/integrations/a2a/gateway/test_adapter.py
+++ b/tests/integrations/a2a/gateway/test_adapter.py
@@ -316,43 +316,6 @@ class TestA2AGatewayAdapterOnMessage:
         assert event.task_id == "task-123"
         assert event.final is True  # text message = completed
 
-    @pytest.mark.asyncio
-    async def test_on_message_cleans_up_on_final_event(
-        self, adapter_with_mocks: A2AGatewayAdapter
-    ) -> None:
-        """Should clean up pending task on final event."""
-        tools = FakeAgentTools()
-        msg = make_platform_message("Done", room_id="room-123")
-
-        # Set up pending task
-        from band.integrations.a2a.gateway.types import PendingA2ATask
-        from a2a.types import Task, TaskStatus
-
-        sse_queue: asyncio.Queue = asyncio.Queue()
-        task = Task(
-            id="task-123",
-            context_id="ctx-123",
-            status=TaskStatus(state=TaskState.working),
-        )
-        adapter_with_mocks._pending_tasks["room-123"] = PendingA2ATask(
-            task=task,
-            sse_queue=sse_queue,
-            peer_id="weather",
-        )
-
-        await adapter_with_mocks.on_message(
-            msg,
-            tools,
-            GatewaySessionState(),
-            None,
-            None,
-            is_session_bootstrap=False,
-            room_id="room-123",
-        )
-
-        # Pending task should be cleaned up
-        assert "room-123" not in adapter_with_mocks._pending_tasks
-
 
 class TestA2AGatewayAdapterRoomManagement:
     """Tests for room creation and management."""
@@ -360,7 +323,7 @@ class TestA2AGatewayAdapterRoomManagement:
     @pytest.fixture
     def adapter_with_mocks(self) -> A2AGatewayAdapter:
         """Create adapter with mocked REST client."""
-        adapter = A2AGatewayAdapter()
+        adapter = A2AGatewayAdapter(new_participant_settle_seconds=0.0)
         adapter._peers = {"weather": make_peer("weather", "Weather Agent")}
 
         # Mock create_agent_chat to return room with ID
@@ -374,13 +337,11 @@ class TestA2AGatewayAdapterRoomManagement:
         return adapter
 
     @pytest.mark.asyncio
-    async def test_get_or_create_room_new_context(
+    async def test_resolve_room_new_context(
         self, adapter_with_mocks: A2AGatewayAdapter
     ) -> None:
         """Should create new room for new context."""
-        room_id, context_id = await adapter_with_mocks._get_or_create_room(
-            None, "weather"
-        )
+        room_id, context_id = await adapter_with_mocks._resolve_room(None, "weather")
 
         assert room_id == "new-room-123"
         assert context_id is not None  # UUID generated
@@ -392,7 +353,7 @@ class TestA2AGatewayAdapterRoomManagement:
         adapter_with_mocks._rest.agent_api_participants.add_agent_chat_participant.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_or_create_room_existing_context(
+    async def test_resolve_room_existing_context(
         self, adapter_with_mocks: A2AGatewayAdapter
     ) -> None:
         """Should reuse existing room for known context."""
@@ -400,7 +361,7 @@ class TestA2AGatewayAdapterRoomManagement:
         adapter_with_mocks._context_to_room["existing-ctx"] = "existing-room"
         adapter_with_mocks._room_participants["existing-room"] = {"weather"}
 
-        room_id, context_id = await adapter_with_mocks._get_or_create_room(
+        room_id, context_id = await adapter_with_mocks._resolve_room(
             "existing-ctx", "weather"
         )
 
@@ -411,7 +372,7 @@ class TestA2AGatewayAdapterRoomManagement:
         adapter_with_mocks._rest.agent_api_chats.create_agent_chat.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_get_or_create_room_adds_new_participant(
+    async def test_resolve_room_adds_new_participant(
         self, adapter_with_mocks: A2AGatewayAdapter
     ) -> None:
         """Should add new participant to existing room."""
@@ -419,9 +380,7 @@ class TestA2AGatewayAdapterRoomManagement:
         adapter_with_mocks._context_to_room["ctx-1"] = "room-1"
         adapter_with_mocks._room_participants["room-1"] = {"other-peer"}
 
-        room_id, context_id = await adapter_with_mocks._get_or_create_room(
-            "ctx-1", "weather"
-        )
+        room_id, context_id = await adapter_with_mocks._resolve_room("ctx-1", "weather")
 
         assert room_id == "room-1"
         assert "weather" in adapter_with_mocks._room_participants["room-1"]
@@ -600,7 +559,7 @@ class TestGatewayContextIdRoomMapping:
     @pytest.fixture
     def adapter_with_tracking(self) -> A2AGatewayAdapter:
         """Create adapter with mocked REST client that tracks room creation."""
-        adapter = A2AGatewayAdapter()
+        adapter = A2AGatewayAdapter(new_participant_settle_seconds=0.0)
         adapter._peers = {"weather": make_peer("weather", "Weather Agent")}
 
         # Track room creation with unique IDs
@@ -629,13 +588,13 @@ class TestGatewayContextIdRoomMapping:
         adapter = adapter_with_tracking
 
         # First request with context_id
-        room_id_1, ctx_1 = await adapter._get_or_create_room("ctx-user-123", "weather")
+        room_id_1, ctx_1 = await adapter._resolve_room("ctx-user-123", "weather")
         create_calls_after_first = (
             adapter._rest.agent_api_chats.create_agent_chat.call_count
         )
 
         # Second request with SAME context_id
-        room_id_2, ctx_2 = await adapter._get_or_create_room("ctx-user-123", "weather")
+        room_id_2, ctx_2 = await adapter._resolve_room("ctx-user-123", "weather")
         create_calls_after_second = (
             adapter._rest.agent_api_chats.create_agent_chat.call_count
         )
@@ -654,8 +613,8 @@ class TestGatewayContextIdRoomMapping:
         """Different context_ids should create different rooms."""
         adapter = adapter_with_tracking
 
-        room_id_1, ctx_1 = await adapter._get_or_create_room("ctx-first", "weather")
-        room_id_2, ctx_2 = await adapter._get_or_create_room("ctx-second", "weather")
+        room_id_1, ctx_1 = await adapter._resolve_room("ctx-first", "weather")
+        room_id_2, ctx_2 = await adapter._resolve_room("ctx-second", "weather")
 
         # Different rooms for different contexts
         assert room_id_1 != room_id_2
@@ -672,8 +631,8 @@ class TestGatewayContextIdRoomMapping:
         adapter = adapter_with_tracking
         adapter._peers["data"] = make_peer("data", "Data Agent")
 
-        room_id_1, _ = await adapter._get_or_create_room("ctx-multi-agent", "weather")
-        room_id_2, _ = await adapter._get_or_create_room("ctx-multi-agent", "data")
+        room_id_1, _ = await adapter._resolve_room("ctx-multi-agent", "weather")
+        room_id_2, _ = await adapter._resolve_room("ctx-multi-agent", "data")
 
         # Same room
         assert room_id_1 == room_id_2


### PR DESCRIPTION
## Summary

Adds `new_participant_settle_seconds` (default `3.0`): a pause after a peer joins and before its first message. Warm rooms are unaffected; set `0` to disable.

## Scope

This is a temporary mitigation, not an exactly-once guarantee. The durable fix is a platform-side exclusive processing claim/lease so an in-flight message cannot be re-served.

## Validation

Covers fresh joins, warm-room reuse, zero-delay opt-out, and concurrent requests for one context.