### PR TITLE
fix: Copilot Docker ACP examples

### DIFF
--- a/examples/acp/copilot_docker/colocated/.env.example
+++ b/examples/acp/copilot_docker/colocated/.env.example
@@ -13,4 +13,5 @@ BAND_WS_URL=wss://app.band.ai/api/v1/socket/websocket
 # Optional overrides for client.py:
 # COPILOT_ACP_HOST=localhost
 # COPILOT_ACP_PORT=8080
+# COPILOT_ACP_CWD=/
 # BAND_MCP_SSE_URL=http://127.0.0.1:3000/sse

--- a/examples/acp/copilot_docker/colocated/README.md
+++ b/examples/acp/copilot_docker/colocated/README.md
@@ -42,6 +42,10 @@ docker run --rm --env-file .env -p 127.0.0.1:8080:8080 copilot-band-acp
 uv run examples/acp/copilot_docker/colocated/client.py
 ```
 
+`client.py` uses `/` as Copilot's working directory by default because the ACP
+server runs in a container. Set `COPILOT_ACP_CWD` to another path only when it
+exists inside the Copilot container.
+
 Then message the `copilot_acp_agent` from a Band room.
 
 ## Design notes / gotchas (verified against the shipped tools)

--- a/examples/acp/copilot_docker/colocated/README.md
+++ b/examples/acp/copilot_docker/colocated/README.md
@@ -56,8 +56,9 @@ Then message the `copilot_acp_agent` from a Band room.
   server on a routable port — the endpoint `CopilotACPAdapter(host=…, port=…)` dials.
 - **Fresh process per connection.** `,fork` execs a new `copilot --acp` for each TCP
   connection, so a reconnect (e.g. an `ACPRuntime` respawn) lands on a process with no
-  prior in-memory sessions. Harmless here — Band rehydrates session state from room
-  history — but don't expect Copilot's native ACP session resume to survive a reconnect.
+  prior in-memory sessions. The SDK uses ACP's session-load capability before trusting
+  a persisted ID; unsupported or unavailable sessions get a fresh session before the
+  prompt is sent. Earlier Copilot conversation state is not resumed after a reconnect.
 - **Bind loopback.** The `docker run -p 127.0.0.1:8080:8080` above keeps the ACP port
   on the host loopback. Copilot here is unauthenticated and runs `--allow-all-tools`,
   so expose it off-host only behind your own auth.

--- a/examples/acp/copilot_docker/colocated/client.py
+++ b/examples/acp/copilot_docker/colocated/client.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[acp]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git", branch = "dev" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
 # ///
 """
 Host-side Band SDK client for the colocated Copilot Docker example.

--- a/examples/acp/copilot_docker/colocated/client.py
+++ b/examples/acp/copilot_docker/colocated/client.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[acp]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git", branch = "dev" }
 # ///
 """
 Host-side Band SDK client for the colocated Copilot Docker example.
@@ -46,6 +46,8 @@ async def main() -> None:
     # Copilot's ACP server, published by the container.
     host = os.getenv("COPILOT_ACP_HOST", "localhost")
     port = int(os.getenv("COPILOT_ACP_PORT", "8080"))
+    # The TCP server runs in a container, so this must be a path it can access.
+    cwd = os.getenv("COPILOT_ACP_CWD", "/")
 
     # band-mcp's SSE endpoint as reachable BY COPILOT — the container's own loopback.
     band_mcp_sse_url = os.getenv("BAND_MCP_SSE_URL", "http://127.0.0.1:3000/sse")
@@ -53,6 +55,7 @@ async def main() -> None:
     config = CopilotACPAdapterConfig(
         host=host,
         port=port,
+        cwd=cwd,
         inject_band_tools=False,  # Copilot is remote; it can't reach our loopback MCP
         mcp_servers=[
             {"type": "sse", "name": "band", "url": band_mcp_sse_url, "headers": []}

--- a/examples/acp/copilot_docker/compose/.env.example
+++ b/examples/acp/copilot_docker/compose/.env.example
@@ -13,4 +13,5 @@ BAND_WS_URL=wss://app.band.ai/api/v1/socket/websocket
 # Optional overrides for client.py:
 # COPILOT_ACP_HOST=localhost
 # COPILOT_ACP_PORT=8080
+# COPILOT_ACP_CWD=/
 # BAND_MCP_SSE_URL=http://band-mcp:3000/sse

--- a/examples/acp/copilot_docker/compose/README.md
+++ b/examples/acp/copilot_docker/compose/README.md
@@ -43,6 +43,10 @@ docker compose up --build # starts copilot (:8080) + band-mcp (internal :3000)
 uv run examples/acp/copilot_docker/compose/client.py
 ```
 
