### PR TITLE
fix: cap oversized ACP event content instead of failing the send

### DIFF
--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -40,6 +40,29 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# The Agent Events API enforces a hard cap on event content (see
+# thenvoi-platform's events_controller.ex `@content_max_length`) and rejects
+# anything larger with a 422 before it ever reaches the room. Event content
+# can be arbitrarily large in practice — e.g. an ACP tool_result mirroring a
+# large file, or a raw exception dump — so truncate defensively rather than
+# letting the send fail.
+_EVENT_CONTENT_MAX_LENGTH = 16384
+_EVENT_TRUNCATION_MARKER = "... [truncated]"
+
+
+def _truncate_event_content(content: str) -> str:
+    """Cut *content* down to ``_EVENT_CONTENT_MAX_LENGTH`` chars.
+
+    A no-op when *content* is already within the limit, so callers can run it
+    unconditionally rather than checking the length themselves first.
+    """
+    if len(content) <= _EVENT_CONTENT_MAX_LENGTH:
+        return content
+    return (
+        content[: _EVENT_CONTENT_MAX_LENGTH - len(_EVENT_TRUNCATION_MARKER)]
+        + _EVENT_TRUNCATION_MARKER
+    )
+
 
 def _normalize_handle(value: str) -> str:
     """Strip leading ``@`` so ``@alice`` and ``alice`` compare equal."""
@@ -1480,6 +1503,17 @@ class AgentTools(AgentToolsProtocol):
         from band.client.rest import ChatEventRequest
 
         logger.debug("Sending %s event to room %s", message_type, self.room_id)
+
+        original_length = len(content)
+        content = _truncate_event_content(content)
+        if len(content) != original_length:
+            logger.warning(
+                "Truncated oversized %s event content for room %s (%d chars > %d limit)",
+                message_type,
+                self.room_id,
+                original_length,
+                _EVENT_CONTENT_MAX_LENGTH,
+            )
 
         response = await self.rest.agent_api_events.create_agent_chat_event(
             chat_id=self.room_id,

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -541,6 +541,29 @@ class TestAgentToolsSendEvent:
         with pytest.raises(RuntimeError, match="Failed to send event"):
             await tools.send_event("Error!", "error")
 
+    async def test_send_event_within_limit_untouched(self, mock_rest_client):
+        """send_event() should pass short content through unchanged."""
+        tools = AgentTools("room-123", mock_rest_client)
+        content = "x" * 16384
+
+        await tools.send_event(content, "tool_result")
+
+        call_args = mock_rest_client.agent_api_events.create_agent_chat_event.call_args
+        assert call_args.kwargs["event"].content == content
+
+    async def test_send_event_truncates_oversized_content(self, mock_rest_client):
+        """send_event() should cap oversized content instead of sending it verbatim."""
+        tools = AgentTools("room-123", mock_rest_client)
+        content = "HEAD" * 10000 + "TAIL" * 10000
+
+        await tools.send_event(content, "tool_result")
+
+        call_args = mock_rest_client.agent_api_events.create_agent_chat_event.call_args
+        sent_content = call_args.kwargs["event"].content
+        assert len(sent_content) == 16384
+        assert sent_content.startswith("HEAD")
+        assert sent_content.endswith("[truncated]")
+
 
 class TestMatchesIdentifier:
     """Tests for the _matches_identifier helper."""


### PR DESCRIPTION
## Summary
- The Agent Events API (`POST /agent/chats/{id}/events`) hard-caps `content` at 16384 chars and rejects anything larger with a 422 — the ACP/GitHub Copilot backend hit this when mirroring large `tool_call`/`tool_result` payloads (e.g. a GitHub MCP `get_file_contents` call on a big file), causing the send to fail outright instead of degrading gracefully.
- The 16384 cap isn't an arbitrary number tied to a technical limit — it's a deliberate guardrail. Every event broadcasts over the room's WebSocket channel to every connected socket, so an unbounded `content` string is a fan-out amplification vector. Per the platform source (`thenvoi-platform/lib/thenvoi_com_web/controllers/api/v1/agent/events_controller.ex:34-39`): *"The caps are generous ceilings (no legitimate event hits them), purely to stop pathological payloads from being broadcast."* The Copilot CLI's large tool_result is exactly the legitimate-but-oversized case that guardrail didn't anticipate.
- `AgentTools.send_event` (`src/band/runtime/tools.py`) — the single chokepoint every adapter funnels through — now truncates oversized content to the cap (keeping the head, dropping the tail with a `"... [truncated]"` marker) before sending, rather than throwing.
- Fixes the root cause generically for every adapter, not just ACP, since all `send_event` calls share this one path.

Linear: INT-1014

## Test plan
- [x] `uv run pytest tests/runtime/test_tools.py -k SendEvent -v --no-cov` — new truncation tests pass (pass-through under the cap, oversized content truncated with marker)
- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/ -q --no-cov` — full suite (3800 passed, 75 skipped)
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run pyrefly check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)