### PR TITLE
feat(sdk): Strands Agents adapter — Tier-1 injectable-model family

### DIFF
--- a/examples/strands/01_basic_agent.py
+++ b/examples/strands/01_basic_agent.py
@@ -1,0 +1,69 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[strands]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Basic Strands Agents example.
+
+This is the simplest way to create a Band agent with AWS Strands Agents.
+The adapter handles tool registration automatically.
+
+Strands has no provider-prefix model string (a bare string means a Bedrock
+model id), so the OpenAI provider is constructed explicitly; it reads
+OPENAI_API_KEY from the environment.
+
+Run with:
+    uv run examples/strands/01_basic_agent.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from dotenv import load_dotenv
+from strands.models.openai import OpenAIModel
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import StrandsAdapter
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    # Create adapter with framework-specific settings
+    adapter = StrandsAdapter(
+        model=OpenAIModel(model_id="gpt-5.4-mini"),
+        custom_section="You are a helpful assistant. Be concise and friendly.",
+    )
+
+    # Create and start agent
+    agent = Agent.from_config(
+        "strands_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Starting Strands agent...")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/strands/02_custom_tools.py
+++ b/examples/strands/02_custom_tools.py
@@ -1,0 +1,81 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[strands]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Strands agent with custom tools and capabilities.
+
+Shows the portable ``CustomToolDef`` (InputModel, handler) form shared across
+adapters, plus enabling memory/contact tools and execution/usage event
+emission via AdapterFeatures.
+
+Run with:
+    uv run examples/strands/02_custom_tools.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from dotenv import load_dotenv
+from pydantic import BaseModel
+from strands.models.openai import OpenAIModel
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import StrandsAdapter
+from band.core.types import AdapterFeatures, Capability, Emit
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+class WeatherInput(BaseModel):
+    """Get the weather for a city."""
+
+    city: str
+
+
+async def get_weather(args: WeatherInput) -> str:
+    return f"{args.city}: sunny, 22°C"
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    adapter = StrandsAdapter(
+        model=OpenAIModel(model_id="gpt-5.4-mini"),
+        custom_section="You can check the weather with the weather tool.",
+        additional_tools=[(WeatherInput, get_weather)],  # CustomToolDef tuple
+        features=AdapterFeatures(
+            emit=frozenset({Emit.EXECUTION, Emit.USAGE}),
+            capabilities=frozenset({Capability.MEMORY, Capability.CONTACTS}),
+        ),
+    )
+
+    agent = Agent.from_config(
+        "strands_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Starting Strands agent with custom tools...")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/strands/setup_logging.py
+++ b/examples/strands/setup_logging.py
@@ -1,0 +1,12 @@
+"""Shared logging configuration for examples."""
+
+from __future__ import annotations
+
+import logging
+
+from band import configure_logging
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure logging to show only band logs, hiding noisy dependencies."""
+    configure_logging(level)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,9 @@ google_adk = [
 agno = [
     "agno>=2.6.0",
 ]
+strands = [
+    "strands-agents[openai]>=1.40,<2",
+]
 
 # dev extra includes ALL framework deps for testing EXCEPT crewai, which is
 # declared conflicting with both parlant and pydantic-ai (see tool.uv.conflicts).
@@ -199,6 +202,8 @@ dev = [
     "opentelemetry-resourcedetector-gcp>=1.12.0a0,!=1.13.0",
     # Include Agno for testing
     "agno>=2.6.0",
+    # Include Strands Agents for testing
+    "strands-agents[openai]>=1.40,<2",
     # Include letta-client for testing
     "letta-client>=0.1.0",
     # Include bridge deps for testing

--- a/src/band/adapters/__init__.py
+++ b/src/band/adapters/__init__.py
@@ -17,6 +17,7 @@ Install the extra you need::
     uv add band-sdk[google_adk]
     uv add band-sdk[opencode]
     uv add band-sdk[slack]
+    uv add band-sdk[strands]
 """
 
 from __future__ import annotations
@@ -62,6 +63,7 @@ if TYPE_CHECKING:
     from band.adapters.slack import SlackAdapter as SlackAdapter
     from band.adapters.slack import SlackApp as SlackApp
     from band.adapters.slack import SlackSessionState as SlackSessionState
+    from band.adapters.strands import StrandsAdapter as StrandsAdapter
 
 __all__ = [
     "LangGraphAdapter",
@@ -92,6 +94,7 @@ __all__ = [
     "SlackAdapter",
     "SlackApp",
     "SlackSessionState",
+    "StrandsAdapter",
 ]
 
 
@@ -125,6 +128,7 @@ _LAZY_IMPORTS: dict[str, str] = {
     "SlackAdapter": "slack",
     "SlackApp": "slack",
     "SlackSessionState": "slack",
+    "StrandsAdapter": "strands",
 }
 
 

--- a/src/band/adapters/__init__.py
+++ b/src/band/adapters/__init__.py
@@ -22,8 +22,9 @@ Install the extra you need::
 
 from __future__ import annotations
 
-import importlib
 from typing import TYPE_CHECKING
+
+from band.exports import lazy_exports
 
 # Type-only imports for static analysis (pyrefly, mypy, etc.)
 if TYPE_CHECKING:
@@ -65,77 +66,28 @@ if TYPE_CHECKING:
     from band.adapters.slack import SlackSessionState as SlackSessionState
     from band.adapters.strands import StrandsAdapter as StrandsAdapter
 
-__all__ = [
-    "LangGraphAdapter",
-    "AnthropicAdapter",
-    "PydanticAIAdapter",
-    "ClaudeSDKAdapter",
-    "CopilotSDKAdapter",
-    "CopilotSDKAdapterConfig",
-    "CopilotACPAdapter",
-    "CopilotACPAdapterConfig",
-    "ParlantAdapter",
-    "CrewAIAdapter",
-    "CrewAIFlowAdapter",
-    "A2AAdapter",
-    "A2AGatewayAdapter",
-    "CodexAdapter",
-    "CodexAdapterConfig",
-    "ACPClientAdapter",
-    "ACPServer",
-    "BandACPServerAdapter",
-    "AgnoAdapter",
-    "GeminiAdapter",
-    "GoogleADKAdapter",
-    "OpencodeAdapter",
-    "OpencodeAdapterConfig",
-    "LettaAdapter",
-    "LettaAdapterConfig",
-    "SlackAdapter",
-    "SlackApp",
-    "SlackSessionState",
-    "StrandsAdapter",
-]
-
-
-# Submodule (under band.adapters) providing each lazily imported name.
-_LAZY_IMPORTS: dict[str, str] = {
-    "LangGraphAdapter": "langgraph",
-    "AnthropicAdapter": "anthropic",
-    "PydanticAIAdapter": "pydantic_ai",
-    "ClaudeSDKAdapter": "claude_sdk",
-    "CopilotSDKAdapter": "copilot_sdk",
-    "CopilotSDKAdapterConfig": "copilot_sdk",
-    "CopilotACPAdapter": "copilot_acp",
-    "CopilotACPAdapterConfig": "copilot_acp",
-    "ParlantAdapter": "parlant",
-    "CrewAIAdapter": "crewai",
-    "CrewAIFlowAdapter": "crewai_flow",
-    "A2AAdapter": "a2a",
-    "A2AGatewayAdapter": "a2a_gateway",
-    "CodexAdapter": "codex",
-    "CodexAdapterConfig": "codex",
-    "ACPClientAdapter": "acp",
-    "ACPServer": "acp",
-    "BandACPServerAdapter": "acp",
-    "AgnoAdapter": "agno",
-    "GeminiAdapter": "gemini",
-    "GoogleADKAdapter": "google_adk",
-    "OpencodeAdapter": "opencode",
-    "OpencodeAdapterConfig": "opencode",
-    "LettaAdapter": "letta",
-    "LettaAdapterConfig": "letta",
-    "SlackAdapter": "slack",
-    "SlackApp": "slack",
-    "SlackSessionState": "slack",
-    "StrandsAdapter": "strands",
-}
-
-
-def __getattr__(name: str) -> type:
-    """Lazy import adapters to avoid loading optional dependencies."""
-    module_name = _LAZY_IMPORTS.get(name)
-    if module_name is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    module = importlib.import_module(f".{module_name}", __name__)
-    return getattr(module, name)
+__all__, __getattr__, __dir__ = lazy_exports(
+    __name__,
+    {
+        "langgraph": ("LangGraphAdapter",),
+        "anthropic": ("AnthropicAdapter",),
+        "pydantic_ai": ("PydanticAIAdapter",),
+        "claude_sdk": ("ClaudeSDKAdapter",),
+        "copilot_sdk": ("CopilotSDKAdapter", "CopilotSDKAdapterConfig"),
+        "copilot_acp": ("CopilotACPAdapter", "CopilotACPAdapterConfig"),
+        "parlant": ("ParlantAdapter",),
+        "crewai": ("CrewAIAdapter",),
+        "crewai_flow": ("CrewAIFlowAdapter",),
+        "a2a": ("A2AAdapter",),
+        "a2a_gateway": ("A2AGatewayAdapter",),
+        "codex": ("CodexAdapter", "CodexAdapterConfig"),
+        "acp": ("ACPClientAdapter", "ACPServer", "BandACPServerAdapter"),
+        "agno": ("AgnoAdapter",),
+        "gemini": ("GeminiAdapter",),
+        "google_adk": ("GoogleADKAdapter",),
+        "opencode": ("OpencodeAdapter", "OpencodeAdapterConfig"),
+        "letta": ("LettaAdapter", "LettaAdapterConfig"),
+        "slack": ("SlackAdapter", "SlackApp", "SlackSessionState"),
+        "strands": ("StrandsAdapter",),
+    },
+)

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -1,0 +1,746 @@
+"""
+Strands Agents adapter using SimpleAdapter pattern.
+
+Modeled on the pydantic-ai adapter: the framework owns the agent loop, the
+model object is injectable at the public ``Agent(model=...)`` seam, and Band
+platform tools are registered as native framework tools.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable, ClassVar
+
+import httpx
+
+try:
+    from strands import Agent, ToolContext, tool
+    from strands.hooks import HookProvider, HookRegistry
+    from strands.hooks.events import AfterToolCallEvent, BeforeToolCallEvent
+    from strands.models import Model
+    from strands.types.tools import (
+        AgentTool,
+        ToolGenerator,
+        ToolResult,
+        ToolSpec,
+        ToolUse,
+    )
+except ImportError as e:
+    raise ImportError(
+        "Strands Agents dependencies not installed. "
+        "Install with: uv add band-sdk[strands]"
+    ) from e
+
+from band_rest.core.api_error import ApiError
+
+from band.core.protocols import AgentToolsProtocol
+from band.core.simple_adapter import SimpleAdapter
+from band.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+    TurnUsage,
+)
+from band.converters.strands import StrandsHistoryConverter, StrandsMessages
+from band.runtime.custom_tools import (
+    CustomToolDef,
+    execute_custom_tool,
+    get_custom_tool_name,
+    is_marked_terminal,
+)
+from band.runtime.prompts import render_system_prompt
+from band.runtime.tools import (
+    band_tool_errored,
+    get_tool_description,
+    is_terminal_success,
+)
+
+logger = logging.getLogger(__name__)
+
+# invocation_state key carrying the current turn's AgentToolsProtocol handle.
+# Strands threads invocation_state from Agent.invoke_async(...) into every tool
+# body (via ToolContext) and hook event, which is what lets the tool functions
+# be built once while each turn binds its own tools handle.
+_BAND_TOOLS_STATE_KEY = "band_tools"
+
+
+def _tools_from_context(tool_context: ToolContext) -> AgentToolsProtocol:
+    """The current turn's platform tools handle, bound via invocation_state."""
+    handle = tool_context.invocation_state.get(_BAND_TOOLS_STATE_KEY)
+    if handle is None:
+        raise RuntimeError(
+            "Band tools handle missing from invocation_state; platform tools "
+            "must be invoked through StrandsAdapter.on_message"
+        )
+    return handle
+
+
+def _result_text(result: ToolResult) -> str:
+    """Flatten a ToolResult's content blocks to text for error detection/reporting."""
+    parts: list[str] = []
+    for block in result.get("content", []):
+        if "text" in block:
+            parts.append(block["text"])
+        elif "json" in block:
+            try:
+                parts.append(json.dumps(block["json"]))
+            except (TypeError, ValueError):
+                parts.append(str(block["json"]))
+    return "\n".join(parts)
+
+
+class _CustomToolBridge(AgentTool):
+    """A portable ``CustomToolDef`` (InputModel, handler) as a native Strands tool.
+
+    The tool spec is derived from the Pydantic input model (same name/schema the
+    other adapters expose), and dispatch validates + executes via
+    ``execute_custom_tool`` so the argument-validation contract matches the
+    tuple form everywhere else.
+    """
+
+    def __init__(self, tool_def: CustomToolDef):
+        super().__init__()
+        self._tool_def = tool_def
+        input_model, _ = tool_def
+        schema = input_model.model_json_schema()
+        schema.pop("title", None)
+        self._name = get_custom_tool_name(input_model)
+        self._spec: ToolSpec = {
+            "name": self._name,
+            "description": input_model.__doc__ or self._name,
+            "inputSchema": {"json": schema},
+        }
+
+    @property
+    def tool_name(self) -> str:
+        return self._name
+
+    @property
+    def tool_spec(self) -> ToolSpec:
+        return self._spec
+
+    @property
+    def tool_type(self) -> str:
+        return "function"
+
+    async def stream(
+        self, tool_use: ToolUse, invocation_state: dict[str, Any], **kwargs: Any
+    ) -> ToolGenerator:
+        try:
+            result = await execute_custom_tool(self._tool_def, tool_use["input"] or {})
+            yield {
+                "toolUseId": tool_use["toolUseId"],
+                "status": "success",
+                "content": [{"text": str(result)}],
+            }
+        except Exception as e:
+            yield {
+                "toolUseId": tool_use["toolUseId"],
+                "status": "error",
+                "content": [{"text": f"Error executing tool '{self._name}': {e}"}],
+            }
+
+
+class _BandTurnHooks(HookProvider):
+    """Per-turn hook provider: L6 execution events + terminal-action tracking.
+
+    A fresh instance is registered on each turn's Agent, so per-turn state
+    (whether a terminal Band action fired) needs no cross-turn bookkeeping.
+    Event emission is best-effort and never crashes the turn.
+    """
+
+    def __init__(
+        self,
+        tools: AgentToolsProtocol,
+        *,
+        emit_execution: bool,
+        custom_terminal_names: frozenset[str],
+    ):
+        self._tools = tools
+        self._emit_execution = emit_execution
+        self._custom_terminal_names = custom_terminal_names
+        self.terminal_fired = False
+
+    def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
+        registry.add_callback(BeforeToolCallEvent, self._on_before_tool)
+        registry.add_callback(AfterToolCallEvent, self._on_after_tool)
+
+    async def _on_before_tool(self, event: BeforeToolCallEvent) -> None:
+        if not self._emit_execution:
+            return
+        try:
+            await self._tools.send_event(
+                content=json.dumps(
+                    {
+                        "name": event.tool_use["name"],
+                        "args": event.tool_use["input"],
+                        "tool_call_id": event.tool_use["toolUseId"],
+                    }
+                ),
+                message_type="tool_call",
+            )
+        except Exception as e:
+            logger.warning("Failed to send tool_call event: %s", e)
+
+    async def _on_after_tool(self, event: AfterToolCallEvent) -> None:
+        # Custom tools count as terminal only if they opted in (band_terminal);
+        # undeclared customs fail loud. A failed Band tool (its wrapper returns
+        # an "Error " string, or Strands recorded an error status) is not terminal.
+        name = event.tool_use["name"]
+        output = _result_text(event.result)
+        succeeded = event.result.get("status") == "success" and not band_tool_errored(
+            name, output
+        )
+        if is_terminal_success(
+            name,
+            succeeded=succeeded,
+            custom_terminal=name in self._custom_terminal_names,
+        ):
+            self.terminal_fired = True
+        if not self._emit_execution:
+            return
+        try:
+            await self._tools.send_event(
+                content=json.dumps(
+                    {
+                        "name": name,
+                        "output": output,
+                        "tool_call_id": event.tool_use["toolUseId"],
+                    }
+                ),
+                message_type="tool_result",
+            )
+        except Exception as e:
+            logger.warning("Failed to send tool_result event: %s", e)
+
+
+class StrandsAdapter(SimpleAdapter[StrandsMessages]):
+    """
+    Strands Agents adapter using SimpleAdapter pattern.
+
+    Uses a Strands Agent for LLM interactions, with platform tools registered
+    as native Strands ``@tool`` functions.
+
+    Example:
+        from strands.models.openai import OpenAIModel
+
+        adapter = StrandsAdapter(
+            model=OpenAIModel(model_id="gpt-5.4-mini"),
+            custom_section="You are a helpful assistant.",
+        )
+        agent = Agent.create(adapter=adapter, agent_id="...", api_key="...")
+        await agent.run()
+    """
+
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION, Emit.USAGE})
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY, Capability.CONTACTS}
+    )
+
+    def __init__(
+        self,
+        model: str | Model,
+        system_prompt: str | None = None,
+        custom_section: str | None = None,
+        history_converter: StrandsHistoryConverter | None = None,
+        additional_tools: list[Callable[..., Any] | CustomToolDef] | None = None,
+        features: AdapterFeatures | None = None,
+    ):
+        """
+        Initialize the Strands adapter.
+
+        Args:
+            model: A Strands ``Model`` instance (e.g.
+                ``strands.models.openai.OpenAIModel(model_id="gpt-5.4-mini")``).
+                A plain string is passed through to Strands, which treats it as
+                a **Bedrock** model id (Strands has no provider-prefix shorthand).
+            system_prompt: Optional custom system prompt (overrides default)
+            custom_section: Optional custom section added to default system prompt
+            history_converter: Optional custom history converter
+            additional_tools: Optional list of Strands-compatible tools (plain
+                callables or ``@strands.tool``-decorated functions) and/or
+                portable ``CustomToolDef`` (InputModel, handler) tuples.
+            features: Shared adapter feature settings (capabilities, emit, tool filters).
+        """
+        super().__init__(
+            history_converter=history_converter or StrandsHistoryConverter(),
+            features=features,
+        )
+
+        self.model = model
+        self.system_prompt = system_prompt
+        self.custom_section = custom_section
+        self._system_prompt: str | None = None
+
+        # Platform + custom tools, built once in on_started (tool bodies bind the
+        # per-turn tools handle via invocation_state, so they carry no turn state).
+        self._strands_tools: list[Any] = []
+
+        # Conversation history per room (Converse-shaped Messages). Band owns
+        # this state; Strands sessions/conversation managers are not used for
+        # cross-turn persistence.
+        self._message_history: dict[str, StrandsMessages] = {}
+
+        # Custom tools: accept native Strands forms and the portable CustomToolDef
+        # (InputModel, handler) tuple the other adapters take — tuples are bridged
+        # to native Strands AgentTools; callables pass through unchanged.
+        self._custom_tools: list[Any] = [
+            _CustomToolBridge(t) if isinstance(t, tuple) else t
+            for t in (additional_tools or [])
+        ]
+        # Custom tools that opt in as terminal actions (band_terminal=True on the
+        # handler/function). Only these let a turn with no Band-tool action count
+        # as productive; an undeclared custom tool does not (fail-loud — see
+        # is_terminal_success).
+        terminal_names: set[str] = set()
+        for raw, converted in zip(additional_tools or [], self._custom_tools):
+            handler = raw[1] if isinstance(raw, tuple) else raw
+            if is_marked_terminal(handler):
+                terminal_names.add(
+                    converted.tool_name
+                    if isinstance(converted, AgentTool)
+                    else getattr(converted, "__name__", str(converted))
+                )
+        self._custom_terminal_names: frozenset[str] = frozenset(terminal_names)
+
+    async def on_started(self, agent_name: str, agent_description: str) -> None:
+        """Render the system prompt and build the tool set after metadata is fetched."""
+        await super().on_started(agent_name, agent_description)
+        self._system_prompt = self.system_prompt or render_system_prompt(
+            agent_name=self.agent_name,
+            agent_description=self.agent_description or "An AI assistant",
+            custom_section=self.custom_section or "",
+            features=self.features,
+        )
+        self._strands_tools = self._build_platform_tools() + self._custom_tools
+        logger.info("Strands adapter started for agent: %s", agent_name)
+
+    def _build_agent(self, messages: StrandsMessages, hooks: _BandTurnHooks) -> Agent:
+        """Construct the Strands Agent for one turn, over the room's history.
+
+        A Strands Agent is stateful (it owns ``messages`` and per-agent metrics)
+        and raises on concurrent invocation, while the Band runtime runs one
+        asyncio task per room — so a single shared Agent would break under
+        multi-room concurrency. Instead the heavy pieces (prompt, tool set) are
+        built once in on_started and a lightweight Agent shell is constructed
+        per turn over the room's messages (mirrors the google_adk adapter's
+        fresh-runner-per-message pattern). Bonus: a fresh Agent has fresh
+        metrics, so accumulated usage is exactly this turn's usage.
+        """
+        return Agent(
+            model=self.model,
+            messages=messages,
+            tools=self._strands_tools,
+            system_prompt=self._system_prompt,
+            hooks=[hooks],
+            callback_handler=None,
+            name=self.agent_name or None,
+        )
+
+    def _build_platform_tools(self) -> list[Any]:
+        """Build the Band platform tools as native Strands ``@tool`` functions.
+
+        Descriptions come from the centralized tool definitions. All tools catch
+        exceptions and return "Error ..." strings so the LLM can see failures
+        (and so terminal detection can tell a failed Band tool from a success).
+        """
+
+        def band(name: str, fn: Callable[..., Any]) -> Any:
+            return tool(description=get_tool_description(name), context=True)(fn)
+
+        async def band_send_message(
+            content: str,
+            mentions: list[str],
+            tool_context: ToolContext,
+        ) -> Any:
+            try:
+                return await _tools_from_context(tool_context).send_message(
+                    content, mentions
+                )
+            except Exception as e:
+                return f"Error sending message: {e}"
+
+        async def band_send_event(
+            content: str,
+            message_type: str,
+            tool_context: ToolContext,
+            metadata: dict[str, Any] | None = None,
+        ) -> Any:
+            try:
+                return await _tools_from_context(tool_context).send_event(
+                    content, message_type, metadata
+                )
+            except Exception as e:
+                return f"Error sending event: {e}"
+
+        async def band_add_participant(
+            identifier: str,
+            tool_context: ToolContext,
+            role: str = "member",
+        ) -> Any:
+            try:
+                return await _tools_from_context(tool_context).add_participant(
+                    identifier, role
+                )
+            except Exception as e:
+                return f"Error adding participant '{identifier}': {e}"
+
+        async def band_remove_participant(
+            identifier: str,
+            tool_context: ToolContext,
+        ) -> Any:
+            try:
+                return await _tools_from_context(tool_context).remove_participant(
+                    identifier
+                )
+            except Exception as e:
+                return f"Error removing participant '{identifier}': {e}"
+
+        async def band_lookup_peers(
+            tool_context: ToolContext,
+            page: int = 1,
+            page_size: int = 50,
+        ) -> Any:
+            try:
+                return await _tools_from_context(tool_context).lookup_peers(
+                    page, page_size
+                )
+            except Exception as e:
+                return f"Error looking up peers: {e}"
+
+        async def band_get_participants(tool_context: ToolContext) -> Any:
+            try:
+                return await _tools_from_context(tool_context).get_participants()
+            except Exception as e:
+                return f"Error getting participants: {e}"
+
+        async def band_create_chatroom(
+            tool_context: ToolContext,
+            task_id: str | None = None,
+        ) -> Any:
+            try:
+                return await _tools_from_context(tool_context).create_chatroom(task_id)
+            except Exception as e:
+                return f"Error creating chatroom (task_id={task_id}): {e}"
+
+        strands_tools = [
+            band("band_send_message", band_send_message),
+            band("band_send_event", band_send_event),
+            band("band_add_participant", band_add_participant),
+            band("band_remove_participant", band_remove_participant),
+            band("band_lookup_peers", band_lookup_peers),
+            band("band_get_participants", band_get_participants),
+            band("band_create_chatroom", band_create_chatroom),
+        ]
+
+        # Contact management tools (opt-in via Capability.CONTACTS)
+        if Capability.CONTACTS in self.features.capabilities:
+
+            async def band_list_contacts(
+                tool_context: ToolContext,
+                page: int = 1,
+                page_size: int = 50,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).list_contacts(
+                        page, page_size
+                    )
+                except Exception as e:
+                    return f"Error listing contacts: {e}"
+
+            async def band_add_contact(
+                handle: str,
+                tool_context: ToolContext,
+                message: str | None = None,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).add_contact(
+                        handle, message
+                    )
+                except Exception as e:
+                    return f"Error adding contact '{handle}': {e}"
+
+            async def band_remove_contact(
+                tool_context: ToolContext,
+                handle: str | None = None,
+                contact_id: str | None = None,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).remove_contact(
+                        handle, contact_id
+                    )
+                except Exception as e:
+                    return f"Error removing contact: {e}"
+
+            async def band_list_contact_requests(
+                tool_context: ToolContext,
+                page: int = 1,
+                page_size: int = 50,
+                sent_status: str = "pending",
+            ) -> Any:
+                try:
+                    return await _tools_from_context(
+                        tool_context
+                    ).list_contact_requests(page, page_size, sent_status)
+                except Exception as e:
+                    return f"Error listing contact requests: {e}"
+
+            async def band_respond_contact_request(
+                action: str,
+                tool_context: ToolContext,
+                handle: str | None = None,
+                request_id: str | None = None,
+            ) -> Any:
+                tools = _tools_from_context(tool_context)
+                try:
+                    return await tools.respond_contact_request(
+                        action, handle, request_id
+                    )
+                except Exception as e:
+                    error_msg = f"Error responding to contact request: {e}"
+                    # Auto-send error event so it's visible in the room
+                    try:
+                        await tools.send_event(error_msg, "error")
+                    except Exception:
+                        pass  # Don't fail if error reporting fails
+                    return error_msg
+
+            strands_tools.extend(
+                [
+                    band("band_list_contacts", band_list_contacts),
+                    band("band_add_contact", band_add_contact),
+                    band("band_remove_contact", band_remove_contact),
+                    band("band_list_contact_requests", band_list_contact_requests),
+                    band("band_respond_contact_request", band_respond_contact_request),
+                ]
+            )
+
+        # Memory management tools (enterprise only - opt-in)
+        if Capability.MEMORY in self.features.capabilities:
+
+            async def band_list_memories(
+                tool_context: ToolContext,
+                subject_id: str | None = None,
+                scope: str | None = None,
+                system: str | None = None,
+                type: str | None = None,
+                segment: str | None = None,
+                content_query: str | None = None,
+                page_size: int = 50,
+                status: str | None = None,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).list_memories(
+                        subject_id=subject_id,
+                        scope=scope,
+                        system=system,
+                        type=type,
+                        segment=segment,
+                        content_query=content_query,
+                        page_size=page_size,
+                        status=status,
+                    )
+                except Exception as e:
+                    return f"Error listing memories: {e}"
+
+            async def band_store_memory(
+                content: str,
+                system: str,
+                type: str,
+                segment: str,
+                thought: str,
+                scope: str,
+                tool_context: ToolContext,
+                subject_id: str | None = None,
+                metadata: dict[str, Any] | None = None,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).store_memory(
+                        content=content,
+                        system=system,
+                        type=type,
+                        segment=segment,
+                        thought=thought,
+                        scope=scope,
+                        subject_id=subject_id,
+                        metadata=metadata,
+                    )
+                except Exception as e:
+                    return f"Error storing memory: {e}"
+
+            async def band_get_memory(
+                memory_id: str,
+                tool_context: ToolContext,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).get_memory(memory_id)
+                except Exception as e:
+                    return f"Error getting memory: {e}"
+
+            async def band_supersede_memory(
+                memory_id: str,
+                tool_context: ToolContext,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).supersede_memory(
+                        memory_id
+                    )
+                except Exception as e:
+                    return f"Error superseding memory: {e}"
+
+            async def band_archive_memory(
+                memory_id: str,
+                tool_context: ToolContext,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).archive_memory(
+                        memory_id
+                    )
+                except Exception as e:
+                    return f"Error archiving memory: {e}"
+
+            strands_tools.extend(
+                [
+                    band("band_list_memories", band_list_memories),
+                    band("band_store_memory", band_store_memory),
+                    band("band_get_memory", band_get_memory),
+                    band("band_supersede_memory", band_supersede_memory),
+                    band("band_archive_memory", band_archive_memory),
+                ]
+            )
+
+        return strands_tools
+
+    async def on_message(
+        self,
+        msg: PlatformMessage,
+        tools: AgentToolsProtocol,
+        history: StrandsMessages,  # Already converted by SimpleAdapter
+        participants_msg: str | None,
+        contacts_msg: str | None,
+        *,
+        is_session_bootstrap: bool,
+        room_id: str,
+    ) -> None:
+        """Handle incoming platform message."""
+        if not self._strands_tools:
+            # Safety: build tools if not yet built (should be done in on_started)
+            self._strands_tools = self._build_platform_tools() + self._custom_tools
+
+        # Initialize message history for this room on first message
+        # Note: history is already converted by SimpleAdapter via history_converter
+        if is_session_bootstrap:
+            if history:
+                self._message_history[room_id] = list(history)
+                logger.debug(
+                    "Room %s: rehydrated %s message(s) from platform history",
+                    room_id,
+                    len(history),
+                )
+            else:
+                self._message_history[room_id] = []
+        elif room_id not in self._message_history:
+            # Safety: ensure history exists even if not first message
+            self._message_history[room_id] = []
+
+        # Inject participants message if changed
+        if participants_msg:
+            self._message_history[room_id].append(
+                {"role": "user", "content": [{"text": f"[System]: {participants_msg}"}]}
+            )
+            logger.debug("Room %s: Injected participant update into history", room_id)
+
+        # Inject contacts message if present
+        if contacts_msg:
+            self._message_history[room_id].append(
+                {"role": "user", "content": [{"text": f"[System]: {contacts_msg}"}]}
+            )
+            logger.debug("Room %s: Injected contacts broadcast into history", room_id)
+
+        # Build user message with sender prefix
+        user_message = msg.format_for_llm()
+
+        logger.debug(
+            "Room %s: Running Strands agent (history: %s msgs, prompt: %s...)",
+            room_id,
+            len(self._message_history[room_id]),
+            user_message[:80],
+        )
+
+        turn_hooks = _BandTurnHooks(
+            tools,
+            emit_execution=Emit.EXECUTION in self.features.emit,
+            custom_terminal_names=self._custom_terminal_names,
+        )
+        agent = self._build_agent(self._message_history[room_id], turn_hooks)
+        try:
+            await agent.invoke_async(
+                user_message,
+                invocation_state={_BAND_TOOLS_STATE_KEY: tools},
+            )
+        finally:
+            # Persist whatever the run recorded (also on a failed turn, so the
+            # room keeps the user prompt + any completed tool work), and emit
+            # this turn's usage: the per-turn Agent has per-turn metrics, so
+            # accumulated_usage is exactly this run's total across its model
+            # calls. emit_usage itself gates on Emit.USAGE and never raises.
+            self._message_history[room_id] = agent.messages
+            await self.emit_usage(tools, self._usage_from_agent(agent))
+
+        # A clean run with no terminal work means the model answered in plain text
+        # without calling band_send_message — a silently dropped reply. Surface it
+        # as an error (mirrors the pydantic-ai/crewai adapters).
+        if not turn_hooks.terminal_fired:
+            await self._report_error(
+                tools,
+                "Strands agent completed without sending a Band message. This "
+                "usually means the agent returned a final answer as plain text "
+                "instead of using the band_send_message tool.",
+            )
+
+        logger.debug(
+            "Room %s: Strands agent completed (history now has %s messages)",
+            room_id,
+            len(self._message_history[room_id]),
+        )
+
+    @staticmethod
+    def _usage_from_agent(agent: Agent) -> TurnUsage:
+        """Map the turn's accumulated token usage onto TurnUsage.
+
+        Strands accumulates usage on the agent's EventLoopMetrics across all of
+        the run's model calls; reading it from the agent (not the AgentResult)
+        also covers turns that raised mid-run. totalTokens is derived
+        (input + output) and deliberately not mapped.
+        """
+        try:
+            usage = dict(agent.event_loop_metrics.accumulated_usage)
+        except Exception:  # pragma: no cover - defensive; usage is best-effort
+            return TurnUsage()
+        return TurnUsage.from_mapping(
+            usage,
+            input="inputTokens",
+            output="outputTokens",
+            cache_read="cacheReadInputTokens",
+            cache_write="cacheWriteInputTokens",
+        )
+
+    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
+        """Send an error event to the room (best effort).
+
+        Narrowed to the REST call's real failure modes (ApiError = HTTP status,
+        httpx = transport) so a failed error-report never crashes the turn —
+        while a real bug still raises.
+        """
+        try:
+            await tools.send_event(content=f"Error: {error}", message_type="error")
+        except (ApiError, httpx.HTTPError) as e:
+            logger.warning("Failed to send error event: %s", e)
+
+    async def on_cleanup(self, room_id: str) -> None:
+        """Clean up message history when agent leaves a room."""
+        if room_id in self._message_history:
+            del self._message_history[room_id]
+            logger.debug("Room %s: Cleaned up message history", room_id)

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -81,14 +81,38 @@ def _result_text(result: ToolResult) -> str:
     """Flatten a ToolResult's content blocks to text for error detection/reporting."""
     parts: list[str] = []
     for block in result.get("content", []):