+`client.py` uses `/` as Copilot's working directory by default because the ACP
+server runs in a container. Set `COPILOT_ACP_CWD` to another path only when it
+exists inside the Copilot container.
+
 Then message the `copilot_acp_agent` from a Band room; Copilot handles the turn
 and calls Band tools via band-mcp.
 

--- a/examples/acp/copilot_docker/compose/README.md
+++ b/examples/acp/copilot_docker/compose/README.md
@@ -59,8 +59,9 @@ and calls Band tools via band-mcp.
   `CopilotACPAdapter(host=…, port=…)` dials.
 - **Fresh process per connection.** `,fork` execs a new `copilot --acp` for each TCP
   connection, so a reconnect (e.g. an `ACPRuntime` respawn) lands on a process with no
-  prior in-memory sessions. Harmless here — Band rehydrates session state from room
-  history — but don't expect Copilot's native ACP session resume to survive a reconnect.
+  prior in-memory sessions. The SDK uses ACP's session-load capability before trusting
+  a persisted ID; unsupported or unavailable sessions get a fresh session before the
+  prompt is sent. Earlier Copilot conversation state is not resumed after a reconnect.
 - **Bind loopback.** `docker-compose.yml` publishes the ACP port as
   `127.0.0.1:8080:8080`: an unauthenticated, allow-all `copilot --acp` must not be
   reachable off-host. Widen it (behind your own auth) only for a remote SDK host.

--- a/examples/acp/copilot_docker/compose/client.py
+++ b/examples/acp/copilot_docker/compose/client.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[acp]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git", branch = "dev" }
 # ///
 """
 Host-side Band SDK client for the Copilot Docker Compose example.
@@ -46,6 +46,8 @@ async def main() -> None:
     # Copilot's ACP server, published by the compose stack.
     host = os.getenv("COPILOT_ACP_HOST", "localhost")
     port = int(os.getenv("COPILOT_ACP_PORT", "8080"))
+    # The TCP server runs in a container, so this must be a path it can access.
+    cwd = os.getenv("COPILOT_ACP_CWD", "/")
 
     # band-mcp's SSE endpoint as reachable BY COPILOT (compose DNS), not by us.
     band_mcp_sse_url = os.getenv("BAND_MCP_SSE_URL", "http://band-mcp:3000/sse")
@@ -53,6 +55,7 @@ async def main() -> None:
     config = CopilotACPAdapterConfig(
         host=host,
         port=port,
+        cwd=cwd,
         inject_band_tools=False,  # Copilot is remote; it can't reach our loopback MCP
         mcp_servers=[
             {"type": "sse", "name": "band", "url": band_mcp_sse_url, "headers": []}

--- a/examples/acp/copilot_docker/compose/client.py
+++ b/examples/acp/copilot_docker/compose/client.py
@@ -3,7 +3,7 @@
 # dependencies = ["band-sdk[acp]"]
 #
 # [tool.uv.sources]
-# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git", branch = "dev" }
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git"}
 # ///
 """
 Host-side Band SDK client for the Copilot Docker Compose example.

--- a/src/band/converters/acp_client.py
+++ b/src/band/converters/acp_client.py
@@ -14,10 +14,10 @@ logger = logging.getLogger(__name__)
 
 
 class ACPClientHistoryConverter(HistoryConverter["ACPClientSessionState"]):
-    """Extracts room_id to session_id mappings from platform history.
+    """Extracts room-to-session resume candidates from platform history.
 
