### PR TITLE
ci: enforce actionlint via pre-commit and document the pre-merge validation ladder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,9 @@ jobs:
       # git ls-files globbing that we don't need to re-run per platform.
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
       # examples/ READMEs have illustrative fragments not yet snippet-testable
-      run: uv run pytest --markdown-docs $(git ls-files '*.md' ':!:examples/*') --no-cov
+      run: |
+        # shellcheck disable=SC2046  # word-splitting the ls-files output is the point
+        uv run pytest --markdown-docs $(git ls-files '*.md' ':!:examples/*') --no-cov
 
 
   test-crewai:

--- a/.github/workflows/kit-image-rebuild.yml
+++ b/.github/workflows/kit-image-rebuild.yml
@@ -74,9 +74,11 @@ jobs:
         id: readver
         run: |
           version="$(jq -r '."."' .release-please-manifest.json)"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "tag=band-sdk-v${version}" >> "$GITHUB_OUTPUT"
-          echo "major=${version%%.*}" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=${version}"
+            echo "tag=band-sdk-v${version}"
+            echo "major=${version%%.*}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Compare the pinning ledger with the current upstream digests
         id: bases
@@ -111,9 +113,11 @@ jobs:
           if [ "$python_ref" != "$python_pin" ] || [ "$uv_ref" != "$uv_pin" ]; then
             changed="true"
           fi
-          echo "python_ref=${python_ref}" >> "$GITHUB_OUTPUT"
-          echo "uv_ref=${uv_ref}" >> "$GITHUB_OUTPUT"
-          echo "base_changed=${changed}" >> "$GITHUB_OUTPUT"
+          {
+            echo "python_ref=${python_ref}"
+            echo "uv_ref=${uv_ref}"
+            echo "base_changed=${changed}"
+          } >> "$GITHUB_OUTPUT"
 
       # The published image may still be private (packages start private and the
       # public flip is a post-first-publish step), so authenticate before

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,14 +196,16 @@ jobs:
     steps:
       - name: Publish release summary
         run: |
-          echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ needs.release.outputs.major }}.${{ needs.release.outputs.minor }}.${{ needs.release.outputs.patch }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** ${{ needs.release.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Artifact | Outcome |" >> $GITHUB_STEP_SUMMARY
-          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
-          echo "| GHCR kit image + artifact | ${{ needs.publish-kit.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| add-band pin bump PR | ${{ needs.bump-add-band.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "PyPI publish runs in the release-triggered \`band-publish\` workflow." >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Release Summary"
+            echo ""
+            echo "**Version:** ${{ needs.release.outputs.major }}.${{ needs.release.outputs.minor }}.${{ needs.release.outputs.patch }}"
+            echo "**Tag:** ${{ needs.release.outputs.tag_name }}"
+            echo ""
+            echo "| Artifact | Outcome |"
+            echo "|---|---|"
+            echo "| GHCR kit image + artifact | ${{ needs.publish-kit.result }} |"
+            echo "| add-band pin bump PR | ${{ needs.bump-add-band.result }} |"
+            echo ""
+            echo "PyPI publish runs in the release-triggered \`band-publish\` workflow."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,14 @@ repos:
       - id: commitizen
         stages: [commit-msg]
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+        # concurrency.queue (single|max) is valid workflow syntax that
+        # actionlint doesn't know yet.
+        args: ["-ignore", 'unexpected key "queue"']
+
   - repo: local
     hooks:
       - id: ruff-check

--- a/docs/ci-cd-workflows.md
+++ b/docs/ci-cd-workflows.md
@@ -117,6 +117,31 @@ image), `kit-publish-manual.yml` (serialized manual recovery/rehearsal), and
 `docker/band_python_kit/RELEASING.md` (tag policy, quarantine gate, rehearsal
 and recovery runbook).
 
+## Validating workflow changes before merge
+
+Workflow defects historically surfaced only when a real release or dispatch
+run executed server-side. Use this ladder, cheapest rung first:
+
+1. **actionlint (automatic).** Runs via pre-commit on every commit, and the CI
+   `lint` job runs the same hooks over all files — syntax, expression, and
+   shellcheck errors in `run:` blocks never reach a PR unchecked. One known
+   false positive is ignored in `.pre-commit-config.yaml`:
+   `concurrency.queue` is valid workflow syntax actionlint doesn't know yet.
+2. **Probe-branch dispatch (server-side ground truth).** Some semantics only
+   exist in GitHub's startup validation — env templates are evaluated even
+   under a false `if:`, and reusable-workflow `with:` values are type-checked
+   (a dispatch `number` input arrives as a string; booleans coerce, numbers
+   need `fromJSON`). To validate those without merging: push a branch and run
+   `gh workflow run <file> --ref <branch>` — startup validation and job
+   creation run against the branch's copy of the workflow. Safe by
+   construction: the `release` environment's deployment policy rejects
+   non-main refs before a job can reach publishing credentials, so the probe
+   fails at the environment gate — which doubles as a check that the
+   guardrail still works.
+3. **Rehearsal publish.** `kit-publish-manual` can publish a real, disposable
+   artifact without touching customers: version `0.0.0-rcN`,
+   `move-floating: false` (see `docker/band_python_kit/RELEASING.md`).
+
 ## Typical Development Flow
 
 1. Branch off `main` (e.g. `feat/...-INT-123`).


### PR DESCRIPTION
Fixes INT-1107.

## Problem

The v1.4.0 incident chain (INT-1103/1105) was debugged **through main**: workflow defects only surfaced when real release/dispatch runs executed server-side. Nothing validated `.github/workflows/` before merge.

## Changes

- **`.pre-commit-config.yaml`**: official `actionlint` hook (v1.7.12). Runs locally on every commit; the CI `lint` job already runs `pre-commit run --all-files`, so it's enforced in CI with zero workflow changes. One `-ignore` for actionlint's false positive on `concurrency.queue` — verified valid syntax (`single|max`) in [GitHub's workflow-syntax docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
- **Shellcheck debt the hook surfaces, fixed**: grouped + quoted `$GITHUB_STEP_SUMMARY` / `$GITHUB_OUTPUT` redirects in `release.yml` and `kit-image-rebuild.yml`; explicit `disable=SC2046` in `ci.yml` where word-splitting the `git ls-files` output is intentional. No behavior changes.
- **`docs/ci-cd-workflows.md`**: the validation ladder — (1) actionlint automatically, (2) **probe-branch dispatch** for server-side-only semantics (`gh workflow run <file> --ref <branch>` validates the branch's copy at startup; the `release` environment policy rejects non-main refs before credentials are reachable, so probing is safe by construction — the pattern that root-caused INT-1105 without touching main), (3) rehearsal publish via `kit-publish-manual`.

## What this can and cannot catch

actionlint catches syntax/expression/shell defects locally. GitHub's startup-validation semantics (env templates under false `if:`, reusable `with:` type coercion) reproduce **only** server-side — for those, the documented probe-branch dispatch is the ground truth. Both incident bugs are covered: the `queue`-style unknown-key class by the linter, the INT-1105 class by the documented probe.

Verified: `pre-commit run actionlint --all-files` passes on the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)