### PR TITLE
fix(release): keep the sync step's env template total on release merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,10 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          # A step's env templates are evaluated even when its `if` is false,
+          # so this must stay total on release-creating merges, where the `pr`
+          # output is empty and a bare fromJSON('') fails the whole job.
+          PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr || '{}').headBranchName }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Problem

The [v1.4.0 release run](https://github.com/band-ai/band-sdk-python/actions/runs/29841953779/job/88672800697) failed **after** release-please had already created and tagged `band-sdk-v1.4.0`, so `publish-band` (PyPI), `publish-kit` (GHCR), and `bump-add-band` were all skipped. PyPI is still at 1.3.0.

## Root cause

On a release-creating merge, `steps.release.outputs.pr` is empty. The `if:` guards handle that correctly (the env-less `Install uv` step skipped cleanly), but **GitHub Actions evaluates a step's `env:` templates even when its `if:` is false** — so `fromJSON('')` in `PR_BRANCH` threw `Error reading JToken from JsonReader` and failed the whole job.

This was introduced with the uv.lock auto-advance step (82f5ee6); this was the first release-creating merge since it landed, which is why it only fired now.

## Fix

Default the expression: `fromJSON(steps.release.outputs.pr || '{}').headBranchName` — empty output yields an empty `PR_BRANCH`, and the `if:` still gates execution, so the step behaves identically when a release PR exists.

## Note on 1.4.0 recovery

This PR only prevents recurrence — it does not republish 1.4.0. That needs either the release-please recovery dance (delete release+tag, relabel PR #468 `autorelease: pending`, re-run) or manual publishes (`kit-publish-manual` exists for the kit; PyPI has no manual path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)