-    Scans platform history for ACP client-specific metadata to rebuild
-    the mapping between Band room_ids and remote ACP session_ids.
+    Scans platform history for ACP client-specific metadata. The adapter validates
+    each candidate with the connected ACP agent before reusing it.
 
     The converter looks for messages with metadata containing:
     - acp_client_session_id: The remote ACP agent's session identifier
@@ -31,7 +31,7 @@ class ACPClientHistoryConverter(HistoryConverter["ACPClientSessionState"]):
             raw: Platform history from format_history_for_llm().
 
         Returns:
-            ACPClientSessionState with room_to_session mappings.
+            ACPClientSessionState with room-to-session resume candidates.
         """
         # Runtime import to avoid circular import at module load time
         from band.integrations.acp.client_types import ACPClientSessionState
@@ -46,7 +46,7 @@ class ACPClientHistoryConverter(HistoryConverter["ACPClientSessionState"]):
             if session_id and room_id:
                 room_to_session[room_id] = session_id
                 logger.debug(
-                    "Restored ACP client session mapping: %s -> %s",
+                    "Found persisted ACP session candidate: %s -> %s",
                     room_id,
                     session_id,
                 )
@@ -54,7 +54,7 @@ class ACPClientHistoryConverter(HistoryConverter["ACPClientSessionState"]):
         state = ACPClientSessionState(room_to_session=room_to_session)
 
         logger.debug(
-            "Converted ACP client history: %d room-session mappings",
+            "Converted ACP client history: %d room-session candidates",
             len(room_to_session),
         )
 

--- a/src/band/integrations/acp/client_adapter.py
+++ b/src/band/integrations/acp/client_adapter.py
@@ -169,13 +169,12 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
         del participants_msg, contacts_msg
         await self._ensure_connection()
 
-        if is_session_bootstrap and history:
-            async with self._session_lock:
-                self._rehydrate(room_id, history)
-
         if self._inject_band_tools:
             async with self._session_lock:
                 self._room_tools[room_id] = tools
+
+        if is_session_bootstrap and history:
+            await self._load_persisted_session(room_id, history)
 
         session_id = await self._get_or_create_session(room_id)
         self._runtime.reset_session(session_id)
@@ -184,14 +183,7 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
             self._make_permission_handler(tools, room_id),
         )
 
-        prompt_text = msg.content
-        async with self._session_lock:
-            needs_bootstrap = session_id not in self._bootstrapped_sessions
-            if needs_bootstrap:
-                self._bootstrapped_sessions.add(session_id)
-        if needs_bootstrap:
-            system_context = self._build_system_context(room_id, msg)
-            prompt_text = f"{system_context}\n\n{msg.content}"
+        prompt_text = await self._build_prompt_text(room_id, session_id, msg)
 
         try:
             chunks = await self._runtime.prompt(
@@ -397,7 +389,8 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
             f"Current requester name: {requester_name}\n"
             f"Current requester id: {requester_id}\n"
             f"\n"
-            f"All Band tool calls must include room_id.\n"
+            f"Use each MCP tool's schema for its argument names. When a tool needs "
+            f"the current room, use the Current room_id value above.\n"
         )
 
         return f"[System Context]\n{system_prompt}\n{room_context}"
@@ -447,9 +440,7 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
             if room_id in self._room_to_session:
                 return self._room_to_session[room_id]
 
-            mcp_servers: list[object] = list(self._mcp_servers)
-            if self._inject_band_tools:
-                mcp_servers.append(await self._get_or_start_band_mcp_server())
+            mcp_servers = await self._session_mcp_servers()
 
             session_id = await self._runtime.create_session(
                 cwd=self._cwd,
@@ -463,6 +454,31 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
                 len(mcp_servers),
             )
             return session_id
+
+    async def _session_mcp_servers(self) -> list[object]:
+        """The MCP configuration supplied when creating or loading a session."""
+        mcp_servers: list[object] = list(self._mcp_servers)
+        if self._inject_band_tools:
+            mcp_servers.append(await self._get_or_start_band_mcp_server())
+        return mcp_servers
+
+    async def _build_prompt_text(
+        self,
+        room_id: str,
+        session_id: str,
+        msg: PlatformMessage,
+    ) -> str:
+        """Add room context on the first prompt sent to an ACP session."""
+        async with self._session_lock:
+            needs_bootstrap = session_id not in self._bootstrapped_sessions
+            if needs_bootstrap:
+                self._bootstrapped_sessions.add(session_id)
+
+        if not needs_bootstrap:
+            return msg.content
+
+        system_context = self._build_system_context(room_id, msg)
+        return f"{system_context}\n\n{msg.content}"
 
     async def on_cleanup(self, room_id: str) -> None:
         async with self._session_lock:
@@ -499,21 +515,41 @@ class ACPClientAdapter(SimpleAdapter[ACPClientSessionState]):
         """Tear down now (used by the ``on_message`` error path); see ``cleanup_all``."""
         await self.cleanup_all()
 
-    def _rehydrate(self, room_id: str, history: ACPClientSessionState) -> None:
-        del room_id
-        for restored_room_id, session_id in history.room_to_session.items():
-            if restored_room_id not in self._room_to_session:
-                self._room_to_session[restored_room_id] = session_id
+    async def _load_persisted_session(
+        self,
+        room_id: str,
+        history: ACPClientSessionState,
+    ) -> None:
+        """Accept this room's persisted session ID only after ACP loads it."""
+        async with self._session_lock:
+            if room_id in self._room_to_session:
+                return
+            session_id = history.room_to_session.get(room_id)
+
+        if session_id is None:
+            return
+
+        loaded = await self._runtime.load_session(
+            cwd=self._cwd,
+            session_id=session_id,
+            mcp_servers=await self._session_mcp_servers(),
+        )
+        if not loaded:
+            logger.info(
+                "Persisted ACP session %s is unavailable for room %s; using a new session",
+                session_id,
+                room_id,
+            )
+            return
+
+        async with self._session_lock:
+            if room_id not in self._room_to_session:
+                self._room_to_session[room_id] = session_id
                 logger.debug(
-                    "Restored ACP client session mapping: %s -> %s",
-                    restored_room_id,
+                    "Loaded ACP session mapping: %s -> %s",
+                    room_id,
                     session_id,
                 )
