### PR TITLE
feat: add no-LLM LangGraph example

### DIFF
--- a/agent_config.yaml.example
+++ b/agent_config.yaml.example
@@ -52,6 +52,16 @@ research_ops_agent:
   agent_id: ""
   api_key: ""
 
+# 10_memory_tool_usage.py
+memory_agent:
+  agent_id: ""
+  api_key: ""
+
+# 11_no_llm_graph.py
+no_llm_agent:
+  agent_id: ""
+  api_key: ""
+
 # 07_tom_agent.py - see tom_agent in Shared Agents section
 # 08_jerry_agent.py - see jerry_agent in Shared Agents section
 

--- a/docs/adapters/langgraph.md
+++ b/docs/adapters/langgraph.md
@@ -122,6 +122,8 @@ adapter = LangGraphAdapter(graph_factory=graph_factory)
 
 `llm`, `my_tools`, and `checkpointer` are your application objects. Keep `band_tools` in the graph if the graph should reply to Band rooms, add participants, create chats, or use other Band collaboration tools.
 
+`graph_factory` does not require an LLM at all: the factory only needs to return a compiled graph, so a node can be plain deterministic Python that calls a Band tool (e.g. `band_send_message.ainvoke(...)`) directly instead of routing through model tool-calling. See `examples/langgraph/11_no_llm_graph.py`.
+
 ### Static Graph
 
 Use `graph=` only for a fully self-contained compiled graph. Static graphs do not receive the generated Band tools, do not get `additional_tools` merged in by the adapter, and do not receive the adapter's generated system prompt. If a static graph needs to send room messages, build the Band tool integration into the graph yourself.
@@ -249,3 +251,6 @@ See [examples/langgraph/](../../examples/langgraph/) for runnable scripts.
 | `06_delegate_to_sql_agent.py` | Delegate database queries to a SQL expert. |
 | `07_tom_agent.py` | Run one side of the Tom/Jerry multi-agent demo. |
 | `08_jerry_agent.py` | Run the other side of the Tom/Jerry demo. |
+| `09_research_ops_orchestrator.py` | Build a multi-node operations graph with platform events and subgraph delegation. |
+| `10_memory_tool_usage.py` | Enable durable Band memory tools for a graph. |
+| `11_no_llm_graph.py` | Build a fully deterministic graph with `graph_factory` and no LLM at all. |

