### PR TITLE
feat: upgrade pydantic-ai-slim to 2.x

### DIFF
--- a/.claude/skills/dependabot-triage/SKILL.md
+++ b/.claude/skills/dependabot-triage/SKILL.md
@@ -181,20 +181,26 @@ E2E_TESTS_ENABLED=true uv run pytest tests/e2e/baseline/ -v --no-cov > /tmp/e2e.
 # then tail -f /tmp/e2e.log (watch for PASSED|FAILED|ERROR|403|429|Traceback and the final tally)
 ```
 
-**crewai must be tested in its own venv** — it conflicts with parlant/pydantic-ai
-and is absent from the `dev` extra, so the run above never exercises the crewai
-bump. Target the crewai test **files** explicitly: a bare `-k crewai` over
-`tests/adapters/` still tries to *collect* every adapter module, and the
-non-crewai ones fail to import in the crewai-only venv (collection error).
+**crewai must be tested in its own venv** — it is declared conflicting with
+parlant/pydantic-ai and absent from the `dev` extra, so the run above never
+exercises the crewai bump. Only a handful of tests import the real package (the rest
+fake it through `sys.modules` and already ran above), and those are exactly what
+`ci.yml`'s `test-crewai` job lists — run that list rather than inventing one, so a
+green local run means a green CI job:
 
 ```bash
 uv sync --extra dev-crewai
-uv run pytest tests/adapters/test_crewai_adapter.py \
-  tests/adapters/test_crewai_flow_adapter.py \
-  tests/adapters/test_crewai_flow_phase3.py tests/adapters/test_crewai_flow_phase4.py \
-  tests/adapters/test_crewai_flow_phase5.py tests/adapters/test_crewai_flow_state_source.py \
-  tests/adapters/test_crewai_adapter_soak.py tests/converters/test_crewai.py -v
+# the pytest targets from .github/workflows/ci.yml's "Run crewai tests" step
+uv run pytest tests/adapters/test_crewai_flow_phase3.py \
+  tests/integrations/test_crewai_flow_real_sdk.py \
+  tests/integrations/test_crewai_real_tools.py \
+  tests/test_capability_gating_e2e.py \
+  tests/framework_conformance/ -k crewai
 ```
+
+Do not widen this to `-k crewai` over `tests/adapters/`: pytest still *collects*
+every adapter module there, and the non-crewai ones fail to import in the
+crewai-only venv (collection error).
 
 ## Step 6 — Decide which bumps to keep (bisect on failure)
 

--- a/.claude/skills/dependabot-triage/SKILL.md
+++ b/.claude/skills/dependabot-triage/SKILL.md
@@ -119,7 +119,7 @@ uv lock \
   -P langgraph==1.2.9 \
   -P uvicorn==0.51.0 \
   -P pytest-rerunfailures==16.4 \
-  -P crewai==1.15.4 \
+  -P crewai==1.15.5 \
   -P pydantic-ai-slim==2.13.0 \
   -P langchain-community==0.4.2 \
   -P pytest-asyncio==1.4.0 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,18 +137,13 @@ jobs:
         # dev-crewai venv lacks langgraph/anthropic/parlant/pydantic-ai/etc.;
         # tolerate missing framework configs instead of failing fast.
         BAND_ALLOW_MISSING_FRAMEWORKS: "1"
+      # Only the tests that *need* this venv. Every other crewai test fakes the
+      # package through sys.modules, so the `test` job above already runs it and
+      # a second pass here would add no signal — just a path to forget.
+      # tests/framework_conformance/test_crewai_job_coverage.py keeps this honest.
       run: |
         uv run pytest \
-          tests/adapters/test_crewai_adapter.py \
-          tests/adapters/test_crewai_adapter_soak.py \
-          tests/adapters/test_crewai_flow_adapter.py \
           tests/adapters/test_crewai_flow_phase3.py \
-          tests/adapters/test_crewai_flow_phase4.py \
-          tests/adapters/test_crewai_flow_phase5.py \
-          tests/adapters/test_crewai_flow_state_source.py \
-          tests/converters/test_crewai.py \
-          tests/converters/test_crewai_flow.py \
-          tests/integrations/test_crewai_tools.py \
           tests/integrations/test_crewai_flow_real_sdk.py \
           tests/test_capability_gating_e2e.py \
           tests/framework_conformance/ -k crewai

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
           tests/converters/test_crewai_flow.py \
           tests/integrations/test_crewai_tools.py \
           tests/integrations/test_crewai_flow_real_sdk.py \
+          tests/test_capability_gating_e2e.py \
           tests/framework_conformance/ -k crewai
 
     - name: Pyrefly check (crewai sources)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
         uv run pytest \
           tests/adapters/test_crewai_flow_phase3.py \
           tests/integrations/test_crewai_flow_real_sdk.py \
+          tests/integrations/test_crewai_real_tools.py \
           tests/test_capability_gating_e2e.py \
           tests/framework_conformance/ -k crewai
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -217,7 +217,8 @@ jobs:
       uses: ./.github/actions/setup-e2e
 
     # --- Backend setup: each step is gated to the lane whose server/CLI it stands
-    # up (the `backends` lane co-runs codex + opencode; letta is its own lane). ---
+    # up (the `backends` lane co-runs codex, opencode, and copilot_acp; letta is its
+    # own lane). ---
 
     - name: Set up Node (codex, opencode)
       if: matrix.lane == 'backends'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -456,10 +456,13 @@ pin.
 **Extras layout:**
 - `dev` — includes all framework deps **except** crewai
 - `dev-crewai` — includes crewai + test tooling only (no parlant/pydantic-ai)
-- `crewai` is mutually exclusive with `parlant` and `pydantic-ai` runtime extras
+- `crewai` is declared conflicting with the `parlant` and `pydantic-ai` runtime
+  extras, so one `uv sync` can install only one of them
 
-**For CI:** crewai adapter tests require a separate job/step using
-`uv sync --extra dev-crewai`.
+**For CI:** the `test-crewai` job (`uv sync --extra dev-crewai`) runs only the
+tests that need the real package — every other crewai test fakes it through
+`sys.modules` and already runs in the default `test` job. The list is kept honest
+by `tests/framework_conformance/test_crewai_job_coverage.py`.
 
 ## Environment Variables
 
@@ -482,7 +485,7 @@ pin.
 
 Baseline lane scoping (see `tests/e2e/baseline/README.md`):
 
-- `BAND_E2E_LANE`: The CI lane (a job: a `uv` extra + optional server/CLI setup) to scope the run to. Lane ids are content-based and decoupled from the `uv` extra — `core` (anthropic/openai-family adapters plus `copilot_sdk`, which self-downloads its CLI runtime and authenticates via a stored `copilot login` or a Copilot-entitled `GITHUB_TOKEN`; `dev` extra), `crewai` (`dev-crewai` extra), `google` (gemini/google_adk, split out for rate-limit isolation), `backends` (codex + opencode coding agents), `letta` (self-hosted letta server). Resolves the lane's adapters from the registry (`ci_lanes()`, derived from each adapter's `requires`); out-of-lane adapters skip-with-reason (they're covered by their own lane) while in-lane adapters keep fail-loud (an unwired backend stays red). Unset (the local default) = full matrix, no scoping. CI never lists adapters — it derives lanes from the registry. A test's lane is derived from **all** the frameworks it touches (a matrix cell's adapter plus its `@per_adapter(peer=...)`, or a `@with_adapters` set); a test whose frameworks span more than one home lane fails collection (`assert_every_item_is_schedulable`) unless pinned with `@lane(Lane.X)` to a lane whose extra hosts them all. To add a lane, see `tests/e2e/baseline/README.md` ("Adding a CI lane").
+- `BAND_E2E_LANE`: The CI lane (a job: a `uv` extra + optional server/CLI setup) to scope the run to. Lane ids are content-based and decoupled from the `uv` extra — `core` (anthropic/openai-family adapters plus `copilot_sdk`, which self-downloads its CLI runtime and authenticates via a stored `copilot login` or a Copilot-entitled `GITHUB_TOKEN`; `dev` extra), `crewai` (`dev-crewai` extra), `google` (gemini/google_adk, split out for rate-limit isolation), `backends` (the codex, opencode, and copilot_acp coding agents), `letta` (self-hosted letta server). Resolves the lane's adapters from the registry (`ci_lanes()`, derived from each adapter's `requires`); out-of-lane adapters skip-with-reason (they're covered by their own lane) while in-lane adapters keep fail-loud (an unwired backend stays red). Unset (the local default) = full matrix, no scoping. CI never lists adapters — it derives lanes from the registry. A test's lane is derived from **all** the frameworks it touches (a matrix cell's adapter plus its `@per_adapter(peer=...)`, or a `@with_adapters` set); a test whose frameworks span more than one home lane fails collection (`assert_every_item_is_schedulable`) unless pinned with `@lane(Lane.X)` to a lane whose extra hosts them all. To add a lane, see `tests/e2e/baseline/README.md` ("Adding a CI lane").
 
 Baseline provisioning/cleanup policy (see `tests/e2e/baseline/README.md`):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,16 +440,18 @@ uv run pyrefly check
 
 ## Dependency Conflicts
 
-**crewai cannot coexist** with parlant or pydantic-ai in the same Python
-environment due to conflicting transitive dependencies:
+**crewai is resolved apart from** parlant and pydantic-ai: it carries the
+narrowest transitive pins of the three, and they have repeatedly collided.
 
-| Conflict | crewai 1.14.3 requires | Other package requires |
+| Package | crewai 1.15.5 pins | Other package requires |
 |---|---|---|
-| pydantic | `~=2.11.9` (<2.12) | pydantic-ai-slim >=1.61 needs `>=2.12` |
-| opentelemetry-sdk | `~=1.34.0` (<1.35) | parlant >=3.1 needs `>=1.37` |
+| pydantic | `>=2.11.9,<2.13` | pydantic-ai-slim 2.x needs `>=2.12` |
+| opentelemetry-sdk | `~=1.42.0` (<1.43) | parlant >=3.1 needs `>=1.37` |
 
-This is declared in `pyproject.toml` via `[tool.uv] conflicts` so `uv lock`
-resolves each in a separate fork.
+The current versions happen to overlap, but crewai's ceilings move with every
+release, so `pyproject.toml` declares the extras as `[tool.uv] conflicts` and
+`uv lock` resolves each in its own fork — no upgrade waits on crewai's slowest
+pin.
 
 **Extras layout:**
 - `dev` — includes all framework deps **except** crewai

--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ Three extras are resolved separately, because crewai carries the narrowest trans
 | `crewai` + `parlant` | `opentelemetry-sdk~=1.42.0` | parlant requires `>=1.37` |
 | `crewai` + `pydantic-ai` | `pydantic>=2.11.9,<2.13` | pydantic-ai-slim 2.x requires `pydantic>=2.12` |
 
-Install one per environment. The lockfile declares these as `[tool.uv] conflicts` so `uv lock` resolves each in a separate fork automatically — an upgrade on one side never waits for crewai's ceiling to move.
+Today's versions happen to overlap, but crewai's ceilings move with every release. So the lockfile declares these as `[tool.uv] conflicts` and `uv lock` resolves each in a separate fork — no upgrade on one side waits for crewai's ceiling to move. Consequence: install one per environment, because a single `uv sync` can only pick one fork.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -692,14 +692,14 @@ The SDK reconnects automatically and resubscribes to active rooms. No action is 
 
 ### Adapter Dependency Conflicts
 
-Three extras have mutually exclusive transitive dependencies and cannot share an environment:
+Three extras are resolved separately, because crewai carries the narrowest transitive pins and they have repeatedly collided:
 
-| Conflict | Reason |
-| -------- | ------ |
-| `crewai` + `parlant` | crewai pins `opentelemetry-sdk~=1.34`, parlant requires `>=1.37` |
-| `crewai` + `pydantic-ai` | crewai pins `pydantic~=2.11.9` (<2.12), pydantic-ai-slim >=1.61 requires `pydantic>=2.12` |
+| Pair | crewai's pin | Other side |
+| ---- | ------------ | ---------- |
+| `crewai` + `parlant` | `opentelemetry-sdk~=1.42.0` | parlant requires `>=1.37` |
+| `crewai` + `pydantic-ai` | `pydantic>=2.11.9,<2.13` | pydantic-ai-slim 2.x requires `pydantic>=2.12` |
 
-Install one per environment. The lockfile declares these as `[tool.uv] conflicts` so `uv lock` resolves each in a separate fork automatically.
+Install one per environment. The lockfile declares these as `[tool.uv] conflicts` so `uv lock` resolves each in a separate fork automatically — an upgrade on one side never waits for crewai's ceiling to move.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ For the full picture, rooms, contacts, platform tools, and how messages flow - s
 
 LangGraph supports the built-in Band platform tools, custom LangChain tools through `additional_tools`, feature-gated contact and memory tools, and `Emit.EXECUTION` telemetry for tool calls/results.
 
-> `crewai` and `parlant` cannot be installed together because their transitive dependencies conflict. `crewai` and `pydantic-ai` are also incompatible (crewai pins `pydantic<2.12`, pydantic-ai requires `>=2.12`). Install one per environment.
+> Install `crewai` in its own environment, apart from `parlant` and `pydantic-ai` — it carries the narrowest transitive pins of the three and the lockfile resolves it in a separate fork. See [Adapter Dependency Conflicts](#adapter-dependency-conflicts) for the current pins.
 
 ### Bridge Adapters
 

--- a/docker/band_python_kit/README.md
+++ b/docker/band_python_kit/README.md
@@ -269,9 +269,9 @@ docker build -f docker/band_python_kit/Dockerfile \
 ```
 
 `SDK_EXTRA` accepts any single extra from `pyproject.toml`'s