-
-        logger.info(
-            "Rehydrated ACP client state: %d room-session mappings",
-            len(self._room_to_session),
-        )
 
     async def _ensure_connection(self) -> ACPConnectionProtocol:
         return await self._runtime.ensure_connection(

--- a/src/band/integrations/acp/client_runtime.py
+++ b/src/band/integrations/acp/client_runtime.py
@@ -9,6 +9,7 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Literal, Protocol, cast
 
 from acp import connect_to_agent, spawn_agent_process, text_block
+from acp.exceptions import RequestError
 from acp.interfaces import Client
 
 from band.integrations.acp.client_profiles import (
@@ -20,6 +21,7 @@ from band.integrations.acp.types import CollectedChunk
 logger = logging.getLogger(__name__)
 
 ACP_STDIO_LIMIT_BYTES = 16 * 1024 * 1024
+ACP_SESSION_LOAD_TIMEOUT_SECONDS = 5.0
 PermissionHandler = Callable[..., Awaitable[dict[str, object]]]
 MCPTransportKind = Literal["http", "sse"]
 
@@ -129,6 +131,14 @@ class ACPConnectionProtocol(Protocol):
     async def authenticate(self, *, method_id: str) -> object: ...
 
     async def new_session(self, *, cwd: str, mcp_servers: list[object]) -> object: ...
+
+    async def load_session(
+        self,
+        *,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[object],
+    ) -> object: ...
 
     async def prompt(self, *, session_id: str, prompt: list[object]) -> object: ...
 
@@ -330,6 +340,7 @@ class ACPRuntime:
         ) = None
         self._stop_lock = asyncio.Lock()
         self._agent_mcp_transport: MCPTransportKind = "http"
+        self._agent_supports_session_load = False
 
     async def start(self, *, respawn: bool = False) -> None:
         """Spawn or respawn the ACP agent subprocess."""
@@ -356,6 +367,7 @@ class ACPRuntime:
             self._conn, _ = await ctx.__aenter__()
             init_response = await self._conn.initialize(protocol_version=1)
             self._agent_mcp_transport = self._select_mcp_transport(init_response)
+            self._agent_supports_session_load = self._select_session_load(init_response)
             if self._auth_method:
                 await self._conn.authenticate(method_id=self._auth_method)
                 logger.info("Authenticated with method: %s", self._auth_method)
@@ -396,6 +408,47 @@ class ACPRuntime:
         )
         return session.session_id
 