-        if "text" in block:
-            parts.append(block["text"])
-        elif "json" in block:
-            try:
-                parts.append(json.dumps(block["json"]))
-            except (TypeError, ValueError):
-                parts.append(str(block["json"]))
+        match block:
+            case {"text": text}:
+                parts.append(text)
+            case {"json": value}:
+                try:
+                    parts.append(json.dumps(value))
+                except (TypeError, ValueError):
+                    parts.append(str(value))
     return "\n".join(parts)
+
+
+def _build_custom_tools(
+    additional_tools: list[Callable[..., Any] | CustomToolDef] | None,
+) -> tuple[list[Any], frozenset[str]]:
+    """Convert portable tools and collect the custom terminal actions."""
+    converted = [
+        _CustomToolBridge(tool_def) if isinstance(tool_def, tuple) else tool_def
+        for tool_def in additional_tools or []
+    ]
+    terminal_names = {
+        tool.tool_name
+        if isinstance(tool, AgentTool)
+        else getattr(tool, "__name__", str(tool))
+        for raw, tool in zip(additional_tools or [], converted)
+        if is_marked_terminal(raw[1] if isinstance(raw, tuple) else raw)
+    }
+    return converted, frozenset(terminal_names)
+
+
+def _as_strands_tool(name: str, fn: Callable[..., Any]) -> Any:
+    """Wrap a Band tool with its canonical description and Strands context."""
+    return tool(description=get_tool_description(name), context=True)(fn)
 
 
 class _CustomToolBridge(AgentTool):
@@ -283,27 +307,9 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         # cross-turn persistence.
         self._message_history: dict[str, StrandsMessages] = {}
 
-        # Custom tools: accept native Strands forms and the portable CustomToolDef
-        # (InputModel, handler) tuple the other adapters take — tuples are bridged
-        # to native Strands AgentTools; callables pass through unchanged.
-        self._custom_tools: list[Any] = [
-            _CustomToolBridge(t) if isinstance(t, tuple) else t
-            for t in (additional_tools or [])
-        ]
-        # Custom tools that opt in as terminal actions (band_terminal=True on the
-        # handler/function). Only these let a turn with no Band-tool action count
-        # as productive; an undeclared custom tool does not (fail-loud — see
-        # is_terminal_success).
-        terminal_names: set[str] = set()
-        for raw, converted in zip(additional_tools or [], self._custom_tools):
-            handler = raw[1] if isinstance(raw, tuple) else raw
-            if is_marked_terminal(handler):
-                terminal_names.add(
-                    converted.tool_name
-                    if isinstance(converted, AgentTool)
-                    else getattr(converted, "__name__", str(converted))
-                )
-        self._custom_terminal_names: frozenset[str] = frozenset(terminal_names)
+        self._custom_tools, self._custom_terminal_names = _build_custom_tools(
+            additional_tools
+        )
 
     async def on_started(self, agent_name: str, agent_description: str) -> None:
         """Render the system prompt and build the tool set after metadata is fetched."""
