### PR TITLE
feat: pin proxy-managed API key sentinel for trusted-proxy custody [INT-980]

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ Choose the guide that matches what you need:
 
 The declarative kit and published GHCR image are separate release deliverables.
 
+#### Proxy-managed credentials
+
+When a sandbox is configured for proxy-managed credentials, the agent never
+holds the real Band API key: it passes the literal `proxy-managed` (exported as
+`band.credentials.PROXY_MANAGED_API_KEY`) as its `api_key`, and a trusted
+host-side proxy swaps in the real credential on the outbound request — replacing
+the REST `X-API-Key` header and injecting it on the WebSocket upgrade, where the
+sentinel rides the existing `api_key` query parameter. The sentinel is a
+non-secret placeholder, not a credential, and authenticates nothing on its own.
+Any deployment without such a proxy must pass a genuine Band API key.
+
+See the kit's [credential custody](docker/band_python_kit/README.md#credential-custody-v01)
+for how credentials are supplied today.
+
 ---
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ The declarative kit and published GHCR image are separate release deliverables.
 When a sandbox is configured for proxy-managed credentials, the agent never
 holds the real Band API key: it passes the literal `proxy-managed` (exported as
 `band.credentials.PROXY_MANAGED_API_KEY`) as its `api_key`, and a trusted
-host-side proxy swaps in the real credential on the outbound request — replacing
-the REST `X-API-Key` header and injecting it on the WebSocket upgrade, where the
-sentinel rides the existing `api_key` query parameter. The sentinel is a
-non-secret placeholder, not a credential, and authenticates nothing on its own.
-Any deployment without such a proxy must pass a genuine Band API key.
+host-side proxy swaps in the real credential on the outbound request. The SDK
+passes that value unchanged: REST sends it in `X-API-Key`, while the current
+WebSocket transport sends it in the upgrade's `api_key` query parameter. A
+proxy-managed deployment must support both credential locations; otherwise it
+must use a genuine Band API key. The sentinel is a non-secret placeholder, not
+a credential, and authenticates nothing on its own.
 
 See the kit's [credential custody](docker/band_python_kit/README.md#credential-custody-v01)
 for how credentials are supplied today.

--- a/src/band/agent.py
+++ b/src/band/agent.py
@@ -127,7 +127,11 @@ class Agent:
         Args:
             adapter: Framework adapter (e.g., PydanticAIAdapter)
             agent_id: UUID of the agent