+    async def load_session(
+        self,
+        *,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[object],
+    ) -> bool:
+        """Load a persisted ACP session when the connected agent supports it.
+
+        ACP session IDs are meaningful only to the agent process that owns them.
+        A successful ``session/load`` is therefore the boundary where a persisted ID
+        becomes usable on this connection. An unsupported, unavailable, or slow load
+        returns ``False`` so callers can create a fresh session without blocking a turn.
+        """
+        if not self._agent_supports_session_load:
+            return False
+
+        conn = await self.ensure_connection(can_respawn=False)
+        try:
+            response = await asyncio.wait_for(
+                conn.load_session(
+                    cwd=cwd,
+                    session_id=session_id,
+                    mcp_servers=mcp_servers,
+                ),
+                timeout=ACP_SESSION_LOAD_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "ACP session %s did not load within %s seconds",
+                session_id,
+                ACP_SESSION_LOAD_TIMEOUT_SECONDS,
+            )
+            return False
+        except RequestError as error:
+            if not self._is_missing_session_error(error):
+                raise
+            logger.info("ACP session %s is no longer available", session_id)
+            return False
+        return response is not None
+
     async def prompt(
         self, *, session_id: str, prompt_text: str
     ) -> list[CollectedChunk]:
@@ -427,6 +480,7 @@ class ACPRuntime:
             self._ctx = None
             self._conn = None
             self._client = None
+            self._agent_supports_session_load = False
         if ctx is None:
             return
         try:
@@ -445,6 +499,7 @@ class ACPRuntime:
             logger.exception("Error cleaning up ACP subprocess after %s", reason)
         self._ctx = None
         self._conn = None
+        self._agent_supports_session_load = False
 
     @staticmethod
     def _select_mcp_transport(init_response: object) -> MCPTransportKind:
@@ -457,3 +512,15 @@ class ACPRuntime:
             return "sse"
 
         return "http"
+
+    @staticmethod
+    def _select_session_load(init_response: object) -> bool:
+        capabilities = getattr(init_response, "agent_capabilities", None)
+        return getattr(capabilities, "load_session", False) is True
+
+    @staticmethod
+    def _is_missing_session_error(error: RequestError) -> bool:
+        """Whether an ACP ``session/load`` failure means the session is absent."""
+        return error.code == -32002 or (
+            "session" in str(error).lower() and "not found" in str(error).lower()
+        )

--- a/src/band/integrations/acp/client_types.py
+++ b/src/band/integrations/acp/client_types.py
@@ -10,7 +10,11 @@ from band.integrations.acp.client_runtime import ACPCollectingClient
 
 @dataclass
 class ACPClientSessionState:
-    """Session state for ACP client adapter rehydration."""
+    """Persisted room-to-session resume candidates for the ACP client adapter.
+
+    A session ID is owned by the remote ACP agent, so the adapter must validate it
+    with ACP ``session/load`` after reconnecting before it can be used for a prompt.
+    """
 
     room_to_session: dict[str, str] = field(default_factory=dict)
 

--- a/tests/integrations/acp/test_client_adapter.py
+++ b/tests/integrations/acp/test_client_adapter.py
@@ -239,7 +239,19 @@ class TestACPClientAdapterLocalMcpConfig:
         assert "Band tools" in system_context
         assert "Current room_id: room-123" in system_context
         assert "Current requester name: Pat" in system_context
