### PR TITLE
fix(ci): coerce the number dispatch input so kit-publish-manual can start

### DIFF
--- a/.github/workflows/kit-publish-manual.yml
+++ b/.github/workflows/kit-publish-manual.yml
@@ -63,5 +63,8 @@ jobs:
       major: ${{ inputs.major }}
       move-floating: ${{ inputs.move-floating }}
       extra-build-args: ${{ inputs.extra-build-args }}
-      quarantine-max-age-days: ${{ inputs.quarantine-max-age-days }}
+      # fromJSON: a dispatch `number` input reaches a called workflow's with:
+      # as a string, failing its number type check at startup (a 0-job
+      # "workflow file issue" run); booleans coerce, numbers don't.
+      quarantine-max-age-days: ${{ fromJSON(inputs.quarantine-max-age-days) }}
       relock: ${{ inputs.relock }}


### PR DESCRIPTION
Fixes INT-1105.

## Problem

`kit-publish-manual` has never produced a successful run — every dispatch in its history (4/4, the first three predating #470) fails at startup with *"This run likely failed because of a workflow file issue"* and **zero jobs**. Both kit recovery paths are dead: republishing a tag whose release run failed, and the quarantine-gate emergency override documented in `RELEASING.md`. It currently blocks the GHCR half of the v1.4.0/v1.4.1 recovery (INT-1103).

## Root cause — proven by live bisect

`quarantine-max-age-days: ${{ inputs.quarantine-max-age-days }}` — a `workflow_dispatch` input of `type: number` reaches a called workflow's `with:` as a **string**, failing `kit-publish.yml`'s `number` type check during startup validation. Booleans coerce; numbers don't.

Bisected by dispatching modified copies from a probe branch (`workflow_dispatch` runs the selected ref's file; branch deleted after):

| Variant | Result |
|---|---|
| `queue: max` removed, rest intact | still 0 jobs — queue key exonerated |
| number expr removed, booleans kept as exprs | **jobs created** |
| full original file + `fromJSON()` on the number | **jobs created** ✅ |

The probe run also live-verified the `release` environment deployment policy: the probe branch was rejected with *"not allowed to deploy to release due to environment protection rules"*.

## Fix

One line: `${{ fromJSON(inputs.quarantine-max-age-days) }}` — `fromJSON('7')` yields the number the called workflow's type check expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)