### PR TITLE
fix(release): auto-advance uv.lock on version bumps (unblock kit publish)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Verify uv.lock is in sync with pyproject
+      # Catches lock drift on every PR (including release-please's version-bump
+      # PR), so a stale lock can never silently reach a release and break the
+      # kit image build's `uv sync --locked`.
+      run: uv lock --check
+
     - name: Install dependencies
       run: uv sync --extra dev
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,38 @@ jobs:
           manifest-file: .release-please-manifest.json
           target-branch: main
 
+      # release-please bumps the version in pyproject.toml but not uv.lock's own
+      # band-sdk entry, so `uv sync --locked` (the kit image build) fails on the
+      # release. Re-lock the release PR so the version bump and the lock always
+      # land together. Runs only when a release PR was opened/updated (not on the
+      # release-creating merge, where the lock is already consistent).
+      - name: Install uv
+        if: ${{ steps.release.outputs.pr }}
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Sync uv.lock into the release PR
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$PR_BRANCH"
+          git checkout -B "$PR_BRANCH" FETCH_HEAD
+          uv lock
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock already matches the release version."
+            exit 0
+          fi
+          git config user.name "band-release-bot"
+          git config user.email "release-bot@band.ai"
+          git add uv.lock
+          git commit -m "chore: sync uv.lock to the release version"
+          # Push with the App token (not the default GITHUB_TOKEN) so the PR's CI
+          # re-runs and the `uv lock --check` gate sees the now-consistent lock.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:${PR_BRANCH}"
+
   publish-band:
     needs: [release]
     if: needs.release.outputs.release_created == 'true'

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "band-sdk"
-version = "1.1.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "band-client-rest" },


### PR DESCRIPTION
## Why

The `Release` run for 1.3.0 failed at **`publish-kit / image`** → the kit Dockerfile's `uv sync --locked` refused a stale lock:

> The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.

`uv.lock`'s own `band-sdk` entry was `1.1.0` while `pyproject.toml` was `1.3.0`. release-please bumps the version in `pyproject.toml` (and `src/band/__init__.py`) but **not** `uv.lock`, so every version bump drifts the lock. It went unnoticed because nothing enforced lock consistency — every other CI `uv sync` is non-locked and silently re-resolves. The kit image build is the first (and only) `--locked` consumer, so the drift (present across 1.2.0 and 1.3.0) surfaced as a release failure.

Since the SDK's own version lives in the lock, **this recurs on every release** unless the bump and the re-lock always travel together.

## What

- **Auto-advance** (`release.yml`): after release-please opens/updates the release PR, re-lock and commit `uv.lock` onto that PR branch, so the version bump and the lock land together. Pushed with the App token so the PR's CI re-runs.
- **Enforce** (`ci.yml`): `uv lock --check` on every PR (including the release PR) — drift fails fast instead of only at release time.
- **Resync** `uv.lock` to 1.3.0 (was `1.1.0`; the re-lock is a single line).

## Still needs a maintainer decision (not in this PR)

The **already-cut 1.3.0 kit image** wasn't published (build failed before push). `publish-kit` builds from the `band-sdk-v1.3.0` tag, which still points at the stale-lock commit, and `kit-publish.yml` is `workflow_call`-only (no manual dispatch), so a plain re-run rebuilds the same failure. Options: move the `band-sdk-v1.3.0` tag onto this fix, or add a `workflow_dispatch` re-publish path. Happy to do either.

## Branch note

These workflow/config changes target `main` to fix the release pipeline now; they should also land on `dev` so the next `dev → main` merge doesn't revert them. Can open the mirror PR to `dev` on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