-        assert "must include room_id" in system_context
+        assert "Use each MCP tool's schema" in system_context
+
+    def test_build_system_context_defers_to_external_mcp_tool_schema(self) -> None:
+        """The room value is supplied without assuming a remote tool's field name."""
+        adapter = ACPClientAdapter(command="codex", inject_band_tools=False)
+        adapter.agent_name = "ACP Bridge"
+        adapter.agent_description = "Bridge to ACP agents"
+        msg = make_platform_message("Hello", room_id="room-123")
+
+        system_context = adapter._build_system_context("room-123", msg)
+
+        assert "Use each MCP tool's schema" in system_context
+        assert "must include room_id" not in system_context
 
 
 class TestACPClientAdapterOnStarted:
@@ -590,7 +602,11 @@ class TestACPClientAdapterOnMessage:
         tools = FakeAgentTools()
         msg = make_platform_message("Hello", room_id="room-123")
 
-        history = ACPClientSessionState(room_to_session={"room-abc": "session-abc"})
+        adapter_with_mocks._runtime._agent_supports_session_load = True
+        adapter_with_mocks._runtime._conn.load_session = AsyncMock(
+            return_value=object()
+        )
+        history = ACPClientSessionState(room_to_session={"room-123": "session-abc"})
 
         await adapter_with_mocks.on_message(
             msg,
@@ -602,7 +618,51 @@ class TestACPClientAdapterOnMessage:
             room_id="room-123",
         )
 