@@ -346,9 +352,6 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         exceptions and return "Error ..." strings so the LLM can see failures
         (and so terminal detection can tell a failed Band tool from a success).
         """
-
-        def band(name: str, fn: Callable[..., Any]) -> Any:
-            return tool(description=get_tool_description(name), context=True)(fn)
 
         async def band_send_message(
             content: str,
@@ -426,13 +429,13 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
                 return f"Error creating chatroom (task_id={task_id}): {e}"
 
         strands_tools = [
-            band("band_send_message", band_send_message),
-            band("band_send_event", band_send_event),
-            band("band_add_participant", band_add_participant),
-            band("band_remove_participant", band_remove_participant),
-            band("band_lookup_peers", band_lookup_peers),
-            band("band_get_participants", band_get_participants),
-            band("band_create_chatroom", band_create_chatroom),
+            _as_strands_tool("band_send_message", band_send_message),
+            _as_strands_tool("band_send_event", band_send_event),
+            _as_strands_tool("band_add_participant", band_add_participant),
+            _as_strands_tool("band_remove_participant", band_remove_participant),
+            _as_strands_tool("band_lookup_peers", band_lookup_peers),
+            _as_strands_tool("band_get_participants", band_get_participants),
+            _as_strands_tool("band_create_chatroom", band_create_chatroom),
         ]
 
         # Contact management tools (opt-in via Capability.CONTACTS)
@@ -509,11 +512,15 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
 
             strands_tools.extend(
                 [
-                    band("band_list_contacts", band_list_contacts),
-                    band("band_add_contact", band_add_contact),
-                    band("band_remove_contact", band_remove_contact),
-                    band("band_list_contact_requests", band_list_contact_requests),
-                    band("band_respond_contact_request", band_respond_contact_request),
+                    _as_strands_tool("band_list_contacts", band_list_contacts),
+                    _as_strands_tool("band_add_contact", band_add_contact),
+                    _as_strands_tool("band_remove_contact", band_remove_contact),
+                    _as_strands_tool(
+                        "band_list_contact_requests", band_list_contact_requests
+                    ),
+                    _as_strands_tool(
+                        "band_respond_contact_request", band_respond_contact_request
+                    ),
                 ]
             )
 
@@ -603,15 +610,46 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
 
             strands_tools.extend(
                 [
-                    band("band_list_memories", band_list_memories),
-                    band("band_store_memory", band_store_memory),
-                    band("band_get_memory", band_get_memory),
-                    band("band_supersede_memory", band_supersede_memory),
-                    band("band_archive_memory", band_archive_memory),
+                    _as_strands_tool("band_list_memories", band_list_memories),
+                    _as_strands_tool("band_store_memory", band_store_memory),
+                    _as_strands_tool("band_get_memory", band_get_memory),
+                    _as_strands_tool("band_supersede_memory", band_supersede_memory),
+                    _as_strands_tool("band_archive_memory", band_archive_memory),
                 ]
             )
 
         return strands_tools
+
+    def _history_for_turn(
+        self,
+        room_id: str,
+        history: StrandsMessages,
+        *,
+        is_session_bootstrap: bool,
+    ) -> StrandsMessages:
+        """Return the room history, rehydrating it once when a session starts."""
+        if is_session_bootstrap:
+            self._message_history[room_id] = list(history)
+            if history:
+                logger.debug(
+                    "Room %s: rehydrated %s message(s) from platform history",
+                    room_id,
+                    len(history),
+                )
+        return self._message_history.setdefault(room_id, [])
+
+    @staticmethod
+    def _append_system_context(
+        history: StrandsMessages,
+        participants_msg: str | None,
+        contacts_msg: str | None,
+    ) -> None:
+        """Append platform context that changed since the prior turn."""
+        for message in (participants_msg, contacts_msg):
+            if message:
+                history.append(
+                    {"role": "user", "content": [{"text": f"[System]: {message}"}]}
+                )
 
     async def on_message(
         self,
@@ -629,35 +667,10 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             # Safety: build tools if not yet built (should be done in on_started)
             self._strands_tools = self._build_platform_tools() + self._custom_tools
 
-        # Initialize message history for this room on first message
-        # Note: history is already converted by SimpleAdapter via history_converter
-        if is_session_bootstrap:
-            if history:
-                self._message_history[room_id] = list(history)
-                logger.debug(
-                    "Room %s: rehydrated %s message(s) from platform history",
-                    room_id,
-                    len(history),
-                )
-            else:
-                self._message_history[room_id] = []
-        elif room_id not in self._message_history:
-            # Safety: ensure history exists even if not first message
-            self._message_history[room_id] = []
-
-        # Inject participants message if changed
-        if participants_msg:
-            self._message_history[room_id].append(
-                {"role": "user", "content": [{"text": f"[System]: {participants_msg}"}]}
-            )
-            logger.debug("Room %s: Injected participant update into history", room_id)
-
-        # Inject contacts message if present
-        if contacts_msg:
-            self._message_history[room_id].append(
-                {"role": "user", "content": [{"text": f"[System]: {contacts_msg}"}]}
-            )
-            logger.debug("Room %s: Injected contacts broadcast into history", room_id)
+        room_history = self._history_for_turn(
+            room_id, history, is_session_bootstrap=is_session_bootstrap
+        )
+        self._append_system_context(room_history, participants_msg, contacts_msg)
 
         # Build user message with sender prefix
         user_message = msg.format_for_llm()
@@ -665,7 +678,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         logger.debug(
             "Room %s: Running Strands agent (history: %s msgs, prompt: %s...)",
             room_id,
-            len(self._message_history[room_id]),
+            len(room_history),
             user_message[:80],
         )
 
@@ -674,7 +687,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             emit_execution=Emit.EXECUTION in self.features.emit,
             custom_terminal_names=self._custom_terminal_names,
         )
-        agent = self._build_agent(self._message_history[room_id], turn_hooks)
+        agent = self._build_agent(room_history, turn_hooks)
         try:
             await agent.invoke_async(
                 user_message,

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -1,10 +1,4 @@
-"""
-Strands Agents adapter using SimpleAdapter pattern.
-
-Modeled on the pydantic-ai adapter: the framework owns the agent loop, the
-model object is injectable at the public ``Agent(model=...)`` seam, and Band
-platform tools are registered as native framework tools.
-"""
+"""Band adapter for Strands Agents."""
 
 from __future__ import annotations
 
@@ -59,10 +53,7 @@ from band.runtime.tools import (
 
 logger = logging.getLogger(__name__)
 
-# invocation_state key carrying the current turn's AgentToolsProtocol handle.
-# Strands threads invocation_state from Agent.invoke_async(...) into every tool
-# body (via ToolContext) and hook event, which is what lets the tool functions
-# be built once while each turn binds its own tools handle.
+# Per-turn Band tools are passed through Strands invocation state.
 _BAND_TOOLS_STATE_KEY = "band_tools"
 
 
@@ -116,13 +107,7 @@ def _as_strands_tool(name: str, fn: Callable[..., Any]) -> Any:
 
 
 class _CustomToolBridge(AgentTool):
-    """A portable ``CustomToolDef`` (InputModel, handler) as a native Strands tool.
-
-    The tool spec is derived from the Pydantic input model (same name/schema the
-    other adapters expose), and dispatch validates + executes via
-    ``execute_custom_tool`` so the argument-validation contract matches the
-    tuple form everywhere else.
-    """
+    """Expose a portable custom tool as a native Strands tool."""
 
     def __init__(self, tool_def: CustomToolDef):
         super().__init__()
@@ -168,12 +153,7 @@ class _CustomToolBridge(AgentTool):
 
 
 class _BandTurnHooks(HookProvider):
-    """Per-turn hook provider: L6 execution events + terminal-action tracking.
-
-    A fresh instance is registered on each turn's Agent, so per-turn state
-    (whether a terminal Band action fired) needs no cross-turn bookkeeping.
-    Event emission is best-effort and never crashes the turn.
-    """
+    """Emit execution events and track terminal actions for one turn."""
 
     def __init__(
         self,
@@ -209,9 +189,7 @@ class _BandTurnHooks(HookProvider):
             logger.warning("Failed to send tool_call event: %s", e)
 
     async def _on_after_tool(self, event: AfterToolCallEvent) -> None:
-        # Custom tools count as terminal only if they opted in (band_terminal);
-        # undeclared customs fail loud. A failed Band tool (its wrapper returns
-        # an "Error " string, or Strands recorded an error status) is not terminal.
+        # Only successful Band tools and marked custom tools end a turn.
         name = event.tool_use["name"]
         output = _result_text(event.result)
         succeeded = event.result.get("status") == "success" and not band_tool_errored(
@@ -241,22 +219,7 @@ class _BandTurnHooks(HookProvider):
 
 
 class StrandsAdapter(SimpleAdapter[StrandsMessages]):
-    """
-    Strands Agents adapter using SimpleAdapter pattern.
-
-    Uses a Strands Agent for LLM interactions, with platform tools registered
-    as native Strands ``@tool`` functions.
-
-    Example:
-        from strands.models.openai import OpenAIModel
-
-        adapter = StrandsAdapter(
-            model=OpenAIModel(model_id="gpt-5.4-mini"),
-            custom_section="You are a helpful assistant.",
-        )
-        agent = Agent.create(adapter=adapter, agent_id="...", api_key="...")
-        await agent.run()
-    """
+    """Run a Strands model in a Band room."""
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
@@ -298,13 +261,10 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         self.custom_section = custom_section
         self._system_prompt: str | None = None
 
-        # Platform + custom tools, built once in on_started (tool bodies bind the
-        # per-turn tools handle via invocation_state, so they carry no turn state).
+        # Tool definitions are shared; invocation state supplies per-turn tools.
         self._strands_tools: list[Any] = []
 
-        # Conversation history per room (Converse-shaped Messages). Band owns
-        # this state; Strands sessions/conversation managers are not used for
-        # cross-turn persistence.
+        # Band owns per-room conversation history.
         self._message_history: dict[str, StrandsMessages] = {}
 
         self._custom_tools, self._custom_terminal_names = _build_custom_tools(
@@ -324,17 +284,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         logger.info("Strands adapter started for agent: %s", agent_name)
 
     def _build_agent(self, messages: StrandsMessages, hooks: _BandTurnHooks) -> Agent:
-        """Construct the Strands Agent for one turn, over the room's history.
-
-        A Strands Agent is stateful (it owns ``messages`` and per-agent metrics)
-        and raises on concurrent invocation, while the Band runtime runs one
-        asyncio task per room — so a single shared Agent would break under
-        multi-room concurrency. Instead the heavy pieces (prompt, tool set) are
-        built once in on_started and a lightweight Agent shell is constructed
-        per turn over the room's messages (mirrors the google_adk adapter's
-        fresh-runner-per-message pattern). Bonus: a fresh Agent has fresh
-        metrics, so accumulated usage is exactly this turn's usage.
-        """
+        """Build an isolated agent for one room turn and its usage metrics."""
         return Agent(
             model=self.model,
             messages=messages,
@@ -346,12 +296,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         )
 
     def _build_platform_tools(self) -> list[Any]:
-        """Build the Band platform tools as native Strands ``@tool`` functions.
-
-        Descriptions come from the centralized tool definitions. All tools catch
-        exceptions and return "Error ..." strings so the LLM can see failures
-        (and so terminal detection can tell a failed Band tool from a success).
-        """
+        """Build Band platform tools as native Strands tools."""
 
         async def band_send_message(
             content: str,
@@ -655,7 +600,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         self,
         msg: PlatformMessage,
         tools: AgentToolsProtocol,
-        history: StrandsMessages,  # Already converted by SimpleAdapter
+        history: StrandsMessages,
         participants_msg: str | None,
         contacts_msg: str | None,
         *,
@@ -664,7 +609,6 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
     ) -> None:
         """Handle incoming platform message."""
         if not self._strands_tools:
-            # Safety: build tools if not yet built (should be done in on_started)
             self._strands_tools = self._build_platform_tools() + self._custom_tools
 
         room_history = self._history_for_turn(
@@ -672,7 +616,6 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         )
         self._append_system_context(room_history, participants_msg, contacts_msg)
 
-        # Build user message with sender prefix
         user_message = msg.format_for_llm()
 
         logger.debug(
@@ -694,17 +637,11 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
                 invocation_state={_BAND_TOOLS_STATE_KEY: tools},
             )
         finally:
-            # Persist whatever the run recorded (also on a failed turn, so the
-            # room keeps the user prompt + any completed tool work), and emit
-            # this turn's usage: the per-turn Agent has per-turn metrics, so
-            # accumulated_usage is exactly this run's total across its model
-            # calls. emit_usage itself gates on Emit.USAGE and never raises.
+            # Preserve completed work and usage when the turn fails.
             self._message_history[room_id] = agent.messages
             await self.emit_usage(tools, self._usage_from_agent(agent))
 
-        # A clean run with no terminal work means the model answered in plain text
-        # without calling band_send_message — a silently dropped reply. Surface it
-        # as an error (mirrors the pydantic-ai/crewai adapters).
+        # Plain-text answers are not delivered to the room.
         if not turn_hooks.terminal_fired:
             await self._report_error(
                 tools,
@@ -721,13 +658,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
 
     @staticmethod
     def _usage_from_agent(agent: Agent) -> TurnUsage:
-        """Map the turn's accumulated token usage onto TurnUsage.
-
-        Strands accumulates usage on the agent's EventLoopMetrics across all of
-        the run's model calls; reading it from the agent (not the AgentResult)
-        also covers turns that raised mid-run. totalTokens is derived
-        (input + output) and deliberately not mapped.
-        """
+        """Map the agent's turn usage to Band usage."""
         try:
             usage = dict(agent.event_loop_metrics.accumulated_usage)
         except Exception:  # pragma: no cover - defensive; usage is best-effort
@@ -741,12 +672,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         )
 
     async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Send an error event to the room (best effort).
-
-        Narrowed to the REST call's real failure modes (ApiError = HTTP status,
-        httpx = transport) so a failed error-report never crashes the turn —
-        while a real bug still raises.
-        """
+        """Send a best-effort error event."""
         try:
             await tools.send_event(content=f"Error: {error}", message_type="error")
         except (ApiError, httpx.HTTPError) as e:

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Callable, ClassVar
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any, ClassVar, cast
 
 import httpx
+from pydantic import BaseModel
 
 try:
-    from strands import Agent, ToolContext, tool
+    from strands import Agent
     from strands.hooks import HookProvider, HookRegistry
     from strands.hooks.events import AfterToolCallEvent, BeforeToolCallEvent
     from strands.models import Model
@@ -20,11 +22,11 @@ try:
         ToolSpec,
         ToolUse,
     )
-except ImportError as e:
+except ImportError as error:
     raise ImportError(
         "Strands Agents dependencies not installed. "
         "Install with: uv add band-sdk[strands]"
-    ) from e
+    ) from error
 
 from band_rest.core.api_error import ApiError
 
@@ -34,7 +36,9 @@ from band.core.types import (
     AdapterFeatures,
     Capability,
     Emit,
+    MessageType,
     PlatformMessage,
+    ToolEventKey,
     TurnUsage,
 )
 from band.converters.strands import StrandsHistoryConverter, StrandsMessages
@@ -46,79 +50,84 @@ from band.runtime.custom_tools import (
 )
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
+    ToolDefinition,
+    ToolCallOutcome,
     band_tool_errored,
-    get_tool_description,
     is_terminal_success,
+    iter_tool_definitions,
+    serialize_tool_result,
+    validate_tool_arguments,
 )
 
 logger = logging.getLogger(__name__)
 
-# Per-turn Band tools are passed through Strands invocation state.
-_BAND_TOOLS_STATE_KEY = "band_tools"
+
+def _format_tool_output(value: object) -> str:
+    """Return a stable text representation accepted by Strands tool results."""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        return str(value)
 
 
-def _tools_from_context(tool_context: ToolContext) -> AgentToolsProtocol:
-    """The current turn's platform tools handle, bound via invocation_state."""
-    handle = tool_context.invocation_state.get(_BAND_TOOLS_STATE_KEY)
-    if handle is None:
-        raise RuntimeError(
-            "Band tools handle missing from invocation_state; platform tools "
-            "must be invoked through StrandsAdapter.on_message"
-        )
-    return handle
+def _tool_result(tool_use: ToolUse, *, value: object, ok: bool) -> ToolResult:
+    """Build the framework's typed result envelope at the Strands boundary."""
+    return {
+        "toolUseId": tool_use["toolUseId"],
+        "status": "success" if ok else "error",
+        "content": [{"text": _format_tool_output(value)}],
+    }
 
 
 def _result_text(result: ToolResult) -> str:
-    """Flatten a ToolResult's content blocks to text for error detection/reporting."""
+    """Flatten a tool result for execution events and terminal-state policy."""
     parts: list[str] = []
     for block in result.get("content", []):
         match block:
-            case {"text": text}:
+            case {"text": str() as text}:
                 parts.append(text)
             case {"json": value}:
-                try:
-                    parts.append(json.dumps(value))
-                except (TypeError, ValueError):
-                    parts.append(str(value))
+                parts.append(_format_tool_output(value))
     return "\n".join(parts)
 
 
 def _build_custom_tools(
     additional_tools: list[Callable[..., Any] | CustomToolDef] | None,
-) -> tuple[list[Any], frozenset[str]]:
-    """Convert portable tools and collect the custom terminal actions."""
-    converted = [
-        _CustomToolBridge(tool_def) if isinstance(tool_def, tuple) else tool_def
-        for tool_def in additional_tools or []
+) -> tuple[list[AgentTool | Callable[..., Any]], frozenset[str]]:
+    """Adapt portable custom tools and collect their terminal-action names."""
+    raw_tools = additional_tools or []
+    converted: list[AgentTool | Callable[..., Any]] = [
+        CustomToolBridge(tool_def) if isinstance(tool_def, tuple) else tool_def
+        for tool_def in raw_tools
     ]
-    terminal_names = {
+    terminal_names = frozenset(
         tool.tool_name
         if isinstance(tool, AgentTool)
-        else getattr(tool, "__name__", str(tool))
-        for raw, tool in zip(additional_tools or [], converted)
+        else str(getattr(tool, "__name__", tool))
+        for raw, tool in zip(raw_tools, converted)
         if is_marked_terminal(raw[1] if isinstance(raw, tuple) else raw)
-    }
-    return converted, frozenset(terminal_names)
+    )
+    return converted, terminal_names
 
 
-def _as_strands_tool(name: str, fn: Callable[..., Any]) -> Any:
-    """Wrap a Band tool with its canonical description and Strands context."""
-    return tool(description=get_tool_description(name), context=True)(fn)
+class StrandsToolBridge(AgentTool):
+    """Base class for native Strands tools backed by a Pydantic input model."""
 
-
-class _CustomToolBridge(AgentTool):
-    """Expose a portable custom tool as a native Strands tool."""
-
-    def __init__(self, tool_def: CustomToolDef):
+    def __init__(
+        self,
+        name: str,
+        input_model: type[BaseModel],
+        description: str,
+    ) -> None:
         super().__init__()
-        self._tool_def = tool_def
-        input_model, _ = tool_def
         schema = input_model.model_json_schema()
         schema.pop("title", None)
-        self._name = get_custom_tool_name(input_model)
+        self._name = name
         self._spec: ToolSpec = {
-            "name": self._name,
-            "description": input_model.__doc__ or self._name,
+            "name": name,
+            "description": description,
             "inputSchema": {"json": schema},
         }
 
@@ -134,26 +143,89 @@ class _CustomToolBridge(AgentTool):
     def tool_type(self) -> str:
         return "function"
 
+
+class CustomToolBridge(StrandsToolBridge):
+    """Expose a portable custom tool through Strands' native tool protocol."""
+
+    def __init__(self, tool_def: CustomToolDef):
+        self._tool_def = tool_def
+        input_model, _ = tool_def
+        name = get_custom_tool_name(input_model)
+        super().__init__(name, input_model, input_model.__doc__ or name)
+
     async def stream(
-        self, tool_use: ToolUse, invocation_state: dict[str, Any], **kwargs: Any
+        self,
+        tool_use: ToolUse,
+        invocation_state: dict[str, Any],
+        **kwargs: Any,
     ) -> ToolGenerator:
+        del invocation_state, kwargs
         try:
-            result = await execute_custom_tool(self._tool_def, tool_use["input"] or {})
-            yield {
-                "toolUseId": tool_use["toolUseId"],
-                "status": "success",
-                "content": [{"text": str(result)}],
-            }
-        except Exception as e:
-            yield {
-                "toolUseId": tool_use["toolUseId"],
-                "status": "error",
-                "content": [{"text": f"Error executing tool '{self._name}': {e}"}],
-            }
+            result = await execute_custom_tool(
+                self._tool_def, dict(tool_use["input"] or {})
+            )
+        except Exception as error:
+            yield _tool_result(
+                tool_use,
+                value=f"Error executing tool '{self.tool_name}': {error}",
+                ok=False,
+            )
+            return
+        yield _tool_result(tool_use, value=result, ok=True)
 
 
-class _BandTurnHooks(HookProvider):
-    """Emit execution events and track terminal actions for one turn."""
+class PlatformToolBridge(StrandsToolBridge):
+    """Execute one registered Band tool against a turn-scoped capability.
+
+    Strands calls the typed ``AgentToolsProtocol`` method directly. This is
+    intentional: its framework-conformance contract observes those operations,
+    and the shared registry still supplies the method name, schema, validation,
+    and result serialization.
+    """
+
+    def __init__(self, definition: ToolDefinition, tools: AgentToolsProtocol):
+        self._definition = definition
+        self._tools = tools
+        super().__init__(
+            definition.name,
+            definition.input_model,
+            definition.input_model.__doc__ or definition.name,
+        )
+
+    async def stream(
+        self,
+        tool_use: ToolUse,
+        invocation_state: dict[str, Any],
+        **kwargs: Any,
+    ) -> ToolGenerator:
+        del invocation_state, kwargs
+        outcome = await self._execute(dict(tool_use["input"] or {}))
+        yield _tool_result(tool_use, value=outcome.value, ok=outcome.ok)
+
+    async def _execute(self, arguments: dict[str, Any]) -> ToolCallOutcome:
+        """Validate and dispatch through the registered typed protocol method."""
+        try:
+            validated = validate_tool_arguments(
+                self.tool_name, self._definition.input_model, arguments
+            )
+        except ValueError as error:
+            return ToolCallOutcome(value=str(error), ok=False, error_message=str(error))
+
+        try:
+            method = cast(
+                Callable[..., Awaitable[object]],
+                getattr(self._tools, self._definition.method_name),
+            )
+            value = await method(**validated)
+        except Exception as error:
+            logger.exception("Platform tool %s failed", self.tool_name)
+            message = f"Error executing {self.tool_name}: {error}"
+            return ToolCallOutcome(value=message, ok=False, error_message=message)
+        return ToolCallOutcome(value=serialize_tool_result(value), ok=True)
+
+
+class BandTurnHooks(HookProvider):
+    """Emit execution events and record whether a turn completed useful work."""
 
     def __init__(
         self,
@@ -161,35 +233,30 @@ class _BandTurnHooks(HookProvider):
         *,
         emit_execution: bool,
         custom_terminal_names: frozenset[str],
-    ):
+    ) -> None:
         self._tools = tools
         self._emit_execution = emit_execution
         self._custom_terminal_names = custom_terminal_names
         self.terminal_fired = False
 
     def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
+        del kwargs
         registry.add_callback(BeforeToolCallEvent, self._on_before_tool)
         registry.add_callback(AfterToolCallEvent, self._on_after_tool)
 
     async def _on_before_tool(self, event: BeforeToolCallEvent) -> None:
         if not self._emit_execution:
             return
-        try:
-            await self._tools.send_event(
-                content=json.dumps(
-                    {
-                        "name": event.tool_use["name"],
-                        "args": event.tool_use["input"],
-                        "tool_call_id": event.tool_use["toolUseId"],
-                    }
-                ),
-                message_type="tool_call",
-            )
-        except Exception as e:
-            logger.warning("Failed to send tool_call event: %s", e)
+        await self._emit_event(
+            MessageType.TOOL_CALL,
+            {
+                ToolEventKey.NAME: event.tool_use["name"],
+                ToolEventKey.ARGS: event.tool_use["input"],
+                ToolEventKey.TOOL_CALL_ID: event.tool_use["toolUseId"],
+            },
+        )
 
     async def _on_after_tool(self, event: AfterToolCallEvent) -> None:
-        # Only successful Band tools and marked custom tools end a turn.
         name = event.tool_use["name"]
         output = _result_text(event.result)
         succeeded = event.result.get("status") == "success" and not band_tool_errored(
@@ -203,19 +270,27 @@ class _BandTurnHooks(HookProvider):
             self.terminal_fired = True
         if not self._emit_execution:
             return
+        await self._emit_event(
+            MessageType.TOOL_RESULT,
+            {
+                ToolEventKey.NAME: name,
+                ToolEventKey.OUTPUT: output,
+                ToolEventKey.TOOL_CALL_ID: event.tool_use["toolUseId"],
+            },
+        )
+
+    async def _emit_event(
+        self,
+        message_type: MessageType,
+        payload: Mapping[ToolEventKey, object],
+    ) -> None:
         try:
             await self._tools.send_event(
-                content=json.dumps(
-                    {
-                        "name": name,
-                        "output": output,
-                        "tool_call_id": event.tool_use["toolUseId"],
-                    }
-                ),
-                message_type="tool_result",
+                content=json.dumps(payload, default=str),
+                message_type=message_type,
             )
-        except Exception as e:
-            logger.warning("Failed to send tool_result event: %s", e)
+        except Exception as error:
+            logger.warning("Failed to send %s event: %s", message_type, error)
 
 
 class StrandsAdapter(SimpleAdapter[StrandsMessages]):
@@ -234,45 +309,23 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         history_converter: StrandsHistoryConverter | None = None,
         additional_tools: list[Callable[..., Any] | CustomToolDef] | None = None,
         features: AdapterFeatures | None = None,
-    ):
-        """
-        Initialize the Strands adapter.
-
-        Args:
-            model: A Strands ``Model`` instance (e.g.
-                ``strands.models.openai.OpenAIModel(model_id="gpt-5.4-mini")``).
-                A plain string is passed through to Strands, which treats it as
-                a **Bedrock** model id (Strands has no provider-prefix shorthand).
-            system_prompt: Optional custom system prompt (overrides default)
-            custom_section: Optional custom section added to default system prompt
-            history_converter: Optional custom history converter
-            additional_tools: Optional list of Strands-compatible tools (plain
-                callables or ``@strands.tool``-decorated functions) and/or
-                portable ``CustomToolDef`` (InputModel, handler) tuples.
-            features: Shared adapter feature settings (capabilities, emit, tool filters).
-        """
+    ) -> None:
+        """Create an adapter around a Strands model or Bedrock model identifier."""
         super().__init__(
             history_converter=history_converter or StrandsHistoryConverter(),
             features=features,
         )
-
         self.model = model
         self.system_prompt = system_prompt
         self.custom_section = custom_section
         self._system_prompt: str | None = None
-
-        # Tool definitions are shared; invocation state supplies per-turn tools.
-        self._strands_tools: list[Any] = []
-
-        # Band owns per-room conversation history.
         self._message_history: dict[str, StrandsMessages] = {}
-
         self._custom_tools, self._custom_terminal_names = _build_custom_tools(
             additional_tools
         )
 
     async def on_started(self, agent_name: str, agent_description: str) -> None:
-        """Render the system prompt and build the tool set after metadata is fetched."""
+        """Render the prompt after the platform supplies agent metadata."""
         await super().on_started(agent_name, agent_description)
         self._system_prompt = self.system_prompt or render_system_prompt(
             agent_name=self.agent_name,
@@ -280,290 +333,37 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             custom_section=self.custom_section or "",
             features=self.features,
         )
-        self._strands_tools = self._build_platform_tools() + self._custom_tools
         logger.info("Strands adapter started for agent: %s", agent_name)
 
-    def _build_agent(self, messages: StrandsMessages, hooks: _BandTurnHooks) -> Agent:
-        """Build an isolated agent for one room turn and its usage metrics."""
+    def _build_agent(
+        self,
+        messages: StrandsMessages,
+        tools: AgentToolsProtocol,
+        hooks: BandTurnHooks,
+    ) -> Agent:
+        """Create an isolated agent whose tools own one turn's capability."""
+        framework_tools = self._build_platform_tools(tools) + self._custom_tools
         return Agent(
             model=self.model,
             messages=messages,
-            tools=self._strands_tools,
+            # Strands accepts functions, dict specs, providers, and AgentTools,
+            # but its public annotation cannot express that mixed collection.
+            tools=cast(list[Any], framework_tools),
             system_prompt=self._system_prompt,
             hooks=[hooks],
             callback_handler=None,
             name=self.agent_name or None,
         )
 
-    def _build_platform_tools(self) -> list[Any]:
-        """Build Band platform tools as native Strands tools."""
-
-        async def band_send_message(
-            content: str,
-            mentions: list[str],
-            tool_context: ToolContext,
-        ) -> Any:
-            try:
-                return await _tools_from_context(tool_context).send_message(
-                    content, mentions
-                )
-            except Exception as e:
-                return f"Error sending message: {e}"
-
-        async def band_send_event(
-            content: str,
-            message_type: str,
-            tool_context: ToolContext,
-            metadata: dict[str, Any] | None = None,
-        ) -> Any:
-            try:
-                return await _tools_from_context(tool_context).send_event(
-                    content, message_type, metadata
-                )
-            except Exception as e:
-                return f"Error sending event: {e}"
-
-        async def band_add_participant(
-            identifier: str,
-            tool_context: ToolContext,
-            role: str = "member",
-        ) -> Any:
-            try:
-                return await _tools_from_context(tool_context).add_participant(
-                    identifier, role
-                )
-            except Exception as e:
-                return f"Error adding participant '{identifier}': {e}"
-
-        async def band_remove_participant(
-            identifier: str,
-            tool_context: ToolContext,
-        ) -> Any:
-            try:
-                return await _tools_from_context(tool_context).remove_participant(
-                    identifier
-                )
-            except Exception as e:
-                return f"Error removing participant '{identifier}': {e}"
-
-        async def band_lookup_peers(
-            tool_context: ToolContext,
-            page: int = 1,
-            page_size: int = 50,
-        ) -> Any:
-            try:
-                return await _tools_from_context(tool_context).lookup_peers(
-                    page, page_size
-                )
-            except Exception as e:
-                return f"Error looking up peers: {e}"
-
-        async def band_get_participants(tool_context: ToolContext) -> Any:
-            try:
-                return await _tools_from_context(tool_context).get_participants()
-            except Exception as e:
-                return f"Error getting participants: {e}"
-
-        async def band_create_chatroom(
-            tool_context: ToolContext,
-            task_id: str | None = None,
-        ) -> Any:
-            try:
-                return await _tools_from_context(tool_context).create_chatroom(task_id)
-            except Exception as e:
-                return f"Error creating chatroom (task_id={task_id}): {e}"
-
-        strands_tools = [
-            _as_strands_tool("band_send_message", band_send_message),
-            _as_strands_tool("band_send_event", band_send_event),
-            _as_strands_tool("band_add_participant", band_add_participant),
-            _as_strands_tool("band_remove_participant", band_remove_participant),
-            _as_strands_tool("band_lookup_peers", band_lookup_peers),
-            _as_strands_tool("band_get_participants", band_get_participants),
-            _as_strands_tool("band_create_chatroom", band_create_chatroom),
+    def _build_platform_tools(self, tools: AgentToolsProtocol) -> list[AgentTool]:
+        """Adapt the central Band tool registry to Strands for this turn."""
+        return [
+            PlatformToolBridge(definition, tools)
+            for definition in iter_tool_definitions(
+                include_memory=Capability.MEMORY in self.features.capabilities,
+                include_contacts=Capability.CONTACTS in self.features.capabilities,
+            )
         ]
-
-        # Contact management tools (opt-in via Capability.CONTACTS)
-        if Capability.CONTACTS in self.features.capabilities:
-
-            async def band_list_contacts(
-                tool_context: ToolContext,
-                page: int = 1,
-                page_size: int = 50,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).list_contacts(
-                        page, page_size
-                    )
-                except Exception as e:
-                    return f"Error listing contacts: {e}"
-
-            async def band_add_contact(
-                handle: str,
-                tool_context: ToolContext,
-                message: str | None = None,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).add_contact(
-                        handle, message
-                    )
-                except Exception as e:
-                    return f"Error adding contact '{handle}': {e}"
-
-            async def band_remove_contact(
-                tool_context: ToolContext,
-                handle: str | None = None,
-                contact_id: str | None = None,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).remove_contact(
-                        handle, contact_id
-                    )
-                except Exception as e:
-                    return f"Error removing contact: {e}"
-
-            async def band_list_contact_requests(
-                tool_context: ToolContext,
-                page: int = 1,
-                page_size: int = 50,
-                sent_status: str = "pending",
-            ) -> Any:
-                try:
-                    return await _tools_from_context(
-                        tool_context
-                    ).list_contact_requests(page, page_size, sent_status)
-                except Exception as e:
-                    return f"Error listing contact requests: {e}"
-
-            async def band_respond_contact_request(
-                action: str,
-                tool_context: ToolContext,
-                handle: str | None = None,
-                request_id: str | None = None,
-            ) -> Any:
-                tools = _tools_from_context(tool_context)
-                try:
-                    return await tools.respond_contact_request(
-                        action, handle, request_id
-                    )
-                except Exception as e:
-                    error_msg = f"Error responding to contact request: {e}"
-                    # Auto-send error event so it's visible in the room
-                    try:
-                        await tools.send_event(error_msg, "error")
-                    except Exception:
-                        pass  # Don't fail if error reporting fails
-                    return error_msg
-
-            strands_tools.extend(
-                [
-                    _as_strands_tool("band_list_contacts", band_list_contacts),
-                    _as_strands_tool("band_add_contact", band_add_contact),
-                    _as_strands_tool("band_remove_contact", band_remove_contact),
-                    _as_strands_tool(
-                        "band_list_contact_requests", band_list_contact_requests
-                    ),
-                    _as_strands_tool(
-                        "band_respond_contact_request", band_respond_contact_request
-                    ),
-                ]
-            )
-
-        # Memory management tools (enterprise only - opt-in)
-        if Capability.MEMORY in self.features.capabilities:
-
-            async def band_list_memories(
-                tool_context: ToolContext,
-                subject_id: str | None = None,
-                scope: str | None = None,
-                system: str | None = None,
-                type: str | None = None,
-                segment: str | None = None,
-                content_query: str | None = None,
-                page_size: int = 50,
-                status: str | None = None,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).list_memories(
-                        subject_id=subject_id,
-                        scope=scope,
-                        system=system,
-                        type=type,
-                        segment=segment,
-                        content_query=content_query,
-                        page_size=page_size,
-                        status=status,
-                    )
-                except Exception as e:
-                    return f"Error listing memories: {e}"
-
-            async def band_store_memory(
-                content: str,
-                system: str,
-                type: str,
-                segment: str,
-                thought: str,
-                scope: str,
-                tool_context: ToolContext,
-                subject_id: str | None = None,
-                metadata: dict[str, Any] | None = None,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).store_memory(
-                        content=content,
-                        system=system,
-                        type=type,
-                        segment=segment,
-                        thought=thought,
-                        scope=scope,
-                        subject_id=subject_id,
-                        metadata=metadata,
-                    )
-                except Exception as e:
-                    return f"Error storing memory: {e}"
-
-            async def band_get_memory(
-                memory_id: str,
-                tool_context: ToolContext,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).get_memory(memory_id)
-                except Exception as e:
-                    return f"Error getting memory: {e}"
-
-            async def band_supersede_memory(
-                memory_id: str,
-                tool_context: ToolContext,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).supersede_memory(
-                        memory_id
-                    )
-                except Exception as e:
-                    return f"Error superseding memory: {e}"
-
-            async def band_archive_memory(
-                memory_id: str,
-                tool_context: ToolContext,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).archive_memory(
-                        memory_id
-                    )
-                except Exception as e:
-                    return f"Error archiving memory: {e}"
-
-            strands_tools.extend(
-                [
-                    _as_strands_tool("band_list_memories", band_list_memories),
-                    _as_strands_tool("band_store_memory", band_store_memory),
-                    _as_strands_tool("band_get_memory", band_get_memory),
-                    _as_strands_tool("band_supersede_memory", band_supersede_memory),
-                    _as_strands_tool("band_archive_memory", band_archive_memory),
-                ]
-            )
-
-        return strands_tools
 
     def _history_for_turn(
         self,
@@ -572,15 +372,11 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         *,
         is_session_bootstrap: bool,
     ) -> StrandsMessages:
-        """Return the room history, rehydrating it once when a session starts."""
+        """Get the room transcript, using platform history only at session start."""
         if is_session_bootstrap:
             self._message_history[room_id] = list(history)
             if history:
-                logger.debug(
-                    "Room %s: rehydrated %s message(s) from platform history",
-                    room_id,
-                    len(history),
-                )
+                logger.debug("Room %s: rehydrated %s message(s)", room_id, len(history))
         return self._message_history.setdefault(room_id, [])
 
     @staticmethod
@@ -589,12 +385,29 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         participants_msg: str | None,
         contacts_msg: str | None,
     ) -> None:
-        """Append platform context that changed since the prior turn."""
+        """Append changed platform context to the transcript."""
         for message in (participants_msg, contacts_msg):
             if message:
                 history.append(
                     {"role": "user", "content": [{"text": f"[System]: {message}"}]}
                 )
+
+    async def _run_turn(
+        self,
+        *,
+        message: str,
+        room_id: str,
+        history: StrandsMessages,
+        tools: AgentToolsProtocol,
+        hooks: BandTurnHooks,
+    ) -> None:
+        """Run the framework loop while preserving transcript and usage on failure."""
+        agent = self._build_agent(history, tools, hooks)
+        try:
+            await agent.invoke_async(message)
+        finally:
+            self._message_history[room_id] = agent.messages
+            await self.emit_usage(tools, self._usage_from_agent(agent))
 
     async def on_message(
         self,
@@ -607,17 +420,12 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         is_session_bootstrap: bool,
         room_id: str,
     ) -> None:
-        """Handle incoming platform message."""
-        if not self._strands_tools:
-            self._strands_tools = self._build_platform_tools() + self._custom_tools
-
+        """Run one room turn and surface a missing tool-based reply."""
         room_history = self._history_for_turn(
             room_id, history, is_session_bootstrap=is_session_bootstrap
         )
         self._append_system_context(room_history, participants_msg, contacts_msg)
-
         user_message = msg.format_for_llm()
-
         logger.debug(
             "Room %s: Running Strands agent (history: %s msgs, prompt: %s...)",
             room_id,
@@ -625,31 +433,25 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             user_message[:80],
         )
 
