### PR TITLE
chore: add .band/changelog.yml for changelog automation

### DIFF
--- a/.band/changelog.yml
+++ b/.band/changelog.yml
@@ -1,0 +1,8 @@
+# Config for the changelog-generator:generate skill (band-ai/private-agent-skills).
+# Read on release by the changelog automation (CI workflow or scheduled routine).
+fern_repo: thenvoi/fern
+fern_changelog_path: fern/changelog/sdks
+linear:
+  team_key: INT
+slack:
+  channel: integrations


### PR DESCRIPTION
## Summary

Adds the non-secret config file read by the `changelog-generator:generate` skill (band-ai/private-agent-skills) when a release is published: Fern docs repo + changelog path, Linear team, and the Slack announcement channel.

A scheduled Claude routine now polls for new `band-sdk` releases every 3 hours and runs the skill against this repo — it carries these same values inline as a fallback, so nothing breaks before this merges; this file makes the repo self-describing for the routine and any future CI trigger.

## Testing

- [x] Config-only change; keys match the skill's documented input contract

🎺