-        assert adapter_with_mocks._room_to_session["room-abc"] == "session-abc"
+        assert adapter_with_mocks._room_to_session["room-123"] == "session-abc"
+        adapter_with_mocks._runtime._conn.load_session.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_on_message_creates_new_session_when_persisted_session_cannot_load(
+        self, adapter_with_mocks: ACPClientAdapter
+    ) -> None:
+        """A rebooted ephemeral ACP agent creates a session before prompting."""
+        stale_session = "stale-session"
+        fresh_session = MagicMock(session_id="fresh-session")
+        adapter_with_mocks._runtime._conn.new_session = AsyncMock(
+            return_value=fresh_session
+        )
+        adapter_with_mocks._runtime._agent_supports_session_load = True
+        adapter_with_mocks._runtime._conn.load_session = AsyncMock(return_value=None)
+
+        async def prompt_new_session(**kwargs):
+            session_id = kwargs["session_id"]
+            adapter_with_mocks._runtime._client._session_chunks[session_id] = [
+                CollectedChunk(chunk_type="text", content="Recovered reply")
+            ]
+
+        adapter_with_mocks._runtime._conn.prompt = AsyncMock(
+            side_effect=prompt_new_session
+        )
+        tools = FakeAgentTools()
+        msg = make_platform_message("Hello", room_id="room-123")
+
+        await adapter_with_mocks.on_message(
+            msg,
+            tools,
+            ACPClientSessionState(room_to_session={"room-123": stale_session}),
+            None,
+            None,
+            is_session_bootstrap=True,
+            room_id="room-123",
+        )
+
+        assert adapter_with_mocks._room_to_session["room-123"] == "fresh-session"
+        adapter_with_mocks._runtime._conn.new_session.assert_awaited_once()
+        adapter_with_mocks._runtime._conn.load_session.assert_awaited_once()
+        prompt_calls = adapter_with_mocks._runtime._conn.prompt.call_args_list
+        assert [call.kwargs["session_id"] for call in prompt_calls] == ["fresh-session"]
+        assert "[System Context]" in prompt_calls[0].kwargs["prompt"][0].text
+        assert tools.messages_sent[0]["content"] == "Recovered reply"
 
     @pytest.mark.asyncio
     async def test_on_message_error_sends_error_event(

--- a/tests/integrations/acp/test_client_runtime.py
+++ b/tests/integrations/acp/test_client_runtime.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from acp.client.connection import ClientSideConnection
+from acp.exceptions import RequestError
 
 from band.integrations.acp.client_profiles import (
     CursorACPClientProfile,
@@ -136,7 +137,8 @@ class TestACPRuntime:
         mock_conn.initialize = AsyncMock(
             return_value=MagicMock(
                 agent_capabilities=MagicMock(
-                    mcp_capabilities=MagicMock(http=False, sse=True)
+                    load_session=True,
+                    mcp_capabilities=MagicMock(http=False, sse=True),
                 )
             )
         )
@@ -153,6 +155,7 @@ class TestACPRuntime:
 
         assert runtime._conn is mock_conn
         assert runtime._agent_mcp_transport == "sse"
+        assert runtime._agent_supports_session_load
         mock_conn.initialize.assert_awaited_once_with(protocol_version=1)
         mock_conn.authenticate.assert_awaited_once_with(method_id="cursor_login")
 
@@ -173,6 +176,67 @@ class TestACPRuntime:
         assert chunks == []
         mock_conn.new_session.assert_awaited_once_with(cwd="/tmp", mcp_servers=[])
         mock_conn.prompt.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_load_session_uses_only_a_declared_capability(self) -> None:
+        mock_conn = AsyncMock()
+        mock_conn.load_session = AsyncMock(return_value=MagicMock())
+        runtime = ACPRuntime(command=["codex"])
+        runtime._conn = mock_conn
+
+        assert not await runtime.load_session(
+            cwd="/tmp", session_id="sess-1", mcp_servers=[]
+        )
+        mock_conn.load_session.assert_not_awaited()
+
+        runtime._agent_supports_session_load = True
+        assert await runtime.load_session(
+            cwd="/tmp", session_id="sess-1", mcp_servers=[]
+        )
+        mock_conn.load_session.assert_awaited_once_with(
+            cwd="/tmp", session_id="sess-1", mcp_servers=[]
+        )
+
+    @pytest.mark.asyncio
+    async def test_load_session_handles_an_unavailable_persisted_session(self) -> None:
+        mock_conn = AsyncMock()
+        mock_conn.load_session = AsyncMock(
+            side_effect=RequestError(-32002, "Session sess-1 not found")
+        )
+        runtime = ACPRuntime(command=["codex"])
+        runtime._conn = mock_conn
+        runtime._agent_supports_session_load = True
+
+        assert not await runtime.load_session(
+            cwd="/tmp", session_id="sess-1", mcp_servers=[]
+        )
+
+    @pytest.mark.asyncio
+    async def test_load_session_timeout_is_treated_as_unavailable(self) -> None:
+        mock_conn = AsyncMock()
+        mock_conn.load_session = AsyncMock(side_effect=TimeoutError)
+        runtime = ACPRuntime(command=["codex"])
+        runtime._conn = mock_conn
+        runtime._agent_supports_session_load = True
+
+        with patch(
+            "band.integrations.acp.client_runtime.ACP_SESSION_LOAD_TIMEOUT_SECONDS",
+            0.01,
+        ):
+            assert not await runtime.load_session(
+                cwd="/tmp", session_id="sess-1", mcp_servers=[]
+            )
+
+    @pytest.mark.asyncio
+    async def test_load_session_propagates_non_session_errors(self) -> None:
+        mock_conn = AsyncMock()
+        mock_conn.load_session = AsyncMock(side_effect=RequestError.invalid_params())
+        runtime = ACPRuntime(command=["codex"])
+        runtime._conn = mock_conn
+        runtime._agent_supports_session_load = True
+
+        with pytest.raises(RequestError, match="Invalid params"):
+            await runtime.load_session(cwd="/tmp", session_id="sess-1", mcp_servers=[])
 
     @pytest.mark.asyncio
     async def test_start_cleans_up_failed_initialize(self) -> None:


### PR DESCRIPTION
## Summary
- point the standalone example metadata at the SDK dev branch
- use a container-visible configurable ACP working directory
- document COPILOT_ACP_CWD in both Docker topologies

## Validation
- uv run ruff check examples/acp/copilot_docker/compose/client.py examples/acp/copilot_docker/colocated/client.py
- uv run pytest tests/adapters/test_copilot_acp_adapter.py -v
- rebuilt Docker examples and verified ACP session creation against the Compose stack

Linear: INT-1013