-        turn_hooks = _BandTurnHooks(
+        hooks = BandTurnHooks(
             tools,
             emit_execution=Emit.EXECUTION in self.features.emit,
             custom_terminal_names=self._custom_terminal_names,
         )
-        agent = self._build_agent(room_history, turn_hooks)
-        try:
-            await agent.invoke_async(
-                user_message,
-                invocation_state={_BAND_TOOLS_STATE_KEY: tools},
-            )
-        finally:
-            # Preserve completed work and usage when the turn fails.
-            self._message_history[room_id] = agent.messages
-            await self.emit_usage(tools, self._usage_from_agent(agent))
-
-        # Plain-text answers are not delivered to the room.
-        if not turn_hooks.terminal_fired:
+        await self._run_turn(
+            message=user_message,
+            room_id=room_id,
+            history=room_history,
+            tools=tools,
+            hooks=hooks,
+        )
+        if not hooks.terminal_fired:
             await self._report_error(
                 tools,
                 "Strands agent completed without sending a Band message. This "
                 "usually means the agent returned a final answer as plain text "
                 "instead of using the band_send_message tool.",
             )
-
         logger.debug(
             "Room %s: Strands agent completed (history now has %s messages)",
             room_id,
@@ -658,10 +460,10 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
 
     @staticmethod
     def _usage_from_agent(agent: Agent) -> TurnUsage:
-        """Map the agent's turn usage to Band usage."""
+        """Map Strands' accumulated turn usage into the SDK value object."""
         try:
             usage = dict(agent.event_loop_metrics.accumulated_usage)
-        except Exception:  # pragma: no cover - defensive; usage is best-effort
+        except Exception:  # pragma: no cover - usage reporting is best-effort
             return TurnUsage()
         return TurnUsage.from_mapping(
             usage,
@@ -672,14 +474,16 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         )
 
     async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Send a best-effort error event."""
+        """Post a best-effort room-visible adapter error."""
         try:
-            await tools.send_event(content=f"Error: {error}", message_type="error")
-        except (ApiError, httpx.HTTPError) as e:
-            logger.warning("Failed to send error event: %s", e)
+            await tools.send_event(
+                content=f"Error: {error}",
+                message_type=MessageType.ERROR,
+            )
+        except (ApiError, httpx.HTTPError) as report_error:
+            logger.warning("Failed to send error event: %s", report_error)
 
     async def on_cleanup(self, room_id: str) -> None:
-        """Clean up message history when agent leaves a room."""
-        if room_id in self._message_history:
-            del self._message_history[room_id]
+        """Discard the transcript when Band removes the adapter from a room."""
+        if self._message_history.pop(room_id, None) is not None:
             logger.debug("Room %s: Cleaned up message history", room_id)

--- a/src/band/converters/__init__.py
+++ b/src/band/converters/__init__.py
@@ -18,8 +18,9 @@ Install the extra you need::
 
 from __future__ import annotations
 
-import importlib
 from typing import TYPE_CHECKING
+
+from band.exports import lazy_exports
 
 # Type-only imports for static analysis (pyrefly, mypy, etc.)
 if TYPE_CHECKING:
@@ -85,73 +86,25 @@ if TYPE_CHECKING:
         OpencodeHistoryConverter as OpencodeHistoryConverter,
     )
 
-__all__ = [
-    "LangChainHistoryConverter",
-    "LangChainMessages",
-    "AnthropicHistoryConverter",
-    "AnthropicMessages",
-    "PydanticAIHistoryConverter",
-    "PydanticAIMessages",
-    "ClaudeSDKHistoryConverter",
-    "CopilotSDKHistoryConverter",
-    "CopilotSDKSessionState",
-    "ParlantHistoryConverter",
-    "ParlantMessages",
-    "CrewAIHistoryConverter",
-    "CrewAIMessages",
-    "CrewAIFlowSessionState",
-    "CrewAIFlowStateConverter",
-    "A2AHistoryConverter",
-    "GatewayHistoryConverter",
-    "CodexHistoryConverter",
-    "ACPServerHistoryConverter",
-    "ACPClientHistoryConverter",
-    "AgnoHistoryConverter",
-    "AgnoMessages",
-    "GeminiHistoryConverter",
-    "GeminiMessages",
-    "GoogleADKHistoryConverter",
-    "GoogleADKMessages",
-    "OpencodeHistoryConverter",
-]
-
-
-# Submodule (under band.converters) providing each lazily imported name.
-_LAZY_IMPORTS: dict[str, str] = {
-    "LangChainHistoryConverter": "langchain",
-    "LangChainMessages": "langchain",
-    "AnthropicHistoryConverter": "anthropic",
-    "AnthropicMessages": "anthropic",
-    "PydanticAIHistoryConverter": "pydantic_ai",
-    "PydanticAIMessages": "pydantic_ai",
-    "ClaudeSDKHistoryConverter": "claude_sdk",
-    "CopilotSDKHistoryConverter": "copilot_sdk",
-    "CopilotSDKSessionState": "copilot_sdk",
-    "ParlantHistoryConverter": "parlant",
-    "ParlantMessages": "parlant",
-    "CrewAIHistoryConverter": "crewai",
-    "CrewAIMessages": "crewai",
-    "CrewAIFlowStateConverter": "crewai_flow",
-    "CrewAIFlowSessionState": "crewai_flow",
-    "A2AHistoryConverter": "a2a",
-    "GatewayHistoryConverter": "a2a_gateway",
-    "CodexHistoryConverter": "codex",
-    "ACPServerHistoryConverter": "acp_server",
-    "ACPClientHistoryConverter": "acp_client",
-    "AgnoHistoryConverter": "agno",
-    "AgnoMessages": "agno",
-    "GeminiHistoryConverter": "gemini",
-    "GeminiMessages": "gemini",
-    "GoogleADKHistoryConverter": "google_adk",
-    "GoogleADKMessages": "google_adk",
-    "OpencodeHistoryConverter": "opencode",
-}
-
-
-def __getattr__(name: str) -> type:
-    """Lazy import converters to avoid loading optional dependencies."""
-    module_name = _LAZY_IMPORTS.get(name)
-    if module_name is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    module = importlib.import_module(f".{module_name}", __name__)
-    return getattr(module, name)
+__all__, __getattr__, __dir__ = lazy_exports(
+    __name__,
+    {
+        "langchain": ("LangChainHistoryConverter", "LangChainMessages"),
+        "anthropic": ("AnthropicHistoryConverter", "AnthropicMessages"),
+        "pydantic_ai": ("PydanticAIHistoryConverter", "PydanticAIMessages"),
+        "claude_sdk": ("ClaudeSDKHistoryConverter",),
+        "copilot_sdk": ("CopilotSDKHistoryConverter", "CopilotSDKSessionState"),
+        "parlant": ("ParlantHistoryConverter", "ParlantMessages"),
+        "crewai": ("CrewAIHistoryConverter", "CrewAIMessages"),
+        "crewai_flow": ("CrewAIFlowStateConverter", "CrewAIFlowSessionState"),
+        "a2a": ("A2AHistoryConverter",),
+        "a2a_gateway": ("GatewayHistoryConverter",),
+        "codex": ("CodexHistoryConverter",),
+        "acp_server": ("ACPServerHistoryConverter",),
+        "acp_client": ("ACPClientHistoryConverter",),
+        "agno": ("AgnoHistoryConverter", "AgnoMessages"),
+        "gemini": ("GeminiHistoryConverter", "GeminiMessages"),
+        "google_adk": ("GoogleADKHistoryConverter", "GoogleADKMessages"),
+        "opencode": ("OpencodeHistoryConverter",),
+    },
+)

--- a/src/band/converters/parsing.py
+++ b/src/band/converters/parsing.py
@@ -11,6 +11,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
+from band.core.types import ToolEventKey
+
 logger = logging.getLogger(__name__)
 
 
@@ -56,24 +58,24 @@ def parse_tool_call(content: str) -> ParsedToolCall | None:
         )
         return None
 
-    tool_call_id = event.get("tool_call_id")
-    tool_name = event.get("name")
+    tool_call_id = event.get(ToolEventKey.TOOL_CALL_ID)
+    tool_name = event.get(ToolEventKey.NAME)
 
-    if not tool_call_id:
+    if not isinstance(tool_call_id, str) or not tool_call_id:
         logger.warning(
             "Skipping tool_call with missing tool_call_id: %s",
             repr(content[:100]),
         )
         return None
 
-    if not tool_name:
+    if not isinstance(tool_name, str) or not tool_name:
         logger.warning(
             "Skipping tool_call with missing name: %s",
             repr(content[:100]),
         )
         return None
 
-    args = event.get("args", {})
+    args = event.get(ToolEventKey.ARGS, {})
     if not isinstance(args, dict):
         logger.warning(
             "Tool_call args were not an object; using empty args: %s",
@@ -111,17 +113,17 @@ def parse_tool_result(content: str) -> ParsedToolResult | None:
         )
         return None
 
-    tool_call_id = event.get("tool_call_id")
-    tool_name = event.get("name")
+    tool_call_id = event.get(ToolEventKey.TOOL_CALL_ID)
+    tool_name = event.get(ToolEventKey.NAME)
 
-    if not tool_call_id:
+    if not isinstance(tool_call_id, str) or not tool_call_id:
         logger.warning(
             "Skipping tool_result with missing tool_call_id: %s",
             repr(content[:100]),
         )
         return None
 
-    if not tool_name:
+    if not isinstance(tool_name, str) or not tool_name:
         logger.warning(
             "Skipping tool_result with missing name: %s",
             repr(content[:100]),
@@ -130,7 +132,7 @@ def parse_tool_result(content: str) -> ParsedToolResult | None:
 
     return ParsedToolResult(
         name=tool_name,
-        output=str(event.get("output", "")),
+        output=str(event.get(ToolEventKey.OUTPUT, "")),
         tool_call_id=tool_call_id,
-        is_error=event.get("is_error", False),
+        is_error=bool(event.get(ToolEventKey.IS_ERROR, False)),
     )

--- a/src/band/converters/strands.py
+++ b/src/band/converters/strands.py
@@ -1,0 +1,210 @@
+"""Strands Agents history converter."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from strands.types.content import ContentBlock, Message
+except ImportError as e:
+    raise ImportError(
+        "Strands Agents dependencies not installed. "
+        "Install with: uv add band-sdk[strands]"
+    ) from e
+
+from band.core.protocols import HistoryConverter
+from band.core.types import MessageType
+
+from ._tool_parsing import parse_tool_call, parse_tool_result
+
+logger = logging.getLogger(__name__)
+
+# Type alias for Strands conversation history (Bedrock-Converse-shaped messages)
+StrandsMessages = list[Message]
+
+
+def _flush_pending_tool_calls(
+    messages: StrandsMessages, pending_tool_calls: list[ContentBlock]
+) -> None:
+    """Flush pending toolUse blocks into a single assistant message."""
+    if pending_tool_calls:
+        messages.append({"role": "assistant", "content": list(pending_tool_calls)})
+        pending_tool_calls.clear()
+
+
+def _flush_pending_tool_results(
+    messages: StrandsMessages, pending_tool_results: list[ContentBlock]
+) -> None:
+    """Flush pending toolResult blocks into a single user message.
+
+    Converse requires every toolUse in an assistant message to be answered by
+    toolResult blocks in the following user message, so results are batched
+    together to support parallel tool use.
+    """
+    if pending_tool_results:
+        messages.append({"role": "user", "content": list(pending_tool_results)})
+        pending_tool_results.clear()
+
+
+class StrandsHistoryConverter(HistoryConverter[StrandsMessages]):
+    """
+    Converts platform history to Strands (Bedrock Converse) message format.
+
+    Output:
+    - user messages → {"role": "user", "content": [{"text": ...}]}
+    - other agents' messages → user role with [name] prefix
+    - tool_call → assistant message with a toolUse content block
+    - tool_result → user message with a toolResult content block
+      (status "error" when is_error=True)
+    - this agent's text messages → {"role": "assistant", "content": [{"text": ...}]}
+      (dropped when emitted mid tool call, where it would split the toolUse
+      from its toolResult)
+
+    Tool events are stored in platform as JSON:
+    - tool_call: {"name": "...", "args": {...}, "tool_call_id": "..."}
+    - tool_result: {"name": "...", "output": "...", "tool_call_id": "...", "is_error": bool}
+    """
+
+    def __init__(self, agent_name: str = ""):
+        """
+        Initialize converter.
+
+        Args:
+            agent_name: Name of this agent. Messages from this agent are preserved
+                       as assistant turns. Messages from other agents are included
+                       as user turns with a [name] prefix.
+        """
+        self._agent_name = agent_name
+
+    def set_agent_name(self, name: str) -> None:
+        """
+        Set agent name so the converter can recognize this agent's own messages.
+
+        Args:
+            name: Name of this agent
+        """
+        self._agent_name = name
+
+    def convert(self, raw: list[dict[str, Any]]) -> StrandsMessages:
+        """Convert platform history to Strands Converse format."""
+        messages: StrandsMessages = []
+        # Collect tool calls to batch them into a single assistant message
+        pending_tool_calls: list[ContentBlock] = []
+        # Collect tool results to batch them into a single user message
+        pending_tool_results: list[ContentBlock] = []
+
+        for hist in raw:
+            message_type = hist.get("message_type", "text")
+            content = hist.get("content", "")
+
+            match message_type:
+                case MessageType.TOOL_CALL:
+                    self._handle_tool_call(
+                        content, messages, pending_tool_calls, pending_tool_results
+                    )
+                case MessageType.TOOL_RESULT:
+                    self._handle_tool_result(
+                        content, messages, pending_tool_calls, pending_tool_results
+                    )
+                case MessageType.TEXT:
+                    self._handle_text(
+                        hist,
+                        content,
+                        messages,
+                        pending_tool_calls,
+                        pending_tool_results,
+                    )
+                case MessageType.THOUGHT | MessageType.ERROR | MessageType.TASK:
+                    # Known platform-internal types intentionally excluded from
+                    # LLM history.
+                    pass
+                case _:
+                    logger.warning("Unknown message_type in history: %s", message_type)
+
+        # Flush any remaining pending tool calls and results
+        _flush_pending_tool_calls(messages, pending_tool_calls)
+        _flush_pending_tool_results(messages, pending_tool_results)
+
+        return messages
+
+    def _handle_tool_call(
+        self,
+        content: str,
+        messages: StrandsMessages,
+        pending_tool_calls: list[ContentBlock],
+        pending_tool_results: list[ContentBlock],
+    ) -> None:
+        """Collect a tool call for batching, flushing any pending results first."""
+        _flush_pending_tool_results(messages, pending_tool_results)
+
+        parsed = parse_tool_call(content)
+        if parsed:
+            pending_tool_calls.append(
+                {
+                    "toolUse": {
+                        "toolUseId": parsed.tool_call_id,
+                        "name": parsed.name,
+                        "input": parsed.args,
+                    }
+                }
+            )
+
+    def _handle_tool_result(
+        self,
+        content: str,
+        messages: StrandsMessages,
+        pending_tool_calls: list[ContentBlock],
+        pending_tool_results: list[ContentBlock],
+    ) -> None:
+        """Collect a tool result for batching, flushing the calls it answers first."""
+        _flush_pending_tool_calls(messages, pending_tool_calls)
+
+        parsed = parse_tool_result(content)
+        if not parsed:
+            return
+
+        pending_tool_results.append(
+            {
+                "toolResult": {
+                    "toolUseId": parsed.tool_call_id,
+                    "status": "error" if parsed.is_error else "success",
+                    "content": [{"text": parsed.output}],
+                }
+            }
+        )
+
+    def _handle_text(
+        self,
+        hist: dict[str, Any],
+        content: str,
+        messages: StrandsMessages,
+        pending_tool_calls: list[ContentBlock],
+        pending_tool_results: list[ContentBlock],
+    ) -> None:
+        """Append a text turn: own text as assistant, others as user."""
+        role = hist.get("role", "user")
+        sender_name = hist.get("sender_name", "")
+        is_own = (
+            role == "assistant" and self._agent_name and sender_name == self._agent_name
+        )
+
+        # Own platform text while a tool call is unresolved is usually the side
+        # effect of band_send_message. Replaying it here would split the toolUse
+        # from its toolResult, which Converse rejects.
+        if is_own and pending_tool_calls:
+            return
+
+        # Flush pending tool calls and results first
+        _flush_pending_tool_calls(messages, pending_tool_calls)
+        _flush_pending_tool_results(messages, pending_tool_results)
+
+        if is_own:
+            # Preserve own text so restart rehydration knows the agent already replied.
+            messages.append({"role": "assistant", "content": [{"text": content}]})
+        else:
+            # User messages AND other agents' messages
+            formatted_content = (
+                f"[{sender_name}]: {content}" if sender_name else content
+            )
+            messages.append({"role": "user", "content": [{"text": formatted_content}]})

--- a/src/band/converters/strands.py
+++ b/src/band/converters/strands.py
@@ -20,7 +20,6 @@ from .parsing import parse_tool_call, parse_tool_result
 
 logger = logging.getLogger(__name__)
 
-# Type alias for Strands conversation history (Bedrock-Converse-shaped messages)
 StrandsMessages = list[Message]
 
 
@@ -48,23 +47,7 @@ def _flush_pending_tool_results(
 
 
 class StrandsHistoryConverter(HistoryConverter[StrandsMessages]):
-    """
-    Converts platform history to Strands (Bedrock Converse) message format.
-
-    Output:
-    - user messages → {"role": "user", "content": [{"text": ...}]}
-    - other agents' messages → user role with [name] prefix
-    - tool_call → assistant message with a toolUse content block
-    - tool_result → user message with a toolResult content block
-      (status "error" when is_error=True)
-    - this agent's text messages → {"role": "assistant", "content": [{"text": ...}]}
-      (dropped when emitted mid tool call, where it would split the toolUse
-      from its toolResult)
-
-    Tool events are stored in platform as JSON:
-    - tool_call: {"name": "...", "args": {...}, "tool_call_id": "..."}
-    - tool_result: {"name": "...", "output": "...", "tool_call_id": "...", "is_error": bool}
-    """
+    """Convert Band history to Strands Converse messages."""
 
     def __init__(self, agent_name: str = ""):
         """

--- a/src/band/converters/strands.py
+++ b/src/band/converters/strands.py
@@ -16,7 +16,7 @@ except ImportError as e:
 from band.core.protocols import HistoryConverter
 from band.core.types import MessageType
 
-from ._tool_parsing import parse_tool_call, parse_tool_result
+from .parsing import parse_tool_call, parse_tool_result
 
 logger = logging.getLogger(__name__)
 

--- a/src/band/core/types.py
+++ b/src/band/core/types.py
@@ -26,6 +26,16 @@ class MessageType(StrEnum):
     USAGE = "usage"
 
 
+class ToolEventKey(StrEnum):
+    """Canonical JSON keys for execution events written into room history."""
+
+    NAME = "name"
+    ARGS = "args"
+    OUTPUT = "output"
+    TOOL_CALL_ID = "tool_call_id"
+    IS_ERROR = "is_error"
+
+
 # Subset of message types accepted by ``band_send_event`` — the non-history
 # event kinds. Derived from MessageType so the taxonomy stays single-sourced.
 EventMessageType = Literal[MessageType.THOUGHT, MessageType.ERROR, MessageType.TASK]

--- a/src/band/exports.py
+++ b/src/band/exports.py
@@ -1,0 +1,41 @@
+"""Infrastructure for optional public re-exports."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+
+def lazy_exports(
+    package_name: str,
+    module_exports: Mapping[str, Sequence[str]],
+) -> tuple[tuple[str, ...], Callable[[str], Any], Callable[[], list[str]]]:
+    """Create a lazy package export surface from module-owned names."""
+    export_modules: dict[str, str] = {}
+    exports: list[str] = []
+    for module_name, names in module_exports.items():
+        for name in names:
+            if name in export_modules:
+                raise ValueError(f"duplicate lazy export {name!r} in {package_name!r}")
+            export_modules[name] = module_name
+            exports.append(name)
+
+    def resolve(name: str) -> Any:
+        try:
+            module_name = export_modules[name]
+        except KeyError as error:
+            raise AttributeError(
+                f"module {package_name!r} has no attribute {name!r}"
+            ) from error
+
+        module = importlib.import_module(f".{module_name}", package_name)
+        value = getattr(module, name)
+        setattr(sys.modules[package_name], name, value)
+        return value
+
+    def exported_names() -> list[str]:
+        return sorted(set(sys.modules[package_name].__dict__) | set(exports))
+
+    return tuple(exports), resolve, exported_names

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -1,0 +1,412 @@
+"""Unit tests for the Strands adapter (mocked model, no live inference)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, AsyncGenerator, cast
+
+import pytest
+from pydantic import BaseModel
+
+pytest.importorskip("strands", reason="strands extra not installed")
+
+from strands import tool as strands_tool  # noqa: E402
+from strands.models import Model  # noqa: E402
+from strands.types.content import Messages  # noqa: E402
+from strands.types.streaming import StreamEvent  # noqa: E402
+from strands.types.tools import ToolSpec  # noqa: E402
+
+from band.adapters.strands import StrandsAdapter, _CustomToolBridge  # noqa: E402
+from band.converters.strands import StrandsHistoryConverter  # noqa: E402
+from band.core.protocols import AgentToolsProtocol  # noqa: E402
+from band.core.types import (  # noqa: E402
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+    TurnUsage,
+)
+from band.testing.fake_tools import FakeAgentTools  # noqa: E402
+
+
+class _ScriptedModel(Model):
+    """Replays scripted ("tool", name, args) / ("text", body) decisions."""
+
+    def __init__(self, turns: list[Any]):
+        self._turns = list(turns)
+        self._config: dict[str, Any] = {}
+
+    def update_config(self, **model_config: Any) -> None:
+        self._config.update(model_config)
+
+    def get_config(self) -> Any:
+        return self._config
+
+    async def structured_output(
+        self,
+        output_model: Any,
+        prompt: Messages,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        raise NotImplementedError
+        yield {}  # pragma: no cover - makes this an async generator
+
+    async def stream(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        decision = self._turns.pop(0) if self._turns else ("text", "done")
+        yield {"messageStart": {"role": "assistant"}}
+        if decision[0] == "tool":
+            _, name, args = decision
+            yield {
+                "contentBlockStart": {
+                    "start": {"toolUse": {"toolUseId": f"call-{name}", "name": name}}
+                }
+            }
+            yield {
+                "contentBlockDelta": {"delta": {"toolUse": {"input": json.dumps(args)}}}
+            }
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "tool_use"}}
+        else:
+            yield {"contentBlockStart": {"start": {}}}
+            yield {"contentBlockDelta": {"delta": {"text": decision[1]}}}
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "end_turn"}}
+        yield {
+            "metadata": {
+                "usage": {"inputTokens": 7, "outputTokens": 3, "totalTokens": 10},
+                "metrics": {"latencyMs": 1},
+            }
+        }
+
+
+def _make_msg(room_id: str, content: str = "Hello") -> PlatformMessage:
+    return PlatformMessage(
+        id="msg-1",
+        room_id=room_id,
+        content=content,
+        sender_id="user-1",
+        sender_type="User",
+        sender_name="Tester",
+        message_type="text",
+        metadata=None,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+async def _run_message(
+    adapter: StrandsAdapter,
+    tools: FakeAgentTools,
+    room_id: str,
+    *,
+    history: list | None = None,
+    participants_msg: str | None = None,
+    contacts_msg: str | None = None,
+    is_session_bootstrap: bool = True,
+) -> None:
+    await adapter.on_message(
+        msg=_make_msg(room_id),
+        tools=cast("AgentToolsProtocol", tools),
+        history=history or [],
+        participants_msg=participants_msg,
+        contacts_msg=contacts_msg,
+        is_session_bootstrap=is_session_bootstrap,
+        room_id=room_id,
+    )
+
+
+_SEND_TURN = (
+    "tool",
+    "band_send_message",
+    {"content": "hi", "mentions": ["@tester"]},
+)
+
+
+class TestInitialization:
+    def test_defaults(self):
+        adapter = StrandsAdapter(model="some-bedrock-model-id")
+
+        assert adapter.model == "some-bedrock-model-id"
+        assert adapter.system_prompt is None
+        assert adapter.custom_section is None
+        assert adapter._custom_tools == []
+        assert adapter._custom_terminal_names == frozenset()
+        assert isinstance(adapter.history_converter, StrandsHistoryConverter)
+        assert adapter.features == AdapterFeatures()
+
+    def test_feature_declarations(self):
+        assert StrandsAdapter.SUPPORTED_EMIT == frozenset({Emit.EXECUTION, Emit.USAGE})
+        assert StrandsAdapter.SUPPORTED_CAPABILITIES == frozenset(
+            {Capability.MEMORY, Capability.CONTACTS}
+        )
+
+
+class TestCustomToolWiring:
+    def test_custom_tool_def_converted_to_bridge(self):
+        class WeatherInput(BaseModel):
+            """Get the weather for a city."""
+
+            city: str
+
+        async def get_weather(args: WeatherInput) -> str:
+            return f"{args.city}: sunny"
+
+        adapter = StrandsAdapter(
+            model="m", additional_tools=[(WeatherInput, get_weather)]
+        )
+
+        assert len(adapter._custom_tools) == 1
+        bridge = adapter._custom_tools[0]
+        assert isinstance(bridge, _CustomToolBridge)
+        assert bridge.tool_name == "weather"
+        assert bridge.tool_spec["description"] == "Get the weather for a city."
+        assert (
+            bridge.tool_spec["inputSchema"]["json"]["properties"]["city"]["type"]
+            == "string"
+        )
+        # Not marked band_terminal -> not a terminal action.
+        assert adapter._custom_terminal_names == frozenset()
+
+    def test_terminal_marker_captured_from_tuple_handler(self):
+        class DoneInput(BaseModel):
+            """Finish the task."""
+
+            note: str
+
+        async def finish(args: DoneInput) -> str:
+            return "done"
+
+        finish.band_terminal = True  # type: ignore[attr-defined]
+
+        adapter = StrandsAdapter(model="m", additional_tools=[(DoneInput, finish)])
+
+        assert adapter._custom_terminal_names == frozenset({"done"})
+
+    def test_terminal_marker_captured_from_native_tool(self):
+        @strands_tool
+        def native_finish(note: str) -> str:
+            """Finish the task natively."""
+            return "done"
+
+        native_finish.band_terminal = True  # type: ignore[attr-defined]
+
+        adapter = StrandsAdapter(model="m", additional_tools=[native_finish])
+
+        assert adapter._custom_terminal_names == frozenset({"native_finish"})
+
+
+class TestToolRegistration:
+    @pytest.mark.asyncio
+    async def test_base_tools_only_by_default(self):
+        adapter = StrandsAdapter(model="m")
+        await adapter.on_started("Bot", "A bot")
+
+        names = {t.tool_name for t in adapter._strands_tools}
+        assert names == {
+            "band_send_message",
+            "band_send_event",
+            "band_add_participant",
+            "band_remove_participant",
+            "band_lookup_peers",
+            "band_get_participants",
+            "band_create_chatroom",
+        }
+
+    @pytest.mark.asyncio
+    async def test_capability_gated_tools_registered(self):
+        adapter = StrandsAdapter(
+            model="m",
+            features=AdapterFeatures(
+                capabilities={Capability.MEMORY, Capability.CONTACTS}
+            ),
+        )
+        await adapter.on_started("Bot", "A bot")
+
+        names = {t.tool_name for t in adapter._strands_tools}
+        assert {"band_list_contacts", "band_respond_contact_request"} <= names
+        assert {"band_store_memory", "band_archive_memory"} <= names
+
+    @pytest.mark.asyncio
+    async def test_platform_tool_descriptions_from_registry(self):
+        from band.runtime.tools import get_tool_description
+
+        adapter = StrandsAdapter(model="m")
+        await adapter.on_started("Bot", "A bot")
+
+        by_name = {t.tool_name: t for t in adapter._strands_tools}
+        assert by_name["band_send_message"].tool_spec[
+            "description"
+        ] == get_tool_description("band_send_message")
+
+
+class TestOnMessage:
+    @pytest.mark.asyncio
+    async def test_send_message_turn_dispatches_and_persists_history(self):
+        room_id = "room-1"
+        tools = FakeAgentTools(room_id=room_id)
+        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        await adapter.on_started("Bot", "A bot")
+
+        await _run_message(adapter, tools, room_id)
+
+        tools.assert_message_sent(content="hi", mentions=["@tester"], count=1)
+        # user prompt + toolUse + toolResult + final text
+        assert len(adapter._message_history[room_id]) == 4
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_rehydrates_history(self):
+        room_id = "room-rehydrate"
+        tools = FakeAgentTools(room_id=room_id)
+        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        await adapter.on_started("Bot", "A bot")
+
+        prior = [
+            {"role": "user", "content": [{"text": "[Tester]: earlier question"}]},
+            {"role": "assistant", "content": [{"text": "earlier answer"}]},
+        ]
+        await _run_message(adapter, tools, room_id, history=list(prior))
+
+        persisted = adapter._message_history[room_id]
+        assert persisted[:2] == prior
+        assert len(persisted) > 2  # this turn appended on top
+
+    @pytest.mark.asyncio
+    async def test_participants_and_contacts_injected_as_system_turns(self):
+        room_id = "room-inject"
+        tools = FakeAgentTools(room_id=room_id)
+        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        await adapter.on_started("Bot", "A bot")
+
+        await _run_message(
+            adapter,
+            tools,
+            room_id,
+            participants_msg="Alice joined",
+            contacts_msg="Bob is now a contact",
+        )
+
+        texts = [
+            block["text"]
+            for message in adapter._message_history[room_id]
+            for block in message["content"]
+            if "text" in block
+        ]
+        assert "[System]: Alice joined" in texts
+        assert "[System]: Bob is now a contact" in texts
+
+    @pytest.mark.asyncio
+    async def test_no_terminal_action_reports_error(self):
+        room_id = "room-noop"
+        tools = FakeAgentTools(room_id=room_id)
+        adapter = StrandsAdapter(model=_ScriptedModel([("text", "plain answer")]))
+        await adapter.on_started("Bot", "A bot")
+
+        await _run_message(adapter, tools, room_id)
+
+        errors = [e for e in tools.events_sent if e["message_type"] == "error"]
+        assert len(errors) == 1
+        assert "band_send_message" in errors[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_failed_band_tool_is_not_terminal(self):
+        """A platform tool whose wrapper returns "Error ..." does not end the turn productively."""
+
+        class FailingTools(FakeAgentTools):
+            async def send_message(self, content, mentions=None):
+                raise RuntimeError("backend down")
+
+        room_id = "room-fail"
+        tools = FailingTools(room_id=room_id)
+        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        await adapter.on_started("Bot", "A bot")
+
+        await _run_message(adapter, tools, room_id)
+
+        assert tools.messages_sent == []
+        errors = [e for e in tools.events_sent if e["message_type"] == "error"]
+        assert len(errors) == 1
+        # The failed call is visible to the model as an "Error ..." tool result.
+        result_texts = [
+            item["text"]
+            for message in adapter._message_history[room_id]
+            for block in message["content"]
+            if "toolResult" in block
+            for item in block["toolResult"]["content"]
+            if "text" in item
+        ]
+        assert any(t.startswith("Error sending message:") for t in result_texts)
+
+    @pytest.mark.asyncio
+    async def test_usage_emitted_once_per_turn(self):
+        room_id = "room-usage"
+        tools = FakeAgentTools(room_id=room_id)
+        adapter = StrandsAdapter(
+            model=_ScriptedModel([_SEND_TURN, ("text", "done")]),
+            features=AdapterFeatures(emit={Emit.USAGE}),
+        )
+        await adapter.on_started("Bot", "A bot")
+
+        await _run_message(adapter, tools, room_id)
+
+        from band.core.types import USAGE_METADATA_KEY, is_usage_event
+
+        usage_events = [e for e in tools.events_sent if is_usage_event(e["metadata"])]
+        assert len(usage_events) == 1
+        # Two scripted model calls of 7/3 each -> the turn total, not the last call.
+        assert usage_events[0]["metadata"][USAGE_METADATA_KEY] == {
+            "input_tokens": 14,
+            "output_tokens": 6,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        }
+
+
+class TestUsageMapping:
+    def test_usage_from_agent_maps_all_fields(self):
+        class _Metrics:
+            accumulated_usage = {
+                "inputTokens": 10,
+                "outputTokens": 5,
+                "totalTokens": 15,
+                "cacheReadInputTokens": 3,
+                "cacheWriteInputTokens": 2,
+            }
+
+        class _Agent:
+            event_loop_metrics = _Metrics()
+
+        usage = StrandsAdapter._usage_from_agent(cast("Any", _Agent()))
+
+        assert usage == TurnUsage(
+            input_tokens=10,
+            output_tokens=5,
+            cache_read_tokens=3,
+            cache_write_tokens=2,
+        )
+
+
+class TestCleanup:
+    @pytest.mark.asyncio
+    async def test_cleanup_unknown_room_is_noop(self):
+        adapter = StrandsAdapter(model="m")
+        await adapter.on_cleanup("never-seen-room")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_cleanup_removes_room_history(self):
+        room_id = "room-clean"
+        tools = FakeAgentTools(room_id=room_id)
+        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        await adapter.on_started("Bot", "A bot")
+        await _run_message(adapter, tools, room_id)
+        assert room_id in adapter._message_history
+
+        await adapter.on_cleanup(room_id)
+
+        assert room_id not in adapter._message_history

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -246,6 +246,29 @@ class TestToolRegistration:
         ] == get_tool_description("band_send_message")
 
 
+class TestPromptConfiguration:
+    @pytest.mark.asyncio
+    async def test_explicit_system_prompt_overrides_rendered_prompt(self):
+        adapter = StrandsAdapter(
+            model="m",
+            system_prompt="Use only the requested tools.",
+            custom_section="This must not be appended.",
+        )
+
+        await adapter.on_started("Bot", "A bot")
+
+        assert adapter._system_prompt == "Use only the requested tools."
+
+    @pytest.mark.asyncio
+    async def test_custom_section_is_included_in_rendered_prompt(self):
+        adapter = StrandsAdapter(model="m", custom_section="Keep replies concise.")
+
+        await adapter.on_started("Bot", "A bot")
+
+        assert adapter._system_prompt is not None
+        assert "Keep replies concise." in adapter._system_prompt
+
+
 class TestOnMessage:
     @pytest.mark.asyncio
     async def test_send_message_turn_dispatches_and_persists_history(self):

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -17,7 +17,7 @@ from strands.types.content import Messages  # noqa: E402
 from strands.types.streaming import StreamEvent  # noqa: E402
 from strands.types.tools import ToolSpec  # noqa: E402
 
-from band.adapters.strands import StrandsAdapter, _CustomToolBridge  # noqa: E402
+from band.adapters.strands import CustomToolBridge, StrandsAdapter  # noqa: E402
 from band.converters.strands import StrandsHistoryConverter  # noqa: E402
 from band.core.protocols import AgentToolsProtocol  # noqa: E402
 from band.core.types import (  # noqa: E402
@@ -164,7 +164,7 @@ class TestCustomToolWiring:
 
         assert len(adapter._custom_tools) == 1
         bridge = adapter._custom_tools[0]
-        assert isinstance(bridge, _CustomToolBridge)
+        assert isinstance(bridge, CustomToolBridge)
         assert bridge.tool_name == "weather"
         assert bridge.tool_spec["description"] == "Get the weather for a city."
         assert (
@@ -208,7 +208,7 @@ class TestToolRegistration:
         adapter = StrandsAdapter(model="m")
         await adapter.on_started("Bot", "A bot")
 
-        names = {t.tool_name for t in adapter._strands_tools}
+        names = {t.tool_name for t in adapter._build_platform_tools(FakeAgentTools())}
         assert names == {
             "band_send_message",
             "band_send_event",
@@ -229,7 +229,7 @@ class TestToolRegistration:
         )
         await adapter.on_started("Bot", "A bot")
 
-        names = {t.tool_name for t in adapter._strands_tools}
+        names = {t.tool_name for t in adapter._build_platform_tools(FakeAgentTools())}
         assert {"band_list_contacts", "band_respond_contact_request"} <= names
         assert {"band_store_memory", "band_archive_memory"} <= names
 
@@ -240,7 +240,10 @@ class TestToolRegistration:
         adapter = StrandsAdapter(model="m")
         await adapter.on_started("Bot", "A bot")
 
-        by_name = {t.tool_name: t for t in adapter._strands_tools}
+        by_name = {
+            tool.tool_name: tool
+            for tool in adapter._build_platform_tools(FakeAgentTools())
+        }
         assert by_name["band_send_message"].tool_spec[
             "description"
         ] == get_tool_description("band_send_message")
@@ -355,7 +358,7 @@ class TestOnMessage:
         assert tools.messages_sent == []
         errors = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(errors) == 1
-        # The failed call is visible to the model as an "Error ..." tool result.
+        # The shared bridge returns a normalized, model-visible tool failure.
         result_texts = [
             item["text"]
             for message in adapter._message_history[room_id]
@@ -364,7 +367,9 @@ class TestOnMessage:
             for item in block["toolResult"]["content"]
             if "text" in item
         ]
-        assert any(t.startswith("Error sending message:") for t in result_texts)
+        assert any(
+            t.startswith("Error executing band_send_message:") for t in result_texts
+        )
 
     @pytest.mark.asyncio
     async def test_usage_emitted_once_per_turn(self):

--- a/tests/baseline/adapter.py
+++ b/tests/baseline/adapter.py
@@ -30,6 +30,7 @@ class Adapter(StrEnum):
     CODEX = "codex"
     OPENCODE = "opencode"
     LETTA = "letta"
+    STRANDS = "strands"
 
 
 # These modules bridge Band to another protocol or require a bespoke external

--- a/tests/converters/test_strands.py
+++ b/tests/converters/test_strands.py
@@ -1,0 +1,177 @@
+"""Unit tests for the Strands history converter (framework-specific behavior).
+
+The shared behavioral contract is covered by
+tests/framework_conformance/test_converter_conformance.py; these tests pin the
+Converse-specific output shapes: toolUse/toolResult blocks, batching, and
+malformed tool-event handling.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("strands", reason="strands extra not installed")
+
+from band.converters.strands import StrandsHistoryConverter  # noqa: E402
+
+
+def _tool_call(name: str, args: dict, call_id: str) -> dict:
+    return {
+        "role": "assistant",
+        "content": json.dumps({"name": name, "args": args, "tool_call_id": call_id}),
+        "message_type": "tool_call",
+    }
+
+
+def _tool_result(name: str, output: str, call_id: str, is_error: bool = False) -> dict:
+    return {
+        "role": "assistant",
+        "content": json.dumps(
+            {
+                "name": name,
+                "output": output,
+                "tool_call_id": call_id,
+                "is_error": is_error,
+            }
+        ),
+        "message_type": "tool_result",
+    }
+
+
+class TestToolEventFormat:
+    def test_tool_call_becomes_assistant_tool_use_block(self):
+        converter = StrandsHistoryConverter()
+
+        result = converter.convert(
+            [_tool_call("band_send_message", {"content": "hi"}, "call-1")]
+        )
+
+        assert result == [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "toolUse": {
+                            "toolUseId": "call-1",
+                            "name": "band_send_message",
+                            "input": {"content": "hi"},
+                        }
+                    }
+                ],
+            }
+        ]
+
+    def test_tool_result_becomes_user_tool_result_block(self):
+        converter = StrandsHistoryConverter()
+
+        result = converter.convert(
+            [
+                _tool_call("search", {"q": "x"}, "call-1"),
+                _tool_result("search", "found it", "call-1"),
+            ]
+        )
+
+        assert result[1] == {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "call-1",
+                        "status": "success",
+                        "content": [{"text": "found it"}],
+                    }
+                }
+            ],
+        }
+
+    def test_error_tool_result_gets_error_status(self):
+        converter = StrandsHistoryConverter()
+
+        result = converter.convert(
+            [
+                _tool_call("search", {}, "call-1"),
+                _tool_result("search", "boom", "call-1", is_error=True),
+            ]
+        )
+
+        assert result[1]["content"][0]["toolResult"]["status"] == "error"
+
+
+class TestBatching:
+    def test_parallel_tool_calls_batch_into_one_assistant_message(self):
+        converter = StrandsHistoryConverter()
+
+        result = converter.convert(
+            [
+                _tool_call("a", {}, "call-a"),
+                _tool_call("b", {}, "call-b"),
+                _tool_result("a", "ra", "call-a"),
+                _tool_result("b", "rb", "call-b"),
+            ]
+        )
+
+        assert len(result) == 2
+        assert result[0]["role"] == "assistant"
+        assert [b["toolUse"]["toolUseId"] for b in result[0]["content"]] == [
+            "call-a",
+            "call-b",
+        ]
+        assert result[1]["role"] == "user"
+        assert [b["toolResult"]["toolUseId"] for b in result[1]["content"]] == [
+            "call-a",
+            "call-b",
+        ]
+
+    def test_own_text_mid_tool_call_is_dropped(self):
+        """Own text between a toolUse and its toolResult would split the pair."""
+        converter = StrandsHistoryConverter(agent_name="Bot")
+
+        result = converter.convert(
+            [
+                _tool_call("band_send_message", {"content": "hi"}, "call-1"),
+                {
+                    "role": "assistant",
+                    "content": "hi",
+                    "sender_name": "Bot",
+                    "message_type": "text",
+                },
+                _tool_result("band_send_message", "sent", "call-1"),
+            ]
+        )
+
+        assert len(result) == 2
+        assert "toolUse" in result[0]["content"][0]
+        assert "toolResult" in result[1]["content"][0]
+
+
+class TestMalformedInput:
+    def test_malformed_tool_events_are_skipped(self):
+        converter = StrandsHistoryConverter()
+
+        result = converter.convert(
+            [
+                {
+                    "role": "assistant",
+                    "content": "not json at all",
+                    "message_type": "tool_call",
+                },
+                {
+                    "role": "assistant",
+                    "content": json.dumps({"name": "x"}),  # missing tool_call_id
+                    "message_type": "tool_result",
+                },
+            ]
+        )
+
+        assert result == []
+
+    def test_unknown_message_type_is_skipped(self):
+        converter = StrandsHistoryConverter()
+
+        result = converter.convert(
+            [{"role": "user", "content": "hi", "message_type": "mystery"}]
+        )
+
+        assert result == []

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -1,6 +1,6 @@
 """Capability-filtered matrix smokes — demonstrate ``@per_adapter`` filtering.
 
-Two complementary scenarios driven entirely by capability filters, with no
+Three complementary scenarios driven entirely by capability filters, with no
 hard-coded adapter lists:
 
 * ``supports={Capability.MEMORY}`` selects the memory-capable adapters and runs a
@@ -8,6 +8,8 @@ hard-coded adapter lists:
   memory tools per cell);
 * ``without={Capability.MEMORY}`` selects the exact complement (the non-memory
   adapters) and runs a basic reply turn.
+* ``supports={Capability.CONTACTS}`` selects adapters with contact tools enabled
+  and proves they can list contacts through the real platform API.
 
 The two sets partition the matrix, so adding/removing an adapter or flipping its
 ``supports`` in the registry re-balances both tests automatically — the point of
@@ -26,12 +28,15 @@ from band.core.types import Capability
 
 from tests.e2e.baseline.agents import per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import (
+    CONTACTS_AGENT,
     MEMORY_AGENT,
+    list_contacts_instruction,
     recall_memory_instruction,
     store_memory_instruction,
     unique_marker,
 )
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
+from tests.e2e.baseline.toolkit.observations import ContactTool
 from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceManager
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
@@ -109,6 +114,32 @@ async def test_recall_memory_across_memory_adapters(
     # Read side: the agent queried its memory and fetched the record back by id.
     mem.calls.assert_list_called()
     mem.calls.assert_get_called()
+
+
+@per_adapter(supports={Capability.CONTACTS}, **CONTACTS_AGENT)
+@flaky_infra("retry a transient live-turn timeout; assertion failures fail loud")
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_contacts_across_contacts_adapters(
+    agent: ProvisionedAgent,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Every contacts-capable adapter can list contacts through the platform."""
+    room_id = await resource_manager.provision_room(
+        title=f"e2e-cap-contacts-{agent.adapter_id}", participants=[agent.id]
+    )
+    async with reply_capture(room_id) as capture:
+        mid = await user_ops.send_message(
+            room_id,
+            list_contacts_instruction(),
+            mention_id=agent.id,
+            mention_name=agent.name,
+        )
+        await capture.wait_for_processed(mid, agent.id)
+        calls = await capture.tool_calls(sender_id=agent.id)
+
+    calls.assert_fired(ContactTool.LIST.value)
 
 
 @per_adapter(without={Capability.MEMORY})

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -1,22 +1,4 @@
-"""Capability-filtered matrix smokes — demonstrate ``@per_adapter`` filtering.
-
-Three complementary scenarios driven entirely by capability filters, with no
-hard-coded adapter lists:
-
-* ``supports={Capability.MEMORY}`` selects the memory-capable adapters and runs a
-  store-then-read-back memory scenario (``features=memory_features()`` exposes the
-  memory tools per cell);
-* ``without={Capability.MEMORY}`` selects the exact complement (the non-memory
-  adapters) and runs a basic reply turn.
-* ``supports={Capability.CONTACTS}`` selects adapters with contact tools enabled
-  and proves they can list contacts through the real platform API.
-
-The two sets partition the matrix, so adding/removing an adapter or flipping its
-``supports`` in the registry re-balances both tests automatically — the point of
-the demonstration. Under fail-never-skip a cell whose backend/key is absent ERRORs
-with the reason (e.g. ``GOOGLE_API_KEY`` for gemini, ``OPENCODE_BASE_URL`` for
-opencode); that is the honest "not wired up" signal, not a regression.
-"""
+"""Grid tests for adapters that expose memory or contacts capabilities."""
 
 from __future__ import annotations
 