-`[project.optional-dependencies]`. One at a time — some extras have
-conflicting dependencies and cannot share a venv (e.g. `crewai` conflicts
-with `parlant`/`pydantic_ai`). Multi-arch builds work with
+`[project.optional-dependencies]`. One at a time — some extras are declared
+conflicting and resolve in separate lockfile forks, so a venv can only hold one
+of them (e.g. `crewai` versus `parlant`/`pydantic-ai`). Multi-arch builds work with
 `docker buildx build --platform linux/amd64,linux/arm64`.
 
 ### Layout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ letta = [
     "mcp>=1.25.0",
 ]
 pydantic-ai = [
-    "pydantic-ai-slim[anthropic]>=1.56.0",
+    "pydantic-ai-slim[anthropic]>=2.18.0",
     "openai>=2.0.0",
 ]
 anthropic = [
@@ -159,7 +159,7 @@ dev = [
     "httpx>=0.24.0",  # Already in main deps, for mocking
     "pytest-httpx>=0.35.0",  # httpx_mock fixture: REST header-emission proof
     # Include pydantic-ai for testing
-    "pydantic-ai-slim>=1.56.0",
+    "pydantic-ai-slim>=2.18.0",
     # Include anthropic for testing
     "anthropic>=0.75.0",
     # Include claude_sdk for testing
@@ -287,10 +287,11 @@ required-environments = [
     "sys_platform == 'win32' and platform_machine == 'AMD64'",
 ]
 
-# crewai 1.14.3 conflicts with BOTH parlant and pydantic-ai:
-#   - parlant >=3.1 requires opentelemetry-sdk >=1.37, crewai 1.14.3 pins ~=1.34.0
-#   - pydantic-ai-slim >=1.61 requires pydantic>=2.12, crewai 1.14.3 pins pydantic~=2.11.9
-# Declaring them as conflicting extras lets uv resolve each in a separate fork.
+# crewai is resolved apart from BOTH parlant and pydantic-ai. crewai pins a narrow
+# pydantic range (<2.13) and an exact opentelemetry-sdk minor (~=1.42.0), while
+# pydantic-ai-slim 2.x requires pydantic>=2.12 and parlant requires
+# opentelemetry-sdk>=1.37. Declaring the extras as conflicting lets uv resolve each
+# side in its own fork instead of forcing one shared pin that satisfies everyone.
 conflicts = [
     [
         { extra = "crewai" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,8 +143,8 @@ agno = [
     "agno>=2.6.0",
 ]
 
-# dev extra includes ALL framework deps for testing EXCEPT crewai,
-# which conflicts with both parlant and pydantic-ai (see tool.uv.conflicts).
+# dev extra includes ALL framework deps for testing EXCEPT crewai, which is
+# declared conflicting with both parlant and pydantic-ai (see tool.uv.conflicts).
 # To run crewai tests, install with: uv sync --extra dev-crewai
 dev = [
     "pydantic-settings>=2.0.0",
@@ -216,8 +216,9 @@ dev = [
     "pytest-markdown-docs>=0.9.2",
 ]
 
-# CrewAI-only dev extra for testing crewai adapter in isolation.
-# Cannot be combined with dev/parlant/pydantic-ai due to pydantic + opentelemetry conflicts.
+# CrewAI-only dev extra for testing crewai adapter in isolation. Declared conflicting
+# with dev/parlant/pydantic-ai (pydantic + opentelemetry ceilings), so one uv sync
+# resolves either this extra or those, never both.
 dev-crewai = [
     "pydantic-settings>=2.0.0",
     "pytest>=7.0.0",

--- a/src/band/adapters/crewai_flow.py
+++ b/src/band/adapters/crewai_flow.py
@@ -60,11 +60,6 @@ from band.runtime.custom_tools import (
     get_custom_tool_name,
 )
 
-try:  # pragma: no cover - optional dependency guard
-    from crewai.flow.flow import Flow  # type: ignore[import-not-found]
-except ImportError:  # pragma: no cover - exercised only when crewai missing
-    Flow = None  # type: ignore[assignment,misc]
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -6,10 +6,12 @@ Extracted from band.integrations.pydantic_ai.agent.BandPydanticAgent.
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import warnings
-from typing import ClassVar, Any, Callable
+from collections.abc import Callable
+from typing import Any, ClassVar, get_origin, get_type_hints
 
 import httpx
 from pydantic_ai import (
@@ -21,6 +23,7 @@ from pydantic_ai import (
     UnexpectedModelBehavior,
     capture_run_messages,
 )
+from pydantic_ai.capabilities import ProcessHistory
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -85,7 +88,7 @@ def _is_replayable_history_message(message: Any) -> bool:
     """Drop assistant responses that would replay as content:null.
 
     Keep any response with at least one content-bearing part (text, tool
-    calls, builtin tool calls/returns, files). Drop thinking-only and empty
+    calls, native tool calls/returns, files). Drop thinking-only and empty
     responses, which providers reject when sent back as history.
     """
     if isinstance(message, ModelResponse):
@@ -139,6 +142,25 @@ def _custom_tool_def_to_callable(tool_def: CustomToolDef) -> Callable[..., Any]:
     return native
 
 
+def _takes_run_context(fn: Callable[..., Any]) -> bool:
+    """Whether ``fn`` takes pydantic-ai's ``RunContext`` as its first parameter.
+
+    Decides the registration path: ``agent.tool`` requires a RunContext-first
+    callable and raises ``UserError`` for anything else, while ``agent.tool_plain``
+    takes context-free ones — the shape ``_custom_tool_def_to_callable`` produces.
+    Annotations are resolved, so a caller using ``from __future__ import
+    annotations`` is classified on the real type rather than the string.
+    """
+    first = next(iter(inspect.signature(fn).parameters), None)
+    if first is None:
+        return False
+    try:
+        annotation = get_type_hints(fn).get(first)
+    except (NameError, TypeError):  # unresolvable annotation: treat as plain
+        return False
+    return annotation is RunContext or get_origin(annotation) is RunContext
+
+
 class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
     """
     Pydantic AI adapter using SimpleAdapter pattern.
@@ -185,7 +207,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                 and/or portable ``CustomToolDef`` (InputModel, handler) tuples.
                 Each function should follow PydanticAI's tool signature:
                 `def my_tool(ctx: RunContext[AgentToolsProtocol], arg1: str, ...) -> T`
-                These are registered via agent.tool() alongside platform tools.
+                and is registered via agent.tool() alongside platform tools. A
+                context-free callable (no leading ``RunContext``) goes to
+                agent.tool_plain() instead — pydantic-ai rejects it on the other path.
             features: Shared adapter feature settings (capabilities, emit, tool filters).
         """
         # --- Deprecation shim: boolean → features migration ---
@@ -286,7 +310,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             retries=3,
             # Strip content:null responses on every request, including mid-run
             # ones the storage filter can't reach (see the function docstring).
-            history_processors=[_drop_non_replayable_messages],
+            capabilities=[ProcessHistory(_drop_non_replayable_messages)],
         )
 
         # Register platform tools dynamically from centralized definitions
@@ -585,9 +609,13 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             band_archive_memory.__doc__ = get_tool_description("band_archive_memory")
             agent.tool(band_archive_memory)
 
-        # Register custom tools (user-provided PydanticAI-compatible functions)
+        # Register custom tools (user-provided PydanticAI-compatible functions) on
+        # the path their signature calls for — pydantic-ai keeps the two apart.
         for custom_tool in self._custom_tools:
-            agent.tool(custom_tool)
+            if _takes_run_context(custom_tool):
+                agent.tool(custom_tool)
+            else:
+                agent.tool_plain(custom_tool)
             logger.debug("Registered custom tool: %s", custom_tool.__name__)
 
         return agent
@@ -657,7 +685,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # terminal, successful tool ran (excludes read-only lookups and failed
         # band tools) so we can tell a productive turn from a genuine no-op below.
         tool_executed = False
-        # pydantic-ai's result.usage() is already summed across the run's model
+        # pydantic-ai's result.usage is already summed across the run's model
         # calls, so it's set once (on the result event), not accumulated.
         turn_usage = TurnUsage()
         # Snapshot the prior messages' identities so the fallback usage path
@@ -678,72 +706,82 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         # before the AgentRunResultEvent that normally records history — can still
         # persist the *full* turn (user prompt + the agent's tool calls/results), not
         # just the user prompt. This is pydantic-ai's documented hook for a run that
-        # may raise; entered manually so the streaming loop below stays unindented.
+        # may raise; entered manually so the `finally` below can still read what the
+        # failed run captured.
         capture_cm = capture_run_messages()
         captured = capture_cm.__enter__()
         try:
-            async for event in self._agent.run_stream_events(
+            # run_stream_events is an async context manager: it starts the run on the
+            # first iteration and tears the background task down on exit.
+            async with self._agent.run_stream_events(
                 user_message,
                 deps=tools,
                 message_history=self._message_history[room_id],
-            ):
-                if isinstance(event, FunctionToolCallEvent):
-                    if Emit.EXECUTION in self.features.emit:
-                        try:
-                            await tools.send_event(
-                                content=json.dumps(
-                                    {
-                                        "name": event.part.tool_name,
-                                        "args": event.part.args,
-                                        "tool_call_id": event.part.tool_call_id,
-                                    }
-                                ),
-                                message_type="tool_call",
-                            )
-                        except Exception as e:
-                            logger.warning("Failed to send tool_call event: %s", e)
-                elif isinstance(event, FunctionToolResultEvent):
-                    # Custom tools count as terminal only if they opted in
-                    # (band_terminal); undeclared customs fail loud. A failed band
-                    # tool (its wrapper returns an "Error " string) is not terminal.
-                    result_name = event.result.tool_name
-                    if is_terminal_success(
-                        result_name,
-                        succeeded=not band_tool_errored(
-                            result_name, event.result.content
-                        ),
-                        custom_terminal=result_name in self._custom_terminal_names,
-                    ):
-                        tool_executed = True
-                    if Emit.EXECUTION in self.features.emit:
-                        try:
-                            await tools.send_event(
-                                content=json.dumps(
-                                    {
-                                        "name": event.result.tool_name,
-                                        "output": str(event.result.content),
-                                        "tool_call_id": event.tool_call_id,
-                                    }
-                                ),
-                                message_type="tool_result",
-                            )
-                        except Exception as e:
-                            logger.warning("Failed to send tool_result event: %s", e)
-                elif isinstance(event, AgentRunResultEvent):
-                    turn_usage = self._usage_from_result(event.result)
-                    # Keep native run history, but drop responses that replay as
-                    # content:null (e.g. thinking-only) — providers reject them next request.
-                    run_messages = list(event.result.all_messages())
-                    self._message_history[room_id] = _drop_non_replayable_messages(
-                        run_messages
-                    )
-                    dropped = len(run_messages) - len(self._message_history[room_id])
-                    if dropped:
-                        logger.debug(
-                            "Room %s: dropped %s content:null response(s) from history",
-                            room_id,
-                            dropped,
+            ) as events:
+                async for event in events:
+                    if isinstance(event, FunctionToolCallEvent):
+                        if Emit.EXECUTION in self.features.emit:
+                            try:
+                                await tools.send_event(
+                                    content=json.dumps(
+                                        {
+                                            "name": event.part.tool_name,
+                                            "args": event.part.args,
+                                            "tool_call_id": event.part.tool_call_id,
+                                        }
+                                    ),
+                                    message_type="tool_call",
+                                )
+                            except Exception as e:
+                                logger.warning("Failed to send tool_call event: %s", e)
+                    elif isinstance(event, FunctionToolResultEvent):
+                        # Custom tools count as terminal only if they opted in
+                        # (band_terminal); undeclared customs fail loud. A failed band
+                        # tool (its wrapper returns an "Error " string) is not terminal.
+                        result_name = event.part.tool_name
+                        if is_terminal_success(
+                            result_name,
+                            succeeded=not band_tool_errored(
+                                result_name, event.part.content
+                            ),
+                            custom_terminal=result_name in self._custom_terminal_names,
+                        ):
+                            tool_executed = True
+                        if Emit.EXECUTION in self.features.emit:
+                            try:
+                                await tools.send_event(
+                                    content=json.dumps(
+                                        {
+                                            "name": event.part.tool_name,
+                                            "output": str(event.part.content),
+                                            "tool_call_id": event.tool_call_id,
+                                        }
+                                    ),
+                                    message_type="tool_result",
+                                )
+                            except Exception as e:
+                                logger.warning(
+                                    "Failed to send tool_result event: %s", e
+                                )
+                    elif isinstance(event, AgentRunResultEvent):
+                        turn_usage = self._usage_from_result(event.result)
+                        # Keep native run history, but drop responses that replay as
+                        # content:null (e.g. thinking-only) — providers reject them
+                        # on the next request.
+                        run_messages = list(event.result.all_messages())
+                        self._message_history[room_id] = _drop_non_replayable_messages(
+                            run_messages
                         )
+                        dropped = len(run_messages) - len(
+                            self._message_history[room_id]
+                        )
+                        if dropped:
+                            logger.debug(
+                                "Room %s: dropped %s content:null response(s) from "
+                                "history",
+                                room_id,
+                                dropped,
+                            )
         except UnexpectedModelBehavior as e:
             # pydantic-ai forces a final str output (output_type=str). After the
             # agent has already acted via tools this turn (a band_send_message
@@ -809,31 +847,33 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
     def _usage_from_usage_obj(usage: Any) -> TurnUsage:
         """Map a pydantic-ai usage object (RunUsage / RequestUsage) onto TurnUsage.
 
-        Field names moved across pydantic-ai versions (``request_tokens`` /
-        ``response_tokens`` → ``input_tokens`` / ``output_tokens``), so both are
-        read; the first int found wins.
+        Read defensively: both classes carry these fields, but a missing one costs
+        the turn's usage report, never the turn.
         """
 
-        def _int(*names: str) -> int:
-            for name in names:
-                value = getattr(usage, name, None)
-                if isinstance(value, int):
-                    return value
-            return 0
+        def _int(name: str) -> int:
+            value = getattr(usage, name, None)
+            return value if isinstance(value, int) else 0
 
         return TurnUsage(
-            input_tokens=_int("input_tokens", "request_tokens"),
-            output_tokens=_int("output_tokens", "response_tokens"),
+            input_tokens=_int("input_tokens"),
+            output_tokens=_int("output_tokens"),
             cache_read_tokens=_int("cache_read_tokens"),
             cache_write_tokens=_int("cache_write_tokens"),
         )
 
     @staticmethod
     def _usage_from_result(result: Any) -> TurnUsage:
-        """The run's total usage across all model requests (happy path)."""
+        """The run's total usage across all model requests (happy path).
+
+        Usage is telemetry, so a shape change must not fail the turn — but it must
+        not vanish silently either (pydantic-ai 2.x turned ``usage()`` into the
+        ``usage`` property, and a silent catch would just report zeros).
+        """
         try:
-            usage = result.usage()
-        except Exception:  # pragma: no cover - defensive; usage is best-effort
+            usage = result.usage
+        except Exception as e:  # pragma: no cover - defensive; usage is best-effort
+            logger.warning("Could not read pydantic-ai run usage: %s", e)
             return TurnUsage()
         return PydanticAIAdapter._usage_from_usage_obj(usage)
 
@@ -859,7 +899,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         """Sum per-response usage across the given run messages.
 
         The fallback for the benign empty-final-response path, where no
-        ``AgentRunResultEvent`` fires (so ``result.usage()`` is unavailable) yet
+        ``AgentRunResultEvent`` fires (so ``result.usage`` is unavailable) yet
         the turn still spent tokens — each ``ModelResponse`` carries its own
         ``usage``. Pass only the *current run's* messages (the caller filters out
         the prior history by identity); summing the full captured list would

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -65,18 +65,23 @@ from band.runtime.tools import (
 logger = logging.getLogger(__name__)
 
 
-def _is_output_validation_exhausted(exc: UnexpectedModelBehavior) -> bool:
-    """Whether ``exc`` is pydantic-ai's "exhausted output-validation retries".
+OUTPUT_RETRIES_EXHAUSTED = "exceeded maximum output retries"
+"""pydantic-ai's wording when a run burns its output-retry budget.
 
-    pydantic-ai exposes no structured code for this — it only carries the cause in
-    the ``UnexpectedModelBehavior`` message (e.g. "Exceeded maximum retries (N) for
-    output validation"), so we match that text. The coupling to pydantic-ai's
-    wording is deliberate and **fail-safe**: if a future release rewords it, a
-    benign post-tool turn propagates as an error (never the reverse), and the
-    dependency is version-pinned. Must stay distinct from "Received empty model
-    response", which propagates even after tool work.
+It exposes no structured code for this, so the message text is the only signal —
+matched case-insensitively. A guard test asserts pydantic-ai still raises this
+exact phrase, because a silent reword would disable the swallow below rather than
+announce itself.
+"""
+
+
+def _is_output_retries_exhausted(exc: UnexpectedModelBehavior) -> bool:
+    """Whether ``exc`` is pydantic-ai's exhausted output-retry budget.
+
+    The coupling to pydantic-ai's wording is deliberate and **fail-safe**: on a
+    reword a benign post-tool turn propagates as an error, never the reverse.
     """
-    return "output validation" in str(exc).lower()
+    return OUTPUT_RETRIES_EXHAUSTED in str(exc).lower()
 
 
 # A response made up only of these (or with no parts at all) serializes to
@@ -283,10 +288,10 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         )
         self._system_prompt = system
 
-        # We respond via tools only, so the model output is unused. Using `str`
-        # (instead of `None`) keeps newer pydantic-ai-slim versions happy —
-        # 1.87+ rejects `output_type=None` with `UserError("At least one output
-        # type must be provided other than `None`")`.
+        # We respond via tools only, so the model output is unused — but it must
+        # still be a type: pydantic-ai rejects `output_type=None` with
+        # `UserError("At least one output type must be provided other than
+        # `None`")`, so `str` stands in for "we don't care".
         agent: Agent[AgentToolsProtocol, str] = Agent(
             self.model,
             # Pass the rendered prompt as `instructions`, not `system_prompt`.
@@ -786,14 +791,14 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             # pydantic-ai forces a final str output (output_type=str). After the
             # agent has already acted via tools this turn (a band_send_message
             # reply, a band_store_memory, ...) gpt-5.4-mini sometimes returns a
-            # genuinely empty final response, so output-validation retries are
+            # genuinely empty final response, so the output-retry budget is
             # exhausted and this raises. The work already went out, so the empty
             # final answer is benign — mirror the crewai adapter and swallow it.
             # Genuine no-response failures (no terminal tool ran — only read-only
             # lookups or failed tools) still propagate.
-            if tool_executed and _is_output_validation_exhausted(e):
+            if tool_executed and _is_output_retries_exhausted(e):
                 logger.warning(
-                    "Room %s: Pydantic AI exhausted output-validation retries after "
+                    "Room %s: Pydantic AI exhausted its output retries after "
                     "the agent already did productive work this turn; treating as "
                     "non-fatal: %s",
                     room_id,

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -317,11 +317,13 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             #
             # output=0: this agent replies *through* tools, so the forced `str`
             # output below is unsatisfiable by design and its budget can only ever
-            # be spent, never used. Spending it is not free — an output-validation
-            # retry re-runs the turn's tool calls, so every attempt re-posts the
-            # reply to the room. Refusing the retries keeps side effects at exactly
-            # one execution; the resulting UnexpectedModelBehavior is the benign
-            # empty-final case handled below.
+            # be spent, never used. Spending it is not free: each attempt sends the
+            # model a retry prompt asking it to "return text or call a tool", and an
+            # agent told to answer only through tools obliges by calling one — so a
+            # budget of N re-posts the reply to the room N more times, at N+1× the
+            # model round trips. Refusing the retries keeps side effects at exactly
+            # one; the resulting UnexpectedModelBehavior is the benign empty-final
+            # case handled below.
             retries={"tools": 3, "output": 0},
             # Strip content:null responses on every request, including mid-run
             # ones the storage filter can't reach (see the function docstring).

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -309,13 +309,20 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             instructions=system,
             deps_type=AgentToolsProtocol,
             output_type=str,
-            # pydantic-ai defaults to retries=1 for tool-arg and final-output
-            # validation. With a tool-only agent driven by a small model, one retry
-            # is too tight: the model occasionally needs another attempt to emit a
-            # valid tool call (e.g. band_create_chatroom) or a non-empty final
-            # answer before pydantic-ai raises UnexpectedModelBehavior. A modest
-            # budget makes the turn resilient without masking a genuinely stuck run.
-            retries=3,
+            # Two budgets, deliberately different — a bare int would set both.
+            #
+            # tools=3: one retry is too tight for a small model, which occasionally
+            # needs another attempt to emit a valid tool call (e.g.
+            # band_create_chatroom) before pydantic-ai gives up.
+            #
+            # output=0: this agent replies *through* tools, so the forced `str`
+            # output below is unsatisfiable by design and its budget can only ever
+            # be spent, never used. Spending it is not free — an output-validation
+            # retry re-runs the turn's tool calls, so every attempt re-posts the
+            # reply to the room. Refusing the retries keeps side effects at exactly
+            # one execution; the resulting UnexpectedModelBehavior is the benign
+            # empty-final case handled below.
+            retries={"tools": 3, "output": 0},
             # Strip content:null responses on every request, including mid-run
             # ones the storage filter can't reach (see the function docstring).
             capabilities=[ProcessHistory(_drop_non_replayable_messages)],
@@ -791,11 +798,12 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                                 dropped,
                             )
         except UnexpectedModelBehavior as e:
-            # pydantic-ai forces a final str output (output_type=str). After the
-            # agent has already acted via tools this turn (a band_send_message
-            # reply, a band_store_memory, ...) gpt-5.4-mini sometimes returns a
-            # genuinely empty final response, so the output-retry budget is
-            # exhausted and this raises. The work already went out, so the empty
+            # This is the ordinary way a productive turn ends, not a rare mishap.
+            # pydantic-ai forces a final str output (output_type=str), but the agent
+            # answers through tools — so once it has acted (a band_send_message
+            # reply, a band_store_memory, ...) it has nothing left to say and returns
+            # an empty final response. With output retries refused (see the budget
+            # above) that raises immediately. The work already went out, so the empty
             # final answer is benign — mirror the crewai adapter and swallow it.
             # Genuine no-response failures (no terminal tool ran — only read-only
             # lookups or failed tools) still propagate.

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -202,7 +202,10 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         Initialize the Pydantic AI adapter.
 
         Args:
-            model: Pydantic AI model string (e.g., "openai:gpt-5.4", "anthropic:claude-3-5-sonnet-latest")
+            model: Pydantic AI model string (e.g., "openai:gpt-5.4",
+                "anthropic:claude-3-5-sonnet-latest"). Since pydantic-ai 2.0 the bare
+                ``openai:`` prefix routes to OpenAI's Responses API; use
+                ``openai-chat:`` for Chat Completions.
             system_prompt: Optional custom system prompt (overrides default)
             custom_section: Optional custom section added to default system prompt
             enable_execution_reporting: Deprecated. Use features=AdapterFeatures(emit={Emit.EXECUTION}).

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -150,9 +150,11 @@ def _custom_tool_def_to_callable(tool_def: CustomToolDef) -> Callable[..., Any]:
 def _takes_run_context(fn: Callable[..., Any]) -> bool:
     """Whether ``fn`` takes pydantic-ai's ``RunContext`` as its first parameter.
 
-    Decides the registration path: ``agent.tool`` requires a RunContext-first
-    callable and raises ``UserError`` for anything else, while ``agent.tool_plain``
-    takes context-free ones — the shape ``_custom_tool_def_to_callable`` produces.
+    Decides the registration path: ``agent.tool`` handles RunContext-first
+    callables, while ``agent.tool_plain`` handles context-free ones — the shape
+    ``_custom_tool_def_to_callable`` produces. pydantic-ai injects an unannotated
+    first parameter as context; a non-RunContext annotation is invalid on the
+    former path.
     Annotations are resolved, so a caller using ``from __future__ import
     annotations`` is classified on the real type rather than the string.
     """
@@ -163,6 +165,8 @@ def _takes_run_context(fn: Callable[..., Any]) -> bool:
         annotation = get_type_hints(fn).get(first)
     except (NameError, TypeError):  # unresolvable annotation: treat as plain
         return False
+    if annotation is None:
+        return True
     return annotation is RunContext or get_origin(annotation) is RunContext
 
 

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -9,6 +9,7 @@ platform tools, tool execution, verbose mode, delegation, and custom tools.
 
 from __future__ import annotations
 
+import importlib
 import asyncio
 import json
 from datetime import datetime, timezone
@@ -44,31 +45,19 @@ def crewai_mocks(monkeypatch):
     mock_crewai_module.LLM = MagicMock()
     mock_crewai_tools_module.BaseTool = MockBaseTool
 
-    # Evict any cached integration modules so they pick up the freshly-mocked
-    # `nest_asyncio`/`crewai.tools` from sys.modules on next import.
-    for mod in (
-        "band.adapters.crewai",
-        "band.integrations.crewai",
-        "band.integrations.crewai.runtime",
-        "band.integrations.crewai.tools",
-    ):
-        sys.modules.pop(mod, None)
+    # `_nest_asyncio_applied` is process-global. Any test running with a mocked
+    # nest_asyncio can flip it True without anything actually being patched, which
+    # then silently disables the real patch for every later test — so isolate it.
+    runtime = importlib.import_module("band.integrations.crewai.runtime")
+    monkeypatch.setattr(runtime, "_nest_asyncio_applied", False)
 
+    # No sys.modules surgery: every crewai import in the band modules is
+    # TYPE_CHECKING-only or function-local, so they pick the mocks up at call time.
     monkeypatch.setitem(sys.modules, "crewai", mock_crewai_module)
     monkeypatch.setitem(sys.modules, "crewai.tools", mock_crewai_tools_module)
     monkeypatch.setitem(sys.modules, "nest_asyncio", mock_nest_asyncio)
 
-    try:
-        yield mock_crewai_module
-    finally:
-        # Clean up adapter + integration modules to force reimport on next test
-        for mod in (
-            "band.adapters.crewai",
-            "band.integrations.crewai",
-            "band.integrations.crewai.runtime",
-            "band.integrations.crewai.tools",
-        ):
-            sys.modules.pop(mod, None)
+    yield mock_crewai_module
 
 
 @pytest.fixture
@@ -1458,27 +1447,35 @@ class TestExecutionReporting:
 
 class TestLazyNestAsyncio:
     def test_nest_asyncio_not_applied_on_import(self, crewai_mocks):
+        """Importing the adapter must not patch the event loop.
+
+        Reloaded rather than evicted-and-reimported: dropping a band module from
+        ``sys.modules`` re-executes it, but anything still holding a class from the
+        old module object then has a ``__module__`` that resolves to nothing, and
+        pydantic (which looks annotations up through that name) can no longer build
+        the tool models.
+        """
         import importlib
         import sys
 
-        sys.modules.pop("band.adapters.crewai", None)
-        sys.modules.pop("band.integrations.crewai", None)
-        sys.modules.pop("band.integrations.crewai.runtime", None)
+        nest_mock = sys.modules["nest_asyncio"]
+        nest_mock.reset_mock()
 
-        crewai_mocks_nest = sys.modules["nest_asyncio"]
-        crewai_mocks_nest.reset_mock()
+        importlib.reload(importlib.import_module("band.adapters.crewai"))
 
-        importlib.import_module("band.adapters.crewai")
+        nest_mock.apply.assert_not_called()
 
-        crewai_mocks_nest.apply.assert_not_called()
-
-    def test_ensure_nest_asyncio_applies_once(self, CrewAIAdapter, crewai_mocks):
+    def test_ensure_nest_asyncio_applies_once(
+        self, CrewAIAdapter, crewai_mocks, monkeypatch
+    ):
         import importlib
         import sys
 
         module = importlib.import_module("band.integrations.crewai.runtime")
 
-        module._nest_asyncio_applied = False
+        # Reset through monkeypatch so the flag is restored — it is process-global
+        # and a leaked True would silently disable a later test's assertion.
+        monkeypatch.setattr(module, "_nest_asyncio_applied", False)
         nest_mock = sys.modules["nest_asyncio"]
         nest_mock.reset_mock()
 

--- a/tests/adapters/test_crewai_adapter_soak.py
+++ b/tests/adapters/test_crewai_adapter_soak.py
@@ -8,6 +8,7 @@ Asserts:
 
 from __future__ import annotations
 
+import importlib
 import sys
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
@@ -35,28 +36,19 @@ def crewai_mocks(monkeypatch):
     mock_crewai_module.LLM = MagicMock()
     mock_crewai_tools_module.BaseTool = MockBaseTool
 
-    for mod in (
-        "band.adapters.crewai",
-        "band.integrations.crewai",
-        "band.integrations.crewai.runtime",
-        "band.integrations.crewai.tools",
-    ):
-        sys.modules.pop(mod, None)
+    # `_nest_asyncio_applied` is process-global. Any test running with a mocked
+    # nest_asyncio can flip it True without anything actually being patched, which
+    # then silently disables the real patch for every later test — so isolate it.
+    runtime = importlib.import_module("band.integrations.crewai.runtime")
+    monkeypatch.setattr(runtime, "_nest_asyncio_applied", False)
 
+    # No sys.modules surgery: every crewai import in the band modules is
+    # TYPE_CHECKING-only or function-local, so they pick the mocks up at call time.
     monkeypatch.setitem(sys.modules, "crewai", mock_crewai_module)
     monkeypatch.setitem(sys.modules, "crewai.tools", mock_crewai_tools_module)
     monkeypatch.setitem(sys.modules, "nest_asyncio", mock_nest_asyncio)
 
-    try:
-        yield {"crewai": mock_crewai_module, "nest_asyncio": mock_nest_asyncio}
-    finally:
-        for mod in (
-            "band.adapters.crewai",
-            "band.integrations.crewai",
-            "band.integrations.crewai.runtime",
-            "band.integrations.crewai.tools",
-        ):
-            sys.modules.pop(mod, None)
+    yield {"crewai": mock_crewai_module, "nest_asyncio": mock_nest_asyncio}
 
 
 def _make_msg(idx: int, room_id: str) -> PlatformMessage:

--- a/tests/adapters/test_crewai_flow_phase3.py
+++ b/tests/adapters/test_crewai_flow_phase3.py
@@ -691,12 +691,6 @@ class TestRuntimeTools:
         mock_tools_module = MagicMock()
         mock_tools_module.BaseTool = type("BaseTool", (), {})
         monkeypatch.setitem(sys.modules, "crewai.tools", mock_tools_module)
-        for mod in (
-            "band.integrations.crewai",
-            "band.integrations.crewai.runtime",
-            "band.integrations.crewai.tools",
-        ):
-            sys.modules.pop(mod, None)
 
         class EmailsInput(BaseModel):
             """Return the user's recent emails."""
@@ -734,12 +728,6 @@ class TestRuntimeTools:
         mock_tools_module = MagicMock()
         mock_tools_module.BaseTool = type("BaseTool", (), {})
         monkeypatch.setitem(sys.modules, "crewai.tools", mock_tools_module)
-        for mod in (
-            "band.integrations.crewai",
-            "band.integrations.crewai.runtime",
-            "band.integrations.crewai.tools",
-        ):
-            sys.modules.pop(mod, None)
 
         captured = {}
 
@@ -781,12 +769,6 @@ class TestRuntimeTools:
         mock_tools_module = MagicMock()
         mock_tools_module.BaseTool = type("BaseTool", (), {})
         monkeypatch.setitem(sys.modules, "crewai.tools", mock_tools_module)
-        for mod in (
-            "band.integrations.crewai",
-            "band.integrations.crewai.runtime",
-            "band.integrations.crewai.tools",
-        ):
-            sys.modules.pop(mod, None)
 
         class FailingSendTools(FakeAgentTools):
             async def send_message(
@@ -837,12 +819,6 @@ class TestRuntimeTools:
         mock_tools_module = MagicMock()
         mock_tools_module.BaseTool = type("BaseTool", (), {})
         monkeypatch.setitem(sys.modules, "crewai.tools", mock_tools_module)
-        for mod in (
-            "band.integrations.crewai",
-            "band.integrations.crewai.runtime",
-            "band.integrations.crewai.tools",
-        ):
-            sys.modules.pop(mod, None)
 
         ns = "crewai_flow:agent-1"
         prior_payload = {

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -7,52 +7,61 @@ This file contains PydanticAI-specific behavior: agent creation, tool registrati
 stream event handling, execution reporting, and custom tools.
 """
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from typing import Any, AsyncIterator
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from pydantic import BaseModel
 from pydantic_ai import (
     AgentRunResultEvent,
     FunctionToolCallEvent,
     FunctionToolResultEvent,
+    RunContext,
     UnexpectedModelBehavior,
 )
+from pydantic_ai.capabilities import ProcessHistory
 from pydantic_ai.messages import (
-    BuiltinToolCallPart,
     ModelRequest,
     ModelResponse,
+    NativeToolCallPart,
     TextPart,
     ThinkingPart,
     ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
 )
+from pydantic_ai.models.test import TestModel
 
 from band.adapters.pydantic_ai import (
     PydanticAIAdapter,
     _drop_non_replayable_messages,
     _is_replayable_history_message,
 )
+from band.core.protocols import AgentToolsProtocol
 from band.core.types import AdapterFeatures, Capability, PlatformMessage
+from band.runtime.custom_tools import get_custom_tool_name
 
 
 def make_stream_events(
     result_messages: list | None = None,
     tool_calls: list[tuple[str, dict, str]] | None = None,
     tool_results: list[tuple[str, str, str]] | None = None,
-) -> AsyncIterator:
-    """Create a mock async iterator of stream events.
+):
+    """Stand in for ``Agent.run_stream_events()``: an async CM over stream events.
+
+    pydantic-ai 2.x makes ``run_stream_events()`` an async context manager that
+    yields the event iterator (it starts the run on first iteration and tears the
+    background task down on exit), so the fake has to be one too.
 
     Args:
         result_messages: Messages to return in AgentRunResultEvent
         tool_calls: List of (tool_name, args, tool_call_id) tuples
         tool_results: List of (tool_name, output, tool_call_id) tuples
-
-    Returns:
-        Async iterator of stream events
     """
 
     async def stream():
@@ -70,9 +79,9 @@ def make_stream_events(
         if tool_results:
             for tool_name, output, tool_call_id in tool_results:
                 event = MagicMock(spec=FunctionToolResultEvent)
-                event.result = MagicMock()
-                event.result.tool_name = tool_name  # tool_name is on result, not event
-                event.result.content = output
+                event.part = MagicMock()
+                event.part.tool_name = tool_name  # tool_name is on the part, not event
+                event.part.content = output
                 event.tool_call_id = tool_call_id
                 yield event
 
@@ -82,7 +91,11 @@ def make_stream_events(
         result_event.result.all_messages.return_value = result_messages or []
         yield result_event
 
-    return stream()
+    @asynccontextmanager
+    async def events() -> AsyncIterator[AsyncIterator]:
+        yield stream()
+
+    return events()
 
 
 def make_usage_response(
@@ -149,48 +162,39 @@ def mock_pydantic_agent():
 class TestUsageMapping:
     """Tests for the Emit.USAGE seam's usage mapping."""
 
-    def test_usage_from_result_current_field_names(self):
-        """Maps RunUsage.input_tokens/output_tokens to TurnUsage."""
-        from types import SimpleNamespace
+    def test_usage_from_result_reads_the_usage_property(self):
+        """Maps the run result's ``usage`` (a property since 2.x) onto TurnUsage.
 
+        Reading it as a method instead would raise, and the guarded read would then
+        report zeros for every turn — silent, so this is the guard.
+        """
         from band.core.types import TurnUsage
 
-        result = MagicMock()
-        result.usage.return_value = SimpleNamespace(
-            input_tokens=100,
-            output_tokens=20,
-            cache_read_tokens=5,
-            cache_write_tokens=0,
+        result = SimpleNamespace(
+            usage=SimpleNamespace(
+                input_tokens=100,
+                output_tokens=20,
+                cache_read_tokens=5,
+                cache_write_tokens=0,
+            )
         )
         assert PydanticAIAdapter._usage_from_result(result) == TurnUsage(
             input_tokens=100,
             output_tokens=20,
             cache_read_tokens=5,
             cache_write_tokens=0,
-        )
-
-    def test_usage_from_result_legacy_field_names(self):
-        """Falls back to the older request_tokens/response_tokens names."""
-        from types import SimpleNamespace
-
-        from band.core.types import TurnUsage
-
-        result = MagicMock()
-        result.usage.return_value = SimpleNamespace(
-            request_tokens=130,
-            response_tokens=8,
-        )
-        assert PydanticAIAdapter._usage_from_result(result) == TurnUsage(
-            input_tokens=130, output_tokens=8
         )
 
     def test_usage_from_result_swallows_errors(self):
-        """A usage() that raises yields empty usage, never propagates."""
+        """Usage that fails to read yields empty usage, never propagates."""
         from band.core.types import TurnUsage
 
-        result = MagicMock()
-        result.usage.side_effect = RuntimeError("no usage")
-        assert PydanticAIAdapter._usage_from_result(result) == TurnUsage()
+        class Unreadable:
+            @property
+            def usage(self) -> Any:
+                raise RuntimeError("no usage")
+
+        assert PydanticAIAdapter._usage_from_result(Unreadable()) == TurnUsage()
 
     def test_usage_from_messages_sums_model_responses(self):
         """The benign-path fallback sums usage across captured ModelResponses.
@@ -282,9 +286,9 @@ class TestInitialization:
     def test_create_agent_registers_content_null_history_processor(self):
         """The agent must sanitize content:null responses on every request.
 
-        Registering the drop as a history processor (not just the post-run
-        storage filter) is what closes the mid-run gap: the model can emit an
-        empty/thinking-only response within a single turn, and pydantic-ai would
+        Registering the drop as a history-processing capability (not just the
+        post-run storage filter) is what closes the mid-run gap: the model can emit
+        an empty/thinking-only response within a single turn, and pydantic-ai would
         otherwise replay it to the provider as assistant content:null.
         """
         adapter = PydanticAIAdapter(model="openai:gpt-5.4")
@@ -292,9 +296,40 @@ class TestInitialization:
 
         with patch("band.adapters.pydantic_ai.Agent") as MockAgent:
             adapter._create_agent()
-            assert MockAgent.call_args.kwargs["history_processors"] == [
-                _drop_non_replayable_messages
-            ]
+            (capability,) = MockAgent.call_args.kwargs["capabilities"]
+            assert isinstance(capability, ProcessHistory)
+            assert capability.processor is _drop_non_replayable_messages
+
+    def test_create_agent_registers_context_free_custom_tool(self):
+        """A CustomToolDef-derived tool takes no RunContext, so it needs tool_plain.
+
+        pydantic-ai 2.x rejects a context-free callable passed to ``agent.tool()``
+        ("First parameter of tools that take context must be annotated with
+        RunContext[...]"), which would break every tuple-form custom tool at agent
+        creation. Built against a real Agent (TestModel, no network) because a
+        patched Agent accepts either path and would prove nothing.
+        """
+
+        class Echo(BaseModel):
+            """Echo the text back."""
+
+            text: str
+
+        async def handler(args: Echo) -> str:
+            return args.text
+
+        adapter = PydanticAIAdapter(
+            model=TestModel(),  # type: ignore[arg-type]  # real Agent, no network
+            additional_tools=[(Echo, handler)],
+        )
+        adapter.agent_name = "TestBot"
+
+        agent = adapter._create_agent()
+
+        registered = {
+            name for toolset in agent.toolsets for name in getattr(toolset, "tools", ())
+        }
+        assert get_custom_tool_name(Echo) in registered
 
 
 class TestOnStarted:
@@ -615,11 +650,11 @@ class TestHistoryManagement:
         ]
         assert content_null_response not in stored_history
 
-    def test_keeps_response_with_only_builtin_tool_part(self):
-        """Builtin tool calls carry content the provider expects — keep them."""
+    def test_keeps_response_with_only_native_tool_part(self):
+        """Native tool calls carry content the provider expects — keep them."""
         response = ModelResponse(
             parts=[
-                BuiltinToolCallPart(
+                NativeToolCallPart(
                     tool_name="web_search",
                     args={"query": "weather"},
                     tool_call_id="call_1",
@@ -915,8 +950,8 @@ def make_raising_stream(
     tool_result: bool,
     tool_name: str = "band_send_message",
     tool_content: Any = None,
-) -> AsyncIterator:
-    """Async run stream that optionally fires a tool-result event, then raises.
+):
+    """Run stream (async CM, as 2.x returns) that fires a tool result, then raises.
 
     ``tool_name``/``tool_content`` let a test pick a read-only tool or an error
     result to verify those do not count as terminal productive work.
@@ -925,16 +960,20 @@ def make_raising_stream(
     async def stream():
         if tool_result:
             event = MagicMock(spec=FunctionToolResultEvent)
-            event.result = MagicMock()
-            event.result.tool_name = tool_name
-            event.result.content = (
+            event.part = MagicMock()
+            event.part.tool_name = tool_name
+            event.part.content = (
                 {"id": "msg_1"} if tool_content is None else tool_content
             )
             event.tool_call_id = "call_1"
             yield event
         raise error
 
-    return stream()
+    @asynccontextmanager
+    async def events() -> AsyncIterator[AsyncIterator]:
+        yield stream()
+
+    return events()
 
 
 class TestEmptyFinalAnswer:
@@ -1228,7 +1267,7 @@ class TestCustomTools:
     def test_accepts_additional_tools_parameter(self):
         """Adapter accepts list of callables."""
 
-        async def my_tool(ctx, message: str) -> str:
+        async def my_tool(ctx: RunContext[AgentToolsProtocol], message: str) -> str:
             """A custom tool."""
             return f"Echo: {message}"
 
@@ -1243,15 +1282,17 @@ class TestCustomTools:
     def test_multiple_custom_tools(self):
         """Should accept multiple custom tools."""
 
-        async def tool_one(ctx, a: int) -> int:
+        async def tool_one(ctx: RunContext[AgentToolsProtocol], a: int) -> int:
             """Tool one."""
             return a + 1
 
-        def tool_two(ctx, b: str) -> str:
+        def tool_two(ctx: RunContext[AgentToolsProtocol], b: str) -> str:
             """Tool two."""
             return b.upper()
 
-        async def tool_three(ctx, x: float, y: float) -> float:
+        async def tool_three(
+            ctx: RunContext[AgentToolsProtocol], x: float, y: float
+        ) -> float:
             """Tool three."""
             return x + y
 
@@ -1266,7 +1307,7 @@ class TestCustomTools:
     async def test_registers_custom_tools_with_agent(self):
         """Custom tools should be registered via agent.tool()."""
 
-        async def my_echo(ctx, message: str) -> str:
+        async def my_echo(ctx: RunContext[AgentToolsProtocol], message: str) -> str:
             """Echo the message."""
             return f"Echo: {message}"
 
@@ -1297,7 +1338,9 @@ class TestCustomTools:
     ):
         """Custom tool should appear in agent._function_tools after registration."""
 
-        async def calculator(ctx, a: float, b: float) -> float:
+        async def calculator(
+            ctx: RunContext[AgentToolsProtocol], a: float, b: float
+        ) -> float:
             """Add two numbers."""
             return a + b
 
@@ -1327,7 +1370,7 @@ class TestCustomTools:
     ):
         """Custom tools should work during message handling."""
 
-        async def my_helper(ctx, value: str) -> str:
+        async def my_helper(ctx: RunContext[AgentToolsProtocol], value: str) -> str:
             """Helper tool."""
             return f"Helped: {value}"
 

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -340,14 +340,15 @@ class TestInitialization:
         """One turn must post to the room exactly once, however the run ends.
 
         This agent answers through tools, so ``output_type=str`` can never be
-        satisfied and its retry budget is always spent. pydantic-ai 2.x re-runs the
-        turn's tool calls on each output-validation retry, so a budget above zero
-        re-posts the reply once per attempt (a bare ``retries=N`` sets tools *and*
-        output, which is how that budget gets granted by accident).
+        satisfied and its retry budget is always spent. Each attempt sends the model a
+        retry prompt asking it to return text *or call a tool*, and an agent told to
+        answer only through tools calls one again — so a budget above zero re-posts the
+        reply once per attempt (a bare ``retries=N`` sets tools *and* output, which is
+        how that budget gets granted by accident).
 
-        The model here mimics one that keeps answering through the tool: a tool call,
-        then an empty final response, alternating. With output retries refused it
-        runs once; with any budget it would run again on the retry.
+        The FunctionModel below stands in for that model: a tool call, then an empty
+        final response, alternating — the shape a real run exhibits. With output
+        retries refused the tool runs once; with any budget it runs again per attempt.
         """
         posted: list[str] = []
 

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -27,6 +27,7 @@ from pydantic_ai import (
 )
 from pydantic_ai.capabilities import ProcessHistory
 from pydantic_ai.messages import (
+    ModelMessage,
     ModelRequest,
     ModelResponse,
     NativeToolCallPart,
@@ -36,6 +37,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 
 from band.adapters.pydantic_ai import (
@@ -333,6 +335,56 @@ class TestInitialization:
             name for toolset in agent.toolsets for name in getattr(toolset, "tools", ())
         }
         assert get_custom_tool_name(Echo) in registered
+
+    async def test_unsatisfiable_output_never_reruns_a_side_effecting_tool(self):
+        """One turn must post to the room exactly once, however the run ends.
+
+        This agent answers through tools, so ``output_type=str`` can never be
+        satisfied and its retry budget is always spent. pydantic-ai 2.x re-runs the
+        turn's tool calls on each output-validation retry, so a budget above zero
+        re-posts the reply once per attempt (a bare ``retries=N`` sets tools *and*
+        output, which is how that budget gets granted by accident).
+
+        The model here mimics one that keeps answering through the tool: a tool call,
+        then an empty final response, alternating. With output retries refused it
+        runs once; with any budget it would run again on the retry.
+        """
+        posted: list[str] = []
+
+        class Note(BaseModel):
+            """Post a note to the room."""
+
+            text: str
+
+        async def handler(args: Note) -> str:
+            posted.append(args.text)
+            return "posted"
+
+        tool_name = get_custom_tool_name(Note)
+        requests = 0
+
+        def reply_via_tool_then_nothing(
+            messages: list[ModelMessage], info: AgentInfo
+        ) -> ModelResponse:
+            nonlocal requests
+            requests += 1
+            if requests % 2:
+                return ModelResponse(
+                    parts=[ToolCallPart(tool_name=tool_name, args={"text": "hi"})]
+                )
+            return ModelResponse(parts=[TextPart(content="")])
+
+        adapter = PydanticAIAdapter(
+            model=FunctionModel(reply_via_tool_then_nothing),  # type: ignore[arg-type]
+            additional_tools=[(Note, handler)],
+        )
+        adapter.agent_name = "TestBot"
+
+        with pytest.raises(UnexpectedModelBehavior) as exc:
+            await adapter._create_agent().run("go", deps=MagicMock())
+
+        assert _is_output_retries_exhausted(exc.value)
+        assert posted == ["hi"]
 
 
 class TestOnStarted:

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -10,6 +10,7 @@ stream event handling, execution reporting, and custom tools.
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -38,8 +39,10 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.test import TestModel
 
 from band.adapters.pydantic_ai import (
+    OUTPUT_RETRIES_EXHAUSTED,
     PydanticAIAdapter,
     _drop_non_replayable_messages,
+    _is_output_retries_exhausted,
     _is_replayable_history_message,
 )
 from band.core.protocols import AgentToolsProtocol
@@ -271,10 +274,10 @@ class TestInitialization:
         assert adapter.model == "openai:gpt-5.4"
 
     def test_create_agent_uses_str_output_type(self):
-        """INT-488: Agent must be constructed with output_type=str, never None.
+        """Agent must be constructed with output_type=str, never None.
 
-        pydantic-ai-slim 1.87+ raises UserError("At least one output type must
-        be provided other than `None`") when output_type is None or omitted.
+        pydantic-ai raises UserError("At least one output type must be provided
+        other than `None`") when output_type is None.
         """
         adapter = PydanticAIAdapter(model="openai:gpt-5.4")
         adapter.agent_name = "TestBot"
@@ -978,25 +981,42 @@ def make_raising_stream(
 
 class TestEmptyFinalAnswer:
     """gpt-5.4-mini can return an empty final answer after the agent already
-    replied/acted via tools, exhausting pydantic-ai's output_type=str validation
-    retries. That is benign — the work already went out — so it must not fail the
+    replied/acted via tools, exhausting pydantic-ai's output_type=str retry
+    budget. That is benign — the work already went out — so it must not fail the
     message, but a genuine no-work failure must still surface.
     """
+
+    def test_swallow_matches_the_wording_pydantic_ai_actually_raises(self) -> None:
+        """The swallow keys on message text, since pydantic-ai exposes no code for it.
+
+        Every other test here builds the exception by hand, so a reword upstream
+        would leave them green while the swallow quietly stopped matching — which is
+        exactly what 2.x did to the 1.x phrasing ("Exceeded maximum retries (N) for
+        output validation"). Read the real source so a future reword fails here.
+        """
+        from pydantic_ai import _tool_execution
+
+        source = Path(_tool_execution.__file__).read_text(encoding="utf-8").lower()
+        assert OUTPUT_RETRIES_EXHAUSTED in source
+        assert _is_output_retries_exhausted(
+            UnexpectedModelBehavior("Exceeded maximum output retries (3)")
+        )
+        assert not _is_output_retries_exhausted(
+            UnexpectedModelBehavior("Invalid response, unable to find output")
+        )
 
     @pytest.mark.asyncio
     async def test_empty_output_after_tool_is_benign(
         self, sample_message, mock_tools, mock_pydantic_agent
     ):
-        """Output-validation exhaustion after a tool ran is swallowed."""
+        """Output-retry exhaustion after a tool ran is swallowed."""
         adapter = PydanticAIAdapter(model="openai:gpt-5.4")
         with patch.object(adapter, "_create_agent", return_value=mock_pydantic_agent):
             await adapter.on_started("TestBot", "Test bot")
 
         adapter._agent.run_stream_events = MagicMock(
             return_value=make_raising_stream(
-                UnexpectedModelBehavior(
-                    "Exceeded maximum retries (1) for output validation"
-                ),
+                UnexpectedModelBehavior("Exceeded maximum output retries (1)"),
                 tool_result=True,
             )
         )
@@ -1046,9 +1066,7 @@ class TestEmptyFinalAnswer:
 
         adapter._agent.run_stream_events = MagicMock(
             return_value=make_raising_stream(
-                UnexpectedModelBehavior(
-                    "Exceeded maximum retries (1) for output validation"
-                ),
+                UnexpectedModelBehavior("Exceeded maximum output retries (1)"),
                 tool_result=True,
             )
         )
@@ -1091,9 +1109,7 @@ class TestEmptyFinalAnswer:
 
         adapter._agent.run_stream_events = MagicMock(
             return_value=make_raising_stream(
-                UnexpectedModelBehavior(
-                    "Exceeded maximum retries (1) for output validation"
-                ),
+                UnexpectedModelBehavior("Exceeded maximum output retries (1)"),
                 tool_result=False,
             )
         )
@@ -1132,7 +1148,7 @@ class TestEmptyFinalAnswer:
 
         adapter._agent.run_stream_events = MagicMock(
             return_value=make_raising_stream(
-                UnexpectedModelBehavior("Received empty model response"),
+                UnexpectedModelBehavior("Invalid response, unable to find output"),
                 tool_result=True,
             )
         )
@@ -1180,7 +1196,7 @@ class TestEmptyFinalAnswer:
 
         adapter._agent.run_stream_events = MagicMock(
             return_value=make_raising_stream(
-                UnexpectedModelBehavior("Received empty model response"),
+                UnexpectedModelBehavior("Invalid response, unable to find output"),
                 tool_result=True,
             )
         )
@@ -1208,9 +1224,7 @@ class TestEmptyFinalAnswer:
 
         adapter._agent.run_stream_events = MagicMock(
             return_value=make_raising_stream(
-                UnexpectedModelBehavior(
-                    "Exceeded maximum retries (1) for output validation"
-                ),
+                UnexpectedModelBehavior("Exceeded maximum output retries (1)"),
                 tool_result=True,
                 tool_name="band_lookup_peers",
                 tool_content=[{"id": "peer_1"}],
@@ -1240,9 +1254,7 @@ class TestEmptyFinalAnswer:
 
         adapter._agent.run_stream_events = MagicMock(
             return_value=make_raising_stream(
-                UnexpectedModelBehavior(
-                    "Exceeded maximum retries (1) for output validation"
-                ),
+                UnexpectedModelBehavior("Exceeded maximum output retries (1)"),
                 tool_result=True,
                 tool_name="band_send_message",
                 tool_content="Error sending message: no mentions",

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -336,6 +336,28 @@ class TestInitialization:
         }
         assert get_custom_tool_name(Echo) in registered
 
+    def test_create_agent_registers_unannotated_context_custom_tool(self):
+        """pydantic-ai injects an unannotated first parameter as context."""
+
+        def echo(ctx, message: str) -> str:
+            return message
+
+        adapter = PydanticAIAdapter(
+            model=TestModel(),  # type: ignore[arg-type]  # real Agent, no network
+            additional_tools=[echo],
+        )
+        adapter.agent_name = "TestBot"
+
+        agent = adapter._create_agent()
+        echo_tool = next(
+            tool
+            for toolset in agent.toolsets
+            for tool in getattr(toolset, "tools", {}).values()
+            if tool.name == "echo"
+        )
+
+        assert echo_tool.function_schema.json_schema["required"] == ["message"]
+
     async def test_unsatisfiable_output_never_reruns_a_side_effecting_tool(self):
         """One turn must post to the room exactly once, however the run ends.
 

--- a/tests/e2e/baseline/README.md
+++ b/tests/e2e/baseline/README.md
@@ -530,7 +530,8 @@ legitimate skip is `E2E_TESTS_ENABLED` (the on/off switch for the whole live sui
 `BAND_API_KEY_USER` missing while E2E is enabled **fails** (the always-on gate), and
 any `@requires(Dep.X)` requirement **fails** when absent, naming the missing env
 var/CLI/server. Consequence: no single environment turns the full adapter matrix
-green in one job (crewai needs its own venv; codex/opencode/letta need a backend) —
+green in one job (crewai needs its own venv; codex/opencode/copilot_acp/letta need a
+backend) —
 a red cell means "this backend isn't wired up", which is intended. The one
 deliberate exception is **lane scoping** (`BAND_E2E_LANE`, see CI lanes below): an
 *out-of-lane* adapter *skips with a reason* (it's covered by its own lane, so this
@@ -555,15 +556,15 @@ the `dev` extra but are split out for isolation.
 | Lane | `uv` extra | Adapters | Backend the CI job provides |
 |------|-----------|----------|------------------------------|
 | `core` | `dev` | anthropic, claude_sdk, agno, langgraph, pydantic_ai, copilot_sdk | provider keys (secrets); copilot_sdk self-downloads its CLI runtime and needs a Copilot-entitled `GITHUB_TOKEN` (BYOK inference reuses `ANTHROPIC_API_KEY`) |
-| `crewai` | `dev-crewai` | crewai, crewai_flow | provider keys; isolated venv (crewai conflicts with `dev`'s deps — `pyproject.toml [tool.uv] conflicts`) |
+| `crewai` | `dev-crewai` | crewai, crewai_flow | provider keys; isolated venv (crewai is declared conflicting with `dev`'s framework extras — `pyproject.toml [tool.uv] conflicts` — so one `uv sync` can't hold both) |
 | `google` | `dev` | gemini, google_adk | provider keys; split from `core` so Google free-tier rate-limit flakiness is isolated |
-| `backends` | `dev` | codex, opencode | the CLI/server coding agents in one job: the `codex` CLI + login + a disposable `CODEX_CWD` (+ the codex-acp e2e), and a running `opencode serve` (`OPENCODE_BASE_URL`) |
+| `backends` | `dev` | codex, opencode, copilot_acp | the CLI/server coding agents in one job: the `codex` CLI + login + a disposable `CODEX_CWD` (+ the codex-acp e2e), a running `opencode serve` (`OPENCODE_BASE_URL`), and the `copilot` CLI (`.github/scripts/setup-copilot.sh`; auth is the job-env `GITHUB_TOKEN`) |
 | `letta` | `dev` | letta | a self-hosted Letta server (docker — `.github/scripts/setup-letta.sh`); the adapter self-hosts its Band MCP server inside pytest (see "Letta lane" below). **Linux-only** (`LINUX_ONLY_LANES`) — no Windows cells |
 
-`backends` folds codex + opencode into one job (both install `dev`, differ only in
-the backend their job stands up) so a job-per-backend isn't needed; the cost is that
-one backend failing to come up can redden the other's cells (the per-adapter report
-still shows which). `google` gets its own lane so Google free-tier rate-limit
+`backends` folds codex, opencode, and copilot_acp into one job (all install `dev`,
+differing only in the CLI/server their job stands up) so a job-per-backend isn't
+needed; the cost is that one backend failing to come up can redden the others' cells
+(the per-adapter report still shows which). `google` gets its own lane so Google free-tier rate-limit
 flakiness is isolated; `letta` stands alone for the live Letta server its job stands up.
 
 **The knob:** `BAND_E2E_LANE=<lane id>`. Scheduling is *derived*: a test's lane is the

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -322,9 +322,8 @@ def _build_crewai_config() -> AdapterConfig:
 def _get_crewai_flow_adapter_cls() -> type:
     """The CrewAIFlowAdapter class for the conformance config.
 
-    Plain import, as for ``_get_crewai_adapter_cls``. The module-level
-    ``from crewai.flow.flow import Flow`` is already guarded by try/except, so it
-    binds ``Flow = None`` when crewai is absent.
+    Plain import, as for ``_get_crewai_adapter_cls``. The adapter no longer
+    imports ``Flow`` at module scope, so this remains safe when crewai is absent.
     """
     from band.adapters.crewai_flow import CrewAIFlowAdapter
 

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import functools
 import inspect
-import threading
 from dataclasses import dataclass, field
 from typing import Any, Callable
 from unittest.mock import MagicMock
@@ -103,36 +102,10 @@ def _langgraph_factory(**kw: Any) -> Any:
     return LangGraphAdapter(**kw)
 
 
-# Without crewai installed, the CrewAI conformance instance is backed by mocks and
-# is ONLY safe for inspecting primitive attributes (model, role, etc.) and calling
-# on_cleanup (which only does dict.pop + logging, no CrewAI interaction) — the
-# methods that touch CrewAI objects (on_message, _invoke_crew) are guarded. In the
-# dev-crewai venv the class is imported for real and needs no guarding.
+# The CrewAI conformance instance is config-only: safe for inspecting primitive
+# attributes (model, role, etc.) and on_cleanup, never for runtime work — the
+# factories below guard the methods that would build a Crew or hit an LLM.
 # For runtime tests, use monkeypatch fixtures in tests/adapters/test_crewai_adapter.py.
-
-
-class _MockBaseTool:
-    """Minimal stand-in for ``crewai.tools.BaseTool`` at import time."""
-
-    name: str = ""
-    description: str = ""
-
-    def __init__(self):
-        pass
-
-
-_crewai_import_lock = threading.Lock()
-
-
-_CREWAI_AFFECTED_MODULES = (
-    "band.adapters.crewai",
-    "band.integrations.crewai",
-    "band.integrations.crewai.runtime",
-    "band.integrations.crewai.tools",
-    "crewai",
-    "crewai.tools",
-    "nest_asyncio",
-)
 
 
 def _crewai_installed() -> bool:
@@ -144,84 +117,19 @@ def _crewai_installed() -> bool:
     return True
 
 
-@functools.lru_cache(maxsize=1)
 def _get_crewai_adapter_cls() -> type:
     """The CrewAIAdapter class for the conformance config.
 
-    With crewai installed, import it for real. The mocked import below restores
-    ``sys.modules`` by *removing* the band.integrations.crewai tree it pulled in,
-    which leaves the tool models unable to resolve their own annotations later:
-    pydantic defers those forward refs and looks the defining module up by name at
-    first instantiation, so ``on_started`` then dies with "`SendMessageTool` is not
-    fully defined". It only appeared to work when some other test happened to
-    re-import the real module first.
+    A plain import: every crewai import in the adapter is TYPE_CHECKING-only or
+    function-local, so the module loads and the class constructs with crewai
+    absent. (This used to import under mocked crewai modules and then evict the
+    band.integrations.crewai tree from ``sys.modules``, which left the tool models
+    unable to resolve their own annotations — pydantic looks the defining module up
+    by name — so ``on_started`` died with "`SendMessageTool` is not fully defined".)
     """
-    if _crewai_installed():
-        import importlib
+    from band.adapters.crewai import CrewAIAdapter
 
-        return importlib.import_module("band.adapters.crewai").CrewAIAdapter
-    return _import_crewai_adapter_with_mocks()
-
-
-def _import_crewai_adapter_with_mocks() -> type:
-    """Import CrewAIAdapter with mocked crewai dependencies.
-
-    For the venvs without crewai: uses ``patch.dict(sys.modules, ...)`` to
-    temporarily inject mock modules, imports the adapter, then cleans up. The
-    returned class retains mock references in its module globals — safe for
-    attribute inspection only, which is why the config skips every runtime path
-    (``skip_on_started_conformance``) when crewai is absent.
-
-    Cached so the heavy sys.modules teardown/reimport happens at most once.
-    Protected by ``_crewai_import_lock`` so concurrent pytest-xdist workers
-    cannot interleave the ``sys.modules`` snapshot / restore sequence.
-
-    **Save/restore semantics**: any modules that were already in
-    ``sys.modules`` before this function runs are restored afterwards,
-    preventing ordering-dependent failures when framework-specific tests
-    (which do their own mocking) import the real adapter module first.
-    """
-    import importlib
-    import sys
-    from unittest.mock import patch
-
-    adapter_module_name = "band.adapters.crewai"
-
-    with _crewai_import_lock:
-        # Snapshot modules that existed before we touch sys.modules.
-        saved: dict[str, Any] = {}
-        _sentinel = object()
-        for mod in _CREWAI_AFFECTED_MODULES:
-            prev = sys.modules.get(mod, _sentinel)
-            if prev is not _sentinel:
-                saved[mod] = prev
-            sys.modules.pop(mod, None)
-
-        mock_crewai = MagicMock()
-        mock_crewai.Agent = MagicMock()
-        mock_crewai.LLM = MagicMock()
-        mock_crewai_tools = MagicMock()
-        mock_crewai_tools.BaseTool = _MockBaseTool
-
-        mock_entries = {
-            "crewai": mock_crewai,
-            "crewai.tools": mock_crewai_tools,
-            "nest_asyncio": MagicMock(),
-        }
-
-        with patch.dict(sys.modules, mock_entries):
-            cls = importlib.import_module(adapter_module_name).CrewAIAdapter
-
-        # Restore pre-existing modules so framework-specific tests that
-        # already imported the real adapter/crewai are not disrupted.
-        # Modules that were absent before are removed (clean state).
-        for mod in _CREWAI_AFFECTED_MODULES:
-            if mod in saved:
-                sys.modules[mod] = saved[mod]
-            else:
-                sys.modules.pop(mod, None)
-
-    return cls
+    return CrewAIAdapter
 
 
 async def _crewai_conformance_guard(*_args: Any, **_kw: Any) -> None:
@@ -414,77 +322,16 @@ def _build_crewai_config() -> AdapterConfig:
     )
 
 
-@functools.lru_cache(maxsize=1)
 def _get_crewai_flow_adapter_cls() -> type:
     """The CrewAIFlowAdapter class for the conformance config.
 
-    Real import when crewai is installed, for the same reason as
-    ``_get_crewai_adapter_cls``: the mocked import takes the
-    band.integrations.crewai tree back out of ``sys.modules`` and breaks the tool
-    models' deferred annotation resolution.
+    Plain import, as for ``_get_crewai_adapter_cls``. The module-level
+    ``from crewai.flow.flow import Flow`` is already guarded by try/except, so it
+    binds ``Flow = None`` when crewai is absent.
     """
-    if _crewai_installed():
-        import importlib
+    from band.adapters.crewai_flow import CrewAIFlowAdapter
 
-        return importlib.import_module("band.adapters.crewai_flow").CrewAIFlowAdapter
-    return _import_crewai_flow_adapter_with_mocks()
-
-
-def _import_crewai_flow_adapter_with_mocks() -> type:
-    """Import CrewAIFlowAdapter with mocked crewai dependencies.
-
-    The flow adapter has its own optional crewai.flow.flow import. The
-    integration tools module (used by build_band_crewai_tools when a
-    sub-Crew is constructed at runtime) imports crewai.tools, so the same
-    mock pattern as ``_import_crewai_adapter_with_mocks`` is reused.
-    """
-    import importlib
-    import sys
-    from unittest.mock import patch
-
-    adapter_module_name = "band.adapters.crewai_flow"
-    affected = _CREWAI_AFFECTED_MODULES + (
-        adapter_module_name,
-        "band.integrations.crewai",
-        "band.integrations.crewai.runtime",
-        "band.integrations.crewai.tools",
-    )
-
-    with _crewai_import_lock:
-        saved: dict[str, Any] = {}
-        _sentinel = object()
-        for mod in affected:
-            prev = sys.modules.get(mod, _sentinel)
-            if prev is not _sentinel:
-                saved[mod] = prev
-            sys.modules.pop(mod, None)
-
-        mock_crewai = MagicMock()
-        mock_crewai.Agent = MagicMock()
-        mock_crewai.LLM = MagicMock()
-        mock_crewai_tools = MagicMock()
-        mock_crewai_tools.BaseTool = _MockBaseTool
-        mock_flow_module = MagicMock()
-        mock_flow_module.Flow = type("Flow", (), {})
-
-        mock_entries = {
-            "crewai": mock_crewai,
-            "crewai.tools": mock_crewai_tools,
-            "crewai.flow": MagicMock(flow=mock_flow_module),
-            "crewai.flow.flow": mock_flow_module,
-            "nest_asyncio": MagicMock(),
-        }
-
-        with patch.dict(sys.modules, mock_entries):
-            cls = importlib.import_module(adapter_module_name).CrewAIFlowAdapter
-
-        for mod in affected:
-            if mod in saved:
-                sys.modules[mod] = saved[mod]
-            else:
-                sys.modules.pop(mod, None)
-
-    return cls
+    return CrewAIFlowAdapter
 
 
 def _crewai_flow_factory(**kw: Any) -> Any:

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -103,11 +103,11 @@ def _langgraph_factory(**kw: Any) -> Any:
     return LangGraphAdapter(**kw)
 
 
-# CrewAI conformance instances are ONLY safe for inspecting primitive
-# attributes (model, role, etc.) and calling on_cleanup (which only does
-# dict.pop + logging, no CrewAI interaction).  Runtime methods that interact
-# with CrewAI objects (on_message, _invoke_crew) are guarded because the
-# class is imported with mocked crewai dependencies.
+# Without crewai installed, the CrewAI conformance instance is backed by mocks and
+# is ONLY safe for inspecting primitive attributes (model, role, etc.) and calling
+# on_cleanup (which only does dict.pop + logging, no CrewAI interaction) — the
+# methods that touch CrewAI objects (on_message, _invoke_crew) are guarded. In the
+# dev-crewai venv the class is imported for real and needs no guarding.
 # For runtime tests, use monkeypatch fixtures in tests/adapters/test_crewai_adapter.py.
 
 
@@ -135,13 +135,42 @@ _CREWAI_AFFECTED_MODULES = (
 )
 
 
+def _crewai_installed() -> bool:
+    """Whether the real crewai package is importable (the dev-crewai venv)."""
+    try:
+        import crewai  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 @functools.lru_cache(maxsize=1)
 def _get_crewai_adapter_cls() -> type:
+    """The CrewAIAdapter class for the conformance config.
+
+    With crewai installed, import it for real. The mocked import below restores
+    ``sys.modules`` by *removing* the band.integrations.crewai tree it pulled in,
+    which leaves the tool models unable to resolve their own annotations later:
+    pydantic defers those forward refs and looks the defining module up by name at
+    first instantiation, so ``on_started`` then dies with "`SendMessageTool` is not
+    fully defined". It only appeared to work when some other test happened to
+    re-import the real module first.
+    """
+    if _crewai_installed():
+        import importlib
+
+        return importlib.import_module("band.adapters.crewai").CrewAIAdapter
+    return _import_crewai_adapter_with_mocks()
+
+
+def _import_crewai_adapter_with_mocks() -> type:
     """Import CrewAIAdapter with mocked crewai dependencies.
 
-    Uses ``patch.dict(sys.modules, ...)`` to temporarily inject mock modules,
-    imports the adapter, then cleans up.  The returned class retains mock
-    references in its module globals — safe for attribute inspection only.
+    For the venvs without crewai: uses ``patch.dict(sys.modules, ...)`` to
+    temporarily inject mock modules, imports the adapter, then cleans up. The
+    returned class retains mock references in its module globals — safe for
+    attribute inspection only, which is why the config skips every runtime path
+    (``skip_on_started_conformance``) when crewai is absent.
 
     Cached so the heavy sys.modules teardown/reimport happens at most once.
     Protected by ``_crewai_import_lock`` so concurrent pytest-xdist workers
@@ -192,28 +221,23 @@ def _get_crewai_adapter_cls() -> type:
             else:
                 sys.modules.pop(mod, None)
 
-    # Mark the class as conformance-only so accidental runtime use is detectable.
-    cls._CONFORMANCE_ONLY = True
     return cls
 
 
 async def _crewai_conformance_guard(*_args: Any, **_kw: Any) -> None:
     raise RuntimeError(
-        "CrewAI conformance instance has mocked dependencies — "
+        "CrewAI conformance instance is config-only — "
         "use tests/adapters/test_crewai_adapter.py fixtures for runtime tests."
     )
 
 
 def _crewai_factory(**kw: Any) -> Any:
     cls = _get_crewai_adapter_cls()
-    assert getattr(cls, "_CONFORMANCE_ONLY", False), (
-        "CrewAI adapter used here is for conformance config only; "
-        "use tests/adapters/test_crewai_adapter.py fixtures for runtime tests."
-    )
     instance = cls(**kw)
-    # Guard runtime methods that would silently operate on MagicMock objects.
-    # on_cleanup is intentionally NOT guarded — it only does dict.pop + logging
-    # and does not interact with CrewAI objects.
+    # Guard the runtime methods unconditionally: mock-backed they would silently
+    # operate on MagicMocks, and real-backed they would build a Crew and call an
+    # LLM for real. on_cleanup is intentionally never guarded (dict.pop + logging,
+    # no CrewAI interaction).
     for method_name in ("on_message", "_invoke_crew"):
         if hasattr(instance, method_name):
             setattr(instance, method_name, _crewai_conformance_guard)
@@ -347,13 +371,7 @@ def _build_langgraph_config() -> AdapterConfig:
 
 def _build_crewai_config() -> AdapterConfig:
     crewai_cls = _get_crewai_adapter_cls()
-
-    try:
-        import crewai  # noqa: F401
-
-        _crewai_available = True
-    except ImportError:
-        _crewai_available = False
+    _crewai_available = _crewai_installed()
 
     return AdapterConfig(
         framework_id="crewai",
@@ -398,12 +416,27 @@ def _build_crewai_config() -> AdapterConfig:
 
 @functools.lru_cache(maxsize=1)
 def _get_crewai_flow_adapter_cls() -> type:
+    """The CrewAIFlowAdapter class for the conformance config.
+
+    Real import when crewai is installed, for the same reason as
+    ``_get_crewai_adapter_cls``: the mocked import takes the
+    band.integrations.crewai tree back out of ``sys.modules`` and breaks the tool
+    models' deferred annotation resolution.
+    """
+    if _crewai_installed():
+        import importlib
+
+        return importlib.import_module("band.adapters.crewai_flow").CrewAIFlowAdapter
+    return _import_crewai_flow_adapter_with_mocks()
+
+
+def _import_crewai_flow_adapter_with_mocks() -> type:
     """Import CrewAIFlowAdapter with mocked crewai dependencies.
 
     The flow adapter has its own optional crewai.flow.flow import. The
     integration tools module (used by build_band_crewai_tools when a
     sub-Crew is constructed at runtime) imports crewai.tools, so the same
-    mock pattern as ``_get_crewai_adapter_cls`` is reused.
+    mock pattern as ``_import_crewai_adapter_with_mocks`` is reused.
     """
     import importlib
     import sys
@@ -451,7 +484,6 @@ def _get_crewai_flow_adapter_cls() -> type:
             else:
                 sys.modules.pop(mod, None)
 
-    cls._CONFORMANCE_ONLY = True
     return cls
 
 
@@ -463,7 +495,7 @@ def _crewai_flow_factory(**kw: Any) -> Any:
 
     async def _guard(*_a: Any, **_k: Any) -> None:
         raise RuntimeError(
-            "CrewAIFlow conformance instance has mocked dependencies — "
+            "CrewAIFlow conformance instance is config-only — "
             "use tests/adapters/test_crewai_flow_*.py fixtures for runtime tests."
         )
 

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -120,12 +120,10 @@ def _crewai_installed() -> bool:
 def _get_crewai_adapter_cls() -> type:
     """The CrewAIAdapter class for the conformance config.
 
-    A plain import: every crewai import in the adapter is TYPE_CHECKING-only or
-    function-local, so the module loads and the class constructs with crewai
-    absent. (This used to import under mocked crewai modules and then evict the
-    band.integrations.crewai tree from ``sys.modules``, which left the tool models
-    unable to resolve their own annotations — pydantic looks the defining module up
-    by name — so ``on_started`` died with "`SendMessageTool` is not fully defined".)
+    A plain import needs no crewai: every crewai import in the adapter is
+    TYPE_CHECKING-only or function-local, so the module loads and the class
+    constructs with the package absent. Do not fake crewai through ``sys.modules``
+    to get here — see ``tests/test_module_isolation.py`` for what that costs.
     """
     from band.adapters.crewai import CrewAIAdapter
 
@@ -142,10 +140,9 @@ async def _crewai_conformance_guard(*_args: Any, **_kw: Any) -> None:
 def _crewai_factory(**kw: Any) -> Any:
     cls = _get_crewai_adapter_cls()
     instance = cls(**kw)
-    # Guard the runtime methods unconditionally: mock-backed they would silently
-    # operate on MagicMocks, and real-backed they would build a Crew and call an
-    # LLM for real. on_cleanup is intentionally never guarded (dict.pop + logging,
-    # no CrewAI interaction).
+    # Guard the runtime methods in both venvs: without crewai they would fail on its
+    # function-local import, and with it they would build a Crew and call an LLM for
+    # real. on_cleanup is never guarded (dict.pop + logging, no CrewAI interaction).
     for method_name in ("on_message", "_invoke_crew"):
         if hasattr(instance, method_name):
             setattr(instance, method_name, _crewai_conformance_guard)

--- a/tests/framework_configs/sentinel.py
+++ b/tests/framework_configs/sentinel.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from os import environ
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class MissingSentinel:
@@ -16,10 +16,31 @@ class MissingSentinel:
 
 MISSING = MissingSentinel()
 
-IN_CI = bool(environ.get("CI") or environ.get("GITHUB_ACTIONS"))
+
+class StrictnessSettings(BaseSettings):
+    """Env switches deciding whether a missing framework is fatal.
+
+    Parsed as booleans, not merely tested for presence: CI passes the opt-out
+    per matrix cell, so the disabled cells send ``BAND_ALLOW_MISSING_FRAMEWORKS=0``
+    — which a presence check reads as "opt out" and silently disables strictness
+    everywhere.
+    """
+
+    model_config = SettingsConfigDict(
+        extra="ignore", case_sensitive=False, env_ignore_empty=True
+    )
+
+    ci: bool = False
+    github_actions: bool = False
+    band_allow_missing_frameworks: bool = False
+
+
+_strictness = StrictnessSettings()
+
+IN_CI = _strictness.ci or _strictness.github_actions
 
 # Strict CI mode: framework config builders raise on import failure instead of
 # warning. Opt out via BAND_ALLOW_MISSING_FRAMEWORKS=1 for partial-deps CI
 # environments (e.g. the dev-crewai matrix job, which only has crewai
 # installed and cannot import langgraph/anthropic/parlant/pydantic-ai/etc.).
-STRICT_CI = IN_CI and not environ.get("BAND_ALLOW_MISSING_FRAMEWORKS")
+STRICT_CI = IN_CI and not _strictness.band_allow_missing_frameworks

--- a/tests/framework_configs/sentinel.py
+++ b/tests/framework_configs/sentinel.py
@@ -20,10 +20,10 @@ MISSING = MissingSentinel()
 class StrictnessSettings(BaseSettings):
     """Env switches deciding whether a missing framework is fatal.
 
-    Parsed as booleans, not merely tested for presence: CI passes the opt-out
-    per matrix cell, so the disabled cells send ``BAND_ALLOW_MISSING_FRAMEWORKS=0``
-    — which a presence check reads as "opt out" and silently disables strictness
-    everywhere.
+    Parsed as booleans, not merely tested for presence: CI sets the opt-out
+    explicitly per matrix cell, so a cell that wants strictness sends
+    ``BAND_ALLOW_MISSING_FRAMEWORKS=0`` — which a presence check would read as
+    "opt out" and silently turn strictness off.
     """
 
     model_config = SettingsConfigDict(

--- a/tests/framework_conformance/test_config_drift.py
+++ b/tests/framework_conformance/test_config_drift.py
@@ -119,7 +119,9 @@ class TestCrewAIConformanceGuards:
     """Verify that CrewAI conformance instances guard runtime methods.
 
     If the guard loop in ``_crewai_factory`` is accidentally removed, these
-    tests will fail — preventing silent execution on MagicMock objects.
+    tests fail: a conformance instance would then either operate silently on
+    MagicMocks (no crewai installed) or build a Crew and call an LLM for real
+    (dev-crewai venv).
     """
 
     @staticmethod

--- a/tests/framework_conformance/test_crewai_job_coverage.py
+++ b/tests/framework_conformance/test_crewai_job_coverage.py
@@ -3,18 +3,19 @@
 crewai lives in its own venv (`dev-crewai`), which cannot import the other
 frameworks — so the crewai CI job cannot just run `pytest`, it names the test
 files one by one. That list is the only thing standing between a crewai test and
-never running anywhere: the default `test` job skips crewai tests (crewai absent)
-and the crewai job only collects what the list names. A file dropped from it goes
-silently uncovered, which is exactly what happened to the crewai cases in
-`test_capability_gating_e2e.py`.
+never running anywhere: the default `test` job skips whatever needs the
+crewai-only deps, and the crewai job only collects what the list names. A file
+dropped from it goes silently uncovered, which is what happened to the crewai
+cases in `test_capability_gating_e2e.py`.
 
-So derive the set that *needs* the crewai venv from the tests themselves and
-assert the workflow covers every one.
+So derive the set that *needs* the crewai venv from the tests themselves — via
+the deps only that venv has — and assert the workflow covers every one.
 """
 
 from __future__ import annotations
 
 import re
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -25,25 +26,54 @@ from tests.paths import REPO_ROOT
 _CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
 _TESTS_ROOT = REPO_ROOT / "tests"
 
-# A test file needs crewai installed if it imports crewai for real (directly or
-# behind an availability probe). Filename is not the signal — the miss this guard
-# exists for was a file with no "crewai" in its name.
-_NEEDS_CREWAI = re.compile(
-    r"^\s*(?:import|from)\s+crewai\b|importorskip\(\s*[\"']crewai", re.MULTILINE
-)
+# Import names of the distributions only `dev-crewai` installs. Kept as a map so
+# the drift test below can prove it still matches pyproject: a new dev-crewai-only
+# dep fails there rather than silently narrowing what this guard detects.
+_CREWAI_ONLY_MODULES = {
+    "crewai": "crewai",
+    "nest-asyncio": "nest_asyncio",
+    "pillow": "PIL",
+}
 
 
-def _crewai_test_files() -> set[Path]:
-    """Repo-relative unit-test files that import crewai.
+def _needs_crewai_venv() -> re.Pattern[str]:
+    """Match a real (non-TYPE_CHECKING) use of a crewai-venv-only module.
+
+    Filename is not the signal — most crewai test files fake the package through
+    ``sys.modules`` and run fine in `dev`, while the miss this guard exists for
+    was a file with no "crewai" in its name at all.
+    """
+    names = "|".join(sorted(_CREWAI_ONLY_MODULES.values()))
+    return re.compile(
+        rf"^\s*(?:import|from)\s+(?:{names})\b|importorskip\(\s*[\"'](?:{names})",
+        re.MULTILINE,
+    )
+
+
+def _crewai_only_distributions() -> set[str]:
+    """Distributions in the `dev-crewai` extra that `dev` does not install."""
+    extras = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
+        "project"
+    ]["optional-dependencies"]
+
+    def name(requirement: str) -> str:
+        return re.split(r"[<>=!\[;]", requirement, maxsplit=1)[0].strip()
+
+    return {name(r) for r in extras["dev-crewai"]} - {name(r) for r in extras["dev"]}
+
+
+def _tests_needing_crewai_venv() -> set[Path]:
+    """Repo-relative unit-test files that only the crewai venv can run.
 
     `tests/e2e/**` is excluded: those run from the e2e workflow's own crewai lane,
     not this job.
     """
+    pattern = _needs_crewai_venv()
     return {
         path.relative_to(REPO_ROOT)
         for path in _TESTS_ROOT.rglob("test_*.py")
         if "e2e" not in path.relative_to(_TESTS_ROOT).parts
-        and _NEEDS_CREWAI.search(path.read_text(encoding="utf-8"))
+        and pattern.search(path.read_text(encoding="utf-8"))
     }
 
 
@@ -63,18 +93,16 @@ def _crewai_job_paths() -> set[Path]:
 
 def _covered_by(target: Path, listed: set[Path]) -> bool:
     """Whether ``target`` is named outright or sits under a listed directory."""
-    return target in listed or any(
-        parent in listed for parent in (target, *target.parents)
-    )
+    return any(parent in listed for parent in (target, *target.parents))
 
 
-def test_crewai_job_runs_every_test_that_imports_crewai() -> None:
-    needed = _crewai_test_files()
+def test_crewai_job_runs_every_test_that_needs_its_venv() -> None:
+    needed = _tests_needing_crewai_venv()
     listed = _crewai_job_paths()
     missing = sorted(str(path) for path in needed if not _covered_by(path, listed))
     assert not missing, (
-        "these test files import crewai but ci.yml's crewai job never collects "
-        f"them, so they run nowhere: {missing}"
+        "these test files need a dev-crewai-only dependency but ci.yml's crewai "
+        f"job never collects them, so they run nowhere: {missing}"
     )
 
 
@@ -87,16 +115,26 @@ def test_crewai_job_paths_all_exist() -> None:
     assert not stale, f"ci.yml's crewai job lists paths that no longer exist: {stale}"
 
 
-def test_crewai_detection_finds_the_real_importers() -> None:
-    """Guard the guard: if the import regex drifts, the tests above pass empty.
+def test_crewai_only_dependency_set_matches_pyproject() -> None:
+    """The detected module set is derived from a real dep list, not a guess."""
+    assert _crewai_only_distributions() == set(_CREWAI_ONLY_MODULES), (
+        "the dev-crewai-only dependencies changed; update _CREWAI_ONLY_MODULES so "
+        "this guard still detects every test that needs that venv"
+    )
 
-    Most crewai test files fake the package through ``sys.modules`` and run in
-    either venv (the default `test` job covers them). Only these two need crewai
-    installed, which makes them the canary for the detection.
+
+def test_detection_finds_the_tests_that_only_the_crewai_venv_can_run() -> None:
+    """Guard the guard: if the pattern drifts, the tests above pass empty.
+
+    These three are the whole set today — `phase3` for its nest_asyncio cases,
+    the others for importing crewai itself.
     """
-    needed = _crewai_test_files()
-    assert Path("tests/test_capability_gating_e2e.py") in needed
-    assert Path("tests/integrations/test_crewai_flow_real_sdk.py") in needed
+    needed = _tests_needing_crewai_venv()
+    assert needed == {
+        Path("tests/adapters/test_crewai_flow_phase3.py"),
+        Path("tests/integrations/test_crewai_flow_real_sdk.py"),
+        Path("tests/test_capability_gating_e2e.py"),
+    }
 
 
 @pytest.mark.parametrize("flag", ["1", "0", ""])

--- a/tests/framework_conformance/test_crewai_job_coverage.py
+++ b/tests/framework_conformance/test_crewai_job_coverage.py
@@ -126,13 +126,14 @@ def test_crewai_only_dependency_set_matches_pyproject() -> None:
 def test_detection_finds_the_tests_that_only_the_crewai_venv_can_run() -> None:
     """Guard the guard: if the pattern drifts, the tests above pass empty.
 
-    These three are the whole set today — `phase3` for its nest_asyncio cases,
-    the others for importing crewai itself.
+    These are the whole set today — `phase3` for its nest_asyncio cases, the rest
+    for importing crewai itself.
     """
     needed = _tests_needing_crewai_venv()
     assert needed == {
         Path("tests/adapters/test_crewai_flow_phase3.py"),
         Path("tests/integrations/test_crewai_flow_real_sdk.py"),
+        Path("tests/integrations/test_crewai_real_tools.py"),
         Path("tests/test_capability_gating_e2e.py"),
     }
 

--- a/tests/framework_conformance/test_crewai_job_coverage.py
+++ b/tests/framework_conformance/test_crewai_job_coverage.py
@@ -1,0 +1,119 @@
+"""Guard against drift in ci.yml's hand-listed crewai test paths.
+
+crewai lives in its own venv (`dev-crewai`), which cannot import the other
+frameworks — so the crewai CI job cannot just run `pytest`, it names the test
+files one by one. That list is the only thing standing between a crewai test and
+never running anywhere: the default `test` job skips crewai tests (crewai absent)
+and the crewai job only collects what the list names. A file dropped from it goes
+silently uncovered, which is exactly what happened to the crewai cases in
+`test_capability_gating_e2e.py`.
+
+So derive the set that *needs* the crewai venv from the tests themselves and
+assert the workflow covers every one.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.paths import REPO_ROOT
+
+_CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
+_TESTS_ROOT = REPO_ROOT / "tests"
+
+# A test file needs crewai installed if it imports crewai for real (directly or
+# behind an availability probe). Filename is not the signal — the miss this guard
+# exists for was a file with no "crewai" in its name.
+_NEEDS_CREWAI = re.compile(
+    r"^\s*(?:import|from)\s+crewai\b|importorskip\(\s*[\"']crewai", re.MULTILINE
+)
+
+
+def _crewai_test_files() -> set[Path]:
+    """Repo-relative unit-test files that import crewai.
+
+    `tests/e2e/**` is excluded: those run from the e2e workflow's own crewai lane,
+    not this job.
+    """
+    return {
+        path.relative_to(REPO_ROOT)
+        for path in _TESTS_ROOT.rglob("test_*.py")
+        if "e2e" not in path.relative_to(_TESTS_ROOT).parts
+        and _NEEDS_CREWAI.search(path.read_text(encoding="utf-8"))
+    }
+
+
+def _crewai_job_paths() -> set[Path]:
+    """The pytest targets of ci.yml's crewai test step."""
+    workflow = yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["test-crewai"]["steps"]
+    command = next(
+        step["run"] for step in steps if step.get("name") == "Run crewai tests"
+    )
+    return {
+        Path(token)
+        for token in command.replace("\\\n", " ").split()
+        if token.startswith("tests/")
+    }
+
+
+def _covered_by(target: Path, listed: set[Path]) -> bool:
+    """Whether ``target`` is named outright or sits under a listed directory."""
+    return target in listed or any(
+        parent in listed for parent in (target, *target.parents)
+    )
+
+
+def test_crewai_job_runs_every_test_that_imports_crewai() -> None:
+    needed = _crewai_test_files()
+    listed = _crewai_job_paths()
+    missing = sorted(str(path) for path in needed if not _covered_by(path, listed))
+    assert not missing, (
+        "these test files import crewai but ci.yml's crewai job never collects "
+        f"them, so they run nowhere: {missing}"
+    )
+
+
+def test_crewai_job_paths_all_exist() -> None:
+    """The other drift direction: a listed path that was renamed or deleted is a
+    silently empty target, since pytest is given the whole list at once."""
+    stale = sorted(
+        str(path) for path in _crewai_job_paths() if not (REPO_ROOT / path).exists()
+    )
+    assert not stale, f"ci.yml's crewai job lists paths that no longer exist: {stale}"
+
+
+def test_crewai_detection_finds_the_real_importers() -> None:
+    """Guard the guard: if the import regex drifts, the tests above pass empty.
+
+    Most crewai test files fake the package through ``sys.modules`` and run in
+    either venv (the default `test` job covers them). Only these two need crewai
+    installed, which makes them the canary for the detection.
+    """
+    needed = _crewai_test_files()
+    assert Path("tests/test_capability_gating_e2e.py") in needed
+    assert Path("tests/integrations/test_crewai_flow_real_sdk.py") in needed
+
+
+@pytest.mark.parametrize("flag", ["1", "0", ""])
+def test_missing_framework_optout_is_parsed_as_a_boolean(
+    flag: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``BAND_ALLOW_MISSING_FRAMEWORKS=0`` must keep strict mode ON.
+
+    e2e.yml sets the flag per matrix cell and sends "0" for the lanes that should
+    stay strict; a presence check would read that as an opt-out and disable the
+    fail-loud framework-config guard for every lane.
+    """
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("BAND_ALLOW_MISSING_FRAMEWORKS", flag)
+
+    from tests.framework_configs.sentinel import StrictnessSettings
+
+    settings = StrictnessSettings()
+    strict = settings.ci and not settings.band_allow_missing_frameworks
+    assert strict is (flag != "1")

--- a/tests/framework_conformance/test_crewai_job_coverage.py
+++ b/tests/framework_conformance/test_crewai_job_coverage.py
@@ -144,9 +144,10 @@ def test_missing_framework_optout_is_parsed_as_a_boolean(
 ) -> None:
     """``BAND_ALLOW_MISSING_FRAMEWORKS=0`` must keep strict mode ON.
 
-    e2e.yml sets the flag per matrix cell and sends "0" for the lanes that should
-    stay strict; a presence check would read that as an opt-out and disable the
-    fail-loud framework-config guard for every lane.
+    The flag is set explicitly rather than conditionally: e2e.yml sends "0" for every
+    lane that should stay strict, and only ci.yml's crewai job sends "1". A presence
+    check reads that "0" as an opt-out — so the value has to be parsed as a boolean,
+    or a cell asking to stay strict silently disables the fail-loud guard instead.
     """
     monkeypatch.setenv("CI", "true")
     monkeypatch.setenv("BAND_ALLOW_MISSING_FRAMEWORKS", flag)

--- a/tests/integrations/test_crewai_real_tools.py
+++ b/tests/integrations/test_crewai_real_tools.py
@@ -1,0 +1,62 @@
+"""Platform tools built against the *real* crewai package.
+
+Every other crewai test fakes `crewai.tools.BaseTool`, so none of them exercise the
+pydantic model that a real `BaseTool` subclass actually is. That gap hid a failure
+where building the tools raised
+``PydanticUserError: `SendMessageTool` is not fully defined``.
+
+Needs the dev-crewai venv:
+    uv sync --extra dev-crewai
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("crewai", reason="crewai not installed (band-sdk[crewai])")
+
+from band.core.types import AdapterFeatures  # noqa: E402
+from band.integrations.crewai.tools import (  # noqa: E402
+    NoopReporter,
+    build_band_crewai_tools,
+)
+
+EXPECTED_BASE_TOOLS = 7
+
+
+def _build() -> list[Any]:
+    return build_band_crewai_tools(
+        get_context=lambda: None,
+        reporter=NoopReporter(),
+        features=AdapterFeatures(),
+    )
+
+
+def test_platform_tools_build_against_the_real_base_tool() -> None:
+    """The tool models resolve their annotations and instantiate."""
+    tools = _build()
+
+    assert len(tools) == EXPECTED_BASE_TOOLS
+    assert "band_send_message" in {tool.name for tool in tools}
+
+
+def test_a_mocked_crewai_window_does_not_poison_a_later_real_build() -> None:
+    """Faking crewai for one test must leave the next one a working real package.
+
+    The regression this guards: tests that mocked crewai also evicted the
+    band.integrations.crewai modules and never restored them, after which the tool
+    models could no longer resolve their annotations — pydantic resolves them through
+    ``cls.__module__``, and that name no longer pointed at a live module.
+    """
+    fake_tools = MagicMock()
+    fake_tools.BaseTool = type("BaseTool", (), {})
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setitem(sys.modules, "crewai.tools", fake_tools)
+        assert len(_build()) == EXPECTED_BASE_TOOLS
+
+    assert len(_build()) == EXPECTED_BASE_TOOLS

--- a/tests/integrations/test_crewai_tools.py
+++ b/tests/integrations/test_crewai_tools.py
@@ -8,6 +8,7 @@ both consume.
 
 from __future__ import annotations
 
+import importlib
 import json
 import sys
 from unittest.mock import AsyncMock, MagicMock
@@ -31,25 +32,18 @@ def crewai_mocks(monkeypatch):
     mock_crewai_tools_module.BaseTool = MockBaseTool
     mock_nest_asyncio = MagicMock()
 
-    for mod in (
-        "band.integrations.crewai",
-        "band.integrations.crewai.runtime",
-        "band.integrations.crewai.tools",
-    ):
-        sys.modules.pop(mod, None)
+    # `_nest_asyncio_applied` is process-global. Any test running with a mocked
+    # nest_asyncio can flip it True without anything actually being patched, which
+    # then silently disables the real patch for every later test — so isolate it.
+    runtime = importlib.import_module("band.integrations.crewai.runtime")
+    monkeypatch.setattr(runtime, "_nest_asyncio_applied", False)
 
+    # No sys.modules surgery: every crewai import in the band modules is
+    # TYPE_CHECKING-only or function-local, so they pick the mocks up at call time.
     monkeypatch.setitem(sys.modules, "crewai.tools", mock_crewai_tools_module)
     monkeypatch.setitem(sys.modules, "nest_asyncio", mock_nest_asyncio)
 
-    try:
-        yield mock_nest_asyncio
-    finally:
-        for mod in (
-            "band.integrations.crewai",
-            "band.integrations.crewai.runtime",
-            "band.integrations.crewai.tools",
-        ):
-            sys.modules.pop(mod, None)
+    yield mock_nest_asyncio
 
 
 @pytest.fixture

--- a/tests/test_module_isolation.py
+++ b/tests/test_module_isolation.py
@@ -1,0 +1,50 @@
+"""Guard the one test convention whose breach is invisible: sys.modules surgery.
+
+Evicting a module from ``sys.modules`` does not undo an import — the module object
+lives on in every class and function already taken from it, but its name no longer
+resolves. Pydantic looks a model's namespace up through ``cls.__module__``, so a
+model class from an evicted module can no longer resolve its own annotations, and
+building it fails with "... is not fully defined; you should define <name>". The
+crewai tool models hit exactly that: four test modules evicted
+``band.integrations.crewai.*`` and never restored it, so a later test that used the
+real package died — but only when it happened to run after one of them, which is
+why CI stayed green for so long.
+
+``monkeypatch.setitem`` and ``patch.dict(sys.modules, ...)`` both restore what they
+replaced, so there is no reason for a test to reach for a raw pop.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tests.paths import REPO_ROOT
+
+_TESTS_ROOT = REPO_ROOT / "tests"
+
+# This file is exempt: it carries the pattern below as data to match against.
+_THIS_FILE = Path(__file__).resolve()
+
+_RAW_EVICTION = re.compile(r"sys\.modules\.pop\(|del\s+sys\.modules\[")
+
+
+def test_no_test_evicts_modules_from_sys_modules() -> None:
+    offenders = sorted(
+        str(path.relative_to(REPO_ROOT))
+        for path in _TESTS_ROOT.rglob("test_*.py")
+        if path.resolve() != _THIS_FILE
+        and _RAW_EVICTION.search(path.read_text(encoding="utf-8"))
+    )
+    assert not offenders, (
+        "these tests evict modules from sys.modules without restoring them, which "
+        "breaks annotation resolution for anything that later imports the module "
+        f"for real — use monkeypatch.setitem or patch.dict instead: {offenders}"
+    )
+
+
+def test_the_guard_can_actually_see_an_eviction() -> None:
+    """Guard the guard: a pattern that stops matching would pass vacuously."""
+    assert _RAW_EVICTION.search('sys.modules.pop("band.adapters.crewai", None)')
+    assert _RAW_EVICTION.search("del sys.modules[name]")
+    assert not _RAW_EVICTION.search('monkeypatch.setitem(sys.modules, "crewai", m)')

--- a/tests/test_module_isolation.py
+++ b/tests/test_module_isolation.py
@@ -5,10 +5,10 @@ lives on in every class and function already taken from it, but its name no long
 resolves. Pydantic looks a model's namespace up through ``cls.__module__``, so a
 model class from an evicted module can no longer resolve its own annotations, and
 building it fails with "... is not fully defined; you should define <name>". The
-crewai tool models hit exactly that: four test modules evicted
-``band.integrations.crewai.*`` and never restored it, so a later test that used the
-real package died — but only when it happened to run after one of them, which is
-why CI stayed green for so long.
+crewai tool models hit exactly that: tests evicted ``band.integrations.crewai.*``
+to fake the package and never put it back, so a later test using the real package
+died — but only when it happened to run after one of them, which is why CI stayed
+green for so long.
 
 ``monkeypatch.setitem`` and ``patch.dict(sys.modules, ...)`` both restore what they
 replaced, so there is no reason for a test to reach for a raw pop.

--- a/uv.lock
+++ b/uv.lock
@@ -107,8 +107,7 @@ dependencies = [
     { name = "httpx" },
     { name = "httpx-sse" },
     { name = "protobuf" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/97/a6840e01795b182ce751ca165430d46459927cde9bfab838087cbb24aef7/a2a_sdk-0.3.26.tar.gz", hash = "sha256:44068e2d037afbb07ab899267439e9bc7eaa7ac2af94f1e8b239933c993ad52d", size = 274598, upload-time = "2026-04-09T15:21:13.902Z" }
 wheels = [
@@ -129,8 +128,7 @@ name = "agent-client-protocol"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/13/3b893421369767e7043cc115d6ef0df417c298b84563be3a12df0416158d/agent_client_protocol-0.9.0.tar.gz", hash = "sha256:f744c48ab9af0f0b4452e5ab5498d61bcab97c26dbe7d6feec5fd36de49be30b", size = 71853, upload-time = "2026-03-26T01:21:00.379Z" }
 wheels = [
@@ -147,8 +145,7 @@ dependencies = [
     { name = "h11" },
     { name = "httpx", extra = ["http2"] },
     { name = "packaging" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pydantic-settings", version = "2.10.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-crewai' or extra == 'extra-8-band-sdk-dev-crewai'" },
     { name = "pydantic-settings", version = "2.14.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai')" },
     { name = "python-dotenv" },
@@ -330,8 +327,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jmespath" },
     { name = "more-itertools" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version < '3.14' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pyyaml" },
     { name = "yarl" },
 ]
@@ -394,7 +390,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.96.0"
+version = "0.120.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -403,14 +399,13 @@ dependencies = [
     { name = "httpx" },
     { name = "jiter", version = "0.13.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-crewai' or extra == 'extra-8-band-sdk-dev-crewai'" },
     { name = "jiter", version = "0.14.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai')" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/7e/672f533dee813028d2c699bfd2a7f52c9118d7353680d9aa44b9e23f717f/anthropic-0.96.0.tar.gz", hash = "sha256:9de947b737f39452f68aa520f1c2239d44119c9b73b0fb6d4e6ca80f00279ee6", size = 658210, upload-time = "2026-04-16T14:28:02.846Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/5c/3331da4fc009d448008a50c78d86cc929e8c937cd1442245ce3f80561c4e/anthropic-0.120.0.tar.gz", hash = "sha256:6ba6007dc9b00365b20f6101a6618f5196ac1ceef81512e4b5cc0e7436d4975d", size = 1008042, upload-time = "2026-07-24T16:32:52.384Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/5a/72f33204064b6e87601a71a6baf8d855769f8a0c1eaae8d06a1094872371/anthropic-0.96.0-py3-none-any.whl", hash = "sha256:9a6e335a354602a521cd9e777e92bfd46ba6e115bf9bbfe6135311e8fb2015b2", size = 635930, upload-time = "2026-04-16T14:28:01.436Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/8522bdf809e1f95f0d9c936540987a3f6afba01d2921a2bf488dedf836a8/anthropic-0.120.0-py3-none-any.whl", hash = "sha256:591bd531563ec7b63a1e138f5c11f14cb94edda99623b349c2ce2ece8e08b8a5", size = 1022602, upload-time = "2026-07-24T16:32:50.506Z" },
 ]
 
 [[package]]
@@ -490,10 +485,8 @@ version = "0.0.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/e0/600527e9da77b0bda58ba6e48d16e6070ced930e699a656b609f360318b6/band_client_rest-0.0.10.tar.gz", hash = "sha256:d3a753d9cf479949264f7092b550b2616e93da68ab32f23acc2a06a6b69019c7", size = 106806, upload-time = "2026-06-12T15:26:44.651Z" }
@@ -773,8 +766,8 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'crewai'", specifier = ">=12.1.1" },
     { name = "pillow", marker = "extra == 'dev-crewai'", specifier = ">=12.1.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
-    { name = "pydantic-ai-slim", marker = "extra == 'dev'", specifier = ">=1.56.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'pydantic-ai'", specifier = ">=1.56.0" },
+    { name = "pydantic-ai-slim", marker = "extra == 'dev'", specifier = ">=2.18.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'pydantic-ai'", specifier = ">=2.18.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pydantic-settings", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "pydantic-settings", marker = "extra == 'dev-crewai'", specifier = ">=2.0.0" },
@@ -832,8 +825,7 @@ name = "band-testing-python"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (python_full_version < '3.14' and extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (python_full_version < '3.14' and extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pydantic-settings", version = "2.10.1", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
     { name = "pydantic-settings", version = "2.14.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
     { name = "pytest" },
@@ -1264,8 +1256,7 @@ dependencies = [
     { name = "overrides" },
     { name = "posthog" },
     { name = "pybase64" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pypika" },
     { name = "pyyaml" },
     { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" } },
@@ -1591,8 +1582,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "pdfplumber" },
     { name = "portalocker" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pydantic-settings", version = "2.10.1", source = { registry = "https://pypi.org/simple" } },
     { name = "pyjwt" },
     { name = "python-dotenv" },
@@ -1619,8 +1609,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "httpx" },
     { name = "packaging" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pydantic-settings", version = "2.10.1", source = { registry = "https://pypi.org/simple" } },
     { name = "pyjwt" },
     { name = "python-dotenv" },
@@ -1648,8 +1637,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
     { name = "portalocker" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pyjwt" },
     { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" } },
     { name = "tomli", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
@@ -1878,8 +1866,7 @@ version = "0.136.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
     { name = "typing-inspection" },
@@ -1907,8 +1894,7 @@ dependencies = [
     { name = "packaging" },
     { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"], marker = "extra == 'extra-8-band-sdk-dev' or extra == 'extra-8-band-sdk-parlant' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version < '3.14' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic", extra = ["email"], marker = "extra == 'extra-8-band-sdk-dev' or extra == 'extra-8-band-sdk-parlant' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -2105,16 +2091,15 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.56"
+version = "0.0.72"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version < '3.14' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "httpx2" },
+    { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/6b/94b3018a672c7775edfb485f0fed8f6068fba75e49b067e8a1ac5eb96764/genai_prices-0.0.56.tar.gz", hash = "sha256:ac24b16a84d0ab97539bfa48dfa4649689de8e3ce71c12ebacef29efb1998045", size = 65872, upload-time = "2026-03-20T20:33:00.732Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/c8/2549fa8ceaaf0bd61114cf392250a107be657233723bc4e65cb91dba934f/genai_prices-0.0.72.tar.gz", hash = "sha256:a7e481d0ea85922fcf48df6864f2491fc81a4f03dcf0ecbd9aa8c2c6d9fcdbe8", size = 82753, upload-time = "2026-07-22T21:11:03.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/f6/8ef7e4c286deb2709d11ca96a5237caae3ef4876ab3c48095856cfd2df30/genai_prices-0.0.56-py3-none-any.whl", hash = "sha256:dbe86be8f3f556bed1b72209ed36851fec8b01793b3b220f42921a4e7da945f6", size = 68966, upload-time = "2026-03-20T20:33:02.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/2e/1e2c31666f7e4e2d0327a80f1c920fd8764ccd27672c4bc389d79219ece6/genai_prices-0.0.72-py3-none-any.whl", hash = "sha256:21281d8df34d9bfbb736e0763a60ceda02226938cd47379ae437a44fcf8ba23d", size = 85238, upload-time = "2026-07-22T21:11:02.911Z" },
 ]
 
 [[package]]
@@ -2135,8 +2120,7 @@ version = "1.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "python-dateutil" },
 ]
 wheels = [
@@ -2176,8 +2160,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-gcp-trace" },
     { name = "opentelemetry-sdk" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -2280,8 +2263,7 @@ dependencies = [
     { name = "packaging" },
     { name = "proto-plus" },
     { name = "protobuf" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/f3/b2a9417014c93858a2e3266134f931eefd972c2d410b25d7b8782fc6f143/google_cloud_aiplatform-1.148.1.tar.gz", hash = "sha256:75d605fba34e68714bd08e1e482755d0a6e3ae972805f809d088e686c30879e7", size = 10278758, upload-time = "2026-04-17T23:45:26.738Z" }
@@ -2301,8 +2283,7 @@ agent-engines = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "typing-extensions" },
 ]
 
@@ -2526,8 +2507,7 @@ dependencies = [
     { name = "distro" },
     { name = "google-auth", extra = ["requests"] },
     { name = "httpx" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "requests" },
     { name = "sniffio" },
     { name = "tenacity" },
@@ -2863,6 +2843,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httplib2"
 version = "0.31.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2944,6 +2937,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -3077,10 +3086,8 @@ dependencies = [
     { name = "jinja2" },
     { name = "jiter", version = "0.13.0", source = { registry = "https://pypi.org/simple" } },
     { name = "openai" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
     { name = "requests" },
     { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" } },
     { name = "tenacity" },
@@ -3690,8 +3697,7 @@ name = "lance-namespace-urllib3-client"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "typing-extensions" },
     { name = "urllib3" },
@@ -3712,8 +3718,7 @@ dependencies = [
     { name = "overrides", marker = "python_full_version < '3.12'" },
     { name = "packaging" },
     { name = "pyarrow" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "tqdm" },
 ]
 wheels = [
@@ -3732,8 +3737,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/68/a6dbad9c22df4087a0f9e79ddd46226c442b30128bfeee538d5889492a73/langchain-1.3.14.tar.gz", hash = "sha256:1b6696c72ba3bbbce54d745e0180742c9f6ece8bbc59ed5a46c3e20b9a435929", size = 645181, upload-time = "2026-07-16T13:28:18.29Z" }
 wheels = [
@@ -3747,8 +3751,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/e3/d2f9dec95602524b1cfb4be2747ba5bc38d32501b2a56cb4bcb76e80bb45/langchain_anthropic-1.4.3.tar.gz", hash = "sha256:f8a2442463c0629b1b3110eaeaa56fdbdc87df2a802f8c7f5ecf611eb4874ec8", size = 685219, upload-time = "2026-05-03T17:33:27.118Z" }
 wheels = [
@@ -3763,8 +3766,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-text-splitters" },
     { name = "langsmith" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sqlalchemy" },
@@ -3806,8 +3808,7 @@ dependencies = [
     { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pyyaml" },
     { name = "tenacity" },
     { name = "typing-extensions" },
@@ -3865,8 +3866,7 @@ dependencies = [
     { name = "langgraph-checkpoint" },
     { name = "langgraph-prebuilt" },
     { name = "langgraph-sdk" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "xxhash" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/4b/0d1130e26b41a99dcc88353bbe7162a1f255c4db746bd94024268e6af27b/langgraph-1.2.9.tar.gz", hash = "sha256:385f87bc1802c35af7e0aa479278ecba8582d103515eb48256cb2ddcd42d0bd4", size = 722869, upload-time = "2026-07-10T01:30:14.985Z" }
@@ -3924,8 +3924,7 @@ dependencies = [
     { name = "httpx" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
     { name = "packaging" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "requests" },
     { name = "requests-toolbelt" },
     { name = "uuid-utils" },
@@ -3993,8 +3992,7 @@ dependencies = [
     { name = "anyio" },
     { name = "distro" },
     { name = "httpx" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
@@ -4333,8 +4331,7 @@ dependencies = [
     { name = "httpx" },
     { name = "httpx-sse" },
     { name = "jsonschema" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pydantic-settings", version = "2.10.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-crewai' or extra == 'extra-8-band-sdk-dev-crewai'" },
     { name = "pydantic-settings", version = "2.14.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai')" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -4856,8 +4853,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jiter", version = "0.13.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-crewai' or extra == 'extra-8-band-sdk-dev-crewai'" },
     { name = "jiter", version = "0.14.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai')" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "sniffio" },
     { name = "tqdm" },
     { name = "typing-extensions" },
@@ -4872,8 +4868,7 @@ name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version < '3.14' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
@@ -4887,8 +4882,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
     { name = "jsonschema-specifications" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version < '3.14' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pydantic-settings", version = "2.14.2", source = { registry = "https://pypi.org/simple" } },
     { name = "referencing" },
     { name = "rfc3339-validator" },
@@ -4907,8 +4901,7 @@ dependencies = [
     { name = "jsonschema-path" },
     { name = "lazy-object-proxy" },
     { name = "openapi-schema-validator" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version < '3.14' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pydantic-settings", version = "2.14.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/de/0199b15f5dde3ca61df6e6b3987420bfd424db077998f0162e8ffe12e4f5/openapi_spec_validator-0.8.4.tar.gz", hash = "sha256:8bb324b9b08b9b368b1359dec14610c60a8f3a3dd63237184eb04456d4546f49", size = 1756847, upload-time = "2026-03-01T15:48:19.499Z" }
@@ -5376,8 +5369,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mypy" },
     { name = "nanoid" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version < '3.14' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/31/57/4a7f82db584d5a02d270a1723ae96b8bc04ae927731b9c4f8bccb58f05a8/parlant_client-3.3.1.tar.gz", hash = "sha256:c8bbdaaac6718a71376fe2d539254b6f1ef4a82002278d0bd6dc5c9843732f9b", size = 55113, upload-time = "2026-04-14T14:15:18.45Z" }
 wheels = [
@@ -6058,106 +6050,13 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.9"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-]
-dependencies = [
-    { name = "annotated-types", marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "typing-inspection", marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/5d/09a551ba512d7ca404d785072700d3f6727a02f6f3c24ecfd081c7cf0aa8/pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2", size = 788495, upload-time = "2025-09-13T11:26:39.325Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/d3/108f2006987c58e76691d5ae5d200dd3e0f532cb4e5fa3560751c3a1feba/pydantic-2.11.9-py3-none-any.whl", hash = "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2", size = 444855, upload-time = "2025-09-13T11:26:36.909Z" },
-]
-
-[package.optional-dependencies]
-email = [
-    { name = "email-validator", marker = "python_full_version < '3.14'" },
-]
-
-[[package]]
-name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-]
 dependencies = [
-    { name = "annotated-types", marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "typing-inspection", marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
@@ -6166,26 +6065,25 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator", marker = "python_full_version >= '3.14'" },
+    { name = "email-validator" },
 ]
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.60.0"
+version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
-    { name = "griffe" },
+    { name = "griffelib" },
     { name = "httpx" },
     { name = "opentelemetry-api" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version < '3.14' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/97/f73f439f3d415d43f38250f76852121188d0ef6114ec702e84e7d69c301d/pydantic_ai_slim-1.60.0.tar.gz", hash = "sha256:12ba3e6ef933fcb9fc6a307dbdaa43ca15bbc1b8ec77521afd1b7a526d12330f", size = 418839, upload-time = "2026-02-17T00:33:29.672Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/39/c3a941027be87f6bc07e50e1e72ae93e66a1b11b838e33ad5d135d2fe2f0/pydantic_ai_slim-2.18.0.tar.gz", hash = "sha256:dfe47a3602049f779223702a684ed8091b111cfae1851236616d6b0eb3b0b077", size = 902113, upload-time = "2026-07-25T01:21:05.614Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/40/8cb494a4d2ba62b5f92ae8bc79a2abbbf8509cb692edd4bc841695187780/pydantic_ai_slim-1.60.0-py3-none-any.whl", hash = "sha256:6865188a225a2979c82bb022a299d438d805d258c6d3f9810f7fe4e3c86af80a", size = 546410, upload-time = "2026-02-17T00:33:21.901Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/a0619bddf602f69a754540cb82147f9b53dfa2d093e1fe7051c5e6a8eceb/pydantic_ai_slim-2.18.0-py3-none-any.whl", hash = "sha256:4c4076166a63ad96fe6ed5a517223c4a5aba6c9682a17d8d0ac42839cbc83622", size = 1091565, upload-time = "2026-07-25T01:20:57.323Z" },
 ]
 
 [package.optional-dependencies]
@@ -6195,148 +6093,10 @@ anthropic = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.33.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version == '3.13.*' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version < '3.13' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-]
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/8d/71db63483d518cbbf290261a1fc2839d17ff89fce7089e08cad07ccfce67/pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7", size = 2028584, upload-time = "2025-04-23T18:31:03.106Z" },
-    { url = "https://files.pythonhosted.org/packages/24/2f/3cfa7244ae292dd850989f328722d2aef313f74ffc471184dc509e1e4e5a/pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246", size = 1855071, upload-time = "2025-04-23T18:31:04.621Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/d3/4ae42d33f5e3f50dd467761304be2fa0a9417fbf09735bc2cce003480f2a/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f", size = 1897823, upload-time = "2025-04-23T18:31:06.377Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f3/aa5976e8352b7695ff808599794b1fba2a9ae2ee954a3426855935799488/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc", size = 1983792, upload-time = "2025-04-23T18:31:07.93Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/7a/cda9b5a23c552037717f2b2a5257e9b2bfe45e687386df9591eff7b46d28/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de", size = 2136338, upload-time = "2025-04-23T18:31:09.283Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9f/b8f9ec8dd1417eb9da784e91e1667d58a2a4a7b7b34cf4af765ef663a7e5/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a", size = 2730998, upload-time = "2025-04-23T18:31:11.7Z" },
-    { url = "https://files.pythonhosted.org/packages/47/bc/cd720e078576bdb8255d5032c5d63ee5c0bf4b7173dd955185a1d658c456/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef", size = 2003200, upload-time = "2025-04-23T18:31:13.536Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/22/3602b895ee2cd29d11a2b349372446ae9727c32e78a94b3d588a40fdf187/pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e", size = 2113890, upload-time = "2025-04-23T18:31:15.011Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/e6/e3c5908c03cf00d629eb38393a98fccc38ee0ce8ecce32f69fc7d7b558a7/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d", size = 2073359, upload-time = "2025-04-23T18:31:16.393Z" },
-    { url = "https://files.pythonhosted.org/packages/12/e7/6a36a07c59ebefc8777d1ffdaf5ae71b06b21952582e4b07eba88a421c79/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30", size = 2245883, upload-time = "2025-04-23T18:31:17.892Z" },
-    { url = "https://files.pythonhosted.org/packages/16/3f/59b3187aaa6cc0c1e6616e8045b284de2b6a87b027cce2ffcea073adf1d2/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf", size = 2241074, upload-time = "2025-04-23T18:31:19.205Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ed/55532bb88f674d5d8f67ab121a2a13c385df382de2a1677f30ad385f7438/pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51", size = 1910538, upload-time = "2025-04-23T18:31:20.541Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1b/25b7cccd4519c0b23c2dd636ad39d381abf113085ce4f7bec2b0dc755eb1/pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab", size = 1952909, upload-time = "2025-04-23T18:31:22.371Z" },
-    { url = "https://files.pythonhosted.org/packages/49/a9/d809358e49126438055884c4366a1f6227f0f84f635a9014e2deb9b9de54/pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65", size = 1897786, upload-time = "2025-04-23T18:31:24.161Z" },
-    { url = "https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc", size = 2009000, upload-time = "2025-04-23T18:31:25.863Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7", size = 1847996, upload-time = "2025-04-23T18:31:27.341Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/46/6dcdf084a523dbe0a0be59d054734b86a981726f221f4562aed313dbcb49/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025", size = 1880957, upload-time = "2025-04-23T18:31:28.956Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/6b/1ec2c03837ac00886ba8160ce041ce4e325b41d06a034adbef11339ae422/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011", size = 1964199, upload-time = "2025-04-23T18:31:31.025Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/1d/6bf34d6adb9debd9136bd197ca72642203ce9aaaa85cfcbfcf20f9696e83/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f", size = 2120296, upload-time = "2025-04-23T18:31:32.514Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/94/2bd0aaf5a591e974b32a9f7123f16637776c304471a0ab33cf263cf5591a/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88", size = 2676109, upload-time = "2025-04-23T18:31:33.958Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1", size = 2002028, upload-time = "2025-04-23T18:31:39.095Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/d5/7bb781bf2748ce3d03af04d5c969fa1308880e1dca35a9bd94e1a96a922e/pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b", size = 2100044, upload-time = "2025-04-23T18:31:41.034Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/36/def5e53e1eb0ad896785702a5bbfd25eed546cdcf4087ad285021a90ed53/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1", size = 2058881, upload-time = "2025-04-23T18:31:42.757Z" },
-    { url = "https://files.pythonhosted.org/packages/01/6c/57f8d70b2ee57fc3dc8b9610315949837fa8c11d86927b9bb044f8705419/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6", size = 2227034, upload-time = "2025-04-23T18:31:44.304Z" },
-    { url = "https://files.pythonhosted.org/packages/27/b9/9c17f0396a82b3d5cbea4c24d742083422639e7bb1d5bf600e12cb176a13/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea", size = 2234187, upload-time = "2025-04-23T18:31:45.891Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6a/adf5734ffd52bf86d865093ad70b2ce543415e0e356f6cacabbc0d9ad910/pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290", size = 1892628, upload-time = "2025-04-23T18:31:47.819Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e4/5479fecb3606c1368d496a825d8411e126133c41224c1e7238be58b87d7e/pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2", size = 1955866, upload-time = "2025-04-23T18:31:49.635Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/24/8b11e8b3e2be9dd82df4b11408a67c61bb4dc4f8e11b5b0fc888b38118b5/pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab", size = 1888894, upload-time = "2025-04-23T18:31:51.609Z" },
-    { url = "https://files.pythonhosted.org/packages/46/8c/99040727b41f56616573a28771b1bfa08a3d3fe74d3d513f01251f79f172/pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f", size = 2015688, upload-time = "2025-04-23T18:31:53.175Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/cc/5999d1eb705a6cefc31f0b4a90e9f7fc400539b1a1030529700cc1b51838/pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6", size = 1844808, upload-time = "2025-04-23T18:31:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/5e/a0a7b8885c98889a18b6e376f344da1ef323d270b44edf8174d6bce4d622/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef", size = 1885580, upload-time = "2025-04-23T18:31:57.393Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/2a/953581f343c7d11a304581156618c3f592435523dd9d79865903272c256a/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a", size = 1973859, upload-time = "2025-04-23T18:31:59.065Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/55/f1a813904771c03a3f97f676c62cca0c0a4138654107c1b61f19c644868b/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916", size = 2120810, upload-time = "2025-04-23T18:32:00.78Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/c3/053389835a996e18853ba107a63caae0b9deb4a276c6b472931ea9ae6e48/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a", size = 2676498, upload-time = "2025-04-23T18:32:02.418Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d", size = 2000611, upload-time = "2025-04-23T18:32:04.152Z" },
-    { url = "https://files.pythonhosted.org/packages/59/a7/63ef2fed1837d1121a894d0ce88439fe3e3b3e48c7543b2a4479eb99c2bd/pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56", size = 2107924, upload-time = "2025-04-23T18:32:06.129Z" },
-    { url = "https://files.pythonhosted.org/packages/04/8f/2551964ef045669801675f1cfc3b0d74147f4901c3ffa42be2ddb1f0efc4/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5", size = 2063196, upload-time = "2025-04-23T18:32:08.178Z" },
-    { url = "https://files.pythonhosted.org/packages/26/bd/d9602777e77fc6dbb0c7db9ad356e9a985825547dce5ad1d30ee04903918/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e", size = 2236389, upload-time = "2025-04-23T18:32:10.242Z" },
-    { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223, upload-time = "2025-04-23T18:32:12.382Z" },
-    { url = "https://files.pythonhosted.org/packages/58/4d/4f937099c545a8a17eb52cb67fe0447fd9a373b348ccfa9a87f141eeb00f/pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849", size = 1900473, upload-time = "2025-04-23T18:32:14.034Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/75/4a0a9bac998d78d889def5e4ef2b065acba8cae8c93696906c3a91f310ca/pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9", size = 1955269, upload-time = "2025-04-23T18:32:15.783Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/86/1beda0576969592f1497b4ce8e7bc8cbdf614c352426271b1b10d5f0aa64/pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9", size = 1893921, upload-time = "2025-04-23T18:32:18.473Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/27/d4ae6487d73948d6f20dddcd94be4ea43e74349b56eba82e9bdee2d7494c/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8", size = 2025200, upload-time = "2025-04-23T18:33:14.199Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/b8/b3cb95375f05d33801024079b9392a5ab45267a63400bf1866e7ce0f0de4/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593", size = 1859123, upload-time = "2025-04-23T18:33:16.555Z" },
-    { url = "https://files.pythonhosted.org/packages/05/bc/0d0b5adeda59a261cd30a1235a445bf55c7e46ae44aea28f7bd6ed46e091/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612", size = 1892852, upload-time = "2025-04-23T18:33:18.513Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/11/d37bdebbda2e449cb3f519f6ce950927b56d62f0b84fd9cb9e372a26a3d5/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7", size = 2067484, upload-time = "2025-04-23T18:33:20.475Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/55/1f95f0a05ce72ecb02a8a8a1c3be0579bbc29b1d5ab68f1378b7bebc5057/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e", size = 2108896, upload-time = "2025-04-23T18:33:22.501Z" },
-    { url = "https://files.pythonhosted.org/packages/53/89/2b2de6c81fa131f423246a9109d7b2a375e83968ad0800d6e57d0574629b/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8", size = 2069475, upload-time = "2025-04-23T18:33:24.528Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", size = 2239013, upload-time = "2025-04-23T18:33:26.621Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", size = 2238715, upload-time = "2025-04-23T18:33:28.656Z" },
-    { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", size = 2066757, upload-time = "2025-04-23T18:33:30.645Z" },
-]
-
-[[package]]
-name = "pydantic-core"
 version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra == 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-    "python_full_version >= '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
-]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version >= '3.14' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
@@ -6430,18 +6190,17 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.60.0"
+version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "logfire-api" },
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version < '3.14' and extra != 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e6/1cae7cd39ab29f2eebc87c0a82c7ffcdfbe88492d2fb4afaaad91534e1ff/pydantic_graph-1.60.0.tar.gz", hash = "sha256:9710e457c2f8c113fd63629f05174e45bdca917d90c69ec8cf558649f995505f", size = 58492, upload-time = "2026-02-17T00:33:32.66Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/f9/1554e818e6d38bcb3f66ec7da7abe17c28dcd00caa1550b034e175b8841f/pydantic_graph-2.18.0.tar.gz", hash = "sha256:9423defa047b477a561a06eadfd37aaf101a2b690d044adb79de80d7ea203e4e", size = 44017, upload-time = "2026-07-25T01:21:08.152Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/6c/ce1c0eca77c6efbf7c7168c05a244c2756bde876a52575f750471d522024/pydantic_graph-1.60.0-py3-none-any.whl", hash = "sha256:741fa1e48424b0def86079a01100ad0652e75882f0352cd157232b75ace468a5", size = 72345, upload-time = "2026-02-17T00:33:25.077Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/29/fd05a4a84db9dae16c0417d8bcd6847148439a55329d000ef101d7243ded/pydantic_graph-2.18.0-py3-none-any.whl", hash = "sha256:48df74e3ae12ca44f99890e9b4f7020ae70a5a38d20df02db7cb16b0db3c3711", size = 51662, upload-time = "2026-07-25T01:21:00.764Z" },
 ]
 
 [[package]]
@@ -6454,8 +6213,7 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-crewai') or (python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic", marker = "extra == 'extra-8-band-sdk-crewai' or extra == 'extra-8-band-sdk-dev-crewai'" },
     { name = "python-dotenv", marker = "extra == 'extra-8-band-sdk-crewai' or extra == 'extra-8-band-sdk-dev-crewai'" },
     { name = "typing-inspection", marker = "extra == 'extra-8-band-sdk-crewai' or extra == 'extra-8-band-sdk-dev-crewai'" },
 ]
@@ -6531,8 +6289,7 @@ resolution-markers = [
     "python_full_version < '3.13' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev' and extra != 'extra-8-band-sdk-dev-crewai' and extra != 'extra-8-band-sdk-parlant' and extra != 'extra-8-band-sdk-pydantic-ai'",
 ]
 dependencies = [
-    { name = "pydantic", version = "2.11.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version < '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-8-band-sdk-dev') or (python_full_version >= '3.14' and extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-dev' and extra == 'extra-8-band-sdk-dev-crewai') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-dev') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
+    { name = "pydantic", marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai')" },
     { name = "python-dotenv", marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai')" },
     { name = "typing-inspection", marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra != 'extra-8-band-sdk-crewai' and extra != 'extra-8-band-sdk-dev-crewai')" },
 ]
@@ -7992,6 +7749,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes INT-1121. Supersedes #466.

## Summary

- Upgrade `pydantic-ai-slim` from 1.x to `>=2.18.0` and update the lockfile.
- Migrate the Pydantic AI adapter to 2.x APIs: `ProcessHistory`, async streaming context management, event parts, usage access, and context-aware custom-tool registration.
- Preserve correct behavior for retry exhaustion, usage reporting, history filtering, and custom tools with focused regression coverage.
- Keep CrewAI isolated in its dedicated dependency lane; simplify its CI job to the tests that require the real SDK, verify that coverage cannot drift, and remove test module surgery that caused order-dependent conformance failures.
- Correct the dependency-conflict documentation and parse the missing-framework CI flag as a boolean.

## Validation

- `ruff check .`, `ruff format`, and `pyrefly check`
- Unit suite and markdown-doc tests
- Dedicated `dev-crewai` CI command, CrewAI test files, and standalone CrewAI conformance coverage

## Remaining work

- Run the live core-lane E2E smoke to verify the Pydantic AI 2.x Responses API default.