--- a/examples/langgraph/11_no_llm_graph.py
+++ b/examples/langgraph/11_no_llm_graph.py
@@ -42,14 +42,32 @@ _SENDER_PATTERN = re.compile(r"^\[(?P<sender>[^\]]+)\]:\s*(?P<text>.*)$", re.DOT
 _MENTION_TOKEN_PATTERN = re.compile(r"@\[\[[^\]]+\]\]\s*")
 
 
+def _parse_latest_message(message: Any) -> tuple[str, str]:
+    """Split the adapter's ``"[sender]: content"`` format back into parts.
+
+    The adapter formats each platform message this way (see
+    ``PlatformMessage.format_for_llm``) before appending it to
+    ``state["messages"]``.
+    """
+    match = _SENDER_PATTERN.match(str(message.content))
+    sender = match.group("sender") if match else "there"
+    text = match.group("text") if match else str(message.content)
+    # Strip raw "@[[uuid]]" mention tokens before echoing: the echoed text
+    # isn't registered in this reply's `mentions` list, so an unresolved
+    # token would render as "@Unknown" in the chat UI.
+    text = _MENTION_TOKEN_PATTERN.sub("", text).strip()
+    return sender, text
+
+
+def _build_reply(text: str) -> str:
+    return "pong" if "ping" in text.lower() else f"You said: {text}"
+
+
 def build_no_llm_graph_factory() -> Any:
     """Build a graph_factory whose only node is deterministic Python logic.
 
-    The adapter formats each platform message as ``"[sender]: content"``
-    (see ``PlatformMessage.format_for_llm``) before appending it to
-    ``state["messages"]``. The node below parses that prefix back out to
-    know who to @mention, then calls ``band_send_message`` directly — no
-    model, no ``bind_tools``, no ``ToolNode``.
+    The single node calls ``band_send_message`` directly — no model, no
+    ``bind_tools``, no ``ToolNode``.
     """
     checkpointer = InMemorySaver()
 
@@ -57,19 +75,11 @@ def build_no_llm_graph_factory() -> Any:
         send_message = next(t for t in band_tools if t.name == "band_send_message")
 
         async def reply(state: MessagesState) -> dict[str, list[Any]]:
-            last = state["messages"][-1]
-            match = _SENDER_PATTERN.match(str(last.content))
-            sender = match.group("sender") if match else "there"
-            text = match.group("text") if match else str(last.content)
-            # Strip raw "@[[uuid]]" mention tokens before echoing: the echoed
-            # text isn't registered in this reply's `mentions` list, so an
-            # unresolved token would render as "@Unknown" in the chat UI.
-            text = _MENTION_TOKEN_PATTERN.sub("", text).strip()
-
-            reply_text = "pong" if "ping" in text.lower() else f"You said: {text}"
-            await send_message.ainvoke(
-                {"content": f"{reply_text}", "mentions": [sender]}
-            )
+            if not state["messages"]:
+                return {"messages": []}
+            sender, text = _parse_latest_message(state["messages"][-1])
+            reply_text = _build_reply(text)
+            await send_message.ainvoke({"content": reply_text, "mentions": [sender]})
             return {"messages": []}
 
         builder = StateGraph(MessagesState)

--- a/examples/langgraph/11_no_llm_graph.py
+++ b/examples/langgraph/11_no_llm_graph.py
@@ -1,0 +1,111 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[langgraph]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/thenvoi/thenvoi-sdk-python.git" }
+# ///
+"""
+LangGraph agent with no LLM inside — a deterministic ping/pong graph.
+
+The adapter's "advanced pattern" (``graph_factory=``) accepts any LangGraph
+``Pregel`` graph, so a graph never has to call a model. This example replies
+"pong" to any message containing "ping" and otherwise echoes the message
+content back, sending replies straight through the ``band_send_message``
+platform tool from plain Python logic instead of a model-issued tool call.
+
+Run with:
+    uv run examples/langgraph/11_no_llm_graph.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from typing import Any
+
+from dotenv import load_dotenv
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.pregel import Pregel
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import LangGraphAdapter
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+_SENDER_PATTERN = re.compile(r"^\[(?P<sender>[^\]]+)\]:\s*(?P<text>.*)$", re.DOTALL)
+_MENTION_TOKEN_PATTERN = re.compile(r"@\[\[[^\]]+\]\]\s*")
+
+
+def build_no_llm_graph_factory() -> Any:
+    """Build a graph_factory whose only node is deterministic Python logic.
+
+    The adapter formats each platform message as ``"[sender]: content"``
+    (see ``PlatformMessage.format_for_llm``) before appending it to
+    ``state["messages"]``. The node below parses that prefix back out to
+    know who to @mention, then calls ``band_send_message`` directly — no
+    model, no ``bind_tools``, no ``ToolNode``.
+    """
+    checkpointer = InMemorySaver()
+
+    def graph_factory(band_tools: list[Any]) -> Pregel:
+        send_message = next(t for t in band_tools if t.name == "band_send_message")
+
+        async def reply(state: MessagesState) -> dict[str, list[Any]]:
+            last = state["messages"][-1]
+            match = _SENDER_PATTERN.match(str(last.content))
+            sender = match.group("sender") if match else "there"
+            text = match.group("text") if match else str(last.content)
+            # Strip raw "@[[uuid]]" mention tokens before echoing: the echoed
+            # text isn't registered in this reply's `mentions` list, so an
+            # unresolved token would render as "@Unknown" in the chat UI.
+            text = _MENTION_TOKEN_PATTERN.sub("", text).strip()
+
+            reply_text = "pong" if "ping" in text.lower() else f"You said: {text}"
+            print(f"Replying to {sender}: {reply_text}")
+            await send_message.ainvoke(
+                {"content": f"{reply_text}", "mentions": [sender]}
+            )
+            return {"messages": []}
+
+        builder = StateGraph(MessagesState)
+        builder.add_node("reply", reply)
+        builder.add_edge(START, "reply")
+        builder.add_edge("reply", END)
+        return builder.compile(checkpointer=checkpointer)
+
+    return graph_factory
+
+
+async def main() -> None:
+    load_dotenv()
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    adapter = LangGraphAdapter(
+        graph_factory=build_no_llm_graph_factory(), enable_execution_reporting=True
+    )
+
+    agent = Agent.from_config(
+        "no_llm_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Starting no-LLM LangGraph agent...")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/langgraph/11_no_llm_graph.py
+++ b/examples/langgraph/11_no_llm_graph.py
@@ -67,7 +67,6 @@ def build_no_llm_graph_factory() -> Any:
             text = _MENTION_TOKEN_PATTERN.sub("", text).strip()
 
             reply_text = "pong" if "ping" in text.lower() else f"You said: {text}"
-            print(f"Replying to {sender}: {reply_text}")
             await send_message.ainvoke(
                 {"content": f"{reply_text}", "mentions": [sender]}
             )

--- a/examples/langgraph/README.md
+++ b/examples/langgraph/README.md
@@ -80,6 +80,12 @@ await agent.run()
 
 **Supporting files:** `standalone_calculator.py`, `standalone_rag.py`, `standalone_sql_agent.py`
 
+### No LLM Required
+
+| File | Description |
+|------|-------------|
+| `11_no_llm_graph.py` | **Deterministic graph** - `graph_factory` graph with no LLM at all; plain Python logic calls `band_send_message` directly. |
+
 ---
 
 ## Adding Custom Tools
@@ -201,6 +207,9 @@ uv run --extra langgraph python examples/langgraph/09_research_ops_orchestrator.
 
 # Memory tools
 uv run --extra langgraph python examples/langgraph/10_memory_tool_usage.py
+
+# Deterministic graph with no LLM
+uv run --extra langgraph python examples/langgraph/11_no_llm_graph.py
 ```
 
 **Using as external library:**
@@ -247,6 +256,10 @@ research_ops_agent:
 memory_agent:
   agent_id: "agent_memory"
   api_key: "key_memory"
+
+no_llm_agent:
+  agent_id: "agent_no_llm"
+  api_key: "key_no_llm"
 
 # Also used by multi-agent examples:
 tom_agent:


### PR DESCRIPTION
## Summary
- Add `examples/langgraph/11_no_llm_graph.py`, a deterministic `graph_factory` graph that replies via `band_send_message` with plain Python logic — no LLM, no tool-calling loop.
- Document it: note in `docs/adapters/langgraph.md` that `graph_factory` doesn't require an LLM, fill in the examples table (which was also missing rows for `09`/`10`), add it to `examples/langgraph/README.md`, and register `no_llm_agent` (plus the already-missing `memory_agent`) in `agent_config.yaml.example`.

## Test plan
- [ ] `uv run --extra langgraph python examples/langgraph/11_no_llm_graph.py` against a live Band room, verify "ping" -> "pong" and echo behavior
- [x] Docs cross-checked against the actual file paths/tables edited