@@ -50,11 +32,7 @@ async def test_store_memory_across_memory_adapters(
     user_ops: UserOps,
     reply_capture: CaptureFactory,
 ) -> None:
-    """Every memory-capable adapter can store a memory that lands in the store.
-
-    The matrix here is *exactly* the adapters advertising ``Capability.MEMORY`` —
-    selected by the filter, not a list — each built with the memory tools enabled.
-    """
+    """Store an organization-scoped memory through each memory-capable adapter."""
     marker = unique_marker("xmem")
     room_id = await resource_manager.provision_room(
         title=f"e2e-cap-memory-{agent.adapter_id}", participants=[agent.id]
@@ -84,15 +62,7 @@ async def test_recall_memory_across_memory_adapters(
     user_ops: UserOps,
     reply_capture: CaptureFactory,
 ) -> None:
-    """Every memory-capable adapter can store a memory and read it back.
-
-    The complement of ``test_store_memory_across_memory_adapters`` (which proves the
-    *store* lands): the same subgroup drives a store -> list -> get sequence in one
-    turn, so the assertion covers the memory tools' *read* path too. The record must
-    land AND the agent must both query (``assert_list_called``) and fetch it back by
-    id (``assert_get_called``) — list alone would pass on a mis-wired read that
-    returns nothing, so the get hop is what proves an actual read-back.
-    """
+    """Store, list, and fetch a memory through each memory-capable adapter."""
     marker = unique_marker("rmem")
     room_id = await resource_manager.provision_room(
         title=f"e2e-cap-recall-{agent.adapter_id}", participants=[agent.id]
@@ -109,9 +79,7 @@ async def test_recall_memory_across_memory_adapters(
             agent, scope=MemoryListScope.ORGANIZATION, content_query=marker
         )
 
-    # Write side: the record landed in the store.
     mem.stored.assert_stored(content=marker)
-    # Read side: the agent queried its memory and fetched the record back by id.
     mem.calls.assert_list_called()
     mem.calls.assert_get_called()
 

--- a/tests/e2e/baseline/smoke/samples/sample_agents.py
+++ b/tests/e2e/baseline/smoke/samples/sample_agents.py
@@ -29,7 +29,7 @@ from band.core.memory_types import (
 )
 
 from tests.e2e.baseline.smoke.samples.sample_tools import LOOKUP_PROMPT
-from tests.e2e.baseline.toolkit.observations import MemoryTool
+from tests.e2e.baseline.toolkit.observations import ContactTool, MemoryTool
 
 # Fixed role-setter: the actionable instruction (and marker) travels in the user
 # message, exactly like the opaque-tool smokes.
@@ -44,6 +44,11 @@ def memory_features() -> AdapterFeatures:
     """Features for the memory smokes: expose the memory tools, and record the
     tool call as a ``tool_call`` event so the call layer is observable."""
     return AdapterFeatures(capabilities={Capability.MEMORY}, emit={Emit.EXECUTION})
+
+
+def contacts_features() -> AdapterFeatures:
+    """Features for contacts smokes: expose contact tools and record their calls."""
+    return AdapterFeatures(capabilities={Capability.CONTACTS}, emit={Emit.EXECUTION})
 
 
 def usage_features() -> AdapterFeatures:
@@ -94,6 +99,7 @@ MEMORY_SECRETARY_PROMPT = (
 # the same shape instead of re-spelling it.
 TOOL_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT}
 MEMORY_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT, "features": memory_features()}
+CONTACTS_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT, "features": contacts_features()}
 MEMORY_SECRETARY_AGENT = {
     "prompt": MEMORY_SECRETARY_PROMPT,
     "features": memory_features(),
@@ -174,6 +180,15 @@ def store_memory_instruction(marker: str) -> str:
         f"scope = {MemoryStoreScope.ORGANIZATION.value}; "
         "thought = a brief reason. Do not include subject_id. Do not call any "
         "other tool."
+    )
+
+
+def list_contacts_instruction() -> str:
+    """Drive a real contacts read and finish the turn with a Band reply."""
+    return (
+        f"First call {ContactTool.LIST.value} to inspect your contacts. Then use "
+        "band_send_message to briefly confirm that you checked them. Do not call "
+        "any other tools."
     )
 
 

