### PR TITLE
fix(ci): exempt Band-published packages from the quarantine gate

### DIFF
--- a/docker/band_python_kit/RELEASING.md
+++ b/docker/band_python_kit/RELEASING.md
@@ -99,6 +99,13 @@ expected. A trip leaves a **split release**: the PyPI publish (`band-publish.yml
 an independent release-triggered workflow) has already succeeded, but no kit
 artifacts were produced.
 
+Packages Band publishes itself are **exempt** (`FIRST_PARTY` in
+`scripts/check-lock-age.py`): the gate models *upstream* compromise, and
+ageing our own releases would deadlock every kit publish that follows a
+first-party dependency bump. The gate script runs from the checked-out
+release tag, so tags cut before the exemption existed still gate those
+packages — republish those with the override below.
+
 ### Recovery
 
 - **Wait it out (default).** Once the young package has aged past 7 days, use

--- a/scripts/check-lock-age.py
+++ b/scripts/check-lock-age.py
@@ -14,6 +14,13 @@ gate does NOT work: the cutoff makes uv treat the committed lock itself as
 outdated and every gated build fails — proven live on uv 0.9.13 and 0.11.19;
 see astral-sh/uv#18775 for the underlying option-tracking behavior.)
 
+Packages Band publishes itself (``FIRST_PARTY``) are exempt from the age
+window: the gate models *upstream* compromise — a poisoned third-party
+release that the ecosystem detects and yanks within days — and a release we
+made carries no such signal. Ageing our own artifacts would only deadlock
+our own pipeline for a week after every first-party dependency bump.
+Exemptions are printed on every run so they stay visible in the gate log.
+
 Exit codes: 0 = every artifact is old enough; 1 = violations (each listed on
 stderr); 2 = bad usage / unreadable lock. Artifacts without an upload-time
 are violations too — an undatable source must not slip the gate silently.
@@ -33,11 +40,27 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 
+# Band-published PyPI packages (PEP 503 canonical names). Ownership, not
+# trust-by-name-pattern: extend only for packages this org actually releases.
+FIRST_PARTY = frozenset(
+    {
+        "band-client-rest",
+        "band-testing-python",
+        "phoenix-channels-python-client",
+    }
+)
+
+
 @dataclass(frozen=True)
 class Violation:
     package: str
     version: str
     detail: str
+
+
+def canonical(name: str) -> str:
+    """PEP 503 canonical form, so lock spellings always match FIRST_PARTY."""
+    return name.strip().lower().replace("_", "-").replace(".", "-")
 
 
 def parse_upload_time(value: object) -> datetime | None:
@@ -49,17 +72,24 @@ def parse_upload_time(value: object) -> datetime | None:
     return None
 
 
-def find_violations(lock_text: str, cutoff: datetime) -> list[Violation]:
+def find_violations(
+    lock_text: str,
+    cutoff: datetime,
+    first_party: frozenset[str] = FIRST_PARTY,
+) -> list[Violation]:
     """Every registry artifact in the lock must predate ``cutoff``.
 
     Packages without any sdist/wheel entries (the project itself, path
-    sources) carry no artifacts to date and are skipped; an artifact entry
+    sources) carry no artifacts to date and are skipped, as are the
+    ``first_party`` packages we publish ourselves; an artifact entry
     *missing* its upload-time is a violation, not a skip.
     """
     lock = tomllib.loads(lock_text)
     violations: list[Violation] = []
     for package in lock.get("package", []):
         name = package.get("name", "<unnamed>")
+        if canonical(name) in first_party:
+            continue
         version = str(package.get("version", "?"))
         artifacts = list(package.get("wheels", []))
         if sdist := package.get("sdist"):
@@ -110,6 +140,9 @@ def main(argv: list[str] | None = None) -> int:
     else:
         cutoff = datetime.now(tz=UTC) - timedelta(days=args.max_age_days)
 
+    sys.stderr.write(
+        f"first-party exemptions (Band-published): {', '.join(sorted(FIRST_PARTY))}\n"
+    )
     violations = find_violations(args.lock.read_text(encoding="utf-8"), cutoff)
     if violations:
         for v in violations:

--- a/scripts/check-lock-age.py
+++ b/scripts/check-lock-age.py
@@ -33,6 +33,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 import tomllib
 from dataclasses import dataclass
@@ -60,7 +61,7 @@ class Violation:
 
 def canonical(name: str) -> str:
     """PEP 503 canonical form, so lock spellings always match FIRST_PARTY."""
-    return name.strip().lower().replace("_", "-").replace(".", "-")
+    return re.sub(r"[-_.]+", "-", name.strip()).lower()
 
 
 def parse_upload_time(value: object) -> datetime | None:

--- a/tests/docker/test_lock_age.py
+++ b/tests/docker/test_lock_age.py
@@ -113,17 +113,18 @@ wheels = [{ url = "https://example/p.whl", upload-time = "2999-01-01T00:00:00Z" 
 
 def test_first_party_matching_is_pep503_canonical() -> None:
     # uv writes canonical names, but the exemption must not silently lapse on
-    # a spelling variant.
+    # a spelling variant — including PEP 503's separator-run collapse
+    # (Our__Pkg.Name -> our-pkg-name, not our--pkg-name).
     lock = """\
 [[package]]
-name = "Our_Package"
+name = "Our__Package.Name"
 version = "1.0.0"
 wheels = [{ url = "https://example/o.whl", upload-time = "2999-01-01T00:00:00Z" }]
 """
     violations = gate.find_violations(
         lock,
         gate.parse_upload_time("2026-01-01T00:00:00Z"),
-        first_party=frozenset({"our-package"}),
+        first_party=frozenset({"our-package-name"}),
     )
     assert violations == []
 

--- a/tests/docker/test_lock_age.py
+++ b/tests/docker/test_lock_age.py
@@ -96,6 +96,38 @@ wheels = [{ url = "https://example/undated-1.0.0-py3-none-any.whl" }]
     ]
 
 
+def test_first_party_packages_are_exempt_from_the_age_window() -> None:
+    # Band-published packages carry no upstream-compromise signal: a same-day
+    # release of our own dependency must not quarantine our own pipeline.
+    lock = """\
+[[package]]
+name = "phoenix-channels-python-client"
+version = "9.9.9"
+wheels = [{ url = "https://example/p.whl", upload-time = "2999-01-01T00:00:00Z" }]
+"""
+    violations = gate.find_violations(
+        lock, gate.parse_upload_time("2026-01-01T00:00:00Z")
+    )
+    assert violations == []
+
+
+def test_first_party_matching_is_pep503_canonical() -> None:
+    # uv writes canonical names, but the exemption must not silently lapse on
+    # a spelling variant.
+    lock = """\
+[[package]]
+name = "Our_Package"
+version = "1.0.0"
+wheels = [{ url = "https://example/o.whl", upload-time = "2999-01-01T00:00:00Z" }]
+"""
+    violations = gate.find_violations(
+        lock,
+        gate.parse_upload_time("2026-01-01T00:00:00Z"),
+        first_party=frozenset({"our-package"}),
+    )
+    assert violations == []
+
+
 def test_cli_matches_the_publish_workflow_invocation(tmp_path: Path) -> None:
     """kit-publish.yml runs the gate through main() with --lock/--max-age-days;
     pin that CLI contract (plus the --cutoff form) and the exit codes."""


### PR DESCRIPTION
Fixes INT-1106.

## Problem

The kit quarantine gate applies its 7-day minimum public age to **every** locked artifact, including the three PyPI packages Band publishes itself (`band-client-rest`, `band-testing-python`, `phoenix-channels-python-client`). The gate's threat model — from INT-979 — is *upstream* compromise: a freshly-poisoned third-party release that the ecosystem detects and yanks within days. A release Band makes carries no such signal, so gating our own packages only deadlocks the pipeline: the v1.4.1 kit publish tripped on `phoenix-channels-python-client==0.2.2`, published one day earlier by us.

## Fix

`FIRST_PARTY` set in `scripts/check-lock-age.py` (the gate script is the policy's single source of truth — the workflow invocation is unchanged):
- matched by PEP 503 canonical name, so a lock spelling variant can't silently lapse the exemption;
- printed on every gate run, so the active exemptions stay visible in the log;
- third-party artifacts keep the full window.

Verified: 9/9 gate tests pass (2 new — exemption + canonicalization), and the gate now passes the committed lock with the default 7-day window (it fails on `main` today).

## Trade-off, considered

Exempting by name forgoes the age tripwire against Band's own PyPI account being hijacked. Accepted deliberately: a routinely-overridden gate (the alternative, given every first-party bump trips it) protects nothing, and account-hijack is better addressed by trusted publishing/2FA on those packages.

## Scope note

The gate script runs from the checked-out release tag, so tags cut before this change (band-sdk-v1.4.0/v1.4.1) still gate those packages — their kit republish uses the documented `quarantine-max-age-days` override; this fixes all future tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)