-            api_key: API key for authentication
+            api_key: API key for authentication. Normally a Band API key; may be
+                     ``PROXY_MANAGED_API_KEY`` (see ``band.credentials``) when a
+                     trusted host-side proxy replaces the request credential. The
+                     value is passed through verbatim to the REST and WebSocket
+                     transports — it is never validated or treated specially here.
             ws_url: WebSocket URL (default: wss://app.band.ai/api/v1/socket/websocket)
             rest_url: REST API URL (default: https://app.band.ai)
             config: Agent configuration options

--- a/src/band/credentials.py
+++ b/src/band/credentials.py
@@ -1,0 +1,18 @@
+"""Public credential sentinel for the Band SDK."""
+
+from __future__ import annotations
+
+# Non-secret placeholder an agent may pass as its ``api_key`` when a trusted
+# host-side proxy replaces the request credential before it reaches Band (e.g.
+# a Docker Sandboxes kit injecting the real key on the outbound request). It is
+# not a credential and authenticates nothing on its own — only the proxy that
+# supplies the real key makes the request authenticated. Every other deployment
+# must pass a genuine Band API key.
+#
+# This is the importable, documented value for Python callers; it does not
+# dedupe the kit's own declarations (its ``spec.yaml`` / ``sbx secret
+# --placeholder``, which are YAML/shell and can't import it), which must carry
+# the same string by agreement.
+PROXY_MANAGED_API_KEY = "proxy-managed"
+
+__all__ = ["PROXY_MANAGED_API_KEY"]

--- a/tests/websocket/test_client.py
+++ b/tests/websocket/test_client.py
@@ -9,14 +9,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from phoenix_channels_python_client.exceptions import PHXConnectionError
+from websockets.asyncio.server import ServerConnection, serve
 from websockets.datastructures import Headers
 from websockets.exceptions import InvalidStatus
 from websockets.http11 import Response
 
+from band.credentials import PROXY_MANAGED_API_KEY
 from band.client.streaming import (
     DeliveryStatus,
     MessageCreatedPayload,
@@ -472,6 +476,50 @@ async def test_aenter_reraises_unrecognized_upgrade_error(monkeypatch):
 
     with pytest.raises(RuntimeError, match="socket exploded"):
         await client.__aenter__()
+
+
+# --- Upgrade wire-shape test: real SDK connect against an in-process peer ---
+
+
+@asynccontextmanager
+async def upgrade_peer():
+    """In-process WebSocket peer that captures the first upgrade request's query.
+
+    Accepts the connection and records the query params only — it speaks no
+    Phoenix and imitates no proxy. Its sole job is to observe the real wire shape
+    the SDK and its dependency produce on connect. Entered inside the test so the
+    server shares the test's event loop. Yields ``(ws_url, query)``, where
+    ``query`` is a future resolved with the parsed query params.
+    """
+    query: asyncio.Future[dict[str, list[str]]] = (
+        asyncio.get_running_loop().create_future()
+    )
+
+    async def handler(conn: ServerConnection) -> None:
+        if not query.done():
+            query.set_result(parse_qs(urlsplit(conn.request.path).query))
+        await conn.wait_closed()
+
+    # Bind and connect on 127.0.0.1 explicitly: "localhost" on a dual-stack host
+    # binds both ::1 and 127.0.0.1 on independently-chosen ephemeral ports, so
+    # picking one socket's port then resolving "localhost" can hit the other.
+    async with serve(handler, "127.0.0.1", 0) as server:
+        port = next(iter(server.sockets)).getsockname()[1]
+        yield f"ws://127.0.0.1:{port}/socket/websocket", query
+
+
+async def test_upgrade_carries_api_key_vsn_and_agent_id():
+    """The proxy-managed sentinel rides the existing api_key query parameter on
+    the real upgrade, alongside vsn and agent_id — the request shape the sandbox
+    proxy injects the real header onto. Also locks that query shape so Phase B's
+    header-auth work can't silently drop it."""
+    async with upgrade_peer() as (ws_url, query):
+        async with WebSocketClient(ws_url, PROXY_MANAGED_API_KEY, "agent-xyz"):
+            params = await asyncio.wait_for(query, timeout=5)
+
+    assert params["api_key"] == [PROXY_MANAGED_API_KEY]
+    assert params["agent_id"] == ["agent-xyz"]
+    assert params.get("vsn")  # protocol version retained alongside the sentinel
 
 
 # --- Valid payload tests ---


### PR DESCRIPTION
Adds `band.credentials.PROXY_MANAGED_API_KEY = "proxy-managed"` — a documented, importable handle for the placeholder an agent passes as `api_key` when a trusted host-side proxy (Docker Sandboxes kit) injects the real credential on the outbound request.

**Not a behavioral change.** `Agent.create` and the Phoenix client already accept the key verbatim (no format check), so `api_key="proxy-managed"` already reaches REST/WebSocket today. `proxy-managed` is a pre-existing Band convention (`examples/acp/copilot_sandbox/band-mcp-kit/spec.yaml`).

**Scope honesty:** the constant is vocabulary/docs, not a dedupe — no production code inspects the key, and the kit's YAML/shell can't import a Python constant, so it carries the same literal by agreement (INT-981's territory).

The one test connects the real `WebSocketClient` to a local peer and pins the upgrade query shape (`api_key` + `vsn` + `agent_id`), guarding Phase B header-auth from dropping it.

**Blocked for acceptance, not code:** end-to-end custody proof is PLT-1065 (staging) + INT-981 (never-in-VM). The SDK code depends on neither.