--- a/tests/e2e/baseline/toolkit/builders.py
+++ b/tests/e2e/baseline/toolkit/builders.py
@@ -169,6 +169,32 @@ def _build_pydantic_ai(
     )
 
 
+@adapter(Adapter.STRANDS, requires=[Dep.OPENAI], supports=_LLM_TOOL_LOOP)
+def _build_strands(
+    s: BaselineSettings,
+    *,
+    prompt: str | None,
+    features: AdapterFeatures | None,
+    tools: list[ToolSpec] | None = None,
+) -> SimpleAdapter[Any]:
+    from strands.models.openai import OpenAIModel
+
+    from band.adapters.strands import StrandsAdapter
+
+    # Strands has no provider-prefix string shorthand (a bare string means a
+    # Bedrock model id), so the OpenAI provider is constructed explicitly.
+    api_key = s.llm_credentials.openai_api_key
+    return StrandsAdapter(
+        model=OpenAIModel(
+            client_args={"api_key": api_key} if api_key else None,
+            model_id=s.llm_models.openai_model,
+        ),
+        custom_section=prompt,
+        additional_tools=_custom_tool_defs(tools),
+        features=features,
+    )
+
+
 @adapter(Adapter.GEMINI, requires=[Dep.GOOGLE], supports=_LLM_TOOL_LOOP)
 def _build_gemini(
     s: BaselineSettings,

--- a/tests/e2e/baseline/toolkit/observations/__init__.py
+++ b/tests/e2e/baseline/toolkit/observations/__init__.py
@@ -9,7 +9,7 @@ methods, so a check lives with the data it inspects. ``ReplyCapture`` (see
 - :class:`Replies` -- captured agent reply messages.
 - :class:`ToolCall` / :class:`ToolCalls` -- the agent's tool calls (memory tools
   excluded by default); :class:`MemoryToolCalls` -- the call-layer memory view;
-  :class:`MemoryTool` -- canonical memory tool names.
+  :class:`MemoryTool` / :class:`ContactTool` -- canonical capability-tool names.
 - :class:`Events` / :class:`Thoughts` / :class:`Errors` / :class:`Tasks` -- the
   free-text emitted events.
 - :class:`Memories` -- the store-layer view: memory records that actually landed
@@ -34,6 +34,7 @@ from tests.e2e.baseline.toolkit.observations.memories import (
 )
 from tests.e2e.baseline.toolkit.observations.replies import Replies
 from tests.e2e.baseline.toolkit.observations.tool_calls import (
+    ContactTool,
     MemoryTool,
     MemoryToolCalls,
     ToolCall,
@@ -42,6 +43,7 @@ from tests.e2e.baseline.toolkit.observations.tool_calls import (
 from tests.e2e.baseline.toolkit.observations.usage import Usage, UsageRecord
 
 __all__ = [
+    "ContactTool",
     "Errors",
     "Events",
     "Memories",

--- a/tests/e2e/baseline/toolkit/observations/tool_calls.py
+++ b/tests/e2e/baseline/toolkit/observations/tool_calls.py
@@ -34,7 +34,7 @@ from typing import Any, ClassVar
 from band_rest import ChatMessage
 
 from band.core.types import MessageType
-from band.runtime.tools import MEMORY_TOOL_NAMES
+from band.runtime.tools import CONTACT_TOOL_NAMES, MEMORY_TOOL_NAMES
 
 from tests.e2e.baseline.toolkit.observations.matching import tolerant_match
 from tests.e2e.baseline.toolkit.user_ops import UserOps
@@ -61,6 +61,23 @@ if {tool.value for tool in MemoryTool} != set(MEMORY_TOOL_NAMES):
     raise ValueError(
         "MemoryTool drifted from band.runtime.tools.MEMORY_TOOL_NAMES: "
         f"{set(MEMORY_TOOL_NAMES) ^ {tool.value for tool in MemoryTool}}"
+    )
+
+
+class ContactTool(StrEnum):
+    """Canonical contact platform-tool names for capability scenarios."""
+
+    LIST = "band_list_contacts"
+    ADD = "band_add_contact"
+    REMOVE = "band_remove_contact"
+    LIST_REQUESTS = "band_list_contact_requests"
+    RESPOND_REQUEST = "band_respond_contact_request"
+
+
+if {tool.value for tool in ContactTool} != set(CONTACT_TOOL_NAMES):
+    raise ValueError(
+        "ContactTool drifted from band.runtime.tools.CONTACT_TOOL_NAMES: "
+        f"{set(CONTACT_TOOL_NAMES) ^ {tool.value for tool in ContactTool}}"
     )
 
 

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -163,6 +163,14 @@ def _pydantic_ai_factory(**kw: Any) -> Any:
     return PydanticAIAdapter(**kw)
 
 
+def _strands_factory(**kw: Any) -> Any:
+    from band.adapters.strands import StrandsAdapter
+
+    if "model" not in kw:
+        kw["model"] = _STRANDS_INJECTED_MODEL
+    return StrandsAdapter(**kw)
+
+
 def _parlant_factory(**kw: Any) -> Any:
     from band.adapters.parlant import ParlantAdapter
 
@@ -225,6 +233,11 @@ def _google_adk_factory(**kw: Any) -> Any:
 # without a real API key.  ``expected_initial_values["model"]`` then verifies
 # the factory injection, NOT a real adapter default.
 _PYDANTIC_AI_INJECTED_MODEL = "openai:gpt-5.4"
+
+# Strands likewise requires ``model``. A plain string is fine at construction
+# time: the adapter passes it through to Strands (which treats strings as
+# Bedrock model ids), and no client is created until the first message turn.
+_STRANDS_INJECTED_MODEL = "strands-conformance-model"
 
 
 def _build_anthropic_config() -> AdapterConfig:
@@ -469,6 +482,36 @@ def _build_pydantic_ai_config() -> AdapterConfig:
     )
 
 
+def _build_strands_config() -> AdapterConfig:
+    from band.adapters.strands import StrandsAdapter
+
+    return AdapterConfig(
+        framework_id="strands",
+        display_name="Strands",
+        adapter_factory=_strands_factory,
+        expected_initial_values={
+            # Injected by _strands_factory, not a real __init__ default.
+            # Verifies that the factory injection is stored correctly.
+            "model": _STRANDS_INJECTED_MODEL,
+            "system_prompt": _default_from_init(StrandsAdapter, "system_prompt"),
+            "custom_section": _default_from_init(StrandsAdapter, "custom_section"),
+        },
+        custom_kwargs={
+            "model": "custom-bedrock-model-id",
+            "system_prompt": "You are a helpful bot.",
+            "custom_section": "Be concise.",
+        },
+        custom_expected={
+            "model": "custom-bedrock-model-id",
+            "system_prompt": "You are a helpful bot.",
+            "custom_section": "Be concise.",
+        },
+        # on_started only renders the prompt and builds tool wrappers — no
+        # client/agent construction happens until the first message turn.
+        skip_on_started_conformance=False,
+    )
+
+
 def _build_parlant_config() -> AdapterConfig:
     from band.adapters.parlant import ParlantAdapter
 
@@ -692,6 +735,7 @@ _ADAPTER_CONFIG_BUILDERS: list[Callable[[], AdapterConfig]] = [
     _build_claude_sdk_config,
     _build_copilot_sdk_config,
     _build_pydantic_ai_config,
+    _build_strands_config,
     _build_parlant_config,
     _build_codex_config,
     _build_letta_config,

--- a/tests/framework_configs/converters.py
+++ b/tests/framework_configs/converters.py
@@ -136,6 +136,12 @@ def _google_adk_factory(**kw: Any) -> Any:
     return GoogleADKHistoryConverter(**kw)
 
 
+def _strands_factory(**kw: Any) -> Any:
+    from band.converters.strands import StrandsHistoryConverter
+
+    return StrandsHistoryConverter(**kw)
+
+
 # ---------------------------------------------------------------------------
 # Registry  (built lazily to avoid top-level converter imports)
 # ---------------------------------------------------------------------------
@@ -345,6 +351,23 @@ def _build_google_adk_config() -> ConverterConfig:
     )
 
 
+def _build_strands_config() -> ConverterConfig:
+    from tests.framework_configs.output_adapters import StrandsOutputAdapter
+
+    return ConverterConfig(
+        framework_id="strands",
+        display_name="Strands",
+        converter_factory=_strands_factory,
+        empty_result=[],
+        empty_sender_behavior=SenderBehavior.CONTENT_AS_IS,
+        missing_sender_behavior=SenderBehavior.CONTENT_AS_IS,
+        # Keeps own text as an assistant turn so restart rehydration shows the
+        # agent's prior replies (same contract as pydantic-ai).
+        includes_own_text_without_tool_events=True,
+        output_adapter=StrandsOutputAdapter(),
+    )
+
+
 _CONVERTER_CONFIG_BUILDERS: list[Callable[[], ConverterConfig]] = [
     _build_anthropic_config,
     _build_langchain_config,
@@ -356,6 +379,7 @@ _CONVERTER_CONFIG_BUILDERS: list[Callable[[], ConverterConfig]] = [
     _build_agno_config,
     _build_gemini_config,
     _build_google_adk_config,
+    _build_strands_config,
 ]
 
 

--- a/tests/framework_configs/output_adapters.py
+++ b/tests/framework_configs/output_adapters.py
@@ -701,3 +701,83 @@ class SenderDictListAdapter(BaseDictListOutputAdapter):
             assert msg.get("sender_type") == sender_type, (
                 f"Expected sender_type={sender_type!r}, got {msg.get('sender_type')!r}"
             )
+
+
+class StrandsOutputAdapter:
+    """Adapter for Strands converter output (list of Converse Message dicts).
+
+    Each message is ``{"role": "user"|"assistant", "content": [blocks]}`` where a
+    block is ``{"text": ...}``, ``{"toolUse": ...}``, or ``{"toolResult": ...}``.
+    Batched tool blocks share one message, so indexed accessors operate on a
+    flattened (role, block) view (same approach as ``GeminiOutputAdapter``).
+    """
+
+    @staticmethod
+    def _flatten(result: list) -> list[tuple[str, dict[str, Any]]]:
+        """Return a flat list of (role, content_block) tuples."""
+        flat: list[tuple[str, dict[str, Any]]] = []
+        for message in result:
+            for block in message.get("content", []):
+                flat.append((message["role"], block))
+        return flat
+
+    def assert_result_type(self, result: list) -> None:
+        assert isinstance(result, list), f"Expected list, got {type(result).__name__}"
+
+    def result_length(self, result: list) -> int:
+        return len(self._flatten(result))
+
+    def get_content(self, result: list, index: int) -> str:
+        _role, block = self._flatten(result)[index]
+        if "text" in block:
+            return block["text"]
+        if "toolUse" in block:
+            return block["toolUse"].get("name", "")
+        if "toolResult" in block:
+            parts = [
+                item["text"]
+                for item in block["toolResult"].get("content", [])
+                if "text" in item
+            ]
+            return "\n".join(parts)
+        raise ValueError(f"No text/toolUse/toolResult content at index {index}")
+
+    def get_role(self, result: list, index: int) -> str:
+        role, _block = self._flatten(result)[index]
+        return role
+
+    def is_empty(self, result: list) -> bool:
+        return len(result) == 0
+
+    def content_contains(self, result: list, substring: str) -> bool:
+        for role, block in self._flatten(result):
+            if "text" in block and substring in block["text"]:
+                return True
+            if "toolUse" in block:
+                tool_use = block["toolUse"]
+                if substring in tool_use.get("name", ""):
+                    return True
+                if substring in str(tool_use.get("input", {})):
+                    return True
+            if "toolResult" in block:
+                for item in block["toolResult"].get("content", []):
+                    if "text" in item and substring in item["text"]:
+                        return True
+        return False
+
+    def assert_element_type(self, result: list, index: int, expected_role: str) -> None:
+        role = self.get_role(result, index)
+        assert role == expected_role, f"Expected role={expected_role!r}, got {role!r}"
+
+    def assert_sender_metadata(
+        self,
+        result: list,
+        index: int,
+        sender_name: str,
+        sender_type: str | None = None,
+    ) -> None:
+        raise NotImplementedError(
+            "StrandsOutputAdapter.assert_sender_metadata() is not supported. "
+            "Converse messages do not include sender metadata. "
+            "Ensure has_sender_metadata=False in the ConverterConfig."
+        )

--- a/tests/framework_conformance/test_strands_injection_spike.py
+++ b/tests/framework_conformance/test_strands_injection_spike.py
@@ -1,0 +1,313 @@
+"""Tier-1 conformance spike for the Strands adapter (INJECTABLE_MODEL_OBJECT family).
+
+WHAT THIS PROVES
+----------------
+Given a scripted model decision, the StrandsAdapter's real tool wrappers (built
+by ``_build_platform_tools`` and run by Strands' own agent loop) dispatch the
+tool to the platform via ``AgentToolsProtocol`` — no live inference, no secrets,
+no provider API key.
+
+WHY IT IS HONEST (not circular)
+-------------------------------
+The faked decision is installed at the **public** ``Agent(model=...)`` seam:
+``strands.models.Model`` is the framework's documented provider ABC, and the
+adapter passes its ``model`` constructor argument straight through in
+``_build_agent``. Strands ships no dedicated test model, so the spike implements
+the minimal ``Model`` subclass; the scripted surface is still the stable public
+provider contract (``model_seam_kind=PUBLIC_TEST_MODEL``), though the
+``StreamEvent`` dict shapes it emits move with the framework's fast release
+cadence (``drift_risk=HIGH``, pinned ``strands-agents>=1.40,<2``).
+
+OBSERVATION PATH (the load-bearing detail)
+------------------------------------------
+Strands platform-tool wrappers call **typed** ``AgentToolsProtocol`` methods
+directly — ``band_send_message`` calls ``tools.send_message(...)`` — NOT
+``execute_tool_call``. So dispatch is observed on ``FakeAgentTools.messages_sent``
+(``observation_paths={TYPED_METHODS}``); a canary that only watched
+``tool_calls`` would wrongly fail Strands.
+
+STEP-0 FINDINGS (verified against installed strands-agents 1.47.0)
+------------------------------------------------------------------
+1. Per-invocation context: ``agent.invoke_async(prompt, invocation_state={...})``
+   reaches tool bodies via ``@tool(context=True)`` (``tool_context.invocation_state``)
+   and every hook event (``event.invocation_state``). No fallback needed.
+2. Scripted model events (consumed by ``strands.event_loop.streaming``): one tool
+   call is ``messageStart{role:assistant}`` ->
+   ``contentBlockStart{start:{toolUse:{toolUseId,name}}}`` ->
+   ``contentBlockDelta{delta:{toolUse:{input:<json-string>}}}`` ->
+   ``contentBlockStop`` -> ``messageStop{stopReason:"tool_use"}``; a terminal
+   text turn uses ``delta:{text}`` + ``stopReason:"end_turn"``; per-call usage
+   rides an optional trailing ``metadata{usage}`` event. The ``Model`` ABC also
+   requires ``structured_output`` (abstract), implemented as a stub here.
+3. OpenAI provider: ``strands.models.openai.OpenAIModel(client_args={"api_key":...},
+   model_id=...)``. There is NO provider-prefix string shorthand — a bare string
+   to ``Agent(model=...)`` is treated as a *Bedrock* model id.
+4. Hook events: ``BeforeToolCallEvent.tool_use{name,toolUseId,input}``,
+   ``AfterToolCallEvent.result: ToolResult{status,content,toolUseId}``; async
+   callbacks are supported. Usage lives on ``AgentResult.metrics.accumulated_usage``
+   (``inputTokens``/``outputTokens``/``cacheReadInputTokens``/``cacheWriteInputTokens``)
+   and accumulates across turns on a shared Agent — the adapter constructs a
+   per-turn Agent, so the accumulated value is exactly the turn's usage.
+5. History handle: ``agent.messages`` is a public read/write list of Converse
+   ``Message`` dicts; pre-seeding via ``Agent(messages=...)`` and reading back
+   after a run both work, so Band owns per-room history.
+
+InjectionBinding for the Tier-1 injection registry (lands with the taxonomy
+branch; recorded here until ``injection_registry.py`` exists on this branch):
+
+    InjectionBinding(
+        adapter="strands",
+        family=Family.INJECTABLE_MODEL_OBJECT,
+        tier1_status=Tier1Status.HONEST_TODAY,
+        drift_risk=DriftRisk.HIGH,
+        observation_paths=frozenset({ObservationPath.TYPED_METHODS}),
+        seam="band.adapters.strands:StrandsAdapter._build_agent",
+        model_seam_kind=ModelSeamKind.PUBLIC_TEST_MODEL,
+        spike_test="tests/framework_conformance/test_strands_injection_spike.py",
+        version_pin="strands-agents>=1.40,<2",
+        required_modules=("strands",),
+        required_extra="dev",
+    )
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, AsyncGenerator, cast
+
+import pytest
+from pydantic import BaseModel
+
+pytest.importorskip("strands", reason="strands extra not installed")
+
+from strands.models import Model  # noqa: E402
+from strands.types.content import Messages  # noqa: E402
+from strands.types.streaming import StreamEvent  # noqa: E402
+from strands.types.tools import ToolSpec  # noqa: E402
+
+from band.adapters.strands import StrandsAdapter  # noqa: E402
+from band.core.protocols import AgentToolsProtocol  # noqa: E402
+from band.core.types import AdapterFeatures, Emit, PlatformMessage  # noqa: E402
+from band.testing.fake_tools import FakeAgentTools  # noqa: E402
+
+_SEND_CONTENT = "Injected reply: PINEAPPLE"
+_SEND_MENTIONS = ["@tester"]
+
+
+def _make_msg(room_id: str) -> PlatformMessage:
+    return PlatformMessage(
+        id="strands-spike-1",
+        room_id=room_id,
+        content="Say the magic word",
+        sender_id="user-1",
+        sender_type="User",
+        sender_name="Tester",
+        message_type="text",
+        metadata=None,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+class _ScriptedStrandsModel(Model):
+    """A streaming Model that replays one scripted decision per invocation.
+
+    Each ``stream()`` call pops one decision and yields the Converse
+    ``StreamEvent`` sequence Strands' event loop parses (see module docstring):
+
+    * ``("tool", name, args_dict)`` -> a tool-use turn the agent dispatches;
+    * ``("text", body)`` -> a text turn that ends the run.
+    """
+
+    def __init__(self, turns: list[Any]):
+        self._turns = list(turns)
+        self._config: dict[str, Any] = {}
+
+    def update_config(self, **model_config: Any) -> None:
+        self._config.update(model_config)
+
+    def get_config(self) -> Any:
+        return self._config
+
+    async def structured_output(
+        self,
+        output_model: Any,
+        prompt: Messages,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        raise NotImplementedError("spike model does not do structured output")
+        yield {}  # pragma: no cover - makes this an async generator
+
+    async def stream(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        decision = self._turns.pop(0) if self._turns else ("text", "done")
+        yield {"messageStart": {"role": "assistant"}}
+        if decision[0] == "tool":
+            _, name, args = decision
+            yield {
+                "contentBlockStart": {
+                    "start": {"toolUse": {"toolUseId": f"call-{name}", "name": name}}
+                }
+            }
+            yield {
+                "contentBlockDelta": {"delta": {"toolUse": {"input": json.dumps(args)}}}
+            }
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "tool_use"}}
+        else:
+            yield {"contentBlockStart": {"start": {}}}
+            yield {"contentBlockDelta": {"delta": {"text": decision[1]}}}
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "end_turn"}}
+
+
+async def _run(adapter: StrandsAdapter, tools: FakeAgentTools, room_id: str) -> None:
+    """Drive the adapter through its real lifecycle: on_started -> on_message."""
+    await adapter.on_started("StrandsSpikeBot", "Tier-1 Strands injection spike bot.")
+    await adapter.on_message(
+        msg=_make_msg(room_id),
+        tools=cast("AgentToolsProtocol", tools),
+        history=[],
+        participants_msg=None,
+        contacts_msg=None,
+        is_session_bootstrap=True,
+        room_id=room_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_scripted_model_routes_to_typed_send_message() -> None:
+    """A scripted tool-use decision drives the real platform-tool wrapper (L0).
+
+    Observed on messages_sent (typed-method dispatch), NOT tool_calls.
+    """
+    room_id = "strands-spike-room"
+    tools = FakeAgentTools(room_id=room_id)
+    adapter = StrandsAdapter(
+        model=_ScriptedStrandsModel(
+            [
+                (
+                    "tool",
+                    "band_send_message",
+                    {"content": _SEND_CONTENT, "mentions": _SEND_MENTIONS},
+                ),
+                ("text", "done"),
+            ]
+        )
+    )
+    await _run(adapter, tools, room_id)
+
+    # Strands dispatches platform tools through typed AgentToolsProtocol
+    # methods, so observe on messages_sent (the contract's observation_paths).
+    assert len(tools.messages_sent) == 1, (
+        f"expected one send_message dispatch via the real tool wrapper, "
+        f"got messages_sent={tools.messages_sent}, tool_calls={tools.tool_calls}"
+    )
+    assert tools.messages_sent[0]["content"] == _SEND_CONTENT
+    assert tools.messages_sent[0]["mentions"] == _SEND_MENTIONS
+    # And confirm it did NOT route through execute_tool_call (the dual-path proof).
+    assert tools.tool_calls == [], (
+        f"Strands platform tools should bypass execute_tool_call; got {tools.tool_calls}"
+    )
+    # The terminal band action means no error event was reported.
+    assert not [e for e in tools.events_sent if e["message_type"] == "error"]
+
+
+@pytest.mark.asyncio
+async def test_custom_tool_decision_dispatches_to_handler() -> None:
+    """A scripted custom-tool decision reaches the custom handler with validated args (L1)."""
+
+    calls: list[str] = []
+
+    class EchoInput(BaseModel):
+        """Echo the given text back."""
+
+        text: str
+
+    async def echo_handler(args: EchoInput) -> str:
+        calls.append(args.text)
+        return f"echo: {args.text}"
+
+    # Terminal opt-in: the custom tool completes the turn, so no error is reported.
+    echo_handler.band_terminal = True  # type: ignore[attr-defined]
+
+    room_id = "strands-spike-custom"
+    tools = FakeAgentTools(room_id=room_id)
+    adapter = StrandsAdapter(
+        model=_ScriptedStrandsModel(
+            [
+                ("tool", "echo", {"text": "MANGO"}),
+                ("text", "done"),
+            ]
+        ),
+        additional_tools=[(EchoInput, echo_handler)],
+    )
+    await _run(adapter, tools, room_id)
+
+    assert calls == ["MANGO"], f"custom handler not dispatched: {calls}"
+    assert tools.messages_sent == []  # the custom tool is not a platform send
+    # band_terminal opt-in makes the turn productive: no error event.
+    assert not [e for e in tools.events_sent if e["message_type"] == "error"]
+
+
+@pytest.mark.asyncio
+async def test_l6_execution_events_ordered_paired_and_correlated() -> None:
+    """Emit.EXECUTION produces tool_call before tool_result, correlated by id (L6)."""
+    room_id = "strands-spike-l6"
+    tools = FakeAgentTools(room_id=room_id)
+    adapter = StrandsAdapter(
+        model=_ScriptedStrandsModel(
+            [
+                (
+                    "tool",
+                    "band_send_message",
+                    {"content": _SEND_CONTENT, "mentions": _SEND_MENTIONS},
+                ),
+                ("text", "done"),
+            ]
+        ),
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
+    )
+    await _run(adapter, tools, room_id)
+
+    execution = [
+        (e["message_type"], json.loads(e["content"]))
+        for e in tools.events_sent
+        if e["message_type"] in ("tool_call", "tool_result")
+    ]
+    assert [kind for kind, _ in execution] == ["tool_call", "tool_result"], (
+        f"expected one ordered tool_call/tool_result pair, got {execution}"
+    )
+    call, result = execution[0][1], execution[1][1]
+    assert call["name"] == "band_send_message"
+    assert call["args"] == {"content": _SEND_CONTENT, "mentions": _SEND_MENTIONS}
+    assert result["name"] == "band_send_message"
+    assert result["tool_call_id"] == call["tool_call_id"], (
+        f"tool_result not correlated with its tool_call: {execution}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_negative_control_text_only_sends_no_message() -> None:
+    """A text-only scripted decision dispatches nothing and reports the dropped reply."""
+    room_id = "strands-spike-negative"
+    tools = FakeAgentTools(room_id=room_id)
+    adapter = StrandsAdapter(
+        model=_ScriptedStrandsModel([("text", "just a reply, no tools")])
+    )
+    await _run(adapter, tools, room_id)
+
+    assert tools.messages_sent == [], (
+        f"expected no send for a text-only decision, got: {tools.messages_sent}"
+    )
+    assert tools.tool_calls == []
+    # The plain-text answer was silently dropped — the adapter must surface it.
+    errors = [e for e in tools.events_sent if e["message_type"] == "error"]
+    assert len(errors) == 1, f"expected one error event, got: {tools.events_sent}"
+    assert "band_send_message" in errors[0]["content"]

--- a/tests/framework_conformance/test_strands_injection_spike.py
+++ b/tests/framework_conformance/test_strands_injection_spike.py
@@ -28,9 +28,9 @@ directly — ``band_send_message`` calls ``tools.send_message(...)`` — NOT
 
 STEP-0 FINDINGS (verified against installed strands-agents 1.47.0)
 ------------------------------------------------------------------
-1. Per-invocation context: ``agent.invoke_async(prompt, invocation_state={...})``
-   reaches tool bodies via ``@tool(context=True)`` (``tool_context.invocation_state``)
-   and every hook event (``event.invocation_state``). No fallback needed.
+1. Per-turn tool ownership: the adapter builds native tool closures for each
+   ``Agent`` invocation, binding that turn's ``AgentToolsProtocol`` directly.
+   This keeps a room capability out of Strands' untyped ``invocation_state``.
 2. Scripted model events (consumed by ``strands.event_loop.streaming``): one tool
    call is ``messageStart{role:assistant}`` ->
    ``contentBlockStart{start:{toolUse:{toolUseId,name}}}`` ->

--- a/uv.lock
+++ b/uv.lock
@@ -462,6 +462,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aws-bedrock-token-generator"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/39/cf1c2e12bc5a84af0f96a546481213f81fa6e7927d2bbabd81758c6558ca/aws_bedrock_token_generator-1.1.0.tar.gz", hash = "sha256:95ccb07f63a91ac486561f6df05cc4e04784c8ff5086dc687ed9c5fd3ab1b5ba", size = 19123, upload-time = "2025-07-29T19:53:19.511Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/fd/745ece98870c3824d294bcdce5dc5e15381188a41bc80832c246b205e40e/aws_bedrock_token_generator-1.1.0-py3-none-any.whl", hash = "sha256:bd12854f7c7e52dde5d980d369379f12d0cc5f0855099d87f38688b0f9de5cd4", size = 10291, upload-time = "2025-07-29T19:53:18.704Z" },
+]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -614,6 +626,7 @@ dev = [
     { name = "ruff" },
     { name = "slack-sdk" },
     { name = "starlette" },
+    { name = "strands-agents", extra = ["openai"], marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
     { name = "tenacity" },
     { name = "uvicorn" },
     { name = "werkzeug" },
@@ -682,6 +695,9 @@ slack = [
     { name = "slack-sdk" },
     { name = "starlette" },
     { name = "uvicorn" },
+]
+strands = [
+    { name = "strands-agents", extra = ["openai"] },
 ]
 
 [package.metadata]
@@ -806,6 +822,8 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'acp'", specifier = ">=0.40.0" },
     { name = "starlette", marker = "extra == 'dev'", specifier = ">=0.40.0" },
     { name = "starlette", marker = "extra == 'slack'", specifier = ">=0.40.0" },
+    { name = "strands-agents", extras = ["openai"], marker = "extra == 'dev'", specifier = ">=1.40,<2" },
+    { name = "strands-agents", extras = ["openai"], marker = "extra == 'strands'", specifier = ">=1.40,<2" },
     { name = "tenacity", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "tenacity", marker = "extra == 'dev-crewai'", specifier = ">=8.0.0" },
     { name = "uvicorn", marker = "extra == 'a2a-gateway'", specifier = ">=0.32.0" },
@@ -818,7 +836,7 @@ requires-dist = [
     { name = "werkzeug", marker = "extra == 'dev'", specifier = ">=3.1.6" },
     { name = "werkzeug", marker = "extra == 'parlant'", specifier = ">=3.1.6" },
 ]
-provides-extras = ["logging", "codex", "opencode", "letta", "pydantic-ai", "anthropic", "langgraph", "claude-sdk", "copilot-sdk", "parlant", "crewai", "gemini", "a2a", "a2a-gateway", "a2a-gateway-demo", "acp", "slack", "bridge", "bridge-agentcore", "agentcore-runtime", "google-adk", "agno", "dev", "dev-crewai"]
+provides-extras = ["logging", "codex", "opencode", "letta", "pydantic-ai", "anthropic", "langgraph", "claude-sdk", "copilot-sdk", "parlant", "crewai", "gemini", "a2a", "a2a-gateway", "a2a-gateway-demo", "acp", "slack", "bridge", "bridge-agentcore", "agentcore-runtime", "google-adk", "agno", "strands", "dev", "dev-crewai"]
 
 [[package]]
 name = "band-testing-python"
@@ -5053,6 +5071,20 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-threading"
+version = "0.63b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/90/7b0279192fab614d57af3d57584ef7ac9e38fa3df0b1d412224f6f55a85b/opentelemetry_instrumentation_threading-0.63b1.tar.gz", hash = "sha256:afa8c2cada8ed136f07b04dc8739bc861a15e9a5edea1a65e4c5e1919c62946c", size = 9080, upload-time = "2026-05-21T16:36:49.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/3d/3a991a4fcdf5ac82c04215e38cea4e73ad63713707014f9a70d1ab257f5f/opentelemetry_instrumentation_threading-0.63b1-py3-none-any.whl", hash = "sha256:33059298e68c94b13c38b562ad28799ec16a2fd06182ebfc762bb4e956e55d94", size = 8486, upload-time = "2026-05-21T16:35:58.084Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
@@ -7491,6 +7523,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "strands-agents"
+version = "1.50.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jsonschema" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation-threading" },
+    { name = "opentelemetry-sdk" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "typing-extensions" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/8d/49292aa95a380cc8e23013d35b890989064c710888a9422f4eac86041787/strands_agents-1.50.1.tar.gz", hash = "sha256:1c3dadc583a9219e25e8cf4942546544c73ae826d588223ea92c7ce9b1bcc45a", size = 1224179, upload-time = "2026-07-24T21:40:02.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/7c/1fa3979b54b8c7c3abeb17ad53d7035e6957b83ab7b5555ee11d884f47e4/strands_agents-1.50.1-py3-none-any.whl", hash = "sha256:fa8ad193d6aa4bc0bed2a43d85e9446cd4c22336f6c1c89638d55289faccfe4e", size = 641138, upload-time = "2026-07-24T21:40:00.853Z" },
+]
+
+[package.optional-dependencies]
+openai = [
+    { name = "aws-bedrock-token-generator" },
+    { name = "openai" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a **Strands Agents** adapter (`StrandsAdapter`) + history converter for AWS's [Strands Agents SDK](https://github.com/strands-agents/sdk-python) (pinned `strands-agents>=1.40,<2`), modeled on the pydantic-ai adapter — same integration family (`INJECTABLE_MODEL_OBJECT`: the framework owns the loop, the model object is injectable at the public `Agent(model=...)` seam).

- **Adapter** (`src/band/adapters/strands.py`): platform tools as native `@tool` functions (descriptions from `get_tool_description`), contact tools gated on `Capability.CONTACTS`, memory tools on `Capability.MEMORY`; `CustomToolDef` tuples bridged through a native `AgentTool` subclass validating via `execute_custom_tool`; L6 `tool_call`/`tool_result` events via `Before/AfterToolCallEvent` hooks (ordered, paired, correlated by `toolUseId`); per-turn `TurnUsage` from `metrics.accumulated_usage` → `emit_usage`; terminal detection via `is_terminal_success` + `band_tool_errored`, with `_report_error` on a turn that never called a terminal Band tool.
- **Converter** (`src/band/converters/strands.py`): platform history → Converse-shaped `Message`s (`toolUse`/`toolResult` blocks, batched; own text preserved as assistant turns for rehydration).
- **Registration**: `strands` extra (+ in `dev`), lazy import in `band.adapters`, `Adapter.STRANDS` + `@adapter` builder (OpenAI provider, `core` lane derived from `Dep.OPENAI` — no `ci_lanes.py` edit needed, the lane partition is registry-derived), conformance config registries (adapter/converter/output-adapter).
- **Tests**: Tier-1 injection spike, adapter unit tests, converter unit tests; passes the shared adapter/converter conformance suites and every drift guard.
- **Examples**: `examples/strands/01_basic_agent.py`, `02_custom_tools.py` (PEP-723, `band-sdk[strands]`).

## Step-0 findings (verified against installed strands-agents 1.47.0)

1. **Per-invocation context** — `agent.invoke_async(prompt, invocation_state={...})` reaches tool bodies via `@tool(context=True)` → `tool_context.invocation_state`, and every hook event via `event.invocation_state`. Verified empirically; the `self._active_tools` fallback was not needed.
2. **Scripted `Model` stream shape** — subclass `strands.models.Model` (must also implement abstract `structured_output`). One tool call: `messageStart{role:assistant}` → `contentBlockStart{start:{toolUse:{toolUseId,name}}}` → `contentBlockDelta{delta:{toolUse:{input:<json-string>}}}` → `contentBlockStop` → `messageStop{stopReason:"tool_use"}`; text turn: `delta:{text}` + `stopReason:"end_turn"`; per-call usage on a trailing `metadata{usage}` event. Strands ships **no public test model**, so the spike implements the minimal `Model` subclass (still the public provider ABC).
3. **OpenAI provider** — `strands.models.openai.OpenAIModel(client_args={"api_key":...}, model_id=...)`. There is **no `"openai:model"` string shorthand**: a bare string to `Agent(model=...)` is treated as a *Bedrock* model id. Builder + examples use the explicit `OpenAIModel` (the design's ⚠ alternative).
4. **Hook events / usage** — `BeforeToolCallEvent.tool_use{name,toolUseId,input}`, `AfterToolCallEvent.result: ToolResult{status,content,toolUseId}` (+ `.exception`), async callbacks supported. Usage lives on `AgentResult.metrics.accumulated_usage` (`inputTokens/outputTokens/cacheReadInputTokens/cacheWriteInputTokens`) — **not** on `AfterModelCallEvent` — and **accumulates across turns** on a shared Agent.
5. **History handle** — `agent.messages` is a public read/write list of Converse `Message` dicts; pre-seeding via `Agent(messages=...)` and post-run read-back both verified — Band owns per-room history (no Strands sessions).

**Design adjustment (D1), flagged rather than silently diverged:** a Strands `Agent` is *stateful* (owns `messages`, per-Agent metrics) and raises `ConcurrencyException` on concurrent invocation (default mode), while the Band runtime runs one asyncio task per room — a single Agent shared across rooms would break. The adapter builds the heavy pieces (prompt, tool set) once in `on_started` and constructs a lightweight per-turn `Agent` over the room's band-owned history — the same fresh-runner-per-message shape `google_adk.py` already uses. Bonus: fresh per-turn metrics make `accumulated_usage` exactly the turn's usage (no snapshot deltas). Everything else follows the design decisions verbatim.

**Injection registry note:** the Tier-1 `InjectionBinding` registry (`tests/framework_conformance/injection_registry.py`) lives on the unmerged taxonomy branch (`int-826-827-tier1-injection-taxonomy`; PR #368 was closed) and does not exist on `dev`. The spike is standalone (matching how the taxonomy branch keeps spikes standalone), and the exact `InjectionBinding(...)` record for strands — `family=INJECTABLE_MODEL_OBJECT`, `tier1_status=HONEST_TODAY`, `observation_paths={TYPED_METHODS}`, `model_seam_kind=PUBLIC_TEST_MODEL`, `drift_risk=HIGH`, `version_pin="strands-agents>=1.40,<2"`, `seam="band.adapters.strands:StrandsAdapter._build_agent"` — is recorded in the spike's module docstring, ready to paste when the registry lands.

## Verification gate

1. **Dependency isolation** — `uv sync --extra strands` resolves with no conflicts (coexists with the full `dev` extra incl. parlant/pydantic-ai);
   `uv run python -c "import band; from band.adapters import StrandsAdapter"` → OK; in a strands-free env: `OK: plain band-sdk does not import/require strands`.
2. **Conformance** — `uv run pytest tests/framework_conformance -q` → `476 passed, 43 skipped` (incl. the 4 strands injection-spike tests; skips are pre-existing env-gated cases).
3. **Adapter unit tests** — `uv run pytest tests/adapters/test_strands_adapter.py -q` → `17 passed`.
4. **Discovery guard** — `assert_registry_covers_discovered()` + `assert_every_adapter_has_a_ci_home()` pass; strands lands in the `core` lane: `('core', ['agno', 'anthropic', 'claude_sdk', 'langgraph', 'pydantic_ai', 'strands'])`. (`pytest tests/e2e/baseline -k "registry or discovered"` skips locally by design — that tree is live-gated; same guards run in `tests/framework_conformance/test_lane_scheduling.py`, green.)
5. **Lint/type** — `ruff check .` → `All checks passed!`; `ruff format` applied; `pyrefly check src/band/adapters/strands.py src/band/converters/strands.py` → `0 errors` (the project-wide pyrefly run is inert inside a `.claude/worktrees` checkout — pre-existing path quirk, CI unaffected).
6. **Examples smoke** — both example modules import and the adapter dry-constructs with `OpenAIModel(model_id=...)`.
7. **Full unit suite** — `uv run pytest tests/ --ignore=tests/integration --ignore=tests/e2e -q` → `3545 passed, 60 skipped`.

**Live validation (manual, app.band.ai):** registered a fresh `strands-example` agent, ran `examples/strands/01_basic_agent.py` against the local branch, and drove it as a user in room `ac584ec0-0f6b-4481-9361-fc8d23402b21`:
- **L0** — mention → reply via `band_send_message` (haiku received, no error events, clean turn logs).
- **L4** — killed and restarted the process with a user message queued in the backlog; on reboot it rehydrated 4 messages of platform history through `StrandsHistoryConverter` (own prior reply as an assistant turn) and correctly answered a follow-up that referenced its pre-restart reply ("make a joke about that line").

**Not run locally:** the automated baseline matrix (`E2E_TESTS_ENABLED=true … -k strands`). The cell is registered fail-loud in the `core` lane, so the e2e workflow exercises L0–L6.

Relates [INT-971](https://linear.app/thenvoi/issue/INT-971/planing-placeholder-strands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
