### PR TITLE
feat(sdk): add Strands Agents adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   # against the queued merge result. Without this the queue would wait forever.
   merge_group:
 
+# Every job here only reads the repo; nothing uses GITHUB_TOKEN for writes.
+permissions:
+  contents: read
+
 jobs:
 
   lint:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,6 +74,11 @@ on:
 # the orphan sweep only reaps agents older than BAND_E2E_ORPHAN_MAX_AGE_MINUTES,
 # so a concurrent run's fresh agents are never swept out from under it.
 
+# Every job here only reads the repo. The GitHub API work uses E2E_GITHUB_TOKEN,
+# and the scorecard artifacts are downloaded from this same run.
+permissions:
+  contents: read
+
 jobs:
 
   lanes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This is a Python SDK that connects AI agents to the Band collaborative platform.
 
 ## Core Features
 
-1. Multi-framework support (LangGraph, Anthropic, CrewAI, Claude SDK, Copilot SDK, Codex, Pydantic AI, Parlant, Gemini, Letta, Google ADK, OpenCode, Agno)
+1. Multi-framework support (LangGraph, Anthropic, CrewAI, Claude SDK, Copilot SDK, Codex, Pydantic AI, Parlant, Gemini, Letta, Google ADK, OpenCode, Agno, Strands Agents)
 2. A2A protocol support: Bridge to remote A2A agents and expose Band peers as A2A endpoints
 3. ACP integration: Editor-facing server and client adapters over stdio or TCP (Cursor, Codex, Claude Code, GitHub Copilot)
 4. Platform tools for chat, contacts, and memory management

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ For the full picture, rooms, contacts, platform tools, and how messages flow - s
 | Parlant          | `parlant`     | `ParlantAdapter`                     | | [examples](examples/parlant/)         |
 | Letta            | `letta`       | `LettaAdapter`                       | | [examples](examples/letta/)             |
 | Agno             | `agno`        | `AgnoAdapter`                        | | [examples](examples/agno/)              |
+| Strands Agents   | `strands`     | `StrandsAdapter`                     | | [examples](examples/strands/)         |
 | Codex            | `codex`       | `CodexAdapter`                       | [docs](docs/adapters/codex.md) | [examples](examples/codex/)             |
 | OpenCode         | `opencode`    | `OpencodeAdapter`                    | | [examples](examples/opencode/)       |
 
@@ -437,6 +438,7 @@ Adapter emit support:
 | Google ADK | Yes | - | - |
 | Pydantic AI | Yes | - | - |
 | LangGraph | Yes | - | - |
+| Strands Agents | Yes | - | - |
 | Parlant | - | - | - |
 | A2A / A2A Gateway | - | - | - |
 | ACP Client | - | - | - |
@@ -753,7 +755,7 @@ uv run python examples/run_agent.py --example anthropic
 uv run python examples/run_agent.py --example codex
 ```
 
-`examples/run_agent.py` supports `langgraph`, `pydantic_ai`, `anthropic`, `claude_sdk`, `parlant`, `crewai`, `codex`, `a2a`, and `a2a_gateway`, plus contact-management variants. Other supported adapters have direct example files: `examples/gemini/01_basic_agent.py`, `examples/google_adk/01_basic_agent.py`, `examples/letta/01_basic_agent.py`, `examples/agno/01_basic_agent.py`, and `examples/opencode/01_basic_agent.py`.
+`examples/run_agent.py` supports `langgraph`, `pydantic_ai`, `anthropic`, `claude_sdk`, `parlant`, `crewai`, `codex`, `a2a`, and `a2a_gateway`, plus contact-management variants. Other supported adapters have direct example files: `examples/gemini/01_basic_agent.py`, `examples/google_adk/01_basic_agent.py`, `examples/letta/01_basic_agent.py`, `examples/agno/01_basic_agent.py`, `examples/strands/01_basic_agent.py`, and `examples/opencode/01_basic_agent.py`.
 
 For a multi-framework collaboration demo that puts CrewAI agents and A2A-bridged services in the same room, see [examples/mixed](examples/mixed/).
 

--- a/agent_config.yaml.example
+++ b/agent_config.yaml.example
@@ -199,6 +199,19 @@ google_adk_agent:
   api_key: ""
 
 # =============================================================================
+# Strands Agents Examples
+# =============================================================================
+
+# 01_basic_agent.py, 02_custom_tools.py, 03_custom_instructions.py,
+# 04_native_tools.py, 05_bedrock_model.py
+strands_agent:
+  agent_id: ""
+  api_key: ""
+
+# 06_tom_agent.py - see tom_agent in Shared Agents section
+# 07_jerry_agent.py - see jerry_agent in Shared Agents section
+
+# =============================================================================
 # Letta Examples
 # =============================================================================
 
@@ -304,13 +317,13 @@ arena_guesser_3:
 # =============================================================================
 
 # Tom the cat character agent
-# Used by: langgraph/07, claude_sdk/03, anthropic/03, pydantic_ai/03, parlant/04, crewai/05, agno/03, codex/02, opencode/05
+# Used by: langgraph/07, claude_sdk/03, anthropic/03, pydantic_ai/03, parlant/04, crewai/05, agno/03, codex/02, opencode/05, strands/06
 tom_agent:
   agent_id: ""
   api_key: ""
 
 # Jerry the mouse character agent
-# Used by: langgraph/08, claude_sdk/04, anthropic/04, pydantic_ai/04, parlant/05, crewai/06, agno/04, codex/03, opencode/06
+# Used by: langgraph/08, claude_sdk/04, anthropic/04, pydantic_ai/04, parlant/05, crewai/06, agno/04, codex/03, opencode/06, strands/07
 jerry_agent:
   agent_id: ""
   api_key: ""

--- a/examples/strands/01_basic_agent.py
+++ b/examples/strands/01_basic_agent.py
@@ -1,0 +1,69 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[strands]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Basic Strands Agents example.
+
+This is the simplest way to create a Band agent with AWS Strands Agents.
+The adapter handles tool registration automatically.
+
+Strands has no provider-prefix model string (a bare string means a Bedrock
+model id), so the OpenAI provider is constructed explicitly; it reads
+OPENAI_API_KEY from the environment.
+
+Run with:
+    uv run examples/strands/01_basic_agent.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from dotenv import load_dotenv
+from strands.models.openai import OpenAIModel
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import StrandsAdapter
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    # Create adapter with framework-specific settings
+    adapter = StrandsAdapter(
+        model=OpenAIModel(model_id="gpt-5.4-mini"),
+        custom_section="You are a helpful assistant. Be concise and friendly.",
+    )
+
+    # Create and start agent
+    agent = Agent.from_config(
+        "strands_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Starting Strands agent...")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/strands/02_custom_tools.py
+++ b/examples/strands/02_custom_tools.py
@@ -1,0 +1,81 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[strands]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Strands agent with custom tools and capabilities.
+
+Shows the portable ``CustomToolDef`` (InputModel, handler) form shared across
+adapters, plus enabling memory/contact tools and execution/usage event
+emission via AdapterFeatures.
+
+Run with:
+    uv run examples/strands/02_custom_tools.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from dotenv import load_dotenv
+from pydantic import BaseModel
+from strands.models.openai import OpenAIModel
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import StrandsAdapter
+from band.core.types import AdapterFeatures, Capability, Emit
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+class WeatherInput(BaseModel):
+    """Get the weather for a city."""
+
+    city: str
+
+
+async def get_weather(args: WeatherInput) -> str:
+    return f"{args.city}: sunny, 22°C"
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    adapter = StrandsAdapter(
+        model=OpenAIModel(model_id="gpt-5.4-mini"),
+        custom_section="You can check the weather with the weather tool.",
+        additional_tools=[(WeatherInput, get_weather)],  # CustomToolDef tuple
+        features=AdapterFeatures(
+            emit=frozenset({Emit.EXECUTION, Emit.USAGE}),
+            capabilities=frozenset({Capability.MEMORY, Capability.CONTACTS}),
+        ),
+    )
+
+    agent = Agent.from_config(
+        "strands_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Starting Strands agent with custom tools...")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/strands/03_custom_instructions.py
+++ b/examples/strands/03_custom_instructions.py
@@ -1,0 +1,88 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[strands]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Strands agent with a fully custom system prompt.
+
+Two levers shape the prompt:
+
+* ``custom_section`` (see 01_basic_agent.py) is appended to the prompt the SDK
+  renders, so the Band tool contract stays in place;
+* ``system_prompt`` REPLACES that rendered prompt entirely — nothing about the
+  platform tools is injected for you, so the prompt below states the messaging
+  contract itself. Without it the model answers in plain text, the reply never
+  reaches the room, and the adapter reports a dropped-reply error.
+
+Run with:
+    uv run examples/strands/03_custom_instructions.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from dotenv import load_dotenv
+from strands.models.openai import OpenAIModel
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import StrandsAdapter
+from band.core.types import AdapterFeatures, Emit
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+SUPPORT_PROMPT = """
+You are a technical support agent for a software company, working inside a Band
+chat room.
+
+How to reply:
+- Every reply to the room MUST go through the band_send_message tool, mentioning
+  the person you are answering. Plain text answers never reach the room.
+- Send exactly one message per turn.
+
+Guidelines:
+- Ask for the environment (OS, version, exact error) before troubleshooting.
+- Give numbered, verifiable steps.
+- Escalate to a human when the issue needs account or billing access.
+"""
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    adapter = StrandsAdapter(
+        model=OpenAIModel(model_id="gpt-5.4-mini"),
+        # Full override: custom_section would be ignored alongside this.
+        system_prompt=SUPPORT_PROMPT,
+        # Post each tool call and result into the room for visibility.
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
+    )
+
+    agent = Agent.from_config(
+        "strands_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Starting Strands support agent...")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/strands/04_native_tools.py
+++ b/examples/strands/04_native_tools.py
@@ -1,0 +1,100 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[strands]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Strands agent with framework-native tools.
+
+``additional_tools`` accepts both custom-tool forms:
+
+* the portable ``(InputModel, handler)`` pair shared by every Band adapter
+  (see 02_custom_tools.py);
+* Strands' own ``@tool``-decorated functions, shown here — the schema comes from
+  the signature and docstring, so nothing is re-declared.
+
+A tool that finishes the turn on its own (a handoff, a ticket filing) can set
+``band_terminal = True``. Band then treats the turn as productive even though no
+``band_send_message`` was sent, instead of reporting a dropped reply.
+
+Run with:
+    uv run examples/strands/04_native_tools.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from dotenv import load_dotenv
+from strands import tool
+from strands.models.openai import OpenAIModel
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import StrandsAdapter
+from band.core.types import AdapterFeatures, Emit
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+_RATES = {"EUR": 0.92, "GBP": 0.79, "JPY": 157.0}
+
+
+@tool
+def convert_from_usd(amount: float, currency: str) -> str:
+    """Convert an amount in US dollars to EUR, GBP, or JPY."""
+    rate = _RATES.get(currency.upper())
+    if rate is None:
+        return f"Unsupported currency {currency!r}. Supported: {sorted(_RATES)}."
+    return f"{amount} USD = {round(amount * rate, 2)} {currency.upper()}"
+
+
+@tool
+def escalate_to_human(summary: str) -> str:
+    """Hand the conversation to a human teammate with a short summary."""
+    logger.info("Escalated to a human: %s", summary)
+    return "Escalated. A teammate will pick this up."
+
+
+# The handoff ends the turn by itself, so it counts as a terminal action.
+escalate_to_human.band_terminal = True
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    adapter = StrandsAdapter(
+        model=OpenAIModel(model_id="gpt-5.4-mini"),
+        custom_section=(
+            "You convert currencies with the convert_from_usd tool. Escalate to a "
+            "human only when the request is outside currency conversion."
+        ),
+        additional_tools=[convert_from_usd, escalate_to_human],
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
+    )
+
+    agent = Agent.from_config(
+        "strands_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Starting Strands agent with native tools...")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/strands/05_bedrock_model.py
+++ b/examples/strands/05_bedrock_model.py
@@ -1,0 +1,76 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[strands]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Strands agent on Amazon Bedrock.
+
+Strands is model-agnostic, but it has no provider-prefix string shorthand: a
+bare string handed to ``model=`` is a **Bedrock** model id, not a provider
+route. The other examples therefore construct ``OpenAIModel`` explicitly, while
+this one uses the string form and its explicit ``BedrockModel`` equivalent —
+reach for the latter when you need a region, profile, or client config.
+
+Requires Band credentials plus AWS credentials with Bedrock access, e.g.:
+    aws configure          # or AWS_PROFILE / AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY
+    export AWS_REGION=us-east-1
+
+Run with:
+    uv run examples/strands/05_bedrock_model.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from dotenv import load_dotenv
+from strands.models import BedrockModel
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import StrandsAdapter
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+MODEL_ID = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    # `model=MODEL_ID` (a bare string) is equivalent to this and picks up the
+    # ambient AWS region; construct the provider when you need to pin one.
+    model = BedrockModel(model_id=MODEL_ID, region_name=os.getenv("AWS_REGION"))
+
+    adapter = StrandsAdapter(
+        model=model,
+        custom_section="You are a helpful assistant. Be concise and friendly.",
+    )
+
+    agent = Agent.from_config(
+        "strands_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Starting Strands agent on Bedrock model %s...", MODEL_ID)
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/strands/06_tom_agent.py
+++ b/examples/strands/06_tom_agent.py
@@ -1,0 +1,74 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[strands]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Tom the cat agent - tries to catch Jerry!
+
+A character agent driven by Strands. Tom uses the Band platform tools to find
+and invite Jerry, then tries to lure him out of his mouse hole. Run it next to
+07_jerry_agent.py to watch two Strands agents talk to each other.
+
+The character prompt comes from the shared prompts module, so the same persona
+runs across every adapter.
+
+Run with (from repo root):
+    uv run examples/strands/06_tom_agent.py
+
+Note: Must be run from the repo as it imports prompts/characters.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+from strands.models.openai import OpenAIModel
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from prompts.characters import generate_tom_prompt
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import StrandsAdapter
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    adapter = StrandsAdapter(
+        model=OpenAIModel(model_id="gpt-5.4-mini"),
+        custom_section=generate_tom_prompt("Tom"),
+    )
+
+    agent = Agent.from_config(
+        "tom_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Tom is on the prowl, looking for Jerry...")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/strands/07_jerry_agent.py
+++ b/examples/strands/07_jerry_agent.py
@@ -1,0 +1,74 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["band-sdk[strands]"]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""
+Jerry the mouse agent - outsmarts Tom!
+
+The counterpart to 06_tom_agent.py: Jerry taunts Tom from his mouse hole while
+staying safe. Run both to see two Strands-backed peers hold a conversation in a
+Band room.
+
+The character prompt comes from the shared prompts module, so the same persona
+runs across every adapter.
+
+Run with (from repo root):
+    uv run examples/strands/07_jerry_agent.py
+
+Note: Must be run from the repo as it imports prompts/characters.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+from strands.models.openai import OpenAIModel
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from prompts.characters import generate_jerry_prompt
+
+from setup_logging import setup_logging
+from band import Agent
+from band.adapters import StrandsAdapter
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    load_dotenv()
+
+    ws_url = os.getenv("BAND_WS_URL")
+    rest_url = os.getenv("BAND_REST_URL")
+
+    if not ws_url:
+        raise ValueError("BAND_WS_URL environment variable is required")
+    if not rest_url:
+        raise ValueError("BAND_REST_URL environment variable is required")
+
+    adapter = StrandsAdapter(
+        model=OpenAIModel(model_id="gpt-5.4-mini"),
+        custom_section=generate_jerry_prompt("Jerry"),
+    )
+
+    agent = Agent.from_config(
+        "jerry_agent",
+        adapter=adapter,
+        ws_url=ws_url,
+        rest_url=rest_url,
+    )
+
+    logger.info("Jerry is watching for Tom from his mouse hole...")
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/strands/README.md
+++ b/examples/strands/README.md
@@ -1,0 +1,76 @@
+# Strands Agents Examples for Band
+
+Examples for running [AWS Strands Agents](https://strandsagents.com) on the Band
+platform through `StrandsAdapter`.
+
+## Prerequisites
+
+1. **Dependencies** — `uv sync --extra strands` (or `pip install band-sdk[strands]`)
+2. **Band platform** — a registered agent plus `BAND_WS_URL` / `BAND_REST_URL`
+3. **Model credentials** — for these examples `OPENAI_API_KEY`, except
+   `05_bedrock_model.py`, which needs AWS credentials with Bedrock access
+4. **`agent_config.yaml`** — copy `agent_config.yaml.example` from the repo root and
+   fill in `strands_agent` (and `tom_agent` / `jerry_agent` for the character pair)
+
+## Picking a model
+
+Strands has **no provider-prefix string shorthand**: a bare string means a Bedrock
+model id. Any other provider is constructed explicitly.
+
+```python notest
+from strands.models import BedrockModel
+from strands.models.openai import OpenAIModel
+
+from band.adapters import StrandsAdapter
+
+StrandsAdapter(model=OpenAIModel(model_id="gpt-5.4-mini"))          # OpenAI
+StrandsAdapter(model="us.anthropic.claude-sonnet-4-5-20250929-v1:0")  # Bedrock id
+StrandsAdapter(model=BedrockModel(model_id="...", region_name="us-east-1"))
+```
+
+Providers beyond `openai` need their own Strands extra (e.g.
+`strands-agents[anthropic]`).
+
+## Examples
+
+| File | Shows |
+| ---- | ----- |
+| `01_basic_agent.py` | Minimal agent: a model plus `custom_section` |
+| `02_custom_tools.py` | Portable `(InputModel, handler)` tools, memory + contact tools, execution/usage events |
+| `03_custom_instructions.py` | `system_prompt` full override and the messaging contract it must carry |
+| `04_native_tools.py` | Strands' own `@tool` functions, and `band_terminal` for a tool that ends the turn |
+| `05_bedrock_model.py` | Amazon Bedrock, via the bare model id and via `BedrockModel` |
+| `06_tom_agent.py` / `07_jerry_agent.py` | Two Strands peers talking to each other in one room |
+
+## Prompt, tools, capabilities
+
+```python notest
+from band.core.types import AdapterFeatures, Capability, Emit
+
+StrandsAdapter(
+    model=model,
+    custom_section="Appended to the SDK-rendered Band prompt (recommended)",
+    system_prompt="Replaces it entirely — you own the tool contract then",
+    additional_tools=[(WeatherInput, get_weather), native_strands_tool],
+    features=AdapterFeatures(
+        emit=frozenset({Emit.EXECUTION, Emit.USAGE}),
+        capabilities=frozenset({Capability.MEMORY, Capability.CONTACTS}),
+    ),
+)
+```
+
+The adapter registers the Band platform tools itself; a custom tool may not reuse
+one of their names. Band owns per-room history: the transcript is converted into
+Strands `Message` dicts, seeded into a fresh `Agent` per turn, and read back after
+it, so a restart rehydrates from the room.
+
+## Running
+
+```bash
+# from the repo root
+uv run examples/strands/01_basic_agent.py
+
+# the character pair, in two terminals
+uv run examples/strands/06_tom_agent.py
+uv run examples/strands/07_jerry_agent.py
+```

--- a/examples/strands/setup_logging.py
+++ b/examples/strands/setup_logging.py
@@ -1,0 +1,12 @@
+"""Shared logging configuration for examples."""
+
+from __future__ import annotations
+
+import logging
+
+from band import configure_logging
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure logging to show only band logs, hiding noisy dependencies."""
+    configure_logging(level)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,9 @@ google_adk = [
 agno = [
     "agno>=2.6.0",
 ]
+strands = [
+    "strands-agents[openai]>=1.40,<2",
+]
 
 # dev extra includes ALL framework deps for testing EXCEPT crewai, which is
 # declared conflicting with both parlant and pydantic-ai (see tool.uv.conflicts).
@@ -200,6 +203,8 @@ dev = [
     "opentelemetry-resourcedetector-gcp>=1.12.0a0,!=1.13.0",
     # Include Agno for testing
     "agno>=2.6.0",
+    # Include Strands Agents for testing
+    "strands-agents[openai]>=1.40,<2",
     # Include letta-client for testing
     "letta-client>=0.1.0",
     # Include bridge deps for testing

--- a/src/band/adapters/__init__.py
+++ b/src/band/adapters/__init__.py
@@ -32,26 +32,26 @@ if TYPE_CHECKING:
     from band.adapters.anthropic import AnthropicAdapter as AnthropicAdapter
     from band.adapters.pydantic_ai import PydanticAIAdapter as PydanticAIAdapter
     from band.adapters.claude_sdk import ClaudeSDKAdapter as ClaudeSDKAdapter
-    from band.adapters.copilot_sdk import CopilotSDKAdapter as CopilotSDKAdapter
     from band.adapters.copilot_sdk import (
+        CopilotSDKAdapter as CopilotSDKAdapter,
         CopilotSDKAdapterConfig as CopilotSDKAdapterConfig,
     )
-    from band.adapters.copilot_acp import CopilotACPAdapter as CopilotACPAdapter
     from band.adapters.copilot_acp import (
+        CopilotACPAdapter as CopilotACPAdapter,
         CopilotACPAdapterConfig as CopilotACPAdapterConfig,
     )
     from band.adapters.parlant import ParlantAdapter as ParlantAdapter
     from band.adapters.crewai import CrewAIAdapter as CrewAIAdapter
-    from band.adapters.crewai_flow import (
-        CrewAIFlowAdapter as CrewAIFlowAdapter,
-    )
+    from band.adapters.crewai_flow import CrewAIFlowAdapter as CrewAIFlowAdapter
     from band.adapters.a2a import A2AAdapter as A2AAdapter
     from band.adapters.a2a_gateway import (
         A2AGatewayAdapter as A2AGatewayAdapter,
         A2AGatewayAdapterConfig as A2AGatewayAdapterConfig,
     )
-    from band.adapters.codex import CodexAdapter as CodexAdapter
-    from band.adapters.codex import CodexAdapterConfig as CodexAdapterConfig
+    from band.adapters.codex import (
+        CodexAdapter as CodexAdapter,
+        CodexAdapterConfig as CodexAdapterConfig,
+    )
     from band.adapters.acp import (
         ACPClientAdapter as ACPClientAdapter,
         ACPServer as ACPServer,
@@ -60,37 +60,41 @@ if TYPE_CHECKING:
     from band.adapters.agno import AgnoAdapter as AgnoAdapter
     from band.adapters.gemini import GeminiAdapter as GeminiAdapter
     from band.adapters.google_adk import GoogleADKAdapter as GoogleADKAdapter
-    from band.adapters.opencode import OpencodeAdapter as OpencodeAdapter
-    from band.adapters.opencode import OpencodeAdapterConfig as OpencodeAdapterConfig
-    from band.adapters.letta import LettaAdapter as LettaAdapter
-    from band.adapters.letta import LettaAdapterConfig as LettaAdapterConfig
-    from band.adapters.slack import SlackAdapter as SlackAdapter
-    from band.adapters.slack import SlackApp as SlackApp
-    from band.adapters.slack import SlackSessionState as SlackSessionState
+    from band.adapters.opencode import (
+        OpencodeAdapter as OpencodeAdapter,
+        OpencodeAdapterConfig as OpencodeAdapterConfig,
+    )
+    from band.adapters.letta import (
+        LettaAdapter as LettaAdapter,
+        LettaAdapterConfig as LettaAdapterConfig,
+    )
+    from band.adapters.slack import (
+        SlackAdapter as SlackAdapter,
+        SlackApp as SlackApp,
+        SlackSessionState as SlackSessionState,
+    )
     from band.adapters.strands import StrandsAdapter as StrandsAdapter
 
-__all__, __getattr__, __dir__ = lazy_exports(
+__all__, __getattr__ = lazy_exports(
     __name__,
-    {
-        "langgraph": ("LangGraphAdapter",),
-        "anthropic": ("AnthropicAdapter",),
-        "pydantic_ai": ("PydanticAIAdapter",),
-        "claude_sdk": ("ClaudeSDKAdapter",),
-        "copilot_sdk": ("CopilotSDKAdapter", "CopilotSDKAdapterConfig"),
-        "copilot_acp": ("CopilotACPAdapter", "CopilotACPAdapterConfig"),
-        "parlant": ("ParlantAdapter",),
-        "crewai": ("CrewAIAdapter",),
-        "crewai_flow": ("CrewAIFlowAdapter",),
-        "a2a": ("A2AAdapter",),
-        "a2a_gateway": ("A2AGatewayAdapter", "A2AGatewayAdapterConfig"),
-        "codex": ("CodexAdapter", "CodexAdapterConfig"),
-        "acp": ("ACPClientAdapter", "ACPServer", "BandACPServerAdapter"),
-        "agno": ("AgnoAdapter",),
-        "gemini": ("GeminiAdapter",),
-        "google_adk": ("GoogleADKAdapter",),
-        "opencode": ("OpencodeAdapter", "OpencodeAdapterConfig"),
-        "letta": ("LettaAdapter", "LettaAdapterConfig"),
-        "slack": ("SlackAdapter", "SlackApp", "SlackSessionState"),
-        "strands": ("StrandsAdapter",),
-    },
+    langgraph=["LangGraphAdapter"],
+    anthropic=["AnthropicAdapter"],
+    pydantic_ai=["PydanticAIAdapter"],
+    claude_sdk=["ClaudeSDKAdapter"],
+    copilot_sdk=["CopilotSDKAdapter", "CopilotSDKAdapterConfig"],
+    copilot_acp=["CopilotACPAdapter", "CopilotACPAdapterConfig"],
+    parlant=["ParlantAdapter"],
+    crewai=["CrewAIAdapter"],
+    crewai_flow=["CrewAIFlowAdapter"],
+    a2a=["A2AAdapter"],
+    a2a_gateway=["A2AGatewayAdapter", "A2AGatewayAdapterConfig"],
+    codex=["CodexAdapter", "CodexAdapterConfig"],
+    acp=["ACPClientAdapter", "ACPServer", "BandACPServerAdapter"],
+    agno=["AgnoAdapter"],
+    gemini=["GeminiAdapter"],
+    google_adk=["GoogleADKAdapter"],
+    opencode=["OpencodeAdapter", "OpencodeAdapterConfig"],
+    letta=["LettaAdapter", "LettaAdapterConfig"],
+    slack=["SlackAdapter", "SlackApp", "SlackSessionState"],
+    strands=["StrandsAdapter"],
 )

--- a/src/band/adapters/__init__.py
+++ b/src/band/adapters/__init__.py
@@ -17,6 +17,7 @@ Install the extra you need::
     uv add band-sdk[google_adk]
     uv add band-sdk[opencode]
     uv add band-sdk[slack]
+    uv add band-sdk[strands]
 """
 
 from __future__ import annotations
@@ -65,6 +66,7 @@ if TYPE_CHECKING:
     from band.adapters.slack import SlackAdapter as SlackAdapter
     from band.adapters.slack import SlackApp as SlackApp
     from band.adapters.slack import SlackSessionState as SlackSessionState
+    from band.adapters.strands import StrandsAdapter as StrandsAdapter
 
 __all__ = [
     "LangGraphAdapter",
@@ -96,6 +98,7 @@ __all__ = [
     "SlackAdapter",
     "SlackApp",
     "SlackSessionState",
+    "StrandsAdapter",
 ]
 
 
@@ -130,6 +133,7 @@ _LAZY_IMPORTS: dict[str, str] = {
     "SlackAdapter": "slack",
     "SlackApp": "slack",
     "SlackSessionState": "slack",
+    "StrandsAdapter": "strands",
 }
 
 

--- a/src/band/adapters/__init__.py
+++ b/src/band/adapters/__init__.py
@@ -22,8 +22,9 @@ Install the extra you need::
 
 from __future__ import annotations
 
-import importlib
 from typing import TYPE_CHECKING
+
+from band.exports import lazy_exports
 
 # Type-only imports for static analysis (pyrefly, mypy, etc.)
 if TYPE_CHECKING:
@@ -45,8 +46,8 @@ if TYPE_CHECKING:
         CrewAIFlowAdapter as CrewAIFlowAdapter,
     )
     from band.adapters.a2a import A2AAdapter as A2AAdapter
-    from band.adapters.a2a_gateway import A2AGatewayAdapter as A2AGatewayAdapter
     from band.adapters.a2a_gateway import (
+        A2AGatewayAdapter as A2AGatewayAdapter,
         A2AGatewayAdapterConfig as A2AGatewayAdapterConfig,
     )
     from band.adapters.codex import CodexAdapter as CodexAdapter
@@ -68,79 +69,28 @@ if TYPE_CHECKING:
     from band.adapters.slack import SlackSessionState as SlackSessionState
     from band.adapters.strands import StrandsAdapter as StrandsAdapter
 
-__all__ = [
-    "LangGraphAdapter",
-    "AnthropicAdapter",
-    "PydanticAIAdapter",
-    "ClaudeSDKAdapter",
-    "CopilotSDKAdapter",
-    "CopilotSDKAdapterConfig",
-    "CopilotACPAdapter",
-    "CopilotACPAdapterConfig",
-    "ParlantAdapter",
-    "CrewAIAdapter",
-    "CrewAIFlowAdapter",
-    "A2AAdapter",
-    "A2AGatewayAdapter",
-    "A2AGatewayAdapterConfig",
-    "CodexAdapter",
-    "CodexAdapterConfig",
-    "ACPClientAdapter",
-    "ACPServer",
-    "BandACPServerAdapter",
-    "AgnoAdapter",
-    "GeminiAdapter",
-    "GoogleADKAdapter",
-    "OpencodeAdapter",
-    "OpencodeAdapterConfig",
-    "LettaAdapter",
-    "LettaAdapterConfig",
-    "SlackAdapter",
-    "SlackApp",
-    "SlackSessionState",
-    "StrandsAdapter",
-]
-
-
-# Submodule (under band.adapters) providing each lazily imported name.
-_LAZY_IMPORTS: dict[str, str] = {
-    "LangGraphAdapter": "langgraph",
-    "AnthropicAdapter": "anthropic",
-    "PydanticAIAdapter": "pydantic_ai",
-    "ClaudeSDKAdapter": "claude_sdk",
-    "CopilotSDKAdapter": "copilot_sdk",
-    "CopilotSDKAdapterConfig": "copilot_sdk",
-    "CopilotACPAdapter": "copilot_acp",
-    "CopilotACPAdapterConfig": "copilot_acp",
-    "ParlantAdapter": "parlant",
-    "CrewAIAdapter": "crewai",
-    "CrewAIFlowAdapter": "crewai_flow",
-    "A2AAdapter": "a2a",
-    "A2AGatewayAdapter": "a2a_gateway",
-    "A2AGatewayAdapterConfig": "a2a_gateway",
-    "CodexAdapter": "codex",
-    "CodexAdapterConfig": "codex",
-    "ACPClientAdapter": "acp",
-    "ACPServer": "acp",
-    "BandACPServerAdapter": "acp",
-    "AgnoAdapter": "agno",
-    "GeminiAdapter": "gemini",
-    "GoogleADKAdapter": "google_adk",
-    "OpencodeAdapter": "opencode",
-    "OpencodeAdapterConfig": "opencode",
-    "LettaAdapter": "letta",
-    "LettaAdapterConfig": "letta",
-    "SlackAdapter": "slack",
-    "SlackApp": "slack",
-    "SlackSessionState": "slack",
-    "StrandsAdapter": "strands",
-}
-
-
-def __getattr__(name: str) -> type:
-    """Lazy import adapters to avoid loading optional dependencies."""
-    module_name = _LAZY_IMPORTS.get(name)
-    if module_name is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    module = importlib.import_module(f".{module_name}", __name__)
-    return getattr(module, name)
+__all__, __getattr__, __dir__ = lazy_exports(
+    __name__,
+    {
+        "langgraph": ("LangGraphAdapter",),
+        "anthropic": ("AnthropicAdapter",),
+        "pydantic_ai": ("PydanticAIAdapter",),
+        "claude_sdk": ("ClaudeSDKAdapter",),
+        "copilot_sdk": ("CopilotSDKAdapter", "CopilotSDKAdapterConfig"),
+        "copilot_acp": ("CopilotACPAdapter", "CopilotACPAdapterConfig"),
+        "parlant": ("ParlantAdapter",),
+        "crewai": ("CrewAIAdapter",),
+        "crewai_flow": ("CrewAIFlowAdapter",),
+        "a2a": ("A2AAdapter",),
+        "a2a_gateway": ("A2AGatewayAdapter", "A2AGatewayAdapterConfig"),
+        "codex": ("CodexAdapter", "CodexAdapterConfig"),
+        "acp": ("ACPClientAdapter", "ACPServer", "BandACPServerAdapter"),
+        "agno": ("AgnoAdapter",),
+        "gemini": ("GeminiAdapter",),
+        "google_adk": ("GoogleADKAdapter",),
+        "opencode": ("OpencodeAdapter", "OpencodeAdapterConfig"),
+        "letta": ("LettaAdapter", "LettaAdapterConfig"),
+        "slack": ("SlackAdapter", "SlackApp", "SlackSessionState"),
+        "strands": ("StrandsAdapter",),
+    },
+)

--- a/src/band/adapters/agno.py
+++ b/src/band/adapters/agno.py
@@ -18,6 +18,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    ToolEventKey,
     TurnUsage,
 )
 from band.converters.agno import AgnoHistoryConverter, AgnoMessages
@@ -730,9 +731,9 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
                 tools,
                 "tool_call",
                 {
-                    "name": ex.tool_name or "",
-                    "args": ex.tool_args or {},
-                    "tool_call_id": ex.tool_call_id or "",
+                    ToolEventKey.NAME: ex.tool_name or "",
+                    ToolEventKey.ARGS: ex.tool_args or {},
+                    ToolEventKey.TOOL_CALL_ID: ex.tool_call_id or "",
                 },
                 room_id=room_id,
                 msg_id=msg_id,
@@ -742,10 +743,10 @@ class AgnoAdapter(SimpleAdapter[AgnoMessages]):
                 tools,
                 "tool_result",
                 {
-                    "name": ex.tool_name or "",
-                    "output": str(ex.result or ""),
-                    "tool_call_id": ex.tool_call_id or "",
-                    "is_error": bool(ex.tool_call_error),
+                    ToolEventKey.NAME: ex.tool_name or "",
+                    ToolEventKey.OUTPUT: str(ex.result or ""),
+                    ToolEventKey.TOOL_CALL_ID: ex.tool_call_id or "",
+                    ToolEventKey.IS_ERROR: bool(ex.tool_call_error),
                 },
                 room_id=room_id,
                 msg_id=msg_id,

--- a/src/band/adapters/anthropic.py
+++ b/src/band/adapters/anthropic.py
@@ -22,6 +22,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    ToolEventKey,
     TurnUsage,
 )
 from band.converters.anthropic import AnthropicHistoryConverter, AnthropicMessages
@@ -452,9 +453,9 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                     await tools.send_event(
                         content=json.dumps(
                             {
-                                "name": tool_name,
-                                "args": tool_input,
-                                "tool_call_id": tool_use_id,
+                                ToolEventKey.NAME: tool_name,
+                                ToolEventKey.ARGS: tool_input,
+                                ToolEventKey.TOOL_CALL_ID: tool_use_id,
                             }
                         ),
                         message_type="tool_call",
@@ -490,9 +491,9 @@ class AnthropicAdapter(SimpleAdapter[AnthropicMessages]):
                     await tools.send_event(
                         content=json.dumps(
                             {
-                                "name": tool_name,
-                                "output": result_str,
-                                "tool_call_id": tool_use_id,
+                                ToolEventKey.NAME: tool_name,
+                                ToolEventKey.OUTPUT: result_str,
+                                ToolEventKey.TOOL_CALL_ID: tool_use_id,
                             }
                         ),
                         message_type="tool_result",

--- a/src/band/adapters/claude_sdk.py
+++ b/src/band/adapters/claude_sdk.py
@@ -55,6 +55,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    ToolEventKey,
     TurnUsage,
 )
 from band.converters.claude_sdk import (
@@ -734,9 +735,9 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                                 await tools.send_event(
                                     content=json.dumps(
                                         {
-                                            "name": tool_name,
-                                            "args": block.input,
-                                            "tool_call_id": block.id,
+                                            ToolEventKey.NAME: tool_name,
+                                            ToolEventKey.ARGS: block.input,
+                                            ToolEventKey.TOOL_CALL_ID: block.id,
                                         }
                                     ),
                                     message_type="tool_call",
@@ -756,8 +757,8 @@ class ClaudeSDKAdapter(SimpleAdapter[ClaudeSDKSessionState]):
                                 await tools.send_event(
                                     content=json.dumps(
                                         {
-                                            "output": block.content,
-                                            "tool_call_id": block.tool_use_id,
+                                            ToolEventKey.OUTPUT: block.content,
+                                            ToolEventKey.TOOL_CALL_ID: block.tool_use_id,
                                         }
                                     ),
                                     message_type="tool_result",

--- a/src/band/adapters/codex.py
+++ b/src/band/adapters/codex.py
@@ -25,6 +25,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    ToolEventKey,
     TurnUsage,
 )
 from band.integrations.codex import (
@@ -1306,7 +1307,11 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             if should_report:
                 await tools.send_event(
                     content=json.dumps(
-                        {"name": tool_name, "args": arguments, "tool_call_id": call_id}
+                        {
+                            ToolEventKey.NAME: tool_name,
+                            ToolEventKey.ARGS: arguments,
+                            ToolEventKey.TOOL_CALL_ID: call_id,
+                        }
                     ),
                     message_type="tool_call",
                 )
@@ -1342,9 +1347,9 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     await tools.send_event(
                         content=json.dumps(
                             {
-                                "name": tool_name,
-                                "output": text_result,
-                                "tool_call_id": call_id,
+                                ToolEventKey.NAME: tool_name,
+                                ToolEventKey.OUTPUT: text_result,
+                                ToolEventKey.TOOL_CALL_ID: call_id,
                             }
                         ),
                         message_type="tool_result",
@@ -1364,9 +1369,9 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     await tools.send_event(
                         content=json.dumps(
                             {
-                                "name": tool_name,
-                                "output": error_text,
-                                "tool_call_id": call_id,
+                                ToolEventKey.NAME: tool_name,
+                                ToolEventKey.OUTPUT: error_text,
+                                ToolEventKey.TOOL_CALL_ID: call_id,
                             }
                         ),
                         message_type="tool_result",
@@ -1385,9 +1390,9 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
                     await tools.send_event(
                         content=json.dumps(
                             {
-                                "name": tool_name,
-                                "output": error_text,
-                                "tool_call_id": call_id,
+                                ToolEventKey.NAME: tool_name,
+                                ToolEventKey.OUTPUT: error_text,
+                                ToolEventKey.TOOL_CALL_ID: call_id,
                             }
                         ),
                         message_type="tool_result",
@@ -1727,14 +1732,22 @@ class CodexAdapter(SimpleAdapter[CodexSessionState]):
             name, args, output = self._extract_tool_item(item_type, item)
             await tools.send_event(
                 content=json.dumps(
-                    {"name": name, "args": args, "tool_call_id": item_id}
+                    {
+                        ToolEventKey.NAME: name,
+                        ToolEventKey.ARGS: args,
+                        ToolEventKey.TOOL_CALL_ID: item_id,
+                    }
                 ),
                 message_type="tool_call",
                 metadata=metadata,
             )
             await tools.send_event(
                 content=json.dumps(
-                    {"name": name, "output": output, "tool_call_id": item_id}
+                    {
+                        ToolEventKey.NAME: name,
+                        ToolEventKey.OUTPUT: output,
+                        ToolEventKey.TOOL_CALL_ID: item_id,
+                    }
                 ),
                 message_type="tool_result",
                 metadata=metadata,

--- a/src/band/adapters/copilot_sdk.py
+++ b/src/band/adapters/copilot_sdk.py
@@ -24,7 +24,7 @@ from band.converters.copilot_sdk import (
 from band.core.exceptions import BandConfigError
 from band.core.simple_adapter import SimpleAdapter
 from band.core.tool_filter import filter_tool_schemas
-from band.core.types import Capability, Emit, MessageType, TurnUsage
+from band.core.types import Capability, Emit, MessageType, ToolEventKey, TurnUsage
 from band.integrations.copilot_sdk import CopilotSessionManager
 from band.integrations.copilot_sdk.prompts import TURN_COMPLETION_GUIDANCE
 from band.integrations.copilot_sdk.room_ask_user import (
@@ -772,9 +772,9 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
             room_tools,
             json.dumps(
                 {
-                    "name": invocation.tool_name,
-                    "args": arguments,
-                    "tool_call_id": invocation.tool_call_id,
+                    ToolEventKey.NAME: invocation.tool_name,
+                    ToolEventKey.ARGS: arguments,
+                    ToolEventKey.TOOL_CALL_ID: invocation.tool_call_id,
                 }
             ),
             MessageType.TOOL_CALL,
@@ -790,9 +790,9 @@ class CopilotSDKAdapter(SimpleAdapter[CopilotSDKSessionState]):
             room_tools,
             json.dumps(
                 {
-                    "name": invocation.tool_name,
-                    "output": output,
-                    "tool_call_id": invocation.tool_call_id,
+                    ToolEventKey.NAME: invocation.tool_name,
+                    ToolEventKey.OUTPUT: output,
+                    ToolEventKey.TOOL_CALL_ID: invocation.tool_call_id,
                 }
             ),
             MessageType.TOOL_RESULT,

--- a/src/band/adapters/crewai.py
+++ b/src/band/adapters/crewai.py
@@ -27,6 +27,7 @@ from band.integrations.crewai import (
 )
 from band.runtime.custom_tools import CustomToolDef
 from band.runtime.prompts import render_system_prompt
+from band.runtime.tools import missing_reply_error
 
 if TYPE_CHECKING:
     from crewai import Agent as CrewAIAgent
@@ -439,10 +440,13 @@ class CrewAIAdapter(SimpleAdapter[CrewAIMessages]):
             if not (reply_tracker is not None and reply_tracker.replied):
                 await self._report_error(
                     tools,
-                    "CrewAI completed without sending a Band message. This usually "
-                    f"means repeated tool failures exhausted max_iter={self.max_iter} "
-                    "or the agent returned a final answer instead of using the "
-                    "band_send_message tool.",
+                    missing_reply_error(
+                        "CrewAI",
+                        detail=(
+                            "Repeated tool failures may also have exhausted "
+                            f"max_iter={self.max_iter}."
+                        ),
+                    ),
                 )
 
             logger.info(

--- a/src/band/adapters/gemini.py
+++ b/src/band/adapters/gemini.py
@@ -31,6 +31,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    ToolEventKey,
     TurnUsage,
 )
 from band.converters.gemini import GeminiHistoryConverter, GeminiMessages
@@ -523,9 +524,9 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                     await tools.send_event(
                         content=json.dumps(
                             {
-                                "name": tool_name,
-                                "args": tool_input,
-                                "tool_call_id": tool_call_id,
+                                ToolEventKey.NAME: tool_name,
+                                ToolEventKey.ARGS: tool_input,
+                                ToolEventKey.TOOL_CALL_ID: tool_call_id,
                             }
                         ),
                         message_type="tool_call",
@@ -560,10 +561,10 @@ class GeminiAdapter(SimpleAdapter[GeminiMessages]):
                     await tools.send_event(
                         content=json.dumps(
                             {
-                                "name": tool_name,
-                                "output": result_str,
-                                "tool_call_id": tool_call_id,
-                                "is_error": is_error,
+                                ToolEventKey.NAME: tool_name,
+                                ToolEventKey.OUTPUT: result_str,
+                                ToolEventKey.TOOL_CALL_ID: tool_call_id,
+                                ToolEventKey.IS_ERROR: is_error,
                             }
                         ),
                         message_type="tool_result",

--- a/src/band/adapters/google_adk.py
+++ b/src/band/adapters/google_adk.py
@@ -27,6 +27,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    ToolEventKey,
     TurnUsage,
 )
 from band.converters.google_adk import GoogleADKHistoryConverter, GoogleADKMessages
@@ -689,9 +690,9 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
                     await tools.send_event(
                         content=json.dumps(
                             {
-                                "name": getattr(fc, "name", "unknown"),
-                                "args": args,
-                                "tool_call_id": getattr(fc, "id", ""),
+                                ToolEventKey.NAME: getattr(fc, "name", "unknown"),
+                                ToolEventKey.ARGS: args,
+                                ToolEventKey.TOOL_CALL_ID: getattr(fc, "id", ""),
                             }
                         ),
                         message_type="tool_call",
@@ -706,11 +707,11 @@ class GoogleADKAdapter(SimpleAdapter[GoogleADKMessages]):
                     await tools.send_event(
                         content=json.dumps(
                             {
-                                "name": getattr(fr, "name", "unknown"),
-                                "output": str(fr.response)
+                                ToolEventKey.NAME: getattr(fr, "name", "unknown"),
+                                ToolEventKey.OUTPUT: str(fr.response)
                                 if getattr(fr, "response", None)
                                 else "",
-                                "tool_call_id": getattr(fr, "id", ""),
+                                ToolEventKey.TOOL_CALL_ID: getattr(fr, "id", ""),
                             }
                         ),
                         message_type="tool_result",

--- a/src/band/adapters/langgraph.py
+++ b/src/band/adapters/langgraph.py
@@ -19,6 +19,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    ToolEventKey,
     TurnUsage,
 )
 from band.converters.langchain import LangChainHistoryConverter, LangChainMessages
@@ -406,9 +407,9 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
             tool_name = event.get("name", "unknown")
             data = event.get("data") if isinstance(event.get("data"), dict) else {}
             payload = {
-                "name": tool_name,
-                "args": data.get("input", {}),
-                "tool_call_id": event.get("run_id", "unknown"),
+                ToolEventKey.NAME: tool_name,
+                ToolEventKey.ARGS: data.get("input", {}),
+                ToolEventKey.TOOL_CALL_ID: event.get("run_id", "unknown"),
             }
             logger.info("[STREAM] on_tool_start: %s", tool_name)
             try:
@@ -427,10 +428,10 @@ class LangGraphAdapter(SimpleAdapter[LangChainMessages]):
             data = event.get("data") if isinstance(event.get("data"), dict) else {}
             is_error = event_type == "on_tool_error" or bool(data.get("error"))
             payload = {
-                "name": tool_name,
-                "output": data.get("error") or data.get("output", ""),
-                "tool_call_id": event.get("run_id", "unknown"),
-                "is_error": is_error,
+                ToolEventKey.NAME: tool_name,
+                ToolEventKey.OUTPUT: data.get("error") or data.get("output", ""),
+                ToolEventKey.TOOL_CALL_ID: event.get("run_id", "unknown"),
+                ToolEventKey.IS_ERROR: is_error,
             }
             logger.info("[STREAM] %s: %s", event_type, tool_name)
             try:

--- a/src/band/adapters/letta.py
+++ b/src/band/adapters/letta.py
@@ -19,6 +19,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    ToolEventKey,
     TurnUsage,
 )
 from band.integrations.letta.config import (
@@ -504,8 +505,8 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                         "tool_call",
                         tool_name,
                         {
-                            "name": tool_name,
-                            "args": getattr(tool_call, "arguments", "{}")
+                            ToolEventKey.NAME: tool_name,
+                            ToolEventKey.ARGS: getattr(tool_call, "arguments", "{}")
                             if tool_call
                             else "{}",
                         },
@@ -517,8 +518,8 @@ class LettaAdapter(SimpleAdapter[LettaSessionState]):
                         "tool_result",
                         tool_name,
                         {
-                            "name": tool_name,
-                            "output": getattr(resp_msg, "tool_return", ""),
+                            ToolEventKey.NAME: tool_name,
+                            ToolEventKey.OUTPUT: getattr(resp_msg, "tool_return", ""),
                         },
                     )
 

--- a/src/band/adapters/opencode/adapter.py
+++ b/src/band/adapters/opencode/adapter.py
@@ -26,6 +26,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    ToolEventKey,
     TurnUsage,
 )
 from band.integrations.mcp.backends import (
@@ -1158,9 +1159,9 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
             await room_state.tools.send_event(
                 json.dumps(
                     {
-                        "name": tool_name,
-                        "args": state.input,
-                        "tool_call_id": call_id,
+                        ToolEventKey.NAME: tool_name,
+                        ToolEventKey.ARGS: state.input,
+                        ToolEventKey.TOOL_CALL_ID: call_id,
                     }
                 ),
                 "tool_call",
@@ -1186,8 +1187,8 @@ class OpencodeAdapter(SimpleAdapter[OpencodeSessionState]):
             await room_state.tools.send_event(
                 json.dumps(
                     {
-                        "output": output,
-                        "tool_call_id": call_id,
+                        ToolEventKey.OUTPUT: output,
+                        ToolEventKey.TOOL_CALL_ID: call_id,
                     }
                 ),
                 "tool_result",

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -62,6 +62,7 @@ from band.runtime.tools import (
     band_tool_errored,
     get_tool_description,
     is_terminal_success,
+    missing_reply_error,
     serialize_tool_result,
 )
 
@@ -880,16 +881,11 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                     turn_usage = self._usage_from_messages(this_run)
                 await self.emit_usage(tools, turn_usage)
 
-        # A clean run with no terminal work means the model answered in plain text
-        # without calling band_send_message — a silently dropped reply. Surface it
-        # as an error (mirrors the crewai adapter) instead of letting it vanish.
+        # A clean run with no terminal work is a silently dropped reply: the model
+        # either answered in plain text or said nothing at all. Surface it as an
+        # error (mirrors the crewai adapter) instead of letting it vanish.
         if not tool_executed:
-            await self._report_error(
-                tools,
-                "Pydantic AI completed without sending a Band message. This "
-                "usually means the agent returned a final answer as plain text "
-                "instead of using the band_send_message tool.",
-            )
+            await self._report_error(tools, missing_reply_error("Pydantic AI"))
 
         logger.debug(
             "Room %s: Pydantic AI agent completed (history now has %s messages)",

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -23,14 +23,16 @@ from pydantic_ai import (
     UnexpectedModelBehavior,
     capture_run_messages,
 )
-from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.capabilities import Hooks, ProcessHistory
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    TextPart,
     ThinkingPart,
     UserPromptPart,
 )
+from pydantic_ai.models import ModelRequestContext
 
 from band_rest.core.api_error import ApiError
 
@@ -117,6 +119,30 @@ def _drop_non_replayable_messages(messages: list[ModelMessage]) -> list[ModelMes
     the within-run gap.
     """
     return [m for m in messages if _is_replayable_history_message(m)]
+
+
+def _drop_blank_text(
+    ctx: RunContext[AgentToolsProtocol],
+    *,
+    request_context: ModelRequestContext,
+    response: ModelResponse,
+) -> ModelResponse:
+    """Treat blank text as what it is: no output at all.
+
+    An agent that answers through tools has nothing left to say once it has acted,
+    and providers render that as an empty text part rather than a partless response.
+    pydantic-ai recognizes only a partless (or thinking-only) response as "no
+    actionable output" — the ``None`` outcome ``output_type`` allows — so a blank
+    part would instead be met with a retry prompt, spend the refused output budget,
+    and fail the turn. Dropping it also keeps the blank part out of history, where
+    it replays as content:null.
+    """
+    response.parts = [
+        part
+        for part in response.parts
+        if not (isinstance(part, TextPart) and not part.content.strip())
+    ]
+    return response
 
 
 def _custom_tool_def_to_callable(tool_def: CustomToolDef) -> Callable[..., Any]:
@@ -261,7 +287,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         self.custom_section = custom_section
         self._system_prompt: str | None = None
 
-        self._agent: Agent[AgentToolsProtocol, str] | None = None
+        self._agent: Agent[AgentToolsProtocol, str | None] | None = None
         # Conversation history per room (Pydantic AI is stateless, we maintain state)
         self._message_history: dict[str, list] = {}
         # Custom tools: accept both native callables and the portable CustomToolDef
@@ -286,7 +312,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         logger.info("Pydantic AI adapter started for agent: %s", agent_name)
 
     # --- Copied from BandPydanticAgent._create_agent ---
-    def _create_agent(self) -> Agent[AgentToolsProtocol, str]:
+    def _create_agent(self) -> Agent[AgentToolsProtocol, str | None]:
         """Create Pydantic AI Agent with platform tools."""
         system = self.system_prompt or render_system_prompt(
             agent_name=self.agent_name,
@@ -296,11 +322,7 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
         )
         self._system_prompt = system
 
-        # We respond via tools only, so the model output is unused — but it must
-        # still be a type: pydantic-ai rejects `output_type=None` with
-        # `UserError("At least one output type must be provided other than
-        # `None`")`, so `str` stands in for "we don't care".
-        agent: Agent[AgentToolsProtocol, str] = Agent(
+        agent: Agent[AgentToolsProtocol, str | None] = Agent(
             self.model,
             # Pass the rendered prompt as `instructions`, not `system_prompt`.
             # pydantic-ai materializes `system_prompt` as a single SystemPromptPart
@@ -313,26 +335,33 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
             # re-sends `system=` on every call, so the contract stays in force.
             instructions=system,
             deps_type=AgentToolsProtocol,
-            output_type=str,
+            # `str | None`: this agent replies *through* tools, so once it has acted
+            # it has nothing left to say and answers with an empty (or thinking-only)
+            # response. Allowing `None` makes that a valid outcome — pydantic-ai ends
+            # the run instead of sending a retry prompt asking it to "return text or
+            # call a tool", which an agent told to answer only through tools obliges
+            # by calling one, re-posting the reply to the room once per attempt.
+            # (Plain `None` is rejected: at least one non-`None` output type is
+            # required.)
+            output_type=str | None,
             # Two budgets, deliberately different — a bare int would set both.
             #
             # tools=3: one retry is too tight for a small model, which occasionally
             # needs another attempt to emit a valid tool call (e.g.
             # band_create_chatroom) before pydantic-ai gives up.
             #
-            # output=0: this agent replies *through* tools, so the forced `str`
-            # output below is unsatisfiable by design and its budget can only ever
-            # be spent, never used. Spending it is not free: each attempt sends the
-            # model a retry prompt asking it to "return text or call a tool", and an
-            # agent told to answer only through tools obliges by calling one — so a
-            # budget of N re-posts the reply to the room N more times, at N+1× the
-            # model round trips. Refusing the retries keeps side effects at exactly
-            # one; the resulting UnexpectedModelBehavior is the benign empty-final
-            # case handled below.
+            # output=0: with `None` allowed the ordinary end-of-turn response no
+            # longer spends this budget, so what is left to retry is a response the
+            # model cannot fix by trying again — and every attempt risks the extra
+            # room post described above. The resulting UnexpectedModelBehavior is
+            # handled where the run is driven.
             retries={"tools": 3, "output": 0},
-            # Strip content:null responses on every request, including mid-run
-            # ones the storage filter can't reach (see the function docstring).
-            capabilities=[ProcessHistory(_drop_non_replayable_messages)],
+            capabilities=[
+                # Strip content:null responses on every request, including mid-run
+                # ones the storage filter can't reach (see the function docstring).
+                ProcessHistory(_drop_non_replayable_messages),
+                Hooks(after_model_request=_drop_blank_text),
+            ],
         )
 
         # Register platform tools dynamically from centralized definitions
@@ -807,15 +836,15 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                                 dropped,
                             )
         except UnexpectedModelBehavior as e:
-            # This is the ordinary way a productive turn ends, not a rare mishap.
-            # pydantic-ai forces a final str output (output_type=str), but the agent
-            # answers through tools — so once it has acted (a band_send_message
-            # reply, a band_store_memory, ...) it has nothing left to say and returns
-            # an empty final response. With output retries refused (see the budget
-            # above) that raises immediately. The work already went out, so the empty
-            # final answer is benign — mirror the crewai adapter and swallow it.
-            # Genuine no-response failures (no terminal tool ran — only read-only
-            # lookups or failed tools) still propagate.
+            # A turn that already did its work must not fail over the reply the model
+            # owes pydantic-ai. Allowing `None` — and normalizing blank text into it
+            # — ends the ordinary nothing-left-to-say response cleanly, but some
+            # other response the run cannot turn into output can still spend the
+            # refused output budget. Once a terminal tool has run (a
+            # band_send_message reply, a band_store_memory, ...) the work already went
+            # out, so that exhaustion is benign — mirror the crewai adapter and
+            # swallow it. Genuine no-response failures (no terminal tool ran — only
+            # read-only lookups or failed tools) still propagate.
             if tool_executed and _is_output_retries_exhausted(e):
                 logger.warning(
                     "Room %s: Pydantic AI exhausted its output retries after "

--- a/src/band/adapters/pydantic_ai.py
+++ b/src/band/adapters/pydantic_ai.py
@@ -42,6 +42,7 @@ from band.core.types import (
     Capability,
     Emit,
     PlatformMessage,
+    ToolEventKey,
     TurnUsage,
 )
 from band.converters.pydantic_ai import (
@@ -746,9 +747,9 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                                 await tools.send_event(
                                     content=json.dumps(
                                         {
-                                            "name": event.part.tool_name,
-                                            "args": event.part.args,
-                                            "tool_call_id": event.part.tool_call_id,
+                                            ToolEventKey.NAME: event.part.tool_name,
+                                            ToolEventKey.ARGS: event.part.args,
+                                            ToolEventKey.TOOL_CALL_ID: event.part.tool_call_id,
                                         }
                                     ),
                                     message_type="tool_call",
@@ -773,9 +774,11 @@ class PydanticAIAdapter(SimpleAdapter[PydanticAIMessages]):
                                 await tools.send_event(
                                     content=json.dumps(
                                         {
-                                            "name": event.part.tool_name,
-                                            "output": str(event.part.content),
-                                            "tool_call_id": event.tool_call_id,
+                                            ToolEventKey.NAME: event.part.tool_name,
+                                            ToolEventKey.OUTPUT: str(
+                                                event.part.content
+                                            ),
+                                            ToolEventKey.TOOL_CALL_ID: event.tool_call_id,
                                         }
                                     ),
                                     message_type="tool_result",

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -1,0 +1,746 @@
+"""
+Strands Agents adapter using SimpleAdapter pattern.
+
+Modeled on the pydantic-ai adapter: the framework owns the agent loop, the
+model object is injectable at the public ``Agent(model=...)`` seam, and Band
+platform tools are registered as native framework tools.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable, ClassVar
+
+import httpx
+
+try:
+    from strands import Agent, ToolContext, tool
+    from strands.hooks import HookProvider, HookRegistry
+    from strands.hooks.events import AfterToolCallEvent, BeforeToolCallEvent
+    from strands.models import Model
+    from strands.types.tools import (
+        AgentTool,
+        ToolGenerator,
+        ToolResult,
+        ToolSpec,
+        ToolUse,
+    )
+except ImportError as e:
+    raise ImportError(
+        "Strands Agents dependencies not installed. "
+        "Install with: uv add band-sdk[strands]"
+    ) from e
+
+from band_rest.core.api_error import ApiError
+
+from band.core.protocols import AgentToolsProtocol
+from band.core.simple_adapter import SimpleAdapter
+from band.core.types import (
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+    TurnUsage,
+)
+from band.converters.strands import StrandsHistoryConverter, StrandsMessages
+from band.runtime.custom_tools import (
+    CustomToolDef,
+    execute_custom_tool,
+    get_custom_tool_name,
+    is_marked_terminal,
+)
+from band.runtime.prompts import render_system_prompt
+from band.runtime.tools import (
+    band_tool_errored,
+    get_tool_description,
+    is_terminal_success,
+)
+
+logger = logging.getLogger(__name__)
+
+# invocation_state key carrying the current turn's AgentToolsProtocol handle.
+# Strands threads invocation_state from Agent.invoke_async(...) into every tool
+# body (via ToolContext) and hook event, which is what lets the tool functions
+# be built once while each turn binds its own tools handle.
+_BAND_TOOLS_STATE_KEY = "band_tools"
+
+
+def _tools_from_context(tool_context: ToolContext) -> AgentToolsProtocol:
+    """The current turn's platform tools handle, bound via invocation_state."""
+    handle = tool_context.invocation_state.get(_BAND_TOOLS_STATE_KEY)
+    if handle is None:
+        raise RuntimeError(
+            "Band tools handle missing from invocation_state; platform tools "
+            "must be invoked through StrandsAdapter.on_message"
+        )
+    return handle
+
+
+def _result_text(result: ToolResult) -> str:
+    """Flatten a ToolResult's content blocks to text for error detection/reporting."""
+    parts: list[str] = []
+    for block in result.get("content", []):
+        if "text" in block:
+            parts.append(block["text"])
+        elif "json" in block:
+            try:
+                parts.append(json.dumps(block["json"]))
+            except (TypeError, ValueError):
+                parts.append(str(block["json"]))
+    return "\n".join(parts)
+
+
+class _CustomToolBridge(AgentTool):
+    """A portable ``CustomToolDef`` (InputModel, handler) as a native Strands tool.
+
+    The tool spec is derived from the Pydantic input model (same name/schema the
+    other adapters expose), and dispatch validates + executes via
+    ``execute_custom_tool`` so the argument-validation contract matches the
+    tuple form everywhere else.
+    """
+
+    def __init__(self, tool_def: CustomToolDef):
+        super().__init__()
+        self._tool_def = tool_def
+        input_model, _ = tool_def
+        schema = input_model.model_json_schema()
+        schema.pop("title", None)
+        self._name = get_custom_tool_name(input_model)
+        self._spec: ToolSpec = {
+            "name": self._name,
+            "description": input_model.__doc__ or self._name,
+            "inputSchema": {"json": schema},
+        }
+
+    @property
+    def tool_name(self) -> str:
+        return self._name
+
+    @property
+    def tool_spec(self) -> ToolSpec:
+        return self._spec
+
+    @property
+    def tool_type(self) -> str:
+        return "function"
+
+    async def stream(
+        self, tool_use: ToolUse, invocation_state: dict[str, Any], **kwargs: Any
+    ) -> ToolGenerator:
+        try:
+            result = await execute_custom_tool(self._tool_def, tool_use["input"] or {})
+            yield {
+                "toolUseId": tool_use["toolUseId"],
+                "status": "success",
+                "content": [{"text": str(result)}],
+            }
+        except Exception as e:
+            yield {
+                "toolUseId": tool_use["toolUseId"],
+                "status": "error",
+                "content": [{"text": f"Error executing tool '{self._name}': {e}"}],
+            }
+
+
+class _BandTurnHooks(HookProvider):
+    """Per-turn hook provider: L6 execution events + terminal-action tracking.
+
+    A fresh instance is registered on each turn's Agent, so per-turn state
+    (whether a terminal Band action fired) needs no cross-turn bookkeeping.
+    Event emission is best-effort and never crashes the turn.
+    """
+
+    def __init__(
+        self,
+        tools: AgentToolsProtocol,
+        *,
+        emit_execution: bool,
+        custom_terminal_names: frozenset[str],
+    ):
+        self._tools = tools
+        self._emit_execution = emit_execution
+        self._custom_terminal_names = custom_terminal_names
+        self.terminal_fired = False
+
+    def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
+        registry.add_callback(BeforeToolCallEvent, self._on_before_tool)
+        registry.add_callback(AfterToolCallEvent, self._on_after_tool)
+
+    async def _on_before_tool(self, event: BeforeToolCallEvent) -> None:
+        if not self._emit_execution:
+            return
+        try:
+            await self._tools.send_event(
+                content=json.dumps(
+                    {
+                        "name": event.tool_use["name"],
+                        "args": event.tool_use["input"],
+                        "tool_call_id": event.tool_use["toolUseId"],
+                    }
+                ),
+                message_type="tool_call",
+            )
+        except Exception as e:
+            logger.warning("Failed to send tool_call event: %s", e)
+
+    async def _on_after_tool(self, event: AfterToolCallEvent) -> None:
+        # Custom tools count as terminal only if they opted in (band_terminal);
+        # undeclared customs fail loud. A failed Band tool (its wrapper returns
+        # an "Error " string, or Strands recorded an error status) is not terminal.
+        name = event.tool_use["name"]
+        output = _result_text(event.result)
+        succeeded = event.result.get("status") == "success" and not band_tool_errored(
+            name, output
+        )
+        if is_terminal_success(
+            name,
+            succeeded=succeeded,
+            custom_terminal=name in self._custom_terminal_names,
+        ):
+            self.terminal_fired = True
+        if not self._emit_execution:
+            return
+        try:
+            await self._tools.send_event(
+                content=json.dumps(
+                    {
+                        "name": name,
+                        "output": output,
+                        "tool_call_id": event.tool_use["toolUseId"],
+                    }
+                ),
+                message_type="tool_result",
+            )
+        except Exception as e:
+            logger.warning("Failed to send tool_result event: %s", e)
+
+
+class StrandsAdapter(SimpleAdapter[StrandsMessages]):
+    """
+    Strands Agents adapter using SimpleAdapter pattern.
+
+    Uses a Strands Agent for LLM interactions, with platform tools registered
+    as native Strands ``@tool`` functions.
+
+    Example:
+        from strands.models.openai import OpenAIModel
+
+        adapter = StrandsAdapter(
+            model=OpenAIModel(model_id="gpt-5.4-mini"),
+            custom_section="You are a helpful assistant.",
+        )
+        agent = Agent.create(adapter=adapter, agent_id="...", api_key="...")
+        await agent.run()
+    """
+
+    SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION, Emit.USAGE})
+    SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
+        {Capability.MEMORY, Capability.CONTACTS}
+    )
+
+    def __init__(
+        self,
+        model: str | Model,
+        system_prompt: str | None = None,
+        custom_section: str | None = None,
+        history_converter: StrandsHistoryConverter | None = None,
+        additional_tools: list[Callable[..., Any] | CustomToolDef] | None = None,
+        features: AdapterFeatures | None = None,
+    ):
+        """
+        Initialize the Strands adapter.
+
+        Args:
+            model: A Strands ``Model`` instance (e.g.
+                ``strands.models.openai.OpenAIModel(model_id="gpt-5.4-mini")``).
+                A plain string is passed through to Strands, which treats it as
+                a **Bedrock** model id (Strands has no provider-prefix shorthand).
+            system_prompt: Optional custom system prompt (overrides default)
+            custom_section: Optional custom section added to default system prompt
+            history_converter: Optional custom history converter
+            additional_tools: Optional list of Strands-compatible tools (plain
+                callables or ``@strands.tool``-decorated functions) and/or
+                portable ``CustomToolDef`` (InputModel, handler) tuples.
+            features: Shared adapter feature settings (capabilities, emit, tool filters).
+        """
+        super().__init__(
+            history_converter=history_converter or StrandsHistoryConverter(),
+            features=features,
+        )
+
+        self.model = model
+        self.system_prompt = system_prompt
+        self.custom_section = custom_section
+        self._system_prompt: str | None = None
+
+        # Platform + custom tools, built once in on_started (tool bodies bind the
+        # per-turn tools handle via invocation_state, so they carry no turn state).
+        self._strands_tools: list[Any] = []
+
+        # Conversation history per room (Converse-shaped Messages). Band owns
+        # this state; Strands sessions/conversation managers are not used for
+        # cross-turn persistence.
+        self._message_history: dict[str, StrandsMessages] = {}
+
+        # Custom tools: accept native Strands forms and the portable CustomToolDef
+        # (InputModel, handler) tuple the other adapters take — tuples are bridged
+        # to native Strands AgentTools; callables pass through unchanged.
+        self._custom_tools: list[Any] = [
+            _CustomToolBridge(t) if isinstance(t, tuple) else t
+            for t in (additional_tools or [])
+        ]
+        # Custom tools that opt in as terminal actions (band_terminal=True on the
+        # handler/function). Only these let a turn with no Band-tool action count
+        # as productive; an undeclared custom tool does not (fail-loud — see
+        # is_terminal_success).
+        terminal_names: set[str] = set()
+        for raw, converted in zip(additional_tools or [], self._custom_tools):
+            handler = raw[1] if isinstance(raw, tuple) else raw
+            if is_marked_terminal(handler):
+                terminal_names.add(
+                    converted.tool_name
+                    if isinstance(converted, AgentTool)
+                    else getattr(converted, "__name__", str(converted))
+                )
+        self._custom_terminal_names: frozenset[str] = frozenset(terminal_names)
+
+    async def on_started(self, agent_name: str, agent_description: str) -> None:
+        """Render the system prompt and build the tool set after metadata is fetched."""
+        await super().on_started(agent_name, agent_description)
+        self._system_prompt = self.system_prompt or render_system_prompt(
+            agent_name=self.agent_name,
+            agent_description=self.agent_description or "An AI assistant",
+            custom_section=self.custom_section or "",
+            features=self.features,
+        )
+        self._strands_tools = self._build_platform_tools() + self._custom_tools
+        logger.info("Strands adapter started for agent: %s", agent_name)
+
+    def _build_agent(self, messages: StrandsMessages, hooks: _BandTurnHooks) -> Agent:
+        """Construct the Strands Agent for one turn, over the room's history.
+
+        A Strands Agent is stateful (it owns ``messages`` and per-agent metrics)
+        and raises on concurrent invocation, while the Band runtime runs one
+        asyncio task per room — so a single shared Agent would break under
+        multi-room concurrency. Instead the heavy pieces (prompt, tool set) are
+        built once in on_started and a lightweight Agent shell is constructed
+        per turn over the room's messages (mirrors the google_adk adapter's
+        fresh-runner-per-message pattern). Bonus: a fresh Agent has fresh
+        metrics, so accumulated usage is exactly this turn's usage.
+        """
+        return Agent(
+            model=self.model,
+            messages=messages,
+            tools=self._strands_tools,
+            system_prompt=self._system_prompt,
+            hooks=[hooks],
+            callback_handler=None,
+            name=self.agent_name or None,
+        )
+
+    def _build_platform_tools(self) -> list[Any]:
+        """Build the Band platform tools as native Strands ``@tool`` functions.
+
+        Descriptions come from the centralized tool definitions. All tools catch
+        exceptions and return "Error ..." strings so the LLM can see failures
+        (and so terminal detection can tell a failed Band tool from a success).
+        """
+
+        def band(name: str, fn: Callable[..., Any]) -> Any:
+            return tool(description=get_tool_description(name), context=True)(fn)
+
+        async def band_send_message(
+            content: str,
+            mentions: list[str],
+            tool_context: ToolContext,
+        ) -> Any:
+            try:
+                return await _tools_from_context(tool_context).send_message(
+                    content, mentions
+                )
+            except Exception as e:
+                return f"Error sending message: {e}"
+
+        async def band_send_event(
+            content: str,
+            message_type: str,
+            tool_context: ToolContext,
+            metadata: dict[str, Any] | None = None,
+        ) -> Any:
+            try:
+                return await _tools_from_context(tool_context).send_event(
+                    content, message_type, metadata
+                )
+            except Exception as e:
+                return f"Error sending event: {e}"
+
+        async def band_add_participant(
+            identifier: str,
+            tool_context: ToolContext,
+            role: str = "member",
+        ) -> Any:
+            try:
+                return await _tools_from_context(tool_context).add_participant(
+                    identifier, role
+                )
+            except Exception as e:
+                return f"Error adding participant '{identifier}': {e}"
+
+        async def band_remove_participant(
+            identifier: str,
+            tool_context: ToolContext,
+        ) -> Any:
+            try:
+                return await _tools_from_context(tool_context).remove_participant(
+                    identifier
+                )
+            except Exception as e:
+                return f"Error removing participant '{identifier}': {e}"
+
+        async def band_lookup_peers(
+            tool_context: ToolContext,
+            page: int = 1,
+            page_size: int = 50,
+        ) -> Any:
+            try:
+                return await _tools_from_context(tool_context).lookup_peers(
+                    page, page_size
+                )
+            except Exception as e:
+                return f"Error looking up peers: {e}"
+
+        async def band_get_participants(tool_context: ToolContext) -> Any:
+            try:
+                return await _tools_from_context(tool_context).get_participants()
+            except Exception as e:
+                return f"Error getting participants: {e}"
+
+        async def band_create_chatroom(
+            tool_context: ToolContext,
+            task_id: str | None = None,
+        ) -> Any:
+            try:
+                return await _tools_from_context(tool_context).create_chatroom(task_id)
+            except Exception as e:
+                return f"Error creating chatroom (task_id={task_id}): {e}"
+
+        strands_tools = [
+            band("band_send_message", band_send_message),
+            band("band_send_event", band_send_event),
+            band("band_add_participant", band_add_participant),
+            band("band_remove_participant", band_remove_participant),
+            band("band_lookup_peers", band_lookup_peers),
+            band("band_get_participants", band_get_participants),
+            band("band_create_chatroom", band_create_chatroom),
+        ]
+
+        # Contact management tools (opt-in via Capability.CONTACTS)
+        if Capability.CONTACTS in self.features.capabilities:
+
+            async def band_list_contacts(
+                tool_context: ToolContext,
+                page: int = 1,
+                page_size: int = 50,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).list_contacts(
+                        page, page_size
+                    )
+                except Exception as e:
+                    return f"Error listing contacts: {e}"
+
+            async def band_add_contact(
+                handle: str,
+                tool_context: ToolContext,
+                message: str | None = None,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).add_contact(
+                        handle, message
+                    )
+                except Exception as e:
+                    return f"Error adding contact '{handle}': {e}"
+
+            async def band_remove_contact(
+                tool_context: ToolContext,
+                handle: str | None = None,
+                contact_id: str | None = None,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).remove_contact(
+                        handle, contact_id
+                    )
+                except Exception as e:
+                    return f"Error removing contact: {e}"
+
+            async def band_list_contact_requests(
+                tool_context: ToolContext,
+                page: int = 1,
+                page_size: int = 50,
+                sent_status: str = "pending",
+            ) -> Any:
+                try:
+                    return await _tools_from_context(
+                        tool_context
+                    ).list_contact_requests(page, page_size, sent_status)
+                except Exception as e:
+                    return f"Error listing contact requests: {e}"
+
+            async def band_respond_contact_request(
+                action: str,
+                tool_context: ToolContext,
+                handle: str | None = None,
+                request_id: str | None = None,
+            ) -> Any:
+                tools = _tools_from_context(tool_context)
+                try:
+                    return await tools.respond_contact_request(
+                        action, handle, request_id
+                    )
+                except Exception as e:
+                    error_msg = f"Error responding to contact request: {e}"
+                    # Auto-send error event so it's visible in the room
+                    try:
+                        await tools.send_event(error_msg, "error")
+                    except Exception:
+                        pass  # Don't fail if error reporting fails
+                    return error_msg
+
+            strands_tools.extend(
+                [
+                    band("band_list_contacts", band_list_contacts),
+                    band("band_add_contact", band_add_contact),
+                    band("band_remove_contact", band_remove_contact),
+                    band("band_list_contact_requests", band_list_contact_requests),
+                    band("band_respond_contact_request", band_respond_contact_request),
+                ]
+            )
+
+        # Memory management tools (enterprise only - opt-in)
+        if Capability.MEMORY in self.features.capabilities:
+
+            async def band_list_memories(
+                tool_context: ToolContext,
+                subject_id: str | None = None,
+                scope: str | None = None,
+                system: str | None = None,
+                type: str | None = None,
+                segment: str | None = None,
+                content_query: str | None = None,
+                page_size: int = 50,
+                status: str | None = None,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).list_memories(
+                        subject_id=subject_id,
+                        scope=scope,
+                        system=system,
+                        type=type,
+                        segment=segment,
+                        content_query=content_query,
+                        page_size=page_size,
+                        status=status,
+                    )
+                except Exception as e:
+                    return f"Error listing memories: {e}"
+
+            async def band_store_memory(
+                content: str,
+                system: str,
+                type: str,
+                segment: str,
+                thought: str,
+                scope: str,
+                tool_context: ToolContext,
+                subject_id: str | None = None,
+                metadata: dict[str, Any] | None = None,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).store_memory(
+                        content=content,
+                        system=system,
+                        type=type,
+                        segment=segment,
+                        thought=thought,
+                        scope=scope,
+                        subject_id=subject_id,
+                        metadata=metadata,
+                    )
+                except Exception as e:
+                    return f"Error storing memory: {e}"
+
+            async def band_get_memory(
+                memory_id: str,
+                tool_context: ToolContext,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).get_memory(memory_id)
+                except Exception as e:
+                    return f"Error getting memory: {e}"
+
+            async def band_supersede_memory(
+                memory_id: str,
+                tool_context: ToolContext,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).supersede_memory(
+                        memory_id
+                    )
+                except Exception as e:
+                    return f"Error superseding memory: {e}"
+
+            async def band_archive_memory(
+                memory_id: str,
+                tool_context: ToolContext,
+            ) -> Any:
+                try:
+                    return await _tools_from_context(tool_context).archive_memory(
+                        memory_id
+                    )
+                except Exception as e:
+                    return f"Error archiving memory: {e}"
+
+            strands_tools.extend(
+                [
+                    band("band_list_memories", band_list_memories),
+                    band("band_store_memory", band_store_memory),
+                    band("band_get_memory", band_get_memory),
+                    band("band_supersede_memory", band_supersede_memory),
+                    band("band_archive_memory", band_archive_memory),
+                ]
+            )
+
+        return strands_tools
+
+    async def on_message(
+        self,
+        msg: PlatformMessage,
+        tools: AgentToolsProtocol,
+        history: StrandsMessages,  # Already converted by SimpleAdapter
+        participants_msg: str | None,
+        contacts_msg: str | None,
+        *,
+        is_session_bootstrap: bool,
+        room_id: str,
+    ) -> None:
+        """Handle incoming platform message."""
+        if not self._strands_tools:
+            # Safety: build tools if not yet built (should be done in on_started)
+            self._strands_tools = self._build_platform_tools() + self._custom_tools
+
+        # Initialize message history for this room on first message
+        # Note: history is already converted by SimpleAdapter via history_converter
+        if is_session_bootstrap:
+            if history:
+                self._message_history[room_id] = list(history)
+                logger.debug(
+                    "Room %s: rehydrated %s message(s) from platform history",
+                    room_id,
+                    len(history),
+                )
+            else:
+                self._message_history[room_id] = []
+        elif room_id not in self._message_history:
+            # Safety: ensure history exists even if not first message
+            self._message_history[room_id] = []
+
+        # Inject participants message if changed
+        if participants_msg:
+            self._message_history[room_id].append(
+                {"role": "user", "content": [{"text": f"[System]: {participants_msg}"}]}
+            )
+            logger.debug("Room %s: Injected participant update into history", room_id)
+
+        # Inject contacts message if present
+        if contacts_msg:
+            self._message_history[room_id].append(
+                {"role": "user", "content": [{"text": f"[System]: {contacts_msg}"}]}
+            )
+            logger.debug("Room %s: Injected contacts broadcast into history", room_id)
+
+        # Build user message with sender prefix
+        user_message = msg.format_for_llm()
+
+        logger.debug(
+            "Room %s: Running Strands agent (history: %s msgs, prompt: %s...)",
+            room_id,
+            len(self._message_history[room_id]),
+            user_message[:80],
+        )
+
+        turn_hooks = _BandTurnHooks(
+            tools,
+            emit_execution=Emit.EXECUTION in self.features.emit,
+            custom_terminal_names=self._custom_terminal_names,
+        )
+        agent = self._build_agent(self._message_history[room_id], turn_hooks)
+        try:
+            await agent.invoke_async(
+                user_message,
+                invocation_state={_BAND_TOOLS_STATE_KEY: tools},
+            )
+        finally:
+            # Persist whatever the run recorded (also on a failed turn, so the
+            # room keeps the user prompt + any completed tool work), and emit
+            # this turn's usage: the per-turn Agent has per-turn metrics, so
+            # accumulated_usage is exactly this run's total across its model
+            # calls. emit_usage itself gates on Emit.USAGE and never raises.
+            self._message_history[room_id] = agent.messages
+            await self.emit_usage(tools, self._usage_from_agent(agent))
+
+        # A clean run with no terminal work means the model answered in plain text
+        # without calling band_send_message — a silently dropped reply. Surface it
+        # as an error (mirrors the pydantic-ai/crewai adapters).
+        if not turn_hooks.terminal_fired:
+            await self._report_error(
+                tools,
+                "Strands agent completed without sending a Band message. This "
+                "usually means the agent returned a final answer as plain text "
+                "instead of using the band_send_message tool.",
+            )
+
+        logger.debug(
+            "Room %s: Strands agent completed (history now has %s messages)",
+            room_id,
+            len(self._message_history[room_id]),
+        )
+
+    @staticmethod
+    def _usage_from_agent(agent: Agent) -> TurnUsage:
+        """Map the turn's accumulated token usage onto TurnUsage.
+
+        Strands accumulates usage on the agent's EventLoopMetrics across all of
+        the run's model calls; reading it from the agent (not the AgentResult)
+        also covers turns that raised mid-run. totalTokens is derived
+        (input + output) and deliberately not mapped.
+        """
+        try:
+            usage = dict(agent.event_loop_metrics.accumulated_usage)
+        except Exception:  # pragma: no cover - defensive; usage is best-effort
+            return TurnUsage()
+        return TurnUsage.from_mapping(
+            usage,
+            input="inputTokens",
+            output="outputTokens",
+            cache_read="cacheReadInputTokens",
+            cache_write="cacheWriteInputTokens",
+        )
+
+    async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
+        """Send an error event to the room (best effort).
+
+        Narrowed to the REST call's real failure modes (ApiError = HTTP status,
+        httpx = transport) so a failed error-report never crashes the turn —
+        while a real bug still raises.
+        """
+        try:
+            await tools.send_event(content=f"Error: {error}", message_type="error")
+        except (ApiError, httpx.HTTPError) as e:
+            logger.warning("Failed to send error event: %s", e)
+
+    async def on_cleanup(self, room_id: str) -> None:
+        """Clean up message history when agent leaves a room."""
+        if room_id in self._message_history:
+            del self._message_history[room_id]
+            logger.debug("Room %s: Cleaned up message history", room_id)

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -81,14 +81,38 @@ def _result_text(result: ToolResult) -> str:
     """Flatten a ToolResult's content blocks to text for error detection/reporting."""
     parts: list[str] = []
     for block in result.get("content", []):
-        if "text" in block:
-            parts.append(block["text"])
-        elif "json" in block:
-            try:
-                parts.append(json.dumps(block["json"]))
-            except (TypeError, ValueError):
-                parts.append(str(block["json"]))
+        match block:
+            case {"text": text}:
+                parts.append(text)
+            case {"json": value}:
+                try:
+                    parts.append(json.dumps(value))
+                except (TypeError, ValueError):
+                    parts.append(str(value))
     return "\n".join(parts)
+
+
+def _build_custom_tools(
+    additional_tools: list[Callable[..., Any] | CustomToolDef] | None,
+) -> tuple[list[Any], frozenset[str]]:
+    """Convert portable tools and collect the custom terminal actions."""
+    converted = [
+        _CustomToolBridge(tool_def) if isinstance(tool_def, tuple) else tool_def
+        for tool_def in additional_tools or []
+    ]
+    terminal_names = {
+        tool.tool_name
+        if isinstance(tool, AgentTool)
+        else getattr(tool, "__name__", str(tool))
+        for raw, tool in zip(additional_tools or [], converted)
+        if is_marked_terminal(raw[1] if isinstance(raw, tuple) else raw)
+    }
+    return converted, frozenset(terminal_names)
+
+
+def _as_strands_tool(name: str, fn: Callable[..., Any]) -> Any:
+    """Wrap a Band tool with its canonical description and Strands context."""
+    return tool(description=get_tool_description(name), context=True)(fn)
 
 
 class _CustomToolBridge(AgentTool):
@@ -283,27 +307,9 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         # cross-turn persistence.
         self._message_history: dict[str, StrandsMessages] = {}
 
-        # Custom tools: accept native Strands forms and the portable CustomToolDef
-        # (InputModel, handler) tuple the other adapters take — tuples are bridged
-        # to native Strands AgentTools; callables pass through unchanged.
-        self._custom_tools: list[Any] = [
-            _CustomToolBridge(t) if isinstance(t, tuple) else t
-            for t in (additional_tools or [])
-        ]
-        # Custom tools that opt in as terminal actions (band_terminal=True on the
-        # handler/function). Only these let a turn with no Band-tool action count
-        # as productive; an undeclared custom tool does not (fail-loud — see
-        # is_terminal_success).
-        terminal_names: set[str] = set()
-        for raw, converted in zip(additional_tools or [], self._custom_tools):
-            handler = raw[1] if isinstance(raw, tuple) else raw
-            if is_marked_terminal(handler):
-                terminal_names.add(
-                    converted.tool_name
-                    if isinstance(converted, AgentTool)
-                    else getattr(converted, "__name__", str(converted))
-                )
-        self._custom_terminal_names: frozenset[str] = frozenset(terminal_names)
+        self._custom_tools, self._custom_terminal_names = _build_custom_tools(
+            additional_tools
+        )
 
     async def on_started(self, agent_name: str, agent_description: str) -> None:
         """Render the system prompt and build the tool set after metadata is fetched."""
@@ -346,9 +352,6 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         exceptions and return "Error ..." strings so the LLM can see failures
         (and so terminal detection can tell a failed Band tool from a success).
         """
-
-        def band(name: str, fn: Callable[..., Any]) -> Any:
-            return tool(description=get_tool_description(name), context=True)(fn)
 
         async def band_send_message(
             content: str,
@@ -426,13 +429,13 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
                 return f"Error creating chatroom (task_id={task_id}): {e}"
 
         strands_tools = [
-            band("band_send_message", band_send_message),
-            band("band_send_event", band_send_event),
-            band("band_add_participant", band_add_participant),
-            band("band_remove_participant", band_remove_participant),
-            band("band_lookup_peers", band_lookup_peers),
-            band("band_get_participants", band_get_participants),
-            band("band_create_chatroom", band_create_chatroom),
+            _as_strands_tool("band_send_message", band_send_message),
+            _as_strands_tool("band_send_event", band_send_event),
+            _as_strands_tool("band_add_participant", band_add_participant),
+            _as_strands_tool("band_remove_participant", band_remove_participant),
+            _as_strands_tool("band_lookup_peers", band_lookup_peers),
+            _as_strands_tool("band_get_participants", band_get_participants),
+            _as_strands_tool("band_create_chatroom", band_create_chatroom),
         ]
 
         # Contact management tools (opt-in via Capability.CONTACTS)
@@ -509,11 +512,15 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
 
             strands_tools.extend(
                 [
-                    band("band_list_contacts", band_list_contacts),
-                    band("band_add_contact", band_add_contact),
-                    band("band_remove_contact", band_remove_contact),
-                    band("band_list_contact_requests", band_list_contact_requests),
-                    band("band_respond_contact_request", band_respond_contact_request),
+                    _as_strands_tool("band_list_contacts", band_list_contacts),
+                    _as_strands_tool("band_add_contact", band_add_contact),
+                    _as_strands_tool("band_remove_contact", band_remove_contact),
+                    _as_strands_tool(
+                        "band_list_contact_requests", band_list_contact_requests
+                    ),
+                    _as_strands_tool(
+                        "band_respond_contact_request", band_respond_contact_request
+                    ),
                 ]
             )
 
@@ -603,15 +610,46 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
 
             strands_tools.extend(
                 [
-                    band("band_list_memories", band_list_memories),
-                    band("band_store_memory", band_store_memory),
-                    band("band_get_memory", band_get_memory),
-                    band("band_supersede_memory", band_supersede_memory),
-                    band("band_archive_memory", band_archive_memory),
+                    _as_strands_tool("band_list_memories", band_list_memories),
+                    _as_strands_tool("band_store_memory", band_store_memory),
+                    _as_strands_tool("band_get_memory", band_get_memory),
+                    _as_strands_tool("band_supersede_memory", band_supersede_memory),
+                    _as_strands_tool("band_archive_memory", band_archive_memory),
                 ]
             )
 
         return strands_tools
+
+    def _history_for_turn(
+        self,
+        room_id: str,
+        history: StrandsMessages,
+        *,
+        is_session_bootstrap: bool,
+    ) -> StrandsMessages:
+        """Return the room history, rehydrating it once when a session starts."""
+        if is_session_bootstrap:
+            self._message_history[room_id] = list(history)
+            if history:
+                logger.debug(
+                    "Room %s: rehydrated %s message(s) from platform history",
+                    room_id,
+                    len(history),
+                )
+        return self._message_history.setdefault(room_id, [])
+
+    @staticmethod
+    def _append_system_context(
+        history: StrandsMessages,
+        participants_msg: str | None,
+        contacts_msg: str | None,
+    ) -> None:
+        """Append platform context that changed since the prior turn."""
+        for message in (participants_msg, contacts_msg):
+            if message:
+                history.append(
+                    {"role": "user", "content": [{"text": f"[System]: {message}"}]}
+                )
 
     async def on_message(
         self,
@@ -629,35 +667,10 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             # Safety: build tools if not yet built (should be done in on_started)
             self._strands_tools = self._build_platform_tools() + self._custom_tools
 
-        # Initialize message history for this room on first message
-        # Note: history is already converted by SimpleAdapter via history_converter
-        if is_session_bootstrap:
-            if history:
-                self._message_history[room_id] = list(history)
-                logger.debug(
-                    "Room %s: rehydrated %s message(s) from platform history",
-                    room_id,
-                    len(history),
-                )
-            else:
-                self._message_history[room_id] = []
-        elif room_id not in self._message_history:
-            # Safety: ensure history exists even if not first message
-            self._message_history[room_id] = []
-
-        # Inject participants message if changed
-        if participants_msg:
-            self._message_history[room_id].append(
-                {"role": "user", "content": [{"text": f"[System]: {participants_msg}"}]}
-            )
-            logger.debug("Room %s: Injected participant update into history", room_id)
-
-        # Inject contacts message if present
-        if contacts_msg:
-            self._message_history[room_id].append(
-                {"role": "user", "content": [{"text": f"[System]: {contacts_msg}"}]}
-            )
-            logger.debug("Room %s: Injected contacts broadcast into history", room_id)
+        room_history = self._history_for_turn(
+            room_id, history, is_session_bootstrap=is_session_bootstrap
+        )
+        self._append_system_context(room_history, participants_msg, contacts_msg)
 
         # Build user message with sender prefix
         user_message = msg.format_for_llm()
@@ -665,7 +678,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         logger.debug(
             "Room %s: Running Strands agent (history: %s msgs, prompt: %s...)",
             room_id,
-            len(self._message_history[room_id]),
+            len(room_history),
             user_message[:80],
         )
 
@@ -674,7 +687,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             emit_execution=Emit.EXECUTION in self.features.emit,
             custom_terminal_names=self._custom_terminal_names,
         )
-        agent = self._build_agent(self._message_history[room_id], turn_hooks)
+        agent = self._build_agent(room_history, turn_hooks)
         try:
             await agent.invoke_async(
                 user_message,

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -95,6 +95,18 @@ def _result_text(result: ToolResult) -> str:
     return "\n".join(parts)
 
 
+def _input_schema(input_model: type[BaseModel]) -> dict[str, Any]:
+    """The JSON schema Strands advertises for a tool's input model.
+
+    Built fresh per bridge, never shared: Strands normalizes a tool spec by
+    writing defaults into the schema's nested ``properties`` in place, so a
+    cached schema would be mutated by the framework it was handed to.
+    """
+    schema = input_model.model_json_schema()
+    schema.pop("title", None)
+    return schema
+
+
 def _registered_name(tool: AgentTool | Callable[..., Any]) -> str:
     """Return the name Strands registers this tool under."""
     if isinstance(tool, AgentTool):
@@ -142,13 +154,11 @@ class StrandsToolBridge(AgentTool):
         description: str,
     ) -> None:
         super().__init__()
-        schema = input_model.model_json_schema()
-        schema.pop("title", None)
         self._name = name
         self._spec: ToolSpec = {
             "name": name,
             "description": description,
-            "inputSchema": {"json": schema},
+            "inputSchema": {"json": _input_schema(input_model)},
         }
 
     @property

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -56,6 +56,7 @@ from band.runtime.tools import (
     band_tool_errored,
     is_terminal_success,
     iter_tool_definitions,
+    missing_reply_error,
     serialize_tool_result,
     validate_tool_arguments,
 )
@@ -471,12 +472,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             hooks=hooks,
         )
         if not hooks.terminal_fired:
-            await self._report_error(
-                tools,
-                "Strands agent completed without sending a Band message. This "
-                "usually means the agent returned a final answer as plain text "
-                "instead of using the band_send_message tool.",
-            )
+            await self._report_error(tools, missing_reply_error("Strands"))
         logger.debug(
             "Room %s: Strands agent completed (history now has %s messages)",
             room_id,

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -50,6 +50,7 @@ from band.runtime.custom_tools import (
 )
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
+    ALL_TOOL_NAMES,
     ToolDefinition,
     ToolCallOutcome,
     band_tool_errored,
@@ -93,6 +94,19 @@ def _result_text(result: ToolResult) -> str:
     return "\n".join(parts)
 
 
+def _registered_name(tool: AgentTool | Callable[..., Any]) -> str:
+    """Return the name Strands registers this tool under."""
+    if isinstance(tool, AgentTool):
+        return tool.tool_name
+    name = getattr(tool, "__name__", "")
+    if not name:
+        raise ValueError(
+            f"Custom tool {tool!r} has no name. Pass a named function, a "
+            "@strands.tool-decorated tool, or a (InputModel, handler) pair."
+        )
+    return name
+
+
 def _build_custom_tools(
     additional_tools: list[Callable[..., Any] | CustomToolDef] | None,
 ) -> tuple[list[AgentTool | Callable[..., Any]], frozenset[str]]:
@@ -102,11 +116,16 @@ def _build_custom_tools(
         CustomToolBridge(tool_def) if isinstance(tool_def, tuple) else tool_def
         for tool_def in raw_tools
     ]
+    names = [_registered_name(tool) for tool in converted]
+    # Strands' registry is last-wins, so a collision would silently replace the
+    # platform tool the room depends on.
+    shadowed = sorted(set(names) & ALL_TOOL_NAMES)
+    if shadowed:
+        raise ValueError(f"Custom tools may not shadow Band platform tools: {shadowed}")
+
     terminal_names = frozenset(
-        tool.tool_name
-        if isinstance(tool, AgentTool)
-        else str(getattr(tool, "__name__", tool))
-        for raw, tool in zip(raw_tools, converted)
+        name
+        for raw, name in zip(raw_tools, names, strict=True)
         if is_marked_terminal(raw[1] if isinstance(raw, tuple) else raw)
     )
     return converted, terminal_names
@@ -341,7 +360,13 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         tools: AgentToolsProtocol,
         hooks: BandTurnHooks,
     ) -> Agent:
-        """Create an isolated agent whose tools own one turn's capability."""
+        """Create an isolated agent whose tools own one turn's capability.
+
+        Strands' default conversation manager trims the oldest messages once the
+        transcript passes its window (40 messages) and again on context
+        overflow, keeping toolUse/toolResult pairs intact. The persisted room
+        transcript is therefore capped by the framework, not unbounded.
+        """
         framework_tools = self._build_platform_tools(tools) + self._custom_tools
         return Agent(
             model=self.model,

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -1,10 +1,4 @@
-"""
-Strands Agents adapter using SimpleAdapter pattern.
-
-Modeled on the pydantic-ai adapter: the framework owns the agent loop, the
-model object is injectable at the public ``Agent(model=...)`` seam, and Band
-platform tools are registered as native framework tools.
-"""
+"""Band adapter for Strands Agents."""
 
 from __future__ import annotations
 
@@ -59,10 +53,7 @@ from band.runtime.tools import (
 
 logger = logging.getLogger(__name__)
 
-# invocation_state key carrying the current turn's AgentToolsProtocol handle.
-# Strands threads invocation_state from Agent.invoke_async(...) into every tool
-# body (via ToolContext) and hook event, which is what lets the tool functions
-# be built once while each turn binds its own tools handle.
+# Per-turn Band tools are passed through Strands invocation state.
 _BAND_TOOLS_STATE_KEY = "band_tools"
 
 
@@ -116,13 +107,7 @@ def _as_strands_tool(name: str, fn: Callable[..., Any]) -> Any:
 
 
 class _CustomToolBridge(AgentTool):
-    """A portable ``CustomToolDef`` (InputModel, handler) as a native Strands tool.
-
-    The tool spec is derived from the Pydantic input model (same name/schema the
-    other adapters expose), and dispatch validates + executes via
-    ``execute_custom_tool`` so the argument-validation contract matches the
-    tuple form everywhere else.
-    """
+    """Expose a portable custom tool as a native Strands tool."""
 
     def __init__(self, tool_def: CustomToolDef):
         super().__init__()
@@ -168,12 +153,7 @@ class _CustomToolBridge(AgentTool):
 
 
 class _BandTurnHooks(HookProvider):
-    """Per-turn hook provider: L6 execution events + terminal-action tracking.
-
-    A fresh instance is registered on each turn's Agent, so per-turn state
-    (whether a terminal Band action fired) needs no cross-turn bookkeeping.
-    Event emission is best-effort and never crashes the turn.
-    """
+    """Emit execution events and track terminal actions for one turn."""
 
     def __init__(
         self,
@@ -209,9 +189,7 @@ class _BandTurnHooks(HookProvider):
             logger.warning("Failed to send tool_call event: %s", e)
 
     async def _on_after_tool(self, event: AfterToolCallEvent) -> None:
-        # Custom tools count as terminal only if they opted in (band_terminal);
-        # undeclared customs fail loud. A failed Band tool (its wrapper returns
-        # an "Error " string, or Strands recorded an error status) is not terminal.
+        # Only successful Band tools and marked custom tools end a turn.
         name = event.tool_use["name"]
         output = _result_text(event.result)
         succeeded = event.result.get("status") == "success" and not band_tool_errored(
@@ -241,22 +219,7 @@ class _BandTurnHooks(HookProvider):
 
 
 class StrandsAdapter(SimpleAdapter[StrandsMessages]):
-    """
-    Strands Agents adapter using SimpleAdapter pattern.
-
-    Uses a Strands Agent for LLM interactions, with platform tools registered
-    as native Strands ``@tool`` functions.
-
-    Example:
-        from strands.models.openai import OpenAIModel
-
-        adapter = StrandsAdapter(
-            model=OpenAIModel(model_id="gpt-5.4-mini"),
-            custom_section="You are a helpful assistant.",
-        )
-        agent = Agent.create(adapter=adapter, agent_id="...", api_key="...")
-        await agent.run()
-    """
+    """Run a Strands model in a Band room."""
 
     SUPPORTED_EMIT: ClassVar[frozenset[Emit]] = frozenset({Emit.EXECUTION, Emit.USAGE})
     SUPPORTED_CAPABILITIES: ClassVar[frozenset[Capability]] = frozenset(
@@ -298,13 +261,10 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         self.custom_section = custom_section
         self._system_prompt: str | None = None
 
-        # Platform + custom tools, built once in on_started (tool bodies bind the
-        # per-turn tools handle via invocation_state, so they carry no turn state).
+        # Tool definitions are shared; invocation state supplies per-turn tools.
         self._strands_tools: list[Any] = []
 
-        # Conversation history per room (Converse-shaped Messages). Band owns
-        # this state; Strands sessions/conversation managers are not used for
-        # cross-turn persistence.
+        # Band owns per-room conversation history.
         self._message_history: dict[str, StrandsMessages] = {}
 
         self._custom_tools, self._custom_terminal_names = _build_custom_tools(
@@ -324,17 +284,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         logger.info("Strands adapter started for agent: %s", agent_name)
 
     def _build_agent(self, messages: StrandsMessages, hooks: _BandTurnHooks) -> Agent:
-        """Construct the Strands Agent for one turn, over the room's history.
-
-        A Strands Agent is stateful (it owns ``messages`` and per-agent metrics)
-        and raises on concurrent invocation, while the Band runtime runs one
-        asyncio task per room — so a single shared Agent would break under
-        multi-room concurrency. Instead the heavy pieces (prompt, tool set) are
-        built once in on_started and a lightweight Agent shell is constructed
-        per turn over the room's messages (mirrors the google_adk adapter's
-        fresh-runner-per-message pattern). Bonus: a fresh Agent has fresh
-        metrics, so accumulated usage is exactly this turn's usage.
-        """
+        """Build an isolated agent for one room turn and its usage metrics."""
         return Agent(
             model=self.model,
             messages=messages,
@@ -346,12 +296,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         )
 
     def _build_platform_tools(self) -> list[Any]:
-        """Build the Band platform tools as native Strands ``@tool`` functions.
-
-        Descriptions come from the centralized tool definitions. All tools catch
-        exceptions and return "Error ..." strings so the LLM can see failures
-        (and so terminal detection can tell a failed Band tool from a success).
-        """
+        """Build Band platform tools as native Strands tools."""
 
         async def band_send_message(
             content: str,
@@ -655,7 +600,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         self,
         msg: PlatformMessage,
         tools: AgentToolsProtocol,
-        history: StrandsMessages,  # Already converted by SimpleAdapter
+        history: StrandsMessages,
         participants_msg: str | None,
         contacts_msg: str | None,
         *,
@@ -664,7 +609,6 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
     ) -> None:
         """Handle incoming platform message."""
         if not self._strands_tools:
-            # Safety: build tools if not yet built (should be done in on_started)
             self._strands_tools = self._build_platform_tools() + self._custom_tools
 
         room_history = self._history_for_turn(
@@ -672,7 +616,6 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         )
         self._append_system_context(room_history, participants_msg, contacts_msg)
 
-        # Build user message with sender prefix
         user_message = msg.format_for_llm()
 
         logger.debug(
@@ -694,17 +637,11 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
                 invocation_state={_BAND_TOOLS_STATE_KEY: tools},
             )
         finally:
-            # Persist whatever the run recorded (also on a failed turn, so the
-            # room keeps the user prompt + any completed tool work), and emit
-            # this turn's usage: the per-turn Agent has per-turn metrics, so
-            # accumulated_usage is exactly this run's total across its model
-            # calls. emit_usage itself gates on Emit.USAGE and never raises.
+            # Preserve completed work and usage when the turn fails.
             self._message_history[room_id] = agent.messages
             await self.emit_usage(tools, self._usage_from_agent(agent))
 
-        # A clean run with no terminal work means the model answered in plain text
-        # without calling band_send_message — a silently dropped reply. Surface it
-        # as an error (mirrors the pydantic-ai/crewai adapters).
+        # Plain-text answers are not delivered to the room.
         if not turn_hooks.terminal_fired:
             await self._report_error(
                 tools,
@@ -721,13 +658,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
 
     @staticmethod
     def _usage_from_agent(agent: Agent) -> TurnUsage:
-        """Map the turn's accumulated token usage onto TurnUsage.
-
-        Strands accumulates usage on the agent's EventLoopMetrics across all of
-        the run's model calls; reading it from the agent (not the AgentResult)
-        also covers turns that raised mid-run. totalTokens is derived
-        (input + output) and deliberately not mapped.
-        """
+        """Map the agent's turn usage to Band usage."""
         try:
             usage = dict(agent.event_loop_metrics.accumulated_usage)
         except Exception:  # pragma: no cover - defensive; usage is best-effort
@@ -741,12 +672,7 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         )
 
     async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Send an error event to the room (best effort).
-
-        Narrowed to the REST call's real failure modes (ApiError = HTTP status,
-        httpx = transport) so a failed error-report never crashes the turn —
-        while a real bug still raises.
-        """
+        """Send a best-effort error event."""
         try:
             await tools.send_event(content=f"Error: {error}", message_type="error")
         except (ApiError, httpx.HTTPError) as e:

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -32,6 +32,7 @@ from band_rest.core.api_error import ApiError
 
 from band.core.protocols import AgentToolsProtocol
 from band.core.simple_adapter import SimpleAdapter
+from band.core.tool_filter import filter_tool_schemas
 from band.core.types import (
     AdapterFeatures,
     Capability,
@@ -54,6 +55,7 @@ from band.runtime.tools import (
     ToolDefinition,
     ToolCallOutcome,
     band_tool_errored,
+    get_band_tool_category,
     is_terminal_success,
     iter_tool_definitions,
     missing_reply_error,
@@ -306,6 +308,9 @@ class BandTurnHooks(HookProvider):
                 ToolEventKey.NAME: name,
                 ToolEventKey.OUTPUT: output,
                 ToolEventKey.TOOL_CALL_ID: event.tool_use["toolUseId"],
+                # Without this the event replays as a success on the next
+                # bootstrap, telling the model a failed operation worked.
+                ToolEventKey.IS_ERROR: not succeeded,
             },
         )
 
@@ -392,14 +397,24 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         )
 
     def _build_platform_tools(self, tools: AgentToolsProtocol) -> list[AgentTool]:
-        """Adapt the central Band tool registry to Strands for this turn."""
-        return [
-            PlatformToolBridge(definition, tools)
-            for definition in iter_tool_definitions(
-                include_memory=Capability.MEMORY in self.features.capabilities,
-                include_contacts=Capability.CONTACTS in self.features.capabilities,
-            )
-        ]
+        """Adapt the central Band tool registry to Strands for this turn.
+
+        The caller's include/exclude/category filters decide the surface: a tool
+        the features exclude must never reach the model, since reaching it is
+        enough to execute it.
+        """
+        definitions = filter_tool_schemas(
+            list(
+                iter_tool_definitions(
+                    include_memory=Capability.MEMORY in self.features.capabilities,
+                    include_contacts=Capability.CONTACTS in self.features.capabilities,
+                )
+            ),
+            self.features,
+            get_name=lambda definition: definition.name,
+            get_category=lambda definition: get_band_tool_category(definition.name),
+        )
+        return [PlatformToolBridge(definition, tools) for definition in definitions]
 
     def _history_for_turn(
         self,
@@ -416,17 +431,23 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         return self._message_history.setdefault(room_id, [])
 
     @staticmethod
-    def _append_system_context(
-        history: StrandsMessages,
+    def _with_system_context(
+        user_message: str,
         participants_msg: str | None,
         contacts_msg: str | None,
-    ) -> None:
-        """Append changed platform context to the transcript."""
-        for message in (participants_msg, contacts_msg):
-            if message:
-                history.append(
-                    {"role": "user", "content": [{"text": f"[System]: {message}"}]}
-                )
+    ) -> str:
+        """Lead the turn's prompt with any changed platform context.
+
+        Strands appends the prompt as its own user message, so context posted
+        as a separate message would leave two user turns in a row — which
+        Bedrock's Converse rejects.
+        """
+        notices = [
+            f"[System]: {message}"
+            for message in (participants_msg, contacts_msg)
+            if message
+        ]
+        return "\n\n".join([*notices, user_message])
 
     async def _run_turn(
         self,
@@ -460,8 +481,9 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         room_history = self._history_for_turn(
             room_id, history, is_session_bootstrap=is_session_bootstrap
         )
-        self._append_system_context(room_history, participants_msg, contacts_msg)
-        user_message = msg.format_for_llm()
+        user_message = self._with_system_context(
+            msg.format_for_llm(), participants_msg, contacts_msg
+        )
         logger.debug(
             "Room %s: Running Strands agent (history: %s msgs, prompt: %s...)",
             room_id,

--- a/src/band/adapters/strands.py
+++ b/src/band/adapters/strands.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Callable, ClassVar
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any, ClassVar, cast
 
 import httpx
+from pydantic import BaseModel
 
 try:
-    from strands import Agent, ToolContext, tool
+    from strands import Agent
     from strands.hooks import HookProvider, HookRegistry
     from strands.hooks.events import AfterToolCallEvent, BeforeToolCallEvent
     from strands.models import Model
@@ -20,11 +22,11 @@ try:
         ToolSpec,
         ToolUse,
     )
-except ImportError as e:
+except ImportError as error:
     raise ImportError(
         "Strands Agents dependencies not installed. "
         "Install with: uv add band-sdk[strands]"
-    ) from e
+    ) from error
 
 from band_rest.core.api_error import ApiError
 
@@ -34,7 +36,9 @@ from band.core.types import (
     AdapterFeatures,
     Capability,
     Emit,
+    MessageType,
     PlatformMessage,
+    ToolEventKey,
     TurnUsage,
 )
 from band.converters.strands import StrandsHistoryConverter, StrandsMessages
@@ -46,79 +50,84 @@ from band.runtime.custom_tools import (
 )
 from band.runtime.prompts import render_system_prompt
 from band.runtime.tools import (
+    ToolDefinition,
+    ToolCallOutcome,
     band_tool_errored,
-    get_tool_description,
     is_terminal_success,
+    iter_tool_definitions,
+    serialize_tool_result,
+    validate_tool_arguments,
 )
 
 logger = logging.getLogger(__name__)
 
-# Per-turn Band tools are passed through Strands invocation state.
-_BAND_TOOLS_STATE_KEY = "band_tools"
+
+def _format_tool_output(value: object) -> str:
+    """Return a stable text representation accepted by Strands tool results."""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        return str(value)
 
 
-def _tools_from_context(tool_context: ToolContext) -> AgentToolsProtocol:
-    """The current turn's platform tools handle, bound via invocation_state."""
-    handle = tool_context.invocation_state.get(_BAND_TOOLS_STATE_KEY)
-    if handle is None:
-        raise RuntimeError(
-            "Band tools handle missing from invocation_state; platform tools "
-            "must be invoked through StrandsAdapter.on_message"
-        )
-    return handle
+def _tool_result(tool_use: ToolUse, *, value: object, ok: bool) -> ToolResult:
+    """Build the framework's typed result envelope at the Strands boundary."""
+    return {
+        "toolUseId": tool_use["toolUseId"],
+        "status": "success" if ok else "error",
+        "content": [{"text": _format_tool_output(value)}],
+    }
 
 
 def _result_text(result: ToolResult) -> str:
-    """Flatten a ToolResult's content blocks to text for error detection/reporting."""
+    """Flatten a tool result for execution events and terminal-state policy."""
     parts: list[str] = []
     for block in result.get("content", []):
         match block:
-            case {"text": text}:
+            case {"text": str() as text}:
                 parts.append(text)
             case {"json": value}:
-                try:
-                    parts.append(json.dumps(value))
-                except (TypeError, ValueError):
-                    parts.append(str(value))
+                parts.append(_format_tool_output(value))
     return "\n".join(parts)
 
 
 def _build_custom_tools(
     additional_tools: list[Callable[..., Any] | CustomToolDef] | None,
-) -> tuple[list[Any], frozenset[str]]:
-    """Convert portable tools and collect the custom terminal actions."""
-    converted = [
-        _CustomToolBridge(tool_def) if isinstance(tool_def, tuple) else tool_def
-        for tool_def in additional_tools or []
+) -> tuple[list[AgentTool | Callable[..., Any]], frozenset[str]]:
+    """Adapt portable custom tools and collect their terminal-action names."""
+    raw_tools = additional_tools or []
+    converted: list[AgentTool | Callable[..., Any]] = [
+        CustomToolBridge(tool_def) if isinstance(tool_def, tuple) else tool_def
+        for tool_def in raw_tools
     ]
-    terminal_names = {
+    terminal_names = frozenset(
         tool.tool_name
         if isinstance(tool, AgentTool)
-        else getattr(tool, "__name__", str(tool))
-        for raw, tool in zip(additional_tools or [], converted)
+        else str(getattr(tool, "__name__", tool))
+        for raw, tool in zip(raw_tools, converted)
         if is_marked_terminal(raw[1] if isinstance(raw, tuple) else raw)
-    }
-    return converted, frozenset(terminal_names)
+    )
+    return converted, terminal_names
 
 
-def _as_strands_tool(name: str, fn: Callable[..., Any]) -> Any:
-    """Wrap a Band tool with its canonical description and Strands context."""
-    return tool(description=get_tool_description(name), context=True)(fn)
+class StrandsToolBridge(AgentTool):
+    """Base class for native Strands tools backed by a Pydantic input model."""
 
-
-class _CustomToolBridge(AgentTool):
-    """Expose a portable custom tool as a native Strands tool."""
-
-    def __init__(self, tool_def: CustomToolDef):
+    def __init__(
+        self,
+        name: str,
+        input_model: type[BaseModel],
+        description: str,
+    ) -> None:
         super().__init__()
-        self._tool_def = tool_def
-        input_model, _ = tool_def
         schema = input_model.model_json_schema()
         schema.pop("title", None)
-        self._name = get_custom_tool_name(input_model)
+        self._name = name
         self._spec: ToolSpec = {
-            "name": self._name,
-            "description": input_model.__doc__ or self._name,
+            "name": name,
+            "description": description,
             "inputSchema": {"json": schema},
         }
 
@@ -134,26 +143,89 @@ class _CustomToolBridge(AgentTool):
     def tool_type(self) -> str:
         return "function"
 
+
+class CustomToolBridge(StrandsToolBridge):
+    """Expose a portable custom tool through Strands' native tool protocol."""
+
+    def __init__(self, tool_def: CustomToolDef):
+        self._tool_def = tool_def
+        input_model, _ = tool_def
+        name = get_custom_tool_name(input_model)
+        super().__init__(name, input_model, input_model.__doc__ or name)
+
     async def stream(
-        self, tool_use: ToolUse, invocation_state: dict[str, Any], **kwargs: Any
+        self,
+        tool_use: ToolUse,
+        invocation_state: dict[str, Any],
+        **kwargs: Any,
     ) -> ToolGenerator:
+        del invocation_state, kwargs
         try:
-            result = await execute_custom_tool(self._tool_def, tool_use["input"] or {})
-            yield {
-                "toolUseId": tool_use["toolUseId"],
-                "status": "success",
-                "content": [{"text": str(result)}],
-            }
-        except Exception as e:
-            yield {
-                "toolUseId": tool_use["toolUseId"],
-                "status": "error",
-                "content": [{"text": f"Error executing tool '{self._name}': {e}"}],
-            }
+            result = await execute_custom_tool(
+                self._tool_def, dict(tool_use["input"] or {})
+            )
+        except Exception as error:
+            yield _tool_result(
+                tool_use,
+                value=f"Error executing tool '{self.tool_name}': {error}",
+                ok=False,
+            )
+            return
+        yield _tool_result(tool_use, value=result, ok=True)
 
 
-class _BandTurnHooks(HookProvider):
-    """Emit execution events and track terminal actions for one turn."""
+class PlatformToolBridge(StrandsToolBridge):
+    """Execute one registered Band tool against a turn-scoped capability.
+
+    Strands calls the typed ``AgentToolsProtocol`` method directly. This is
+    intentional: its framework-conformance contract observes those operations,
+    and the shared registry still supplies the method name, schema, validation,
+    and result serialization.
+    """
+
+    def __init__(self, definition: ToolDefinition, tools: AgentToolsProtocol):
+        self._definition = definition
+        self._tools = tools
+        super().__init__(
+            definition.name,
+            definition.input_model,
+            definition.input_model.__doc__ or definition.name,
+        )
+
+    async def stream(
+        self,
+        tool_use: ToolUse,
+        invocation_state: dict[str, Any],
+        **kwargs: Any,
+    ) -> ToolGenerator:
+        del invocation_state, kwargs
+        outcome = await self._execute(dict(tool_use["input"] or {}))
+        yield _tool_result(tool_use, value=outcome.value, ok=outcome.ok)
+
+    async def _execute(self, arguments: dict[str, Any]) -> ToolCallOutcome:
+        """Validate and dispatch through the registered typed protocol method."""
+        try:
+            validated = validate_tool_arguments(
+                self.tool_name, self._definition.input_model, arguments
+            )
+        except ValueError as error:
+            return ToolCallOutcome(value=str(error), ok=False, error_message=str(error))
+
+        try:
+            method = cast(
+                Callable[..., Awaitable[object]],
+                getattr(self._tools, self._definition.method_name),
+            )
+            value = await method(**validated)
+        except Exception as error:
+            logger.exception("Platform tool %s failed", self.tool_name)
+            message = f"Error executing {self.tool_name}: {error}"
+            return ToolCallOutcome(value=message, ok=False, error_message=message)
+        return ToolCallOutcome(value=serialize_tool_result(value), ok=True)
+
+
+class BandTurnHooks(HookProvider):
+    """Emit execution events and record whether a turn completed useful work."""
 
     def __init__(
         self,
@@ -161,35 +233,30 @@ class _BandTurnHooks(HookProvider):
         *,
         emit_execution: bool,
         custom_terminal_names: frozenset[str],
-    ):
+    ) -> None:
         self._tools = tools
         self._emit_execution = emit_execution
         self._custom_terminal_names = custom_terminal_names
         self.terminal_fired = False
 
     def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
+        del kwargs
         registry.add_callback(BeforeToolCallEvent, self._on_before_tool)
         registry.add_callback(AfterToolCallEvent, self._on_after_tool)
 
     async def _on_before_tool(self, event: BeforeToolCallEvent) -> None:
         if not self._emit_execution:
             return
-        try:
-            await self._tools.send_event(
-                content=json.dumps(
-                    {
-                        "name": event.tool_use["name"],
-                        "args": event.tool_use["input"],
-                        "tool_call_id": event.tool_use["toolUseId"],
-                    }
-                ),
-                message_type="tool_call",
-            )
-        except Exception as e:
-            logger.warning("Failed to send tool_call event: %s", e)
+        await self._emit_event(
+            MessageType.TOOL_CALL,
+            {
+                ToolEventKey.NAME: event.tool_use["name"],
+                ToolEventKey.ARGS: event.tool_use["input"],
+                ToolEventKey.TOOL_CALL_ID: event.tool_use["toolUseId"],
+            },
+        )
 
     async def _on_after_tool(self, event: AfterToolCallEvent) -> None:
-        # Only successful Band tools and marked custom tools end a turn.
         name = event.tool_use["name"]
         output = _result_text(event.result)
         succeeded = event.result.get("status") == "success" and not band_tool_errored(
@@ -203,19 +270,27 @@ class _BandTurnHooks(HookProvider):
             self.terminal_fired = True
         if not self._emit_execution:
             return
+        await self._emit_event(
+            MessageType.TOOL_RESULT,
+            {
+                ToolEventKey.NAME: name,
+                ToolEventKey.OUTPUT: output,
+                ToolEventKey.TOOL_CALL_ID: event.tool_use["toolUseId"],
+            },
+        )
+
+    async def _emit_event(
+        self,
+        message_type: MessageType,
+        payload: Mapping[ToolEventKey, object],
+    ) -> None:
         try:
             await self._tools.send_event(
-                content=json.dumps(
-                    {
-                        "name": name,
-                        "output": output,
-                        "tool_call_id": event.tool_use["toolUseId"],
-                    }
-                ),
-                message_type="tool_result",
+                content=json.dumps(payload, default=str),
+                message_type=message_type,
             )
-        except Exception as e:
-            logger.warning("Failed to send tool_result event: %s", e)
+        except Exception as error:
+            logger.warning("Failed to send %s event: %s", message_type, error)
 
 
 class StrandsAdapter(SimpleAdapter[StrandsMessages]):
@@ -234,45 +309,23 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         history_converter: StrandsHistoryConverter | None = None,
         additional_tools: list[Callable[..., Any] | CustomToolDef] | None = None,
         features: AdapterFeatures | None = None,
-    ):
-        """
-        Initialize the Strands adapter.
-
-        Args:
-            model: A Strands ``Model`` instance (e.g.
-                ``strands.models.openai.OpenAIModel(model_id="gpt-5.4-mini")``).
-                A plain string is passed through to Strands, which treats it as
-                a **Bedrock** model id (Strands has no provider-prefix shorthand).
-            system_prompt: Optional custom system prompt (overrides default)
-            custom_section: Optional custom section added to default system prompt
-            history_converter: Optional custom history converter
-            additional_tools: Optional list of Strands-compatible tools (plain
-                callables or ``@strands.tool``-decorated functions) and/or
-                portable ``CustomToolDef`` (InputModel, handler) tuples.
-            features: Shared adapter feature settings (capabilities, emit, tool filters).
-        """
+    ) -> None:
+        """Create an adapter around a Strands model or Bedrock model identifier."""
         super().__init__(
             history_converter=history_converter or StrandsHistoryConverter(),
             features=features,
         )
-
         self.model = model
         self.system_prompt = system_prompt
         self.custom_section = custom_section
         self._system_prompt: str | None = None
-
-        # Tool definitions are shared; invocation state supplies per-turn tools.
-        self._strands_tools: list[Any] = []
-
-        # Band owns per-room conversation history.
         self._message_history: dict[str, StrandsMessages] = {}
-
         self._custom_tools, self._custom_terminal_names = _build_custom_tools(
             additional_tools
         )
 
     async def on_started(self, agent_name: str, agent_description: str) -> None:
-        """Render the system prompt and build the tool set after metadata is fetched."""
+        """Render the prompt after the platform supplies agent metadata."""
         await super().on_started(agent_name, agent_description)
         self._system_prompt = self.system_prompt or render_system_prompt(
             agent_name=self.agent_name,
@@ -280,290 +333,37 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             custom_section=self.custom_section or "",
             features=self.features,
         )
-        self._strands_tools = self._build_platform_tools() + self._custom_tools
         logger.info("Strands adapter started for agent: %s", agent_name)
 
-    def _build_agent(self, messages: StrandsMessages, hooks: _BandTurnHooks) -> Agent:
-        """Build an isolated agent for one room turn and its usage metrics."""
+    def _build_agent(
+        self,
+        messages: StrandsMessages,
+        tools: AgentToolsProtocol,
+        hooks: BandTurnHooks,
+    ) -> Agent:
+        """Create an isolated agent whose tools own one turn's capability."""
+        framework_tools = self._build_platform_tools(tools) + self._custom_tools
         return Agent(
             model=self.model,
             messages=messages,
-            tools=self._strands_tools,
+            # Strands accepts functions, dict specs, providers, and AgentTools,
+            # but its public annotation cannot express that mixed collection.
+            tools=cast(list[Any], framework_tools),
             system_prompt=self._system_prompt,
             hooks=[hooks],
             callback_handler=None,
             name=self.agent_name or None,
         )
 
-    def _build_platform_tools(self) -> list[Any]:
-        """Build Band platform tools as native Strands tools."""
-
-        async def band_send_message(
-            content: str,
-            mentions: list[str],
-            tool_context: ToolContext,
-        ) -> Any:
-            try:
-                return await _tools_from_context(tool_context).send_message(
-                    content, mentions
-                )
-            except Exception as e:
-                return f"Error sending message: {e}"
-
-        async def band_send_event(
-            content: str,
-            message_type: str,
-            tool_context: ToolContext,
-            metadata: dict[str, Any] | None = None,
-        ) -> Any:
-            try:
-                return await _tools_from_context(tool_context).send_event(
-                    content, message_type, metadata
-                )
-            except Exception as e:
-                return f"Error sending event: {e}"
-
-        async def band_add_participant(
-            identifier: str,
-            tool_context: ToolContext,
-            role: str = "member",
-        ) -> Any:
-            try:
-                return await _tools_from_context(tool_context).add_participant(
-                    identifier, role
-                )
-            except Exception as e:
-                return f"Error adding participant '{identifier}': {e}"
-
-        async def band_remove_participant(
-            identifier: str,
-            tool_context: ToolContext,
-        ) -> Any:
-            try:
-                return await _tools_from_context(tool_context).remove_participant(
-                    identifier
-                )
-            except Exception as e:
-                return f"Error removing participant '{identifier}': {e}"
-
-        async def band_lookup_peers(
-            tool_context: ToolContext,
-            page: int = 1,
-            page_size: int = 50,
-        ) -> Any:
-            try:
-                return await _tools_from_context(tool_context).lookup_peers(
-                    page, page_size
-                )
-            except Exception as e:
-                return f"Error looking up peers: {e}"
-
-        async def band_get_participants(tool_context: ToolContext) -> Any:
-            try:
-                return await _tools_from_context(tool_context).get_participants()
-            except Exception as e:
-                return f"Error getting participants: {e}"
-
-        async def band_create_chatroom(
-            tool_context: ToolContext,
-            task_id: str | None = None,
-        ) -> Any:
-            try:
-                return await _tools_from_context(tool_context).create_chatroom(task_id)
-            except Exception as e:
-                return f"Error creating chatroom (task_id={task_id}): {e}"
-
-        strands_tools = [
-            _as_strands_tool("band_send_message", band_send_message),
-            _as_strands_tool("band_send_event", band_send_event),
-            _as_strands_tool("band_add_participant", band_add_participant),
-            _as_strands_tool("band_remove_participant", band_remove_participant),
-            _as_strands_tool("band_lookup_peers", band_lookup_peers),
-            _as_strands_tool("band_get_participants", band_get_participants),
-            _as_strands_tool("band_create_chatroom", band_create_chatroom),
+    def _build_platform_tools(self, tools: AgentToolsProtocol) -> list[AgentTool]:
+        """Adapt the central Band tool registry to Strands for this turn."""
+        return [
+            PlatformToolBridge(definition, tools)
+            for definition in iter_tool_definitions(
+                include_memory=Capability.MEMORY in self.features.capabilities,
+                include_contacts=Capability.CONTACTS in self.features.capabilities,
+            )
         ]
-
-        # Contact management tools (opt-in via Capability.CONTACTS)
-        if Capability.CONTACTS in self.features.capabilities:
-
-            async def band_list_contacts(
-                tool_context: ToolContext,
-                page: int = 1,
-                page_size: int = 50,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).list_contacts(
-                        page, page_size
-                    )
-                except Exception as e:
-                    return f"Error listing contacts: {e}"
-
-            async def band_add_contact(
-                handle: str,
-                tool_context: ToolContext,
-                message: str | None = None,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).add_contact(
-                        handle, message
-                    )
-                except Exception as e:
-                    return f"Error adding contact '{handle}': {e}"
-
-            async def band_remove_contact(
-                tool_context: ToolContext,
-                handle: str | None = None,
-                contact_id: str | None = None,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).remove_contact(
-                        handle, contact_id
-                    )
-                except Exception as e:
-                    return f"Error removing contact: {e}"
-
-            async def band_list_contact_requests(
-                tool_context: ToolContext,
-                page: int = 1,
-                page_size: int = 50,
-                sent_status: str = "pending",
-            ) -> Any:
-                try:
-                    return await _tools_from_context(
-                        tool_context
-                    ).list_contact_requests(page, page_size, sent_status)
-                except Exception as e:
-                    return f"Error listing contact requests: {e}"
-
-            async def band_respond_contact_request(
-                action: str,
-                tool_context: ToolContext,
-                handle: str | None = None,
-                request_id: str | None = None,
-            ) -> Any:
-                tools = _tools_from_context(tool_context)
-                try:
-                    return await tools.respond_contact_request(
-                        action, handle, request_id
-                    )
-                except Exception as e:
-                    error_msg = f"Error responding to contact request: {e}"
-                    # Auto-send error event so it's visible in the room
-                    try:
-                        await tools.send_event(error_msg, "error")
-                    except Exception:
-                        pass  # Don't fail if error reporting fails
-                    return error_msg
-
-            strands_tools.extend(
-                [
-                    _as_strands_tool("band_list_contacts", band_list_contacts),
-                    _as_strands_tool("band_add_contact", band_add_contact),
-                    _as_strands_tool("band_remove_contact", band_remove_contact),
-                    _as_strands_tool(
-                        "band_list_contact_requests", band_list_contact_requests
-                    ),
-                    _as_strands_tool(
-                        "band_respond_contact_request", band_respond_contact_request
-                    ),
-                ]
-            )
-
-        # Memory management tools (enterprise only - opt-in)
-        if Capability.MEMORY in self.features.capabilities:
-
-            async def band_list_memories(
-                tool_context: ToolContext,
-                subject_id: str | None = None,
-                scope: str | None = None,
-                system: str | None = None,
-                type: str | None = None,
-                segment: str | None = None,
-                content_query: str | None = None,
-                page_size: int = 50,
-                status: str | None = None,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).list_memories(
-                        subject_id=subject_id,
-                        scope=scope,
-                        system=system,
-                        type=type,
-                        segment=segment,
-                        content_query=content_query,
-                        page_size=page_size,
-                        status=status,
-                    )
-                except Exception as e:
-                    return f"Error listing memories: {e}"
-
-            async def band_store_memory(
-                content: str,
-                system: str,
-                type: str,
-                segment: str,
-                thought: str,
-                scope: str,
-                tool_context: ToolContext,
-                subject_id: str | None = None,
-                metadata: dict[str, Any] | None = None,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).store_memory(
-                        content=content,
-                        system=system,
-                        type=type,
-                        segment=segment,
-                        thought=thought,
-                        scope=scope,
-                        subject_id=subject_id,
-                        metadata=metadata,
-                    )
-                except Exception as e:
-                    return f"Error storing memory: {e}"
-
-            async def band_get_memory(
-                memory_id: str,
-                tool_context: ToolContext,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).get_memory(memory_id)
-                except Exception as e:
-                    return f"Error getting memory: {e}"
-
-            async def band_supersede_memory(
-                memory_id: str,
-                tool_context: ToolContext,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).supersede_memory(
-                        memory_id
-                    )
-                except Exception as e:
-                    return f"Error superseding memory: {e}"
-
-            async def band_archive_memory(
-                memory_id: str,
-                tool_context: ToolContext,
-            ) -> Any:
-                try:
-                    return await _tools_from_context(tool_context).archive_memory(
-                        memory_id
-                    )
-                except Exception as e:
-                    return f"Error archiving memory: {e}"
-
-            strands_tools.extend(
-                [
-                    _as_strands_tool("band_list_memories", band_list_memories),
-                    _as_strands_tool("band_store_memory", band_store_memory),
-                    _as_strands_tool("band_get_memory", band_get_memory),
-                    _as_strands_tool("band_supersede_memory", band_supersede_memory),
-                    _as_strands_tool("band_archive_memory", band_archive_memory),
-                ]
-            )
-
-        return strands_tools
 
     def _history_for_turn(
         self,
@@ -572,15 +372,11 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         *,
         is_session_bootstrap: bool,
     ) -> StrandsMessages:
-        """Return the room history, rehydrating it once when a session starts."""
+        """Get the room transcript, using platform history only at session start."""
         if is_session_bootstrap:
             self._message_history[room_id] = list(history)
             if history:
-                logger.debug(
-                    "Room %s: rehydrated %s message(s) from platform history",
-                    room_id,
-                    len(history),
-                )
+                logger.debug("Room %s: rehydrated %s message(s)", room_id, len(history))
         return self._message_history.setdefault(room_id, [])
 
     @staticmethod
@@ -589,12 +385,29 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         participants_msg: str | None,
         contacts_msg: str | None,
     ) -> None:
-        """Append platform context that changed since the prior turn."""
+        """Append changed platform context to the transcript."""
         for message in (participants_msg, contacts_msg):
             if message:
                 history.append(
                     {"role": "user", "content": [{"text": f"[System]: {message}"}]}
                 )
+
+    async def _run_turn(
+        self,
+        *,
+        message: str,
+        room_id: str,
+        history: StrandsMessages,
+        tools: AgentToolsProtocol,
+        hooks: BandTurnHooks,
+    ) -> None:
+        """Run the framework loop while preserving transcript and usage on failure."""
+        agent = self._build_agent(history, tools, hooks)
+        try:
+            await agent.invoke_async(message)
+        finally:
+            self._message_history[room_id] = agent.messages
+            await self.emit_usage(tools, self._usage_from_agent(agent))
 
     async def on_message(
         self,
@@ -607,17 +420,12 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         is_session_bootstrap: bool,
         room_id: str,
     ) -> None:
-        """Handle incoming platform message."""
-        if not self._strands_tools:
-            self._strands_tools = self._build_platform_tools() + self._custom_tools
-
+        """Run one room turn and surface a missing tool-based reply."""
         room_history = self._history_for_turn(
             room_id, history, is_session_bootstrap=is_session_bootstrap
         )
         self._append_system_context(room_history, participants_msg, contacts_msg)
-
         user_message = msg.format_for_llm()
-
         logger.debug(
             "Room %s: Running Strands agent (history: %s msgs, prompt: %s...)",
             room_id,
@@ -625,31 +433,25 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
             user_message[:80],
         )
 
-        turn_hooks = _BandTurnHooks(
+        hooks = BandTurnHooks(
             tools,
             emit_execution=Emit.EXECUTION in self.features.emit,
             custom_terminal_names=self._custom_terminal_names,
         )
-        agent = self._build_agent(room_history, turn_hooks)
-        try:
-            await agent.invoke_async(
-                user_message,
-                invocation_state={_BAND_TOOLS_STATE_KEY: tools},
-            )
-        finally:
-            # Preserve completed work and usage when the turn fails.
-            self._message_history[room_id] = agent.messages
-            await self.emit_usage(tools, self._usage_from_agent(agent))
-
-        # Plain-text answers are not delivered to the room.
-        if not turn_hooks.terminal_fired:
+        await self._run_turn(
+            message=user_message,
+            room_id=room_id,
+            history=room_history,
+            tools=tools,
+            hooks=hooks,
+        )
+        if not hooks.terminal_fired:
             await self._report_error(
                 tools,
                 "Strands agent completed without sending a Band message. This "
                 "usually means the agent returned a final answer as plain text "
                 "instead of using the band_send_message tool.",
             )
-
         logger.debug(
             "Room %s: Strands agent completed (history now has %s messages)",
             room_id,
@@ -658,10 +460,10 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
 
     @staticmethod
     def _usage_from_agent(agent: Agent) -> TurnUsage:
-        """Map the agent's turn usage to Band usage."""
+        """Map Strands' accumulated turn usage into the SDK value object."""
         try:
             usage = dict(agent.event_loop_metrics.accumulated_usage)
-        except Exception:  # pragma: no cover - defensive; usage is best-effort
+        except Exception:  # pragma: no cover - usage reporting is best-effort
             return TurnUsage()
         return TurnUsage.from_mapping(
             usage,
@@ -672,14 +474,16 @@ class StrandsAdapter(SimpleAdapter[StrandsMessages]):
         )
 
     async def _report_error(self, tools: AgentToolsProtocol, error: str) -> None:
-        """Send a best-effort error event."""
+        """Post a best-effort room-visible adapter error."""
         try:
-            await tools.send_event(content=f"Error: {error}", message_type="error")
-        except (ApiError, httpx.HTTPError) as e:
-            logger.warning("Failed to send error event: %s", e)
+            await tools.send_event(
+                content=f"Error: {error}",
+                message_type=MessageType.ERROR,
+            )
+        except (ApiError, httpx.HTTPError) as report_error:
+            logger.warning("Failed to send error event: %s", report_error)
 
     async def on_cleanup(self, room_id: str) -> None:
-        """Clean up message history when agent leaves a room."""
-        if room_id in self._message_history:
-            del self._message_history[room_id]
+        """Discard the transcript when Band removes the adapter from a room."""
+        if self._message_history.pop(room_id, None) is not None:
             logger.debug("Room %s: Cleaned up message history", room_id)

--- a/src/band/converters/__init__.py
+++ b/src/band/converters/__init__.py
@@ -14,6 +14,7 @@ Install the extra you need::
     uv add band-sdk[codex]
     uv add band-sdk[google_adk]
     uv add band-sdk[opencode]
+    uv add band-sdk[strands]
 """
 
 from __future__ import annotations
@@ -85,26 +86,29 @@ if TYPE_CHECKING:
     from band.converters.opencode import (
         OpencodeHistoryConverter as OpencodeHistoryConverter,
     )
+    from band.converters.strands import (
+        StrandsHistoryConverter as StrandsHistoryConverter,
+        StrandsMessages as StrandsMessages,
+    )
 
-__all__, __getattr__, __dir__ = lazy_exports(
+__all__, __getattr__ = lazy_exports(
     __name__,
-    {
-        "langchain": ("LangChainHistoryConverter", "LangChainMessages"),
-        "anthropic": ("AnthropicHistoryConverter", "AnthropicMessages"),
-        "pydantic_ai": ("PydanticAIHistoryConverter", "PydanticAIMessages"),
-        "claude_sdk": ("ClaudeSDKHistoryConverter",),
-        "copilot_sdk": ("CopilotSDKHistoryConverter", "CopilotSDKSessionState"),
-        "parlant": ("ParlantHistoryConverter", "ParlantMessages"),
-        "crewai": ("CrewAIHistoryConverter", "CrewAIMessages"),
-        "crewai_flow": ("CrewAIFlowStateConverter", "CrewAIFlowSessionState"),
-        "a2a": ("A2AHistoryConverter",),
-        "a2a_gateway": ("GatewayHistoryConverter",),
-        "codex": ("CodexHistoryConverter",),
-        "acp_server": ("ACPServerHistoryConverter",),
-        "acp_client": ("ACPClientHistoryConverter",),
-        "agno": ("AgnoHistoryConverter", "AgnoMessages"),
-        "gemini": ("GeminiHistoryConverter", "GeminiMessages"),
-        "google_adk": ("GoogleADKHistoryConverter", "GoogleADKMessages"),
-        "opencode": ("OpencodeHistoryConverter",),
-    },
+    langchain=["LangChainHistoryConverter", "LangChainMessages"],
+    anthropic=["AnthropicHistoryConverter", "AnthropicMessages"],
+    pydantic_ai=["PydanticAIHistoryConverter", "PydanticAIMessages"],
+    claude_sdk=["ClaudeSDKHistoryConverter"],
+    copilot_sdk=["CopilotSDKHistoryConverter", "CopilotSDKSessionState"],
+    parlant=["ParlantHistoryConverter", "ParlantMessages"],
+    crewai=["CrewAIHistoryConverter", "CrewAIMessages"],
+    crewai_flow=["CrewAIFlowStateConverter", "CrewAIFlowSessionState"],
+    a2a=["A2AHistoryConverter"],
+    a2a_gateway=["GatewayHistoryConverter"],
+    codex=["CodexHistoryConverter"],
+    acp_server=["ACPServerHistoryConverter"],
+    acp_client=["ACPClientHistoryConverter"],
+    agno=["AgnoHistoryConverter", "AgnoMessages"],
+    gemini=["GeminiHistoryConverter", "GeminiMessages"],
+    google_adk=["GoogleADKHistoryConverter", "GoogleADKMessages"],
+    opencode=["OpencodeHistoryConverter"],
+    strands=["StrandsHistoryConverter", "StrandsMessages"],
 )

--- a/src/band/converters/__init__.py
+++ b/src/band/converters/__init__.py
@@ -18,8 +18,9 @@ Install the extra you need::
 
 from __future__ import annotations
 
-import importlib
 from typing import TYPE_CHECKING
+
+from band.exports import lazy_exports
 
 # Type-only imports for static analysis (pyrefly, mypy, etc.)
 if TYPE_CHECKING:
@@ -85,73 +86,25 @@ if TYPE_CHECKING:
         OpencodeHistoryConverter as OpencodeHistoryConverter,
     )
 
-__all__ = [
-    "LangChainHistoryConverter",
-    "LangChainMessages",
-    "AnthropicHistoryConverter",
-    "AnthropicMessages",
-    "PydanticAIHistoryConverter",
-    "PydanticAIMessages",
-    "ClaudeSDKHistoryConverter",
-    "CopilotSDKHistoryConverter",
-    "CopilotSDKSessionState",
-    "ParlantHistoryConverter",
-    "ParlantMessages",
-    "CrewAIHistoryConverter",
-    "CrewAIMessages",
-    "CrewAIFlowSessionState",
-    "CrewAIFlowStateConverter",
-    "A2AHistoryConverter",
-    "GatewayHistoryConverter",
-    "CodexHistoryConverter",
-    "ACPServerHistoryConverter",
-    "ACPClientHistoryConverter",
-    "AgnoHistoryConverter",
-    "AgnoMessages",
-    "GeminiHistoryConverter",
-    "GeminiMessages",
-    "GoogleADKHistoryConverter",
-    "GoogleADKMessages",
-    "OpencodeHistoryConverter",
-]
-
-
-# Submodule (under band.converters) providing each lazily imported name.
-_LAZY_IMPORTS: dict[str, str] = {
-    "LangChainHistoryConverter": "langchain",
-    "LangChainMessages": "langchain",
-    "AnthropicHistoryConverter": "anthropic",
-    "AnthropicMessages": "anthropic",
-    "PydanticAIHistoryConverter": "pydantic_ai",
-    "PydanticAIMessages": "pydantic_ai",
-    "ClaudeSDKHistoryConverter": "claude_sdk",
-    "CopilotSDKHistoryConverter": "copilot_sdk",
-    "CopilotSDKSessionState": "copilot_sdk",
-    "ParlantHistoryConverter": "parlant",
-    "ParlantMessages": "parlant",
-    "CrewAIHistoryConverter": "crewai",
-    "CrewAIMessages": "crewai",
-    "CrewAIFlowStateConverter": "crewai_flow",
-    "CrewAIFlowSessionState": "crewai_flow",
-    "A2AHistoryConverter": "a2a",
-    "GatewayHistoryConverter": "a2a_gateway",
-    "CodexHistoryConverter": "codex",
-    "ACPServerHistoryConverter": "acp_server",
-    "ACPClientHistoryConverter": "acp_client",
-    "AgnoHistoryConverter": "agno",
-    "AgnoMessages": "agno",
-    "GeminiHistoryConverter": "gemini",
-    "GeminiMessages": "gemini",
-    "GoogleADKHistoryConverter": "google_adk",
-    "GoogleADKMessages": "google_adk",
-    "OpencodeHistoryConverter": "opencode",
-}
-
-
-def __getattr__(name: str) -> type:
-    """Lazy import converters to avoid loading optional dependencies."""
-    module_name = _LAZY_IMPORTS.get(name)
-    if module_name is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    module = importlib.import_module(f".{module_name}", __name__)
-    return getattr(module, name)
+__all__, __getattr__, __dir__ = lazy_exports(
+    __name__,
+    {
+        "langchain": ("LangChainHistoryConverter", "LangChainMessages"),
+        "anthropic": ("AnthropicHistoryConverter", "AnthropicMessages"),
+        "pydantic_ai": ("PydanticAIHistoryConverter", "PydanticAIMessages"),
+        "claude_sdk": ("ClaudeSDKHistoryConverter",),
+        "copilot_sdk": ("CopilotSDKHistoryConverter", "CopilotSDKSessionState"),
+        "parlant": ("ParlantHistoryConverter", "ParlantMessages"),
+        "crewai": ("CrewAIHistoryConverter", "CrewAIMessages"),
+        "crewai_flow": ("CrewAIFlowStateConverter", "CrewAIFlowSessionState"),
+        "a2a": ("A2AHistoryConverter",),
+        "a2a_gateway": ("GatewayHistoryConverter",),
+        "codex": ("CodexHistoryConverter",),
+        "acp_server": ("ACPServerHistoryConverter",),
+        "acp_client": ("ACPClientHistoryConverter",),
+        "agno": ("AgnoHistoryConverter", "AgnoMessages"),
+        "gemini": ("GeminiHistoryConverter", "GeminiMessages"),
+        "google_adk": ("GoogleADKHistoryConverter", "GoogleADKMessages"),
+        "opencode": ("OpencodeHistoryConverter",),
+    },
+)

--- a/src/band/converters/anthropic.py
+++ b/src/band/converters/anthropic.py
@@ -7,7 +7,11 @@ from typing import Any
 
 from band.core.protocols import HistoryConverter
 
-from .parsing import parse_tool_call, parse_tool_result
+from .parsing import (
+    INTERRUPTED_TOOL_TEXT,
+    parse_tool_call,
+    parse_tool_result,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +112,7 @@ def _patch_orphaned_tool_uses(messages: AnthropicMessages) -> None:
                 {
                     "type": "tool_result",
                     "tool_use_id": uid,
-                    "content": "Error: tool execution was interrupted",
+                    "content": INTERRUPTED_TOOL_TEXT,
                     "is_error": True,
                 }
                 for uid in sorted_ids

--- a/src/band/converters/google_adk.py
+++ b/src/band/converters/google_adk.py
@@ -8,7 +8,11 @@ from typing import Any
 
 from band.core.protocols import HistoryConverter
 
-from .parsing import parse_tool_call, parse_tool_result
+from .parsing import (
+    INTERRUPTED_TOOL_TEXT,
+    parse_tool_call,
+    parse_tool_result,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +87,7 @@ def _patch_orphaned_tool_calls(messages: GoogleADKMessages) -> None:
                     "type": "function_response",
                     "tool_call_id": uid,
                     "name": call_names.get(uid, ""),
-                    "output": "Error: tool execution was interrupted",
+                    "output": INTERRUPTED_TOOL_TEXT,
                     "is_error": True,
                 }
                 for uid in sorted_ids

--- a/src/band/converters/parsing.py
+++ b/src/band/converters/parsing.py
@@ -11,6 +11,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
+from band.core.types import ToolEventKey
+
 logger = logging.getLogger(__name__)
 
 
@@ -56,24 +58,24 @@ def parse_tool_call(content: str) -> ParsedToolCall | None:
         )
         return None
 
-    tool_call_id = event.get("tool_call_id")
-    tool_name = event.get("name")
+    tool_call_id = event.get(ToolEventKey.TOOL_CALL_ID)
+    tool_name = event.get(ToolEventKey.NAME)
 
-    if not tool_call_id:
+    if not isinstance(tool_call_id, str) or not tool_call_id:
         logger.warning(
             "Skipping tool_call with missing tool_call_id: %s",
             repr(content[:100]),
         )
         return None
 
-    if not tool_name:
+    if not isinstance(tool_name, str) or not tool_name:
         logger.warning(
             "Skipping tool_call with missing name: %s",
             repr(content[:100]),
         )
         return None
 
-    args = event.get("args", {})
+    args = event.get(ToolEventKey.ARGS, {})
     if not isinstance(args, dict):
         logger.warning(
             "Tool_call args were not an object; using empty args: %s",
@@ -111,17 +113,17 @@ def parse_tool_result(content: str) -> ParsedToolResult | None:
         )
         return None
 
-    tool_call_id = event.get("tool_call_id")
-    tool_name = event.get("name")
+    tool_call_id = event.get(ToolEventKey.TOOL_CALL_ID)
+    tool_name = event.get(ToolEventKey.NAME)
 
-    if not tool_call_id:
+    if not isinstance(tool_call_id, str) or not tool_call_id:
         logger.warning(
             "Skipping tool_result with missing tool_call_id: %s",
             repr(content[:100]),
         )
         return None
 
-    if not tool_name:
+    if not isinstance(tool_name, str) or not tool_name:
         logger.warning(
             "Skipping tool_result with missing name: %s",
             repr(content[:100]),
@@ -130,7 +132,7 @@ def parse_tool_result(content: str) -> ParsedToolResult | None:
 
     return ParsedToolResult(
         name=tool_name,
-        output=str(event.get("output", "")),
+        output=str(event.get(ToolEventKey.OUTPUT, "")),
         tool_call_id=tool_call_id,
-        is_error=event.get("is_error", False),
+        is_error=bool(event.get(ToolEventKey.IS_ERROR, False)),
     )

--- a/src/band/converters/parsing.py
+++ b/src/band/converters/parsing.py
@@ -15,6 +15,10 @@ from band.core.types import ToolEventKey
 
 logger = logging.getLogger(__name__)
 
+INTERRUPTED_TOOL_TEXT = "Error: tool execution was interrupted"
+"""Stand-in result a converter synthesizes for a tool call the room never
+answered, so the provider still sees every call closed out."""
+
 
 @dataclass
 class ParsedToolCall:

--- a/src/band/converters/strands.py
+++ b/src/band/converters/strands.py
@@ -1,0 +1,210 @@
+"""Strands Agents history converter."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from strands.types.content import ContentBlock, Message
+except ImportError as e:
+    raise ImportError(
+        "Strands Agents dependencies not installed. "
+        "Install with: uv add band-sdk[strands]"
+    ) from e
+
+from band.core.protocols import HistoryConverter
+from band.core.types import MessageType
+
+from ._tool_parsing import parse_tool_call, parse_tool_result
+
+logger = logging.getLogger(__name__)
+
+# Type alias for Strands conversation history (Bedrock-Converse-shaped messages)
+StrandsMessages = list[Message]
+
+
+def _flush_pending_tool_calls(
+    messages: StrandsMessages, pending_tool_calls: list[ContentBlock]
+) -> None:
+    """Flush pending toolUse blocks into a single assistant message."""
+    if pending_tool_calls:
+        messages.append({"role": "assistant", "content": list(pending_tool_calls)})
+        pending_tool_calls.clear()
+
+
+def _flush_pending_tool_results(
+    messages: StrandsMessages, pending_tool_results: list[ContentBlock]
+) -> None:
+    """Flush pending toolResult blocks into a single user message.
+
+    Converse requires every toolUse in an assistant message to be answered by
+    toolResult blocks in the following user message, so results are batched
+    together to support parallel tool use.
+    """
+    if pending_tool_results:
+        messages.append({"role": "user", "content": list(pending_tool_results)})
+        pending_tool_results.clear()
+
+
+class StrandsHistoryConverter(HistoryConverter[StrandsMessages]):
+    """
+    Converts platform history to Strands (Bedrock Converse) message format.
+
+    Output:
+    - user messages → {"role": "user", "content": [{"text": ...}]}
+    - other agents' messages → user role with [name] prefix
+    - tool_call → assistant message with a toolUse content block
+    - tool_result → user message with a toolResult content block
+      (status "error" when is_error=True)
+    - this agent's text messages → {"role": "assistant", "content": [{"text": ...}]}
+      (dropped when emitted mid tool call, where it would split the toolUse
+      from its toolResult)
+
+    Tool events are stored in platform as JSON:
+    - tool_call: {"name": "...", "args": {...}, "tool_call_id": "..."}
+    - tool_result: {"name": "...", "output": "...", "tool_call_id": "...", "is_error": bool}
+    """
+
+    def __init__(self, agent_name: str = ""):
+        """
+        Initialize converter.
+
+        Args:
+            agent_name: Name of this agent. Messages from this agent are preserved
+                       as assistant turns. Messages from other agents are included
+                       as user turns with a [name] prefix.
+        """
+        self._agent_name = agent_name
+
+    def set_agent_name(self, name: str) -> None:
+        """
+        Set agent name so the converter can recognize this agent's own messages.
+
+        Args:
+            name: Name of this agent
+        """
+        self._agent_name = name
+
+    def convert(self, raw: list[dict[str, Any]]) -> StrandsMessages:
+        """Convert platform history to Strands Converse format."""
+        messages: StrandsMessages = []
+        # Collect tool calls to batch them into a single assistant message
+        pending_tool_calls: list[ContentBlock] = []
+        # Collect tool results to batch them into a single user message
+        pending_tool_results: list[ContentBlock] = []
+
+        for hist in raw:
+            message_type = hist.get("message_type", "text")
+            content = hist.get("content", "")
+
+            match message_type:
+                case MessageType.TOOL_CALL:
+                    self._handle_tool_call(
+                        content, messages, pending_tool_calls, pending_tool_results
+                    )
+                case MessageType.TOOL_RESULT:
+                    self._handle_tool_result(
+                        content, messages, pending_tool_calls, pending_tool_results
+                    )
+                case MessageType.TEXT:
+                    self._handle_text(
+                        hist,
+                        content,
+                        messages,
+                        pending_tool_calls,
+                        pending_tool_results,
+                    )
+                case MessageType.THOUGHT | MessageType.ERROR | MessageType.TASK:
+                    # Known platform-internal types intentionally excluded from
+                    # LLM history.
+                    pass
+                case _:
+                    logger.warning("Unknown message_type in history: %s", message_type)
+
+        # Flush any remaining pending tool calls and results
+        _flush_pending_tool_calls(messages, pending_tool_calls)
+        _flush_pending_tool_results(messages, pending_tool_results)
+
+        return messages
+
+    def _handle_tool_call(
+        self,
+        content: str,
+        messages: StrandsMessages,
+        pending_tool_calls: list[ContentBlock],
+        pending_tool_results: list[ContentBlock],
+    ) -> None:
+        """Collect a tool call for batching, flushing any pending results first."""
+        _flush_pending_tool_results(messages, pending_tool_results)
+
+        parsed = parse_tool_call(content)
+        if parsed:
+            pending_tool_calls.append(
+                {
+                    "toolUse": {
+                        "toolUseId": parsed.tool_call_id,
+                        "name": parsed.name,
+                        "input": parsed.args,
+                    }
+                }
+            )
+
+    def _handle_tool_result(
+        self,
+        content: str,
+        messages: StrandsMessages,
+        pending_tool_calls: list[ContentBlock],
+        pending_tool_results: list[ContentBlock],
+    ) -> None:
+        """Collect a tool result for batching, flushing the calls it answers first."""
+        _flush_pending_tool_calls(messages, pending_tool_calls)
+
+        parsed = parse_tool_result(content)
+        if not parsed:
+            return
+
+        pending_tool_results.append(
+            {
+                "toolResult": {
+                    "toolUseId": parsed.tool_call_id,
+                    "status": "error" if parsed.is_error else "success",
+                    "content": [{"text": parsed.output}],
+                }
+            }
+        )
+
+    def _handle_text(
+        self,
+        hist: dict[str, Any],
+        content: str,
+        messages: StrandsMessages,
+        pending_tool_calls: list[ContentBlock],
+        pending_tool_results: list[ContentBlock],
+    ) -> None:
+        """Append a text turn: own text as assistant, others as user."""
+        role = hist.get("role", "user")
+        sender_name = hist.get("sender_name", "")
+        is_own = (
+            role == "assistant" and self._agent_name and sender_name == self._agent_name
+        )
+
+        # Own platform text while a tool call is unresolved is usually the side
+        # effect of band_send_message. Replaying it here would split the toolUse
+        # from its toolResult, which Converse rejects.
+        if is_own and pending_tool_calls:
+            return
+
+        # Flush pending tool calls and results first
+        _flush_pending_tool_calls(messages, pending_tool_calls)
+        _flush_pending_tool_results(messages, pending_tool_results)
+
+        if is_own:
+            # Preserve own text so restart rehydration knows the agent already replied.
+            messages.append({"role": "assistant", "content": [{"text": content}]})
+        else:
+            # User messages AND other agents' messages
+            formatted_content = (
+                f"[{sender_name}]: {content}" if sender_name else content
+            )
+            messages.append({"role": "user", "content": [{"text": formatted_content}]})

--- a/src/band/converters/strands.py
+++ b/src/band/converters/strands.py
@@ -71,9 +71,9 @@ def _patch_orphaned_tool_uses(messages: StrandsMessages) -> None:
     this repair the broken pair is replayed on every later turn in the room, so
     the whole room stops responding.
 
-    Synthetic results are merged into a following user message only when that
-    message already carries toolResults; a text turn must stay a turn of its
-    own, because providers order the tool answers after it.
+    Synthetic results join a following user message only when that message
+    already carries toolResults; otherwise they are inserted ahead of it, so
+    the tool answers stay first in the turn once same-role messages merge.
 
     Mutates ``messages`` in place.
     """
@@ -104,13 +104,35 @@ def _patch_orphaned_tool_uses(messages: StrandsMessages) -> None:
             )
 
 
+def _merge_consecutive_roles(messages: StrandsMessages) -> StrandsMessages:
+    """Combine neighbouring messages that share a role.
+
+    Bedrock's Converse rejects a conversation that does not alternate between
+    user and assistant, and room history routinely produces same-role
+    neighbours: two peers speaking in a row, or a peer's turn landing behind
+    the tool results it waited for.
+    """
+    merged: StrandsMessages = []
+    for message in messages:
+        if merged and merged[-1]["role"] == message["role"]:
+            merged[-1]["content"] = list(merged[-1]["content"]) + list(
+                message["content"]
+            )
+            continue
+        merged.append(message)
+    return merged
+
+
 class ConverseTranscript:
     """Build Converse messages, keeping each toolUse next to its toolResult.
 
     Converse pairs an assistant toolUse message with the user toolResult
-    message that immediately follows it. Room history interleaves freely — a
-    peer can post while a tool is still running — so turns that arrive inside
-    an open tool exchange are held and replayed once the exchange closes.
+    message that immediately follows it. Room history interleaves freely: a
+    peer can post while a tool is still running, and Strands runs a round's
+    tools concurrently, so a later call can be recorded after an earlier
+    result. An exchange therefore stays open until every call it made has been
+    answered — its calls, its results, and the turns that arrived during it are
+    buffered until then, and only then emitted as one paired sequence.
     """
 
     def __init__(self) -> None:
@@ -126,21 +148,14 @@ class ConverseTranscript:
         return bool(self._unanswered)
 
     def add_tool_use(self, tool_use_id: str, name: str, args: dict[str, Any]) -> None:
-        """Record a tool call, batching parallel calls into one assistant message."""
-        self._emit_tool_results()
-        # A second parallel call does not close the exchange, so turns held during
-        # it stay held — releasing them here would place them before the assistant
-        # message carrying the calls they actually arrived after.
-        if not self.in_tool_exchange:
-            self._release_held_turns()
+        """Record a tool call, batching a round's calls into one assistant message."""
         self._tool_uses.append(
             {"toolUse": {"toolUseId": tool_use_id, "name": name, "input": args}}
         )
         self._unanswered.add(tool_use_id)
 
     def add_tool_result(self, tool_use_id: str, output: str, *, is_error: bool) -> None:
-        """Record a tool result, batching parallel results into one user message."""
-        self._emit_tool_uses()
+        """Record a tool result, closing the exchange once nothing is outstanding."""
         self._tool_results.append(
             {
                 "toolResult": {
@@ -151,6 +166,8 @@ class ConverseTranscript:
             }
         )
         self._unanswered.discard(tool_use_id)
+        if not self.in_tool_exchange:
+            self._close_tool_exchange()
 
     def add_turn(self, role: Role, text: str) -> None:
         """Append a text turn, holding it back while a tool exchange is open."""
@@ -158,39 +175,27 @@ class ConverseTranscript:
         if self.in_tool_exchange:
             self._held_turns.append(turn)
             return
-        self._close_tool_exchange()
         self._messages.append(turn)
 
     def build(self) -> StrandsMessages:
-        """Return the finished transcript with every toolUse answered."""
-        self._emit_tool_uses()
+        """Return the finished transcript: every call answered, roles alternating."""
         self._close_tool_exchange()
         _patch_orphaned_tool_uses(self._messages)
-        return self._messages
+        return _merge_consecutive_roles(self._messages)
 
-    def _emit_tool_uses(self) -> None:
-        """Emit the batched tool calls as one assistant message."""
+    def _close_tool_exchange(self) -> None:
+        """Emit the exchange's calls, then its results, then the turns it held."""
         if self._tool_uses:
             self._messages.append(
                 {"role": "assistant", "content": list(self._tool_uses)}
             )
             self._tool_uses.clear()
-
-    def _close_tool_exchange(self) -> None:
-        """Emit the batched tool results, then the turns held during the exchange."""
-        self._emit_tool_results()
-        self._release_held_turns()
-
-    def _emit_tool_results(self) -> None:
-        """Emit the batched tool results as one user message."""
         if self._tool_results:
             self._messages.append({"role": "user", "content": list(self._tool_results)})
             self._tool_results.clear()
-
-    def _release_held_turns(self) -> None:
-        """Replay the text turns that arrived while the exchange was open."""
         self._messages.extend(self._held_turns)
         self._held_turns.clear()
+        self._unanswered.clear()
 
 
 class StrandsHistoryConverter(HistoryConverter[StrandsMessages]):

--- a/src/band/converters/strands.py
+++ b/src/band/converters/strands.py
@@ -20,7 +20,6 @@ from .parsing import parse_tool_call, parse_tool_result
 
 logger = logging.getLogger(__name__)
 
-# Type alias for Strands conversation history (Bedrock-Converse-shaped messages)
 StrandsMessages = list[Message]
 
 
@@ -48,23 +47,7 @@ def _flush_pending_tool_results(
 
 
 class StrandsHistoryConverter(HistoryConverter[StrandsMessages]):
-    """
-    Converts platform history to Strands (Bedrock Converse) message format.
-
-    Output:
-    - user messages → {"role": "user", "content": [{"text": ...}]}
-    - other agents' messages → user role with [name] prefix
-    - tool_call → assistant message with a toolUse content block
-    - tool_result → user message with a toolResult content block
-      (status "error" when is_error=True)
-    - this agent's text messages → {"role": "assistant", "content": [{"text": ...}]}
-      (dropped when emitted mid tool call, where it would split the toolUse
-      from its toolResult)
-
-    Tool events are stored in platform as JSON:
-    - tool_call: {"name": "...", "args": {...}, "tool_call_id": "..."}
-    - tool_result: {"name": "...", "output": "...", "tool_call_id": "...", "is_error": bool}
-    """
+    """Convert Band history to Strands Converse messages."""
 
     def __init__(self, agent_name: str = ""):
         """

--- a/src/band/converters/strands.py
+++ b/src/band/converters/strands.py
@@ -154,8 +154,20 @@ class ConverseTranscript:
         )
         self._unanswered.add(tool_use_id)
 
-    def add_tool_result(self, tool_use_id: str, output: str, *, is_error: bool) -> None:
+    def add_tool_result(
+        self, tool_use_id: str, name: str, output: str, *, is_error: bool
+    ) -> None:
         """Record a tool result, closing the exchange once nothing is outstanding."""
+        if tool_use_id not in self._unanswered:
+            # The matching tool_call event never reached history (failed send or
+            # unparseable payload). Converse rejects a toolResult with no
+            # preceding toolUse, so give the result a call to answer.
+            logger.warning(
+                "Synthesizing toolUse for orphaned toolResult %s (%s)",
+                tool_use_id,
+                name,
+            )
+            self.add_tool_use(tool_use_id, name, {})
         self._tool_results.append(
             {
                 "toolResult": {
@@ -256,7 +268,10 @@ class StrandsHistoryConverter(HistoryConverter[StrandsMessages]):
         parsed = parse_tool_result(content)
         if parsed:
             transcript.add_tool_result(
-                parsed.tool_call_id, parsed.output, is_error=parsed.is_error
+                parsed.tool_call_id,
+                parsed.name,
+                parsed.output,
+                is_error=parsed.is_error,
             )
 
     def _handle_text(

--- a/src/band/converters/strands.py
+++ b/src/band/converters/strands.py
@@ -16,7 +16,7 @@ except ImportError as e:
 from band.core.protocols import HistoryConverter
 from band.core.types import MessageType
 
-from ._tool_parsing import parse_tool_call, parse_tool_result
+from .parsing import parse_tool_call, parse_tool_result
 
 logger = logging.getLogger(__name__)
 

--- a/src/band/converters/strands.py
+++ b/src/band/converters/strands.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 try:
-    from strands.types.content import ContentBlock, Message
+    from strands.types.content import ContentBlock, Message, Role
 except ImportError as e:
     raise ImportError(
         "Strands Agents dependencies not installed. "
@@ -22,28 +22,161 @@ logger = logging.getLogger(__name__)
 
 StrandsMessages = list[Message]
 
-
-def _flush_pending_tool_calls(
-    messages: StrandsMessages, pending_tool_calls: list[ContentBlock]
-) -> None:
-    """Flush pending toolUse blocks into a single assistant message."""
-    if pending_tool_calls:
-        messages.append({"role": "assistant", "content": list(pending_tool_calls)})
-        pending_tool_calls.clear()
+INTERRUPTED_TOOL_TEXT = "Error: tool execution was interrupted"
 
 
-def _flush_pending_tool_results(
-    messages: StrandsMessages, pending_tool_results: list[ContentBlock]
-) -> None:
-    """Flush pending toolResult blocks into a single user message.
+def _tool_use_ids(message: Message) -> list[str]:
+    """Return the toolUse ids an assistant message asks to be answered."""
+    if message["role"] != "assistant":
+        return []
+    return [
+        block["toolUse"]["toolUseId"]
+        for block in message["content"]
+        if "toolUse" in block
+    ]
 
-    Converse requires every toolUse in an assistant message to be answered by
-    toolResult blocks in the following user message, so results are batched
-    together to support parallel tool use.
+
+def _answered_ids(message: Message | None) -> set[str]:
+    """Return the toolUse ids a user message answers with toolResult blocks."""
+    if message is None or message["role"] != "user":
+        return set()
+    return {
+        block["toolResult"]["toolUseId"]
+        for block in message["content"]
+        if "toolResult" in block
+    }
+
+
+def _synthetic_results(tool_use_ids: list[str]) -> list[ContentBlock]:
+    """Build error toolResults that close out unanswered toolUse blocks."""
+    return [
+        {
+            "toolResult": {
+                "toolUseId": tool_use_id,
+                "status": "error",
+                "content": [{"text": INTERRUPTED_TOOL_TEXT}],
+            }
+        }
+        for tool_use_id in tool_use_ids
+    ]
+
+
+def _patch_orphaned_tool_uses(messages: StrandsMessages) -> None:
+    """Answer every unanswered toolUse with a synthetic error toolResult.
+
+    Converse rejects an assistant toolUse whose toolResult does not follow it,
+    and the room transcript can be missing one: the platform ``tool_result``
+    event may have failed to send, or its payload may be unparseable. Without
+    this repair the broken pair is replayed on every later turn in the room, so
+    the whole room stops responding.
+
+    Synthetic results are merged into a following user message only when that
+    message already carries toolResults; a text turn must stay a turn of its
+    own, because providers order the tool answers after it.
+
+    Mutates ``messages`` in place.
     """
-    if pending_tool_results:
-        messages.append({"role": "user", "content": list(pending_tool_results)})
-        pending_tool_results.clear()
+    # Reverse order so inserting a repair never shifts an index still to visit.
+    for index in reversed(range(len(messages))):
+        pending = _tool_use_ids(messages[index])
+        if not pending:
+            continue
+
+        follower = messages[index + 1] if index + 1 < len(messages) else None
+        answered = _answered_ids(follower)
+        orphaned = [
+            tool_use_id for tool_use_id in pending if tool_use_id not in answered
+        ]
+        if not orphaned:
+            continue
+
+        logger.warning(
+            "Patching %d unanswered toolUse block(s): %s", len(orphaned), orphaned
+        )
+        if follower is not None and answered:
+            follower["content"] = _synthetic_results(orphaned) + list(
+                follower["content"]
+            )
+        else:
+            messages.insert(
+                index + 1, {"role": "user", "content": _synthetic_results(orphaned)}
+            )
+
+
+class ConverseTranscript:
+    """Build Converse messages, keeping each toolUse next to its toolResult.
+
+    Converse pairs an assistant toolUse message with the user toolResult
+    message that immediately follows it. Room history interleaves freely — a
+    peer can post while a tool is still running — so turns that arrive inside
+    an open tool exchange are held and replayed once the exchange closes.
+    """
+
+    def __init__(self) -> None:
+        self._messages: StrandsMessages = []
+        self._tool_uses: list[ContentBlock] = []
+        self._tool_results: list[ContentBlock] = []
+        self._held_turns: StrandsMessages = []
+        self._unanswered: set[str] = set()
+
+    @property
+    def in_tool_exchange(self) -> bool:
+        """Whether a toolUse is still waiting for its toolResult."""
+        return bool(self._unanswered)
+
+    def add_tool_use(self, tool_use_id: str, name: str, args: dict[str, Any]) -> None:
+        """Record a tool call, batching parallel calls into one assistant message."""
+        self._close_tool_exchange()
+        self._tool_uses.append(
+            {"toolUse": {"toolUseId": tool_use_id, "name": name, "input": args}}
+        )
+        self._unanswered.add(tool_use_id)
+
+    def add_tool_result(self, tool_use_id: str, output: str, *, is_error: bool) -> None:
+        """Record a tool result, batching parallel results into one user message."""
+        self._emit_tool_uses()
+        self._tool_results.append(
+            {
+                "toolResult": {
+                    "toolUseId": tool_use_id,
+                    "status": "error" if is_error else "success",
+                    "content": [{"text": output}],
+                }
+            }
+        )
+        self._unanswered.discard(tool_use_id)
+
+    def add_turn(self, role: Role, text: str) -> None:
+        """Append a text turn, holding it back while a tool exchange is open."""
+        turn: Message = {"role": role, "content": [{"text": text}]}
+        if self.in_tool_exchange:
+            self._held_turns.append(turn)
+            return
+        self._close_tool_exchange()
+        self._messages.append(turn)
+
+    def build(self) -> StrandsMessages:
+        """Return the finished transcript with every toolUse answered."""
+        self._emit_tool_uses()
+        self._close_tool_exchange()
+        _patch_orphaned_tool_uses(self._messages)
+        return self._messages
+
+    def _emit_tool_uses(self) -> None:
+        """Emit the batched tool calls as one assistant message."""
+        if self._tool_uses:
+            self._messages.append(
+                {"role": "assistant", "content": list(self._tool_uses)}
+            )
+            self._tool_uses.clear()
+
+    def _close_tool_exchange(self) -> None:
+        """Emit the batched tool results, then the turns held during the exchange."""
+        if self._tool_results:
+            self._messages.append({"role": "user", "content": list(self._tool_results)})
+            self._tool_results.clear()
+        self._messages.extend(self._held_turns)
+        self._held_turns.clear()
 
 
 class StrandsHistoryConverter(HistoryConverter[StrandsMessages]):
@@ -71,11 +204,7 @@ class StrandsHistoryConverter(HistoryConverter[StrandsMessages]):
 
     def convert(self, raw: list[dict[str, Any]]) -> StrandsMessages:
         """Convert platform history to Strands Converse format."""
-        messages: StrandsMessages = []
-        # Collect tool calls to batch them into a single assistant message
-        pending_tool_calls: list[ContentBlock] = []
-        # Collect tool results to batch them into a single user message
-        pending_tool_results: list[ContentBlock] = []
+        transcript = ConverseTranscript()
 
         for hist in raw:
             message_type = hist.get("message_type", "text")
@@ -83,21 +212,11 @@ class StrandsHistoryConverter(HistoryConverter[StrandsMessages]):
 
             match message_type:
                 case MessageType.TOOL_CALL:
-                    self._handle_tool_call(
-                        content, messages, pending_tool_calls, pending_tool_results
-                    )
+                    self._handle_tool_call(content, transcript)
                 case MessageType.TOOL_RESULT:
-                    self._handle_tool_result(
-                        content, messages, pending_tool_calls, pending_tool_results
-                    )
+                    self._handle_tool_result(content, transcript)
                 case MessageType.TEXT:
-                    self._handle_text(
-                        hist,
-                        content,
-                        messages,
-                        pending_tool_calls,
-                        pending_tool_results,
-                    )
+                    self._handle_text(hist, content, transcript)
                 case MessageType.THOUGHT | MessageType.ERROR | MessageType.TASK:
                     # Known platform-internal types intentionally excluded from
                     # LLM history.
@@ -105,65 +224,24 @@ class StrandsHistoryConverter(HistoryConverter[StrandsMessages]):
                 case _:
                     logger.warning("Unknown message_type in history: %s", message_type)
 
-        # Flush any remaining pending tool calls and results
-        _flush_pending_tool_calls(messages, pending_tool_calls)
-        _flush_pending_tool_results(messages, pending_tool_results)
+        return transcript.build()
 
-        return messages
-
-    def _handle_tool_call(
-        self,
-        content: str,
-        messages: StrandsMessages,
-        pending_tool_calls: list[ContentBlock],
-        pending_tool_results: list[ContentBlock],
-    ) -> None:
-        """Collect a tool call for batching, flushing any pending results first."""
-        _flush_pending_tool_results(messages, pending_tool_results)
-
+    def _handle_tool_call(self, content: str, transcript: ConverseTranscript) -> None:
+        """Record a tool call."""
         parsed = parse_tool_call(content)
         if parsed:
-            pending_tool_calls.append(
-                {
-                    "toolUse": {
-                        "toolUseId": parsed.tool_call_id,
-                        "name": parsed.name,
-                        "input": parsed.args,
-                    }
-                }
+            transcript.add_tool_use(parsed.tool_call_id, parsed.name, parsed.args)
+
+    def _handle_tool_result(self, content: str, transcript: ConverseTranscript) -> None:
+        """Record a tool result."""
+        parsed = parse_tool_result(content)
+        if parsed:
+            transcript.add_tool_result(
+                parsed.tool_call_id, parsed.output, is_error=parsed.is_error
             )
 
-    def _handle_tool_result(
-        self,
-        content: str,
-        messages: StrandsMessages,
-        pending_tool_calls: list[ContentBlock],
-        pending_tool_results: list[ContentBlock],
-    ) -> None:
-        """Collect a tool result for batching, flushing the calls it answers first."""
-        _flush_pending_tool_calls(messages, pending_tool_calls)
-
-        parsed = parse_tool_result(content)
-        if not parsed:
-            return
-
-        pending_tool_results.append(
-            {
-                "toolResult": {
-                    "toolUseId": parsed.tool_call_id,
-                    "status": "error" if parsed.is_error else "success",
-                    "content": [{"text": parsed.output}],
-                }
-            }
-        )
-
     def _handle_text(
-        self,
-        hist: dict[str, Any],
-        content: str,
-        messages: StrandsMessages,
-        pending_tool_calls: list[ContentBlock],
-        pending_tool_results: list[ContentBlock],
+        self, hist: dict[str, Any], content: str, transcript: ConverseTranscript
     ) -> None:
         """Append a text turn: own text as assistant, others as user."""
         role = hist.get("role", "user")
@@ -172,22 +250,17 @@ class StrandsHistoryConverter(HistoryConverter[StrandsMessages]):
             role == "assistant" and self._agent_name and sender_name == self._agent_name
         )
 
-        # Own platform text while a tool call is unresolved is usually the side
-        # effect of band_send_message. Replaying it here would split the toolUse
-        # from its toolResult, which Converse rejects.
-        if is_own and pending_tool_calls:
+        # Own platform text during an open tool exchange is usually the side
+        # effect of band_send_message; the tool call already records it, and an
+        # assistant turn here would split the toolUse from its toolResult.
+        if is_own and transcript.in_tool_exchange:
             return
-
-        # Flush pending tool calls and results first
-        _flush_pending_tool_calls(messages, pending_tool_calls)
-        _flush_pending_tool_results(messages, pending_tool_results)
 
         if is_own:
             # Preserve own text so restart rehydration knows the agent already replied.
-            messages.append({"role": "assistant", "content": [{"text": content}]})
+            transcript.add_turn("assistant", content)
         else:
             # User messages AND other agents' messages
-            formatted_content = (
-                f"[{sender_name}]: {content}" if sender_name else content
+            transcript.add_turn(
+                "user", f"[{sender_name}]: {content}" if sender_name else content
             )
-            messages.append({"role": "user", "content": [{"text": formatted_content}]})

--- a/src/band/converters/strands.py
+++ b/src/band/converters/strands.py
@@ -13,16 +13,17 @@ except ImportError as e:
         "Install with: uv add band-sdk[strands]"
     ) from e
 
+from band.converters.parsing import (
+    INTERRUPTED_TOOL_TEXT,
+    parse_tool_call,
+    parse_tool_result,
+)
 from band.core.protocols import HistoryConverter
 from band.core.types import MessageType
-
-from .parsing import parse_tool_call, parse_tool_result
 
 logger = logging.getLogger(__name__)
 
 StrandsMessages = list[Message]
-
-INTERRUPTED_TOOL_TEXT = "Error: tool execution was interrupted"
 
 
 def _tool_use_ids(message: Message) -> list[str]:
@@ -126,7 +127,12 @@ class ConverseTranscript:
 
     def add_tool_use(self, tool_use_id: str, name: str, args: dict[str, Any]) -> None:
         """Record a tool call, batching parallel calls into one assistant message."""
-        self._close_tool_exchange()
+        self._emit_tool_results()
+        # A second parallel call does not close the exchange, so turns held during
+        # it stay held — releasing them here would place them before the assistant
+        # message carrying the calls they actually arrived after.
+        if not self.in_tool_exchange:
+            self._release_held_turns()
         self._tool_uses.append(
             {"toolUse": {"toolUseId": tool_use_id, "name": name, "input": args}}
         )
@@ -172,9 +178,17 @@ class ConverseTranscript:
 
     def _close_tool_exchange(self) -> None:
         """Emit the batched tool results, then the turns held during the exchange."""
+        self._emit_tool_results()
+        self._release_held_turns()
+
+    def _emit_tool_results(self) -> None:
+        """Emit the batched tool results as one user message."""
         if self._tool_results:
             self._messages.append({"role": "user", "content": list(self._tool_results)})
             self._tool_results.clear()
+
+    def _release_held_turns(self) -> None:
+        """Replay the text turns that arrived while the exchange was open."""
         self._messages.extend(self._held_turns)
         self._held_turns.clear()
 

--- a/src/band/core/types.py
+++ b/src/band/core/types.py
@@ -26,6 +26,16 @@ class MessageType(StrEnum):
     USAGE = "usage"
 
 
+class ToolEventKey(StrEnum):
+    """Canonical JSON keys for execution events written into room history."""
+
+    NAME = "name"
+    ARGS = "args"
+    OUTPUT = "output"
+    TOOL_CALL_ID = "tool_call_id"
+    IS_ERROR = "is_error"
+
+
 # Subset of message types accepted by ``band_send_event`` — the non-history
 # event kinds. Derived from MessageType so the taxonomy stays single-sourced.
 EventMessageType = Literal[MessageType.THOUGHT, MessageType.ERROR, MessageType.TASK]

--- a/src/band/exports.py
+++ b/src/band/exports.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import sys
 from collections.abc import Callable, Sequence
 from typing import Any
 
@@ -31,6 +32,10 @@ def lazy_exports(
         module = owners.get(name)
         if module is None:
             raise AttributeError(f"module {package!r} has no attribute {name!r}")
-        return getattr(importlib.import_module(f".{module}", package), name)
+        value = getattr(importlib.import_module(f".{module}", package), name)
+        # Bind into the package namespace so PEP 562 stops consulting this
+        # resolver for the name — later reads are plain attribute lookups.
+        setattr(sys.modules[package], name, value)
+        return value
 
     return list(owners), resolve

--- a/src/band/exports.py
+++ b/src/band/exports.py
@@ -3,39 +3,34 @@
 from __future__ import annotations
 
 import importlib
-import sys
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Sequence
 from typing import Any
 
 
 def lazy_exports(
-    package_name: str,
-    module_exports: Mapping[str, Sequence[str]],
-) -> tuple[tuple[str, ...], Callable[[str], Any], Callable[[], list[str]]]:
-    """Create a lazy package export surface from module-owned names."""
-    export_modules: dict[str, str] = {}
-    exports: list[str] = []
-    for module_name, names in module_exports.items():
-        for name in names:
-            if name in export_modules:
-                raise ValueError(f"duplicate lazy export {name!r} in {package_name!r}")
-            export_modules[name] = module_name
-            exports.append(name)
+    package: str,
+    **module_exports: Sequence[str],
+) -> tuple[list[str], Callable[[str], Any]]:
+    """Build a package's ``__all__`` and PEP 562 ``__getattr__``.
+
+    Each keyword is a submodule of ``package`` and lists the exports it owns. A
+    submodule is imported only when one of its names is first read, so importing
+    the package never pulls in an optional extra::
+
+        __all__, __getattr__ = lazy_exports(
+            __name__,
+            anthropic=["AnthropicAdapter"],
+            codex=["CodexAdapter", "CodexAdapterConfig"],
+        )
+    """
+    owners = {
+        name: module for module, names in module_exports.items() for name in names
+    }
 
     def resolve(name: str) -> Any:
-        try:
-            module_name = export_modules[name]
-        except KeyError as error:
-            raise AttributeError(
-                f"module {package_name!r} has no attribute {name!r}"
-            ) from error
+        module = owners.get(name)
+        if module is None:
+            raise AttributeError(f"module {package!r} has no attribute {name!r}")
+        return getattr(importlib.import_module(f".{module}", package), name)
 
-        module = importlib.import_module(f".{module_name}", package_name)
-        value = getattr(module, name)
-        setattr(sys.modules[package_name], name, value)
-        return value
-
-    def exported_names() -> list[str]:
-        return sorted(set(sys.modules[package_name].__dict__) | set(exports))
-
-    return tuple(exports), resolve, exported_names
+    return list(owners), resolve

--- a/src/band/exports.py
+++ b/src/band/exports.py
@@ -1,0 +1,41 @@
+"""Infrastructure for optional public re-exports."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+
+def lazy_exports(
+    package_name: str,
+    module_exports: Mapping[str, Sequence[str]],
+) -> tuple[tuple[str, ...], Callable[[str], Any], Callable[[], list[str]]]:
+    """Create a lazy package export surface from module-owned names."""
+    export_modules: dict[str, str] = {}
+    exports: list[str] = []
+    for module_name, names in module_exports.items():
+        for name in names:
+            if name in export_modules:
+                raise ValueError(f"duplicate lazy export {name!r} in {package_name!r}")
+            export_modules[name] = module_name
+            exports.append(name)
+
+    def resolve(name: str) -> Any:
+        try:
+            module_name = export_modules[name]
+        except KeyError as error:
+            raise AttributeError(
+                f"module {package_name!r} has no attribute {name!r}"
+            ) from error
+
+        module = importlib.import_module(f".{module_name}", package_name)
+        value = getattr(module, name)
+        setattr(sys.modules[package_name], name, value)
+        return value
+
+    def exported_names() -> list[str]:
+        return sorted(set(sys.modules[package_name].__dict__) | set(exports))
+
+    return tuple(exports), resolve, exported_names

--- a/src/band/integrations/crewai/tools.py
+++ b/src/band/integrations/crewai/tools.py
@@ -58,6 +58,7 @@ from band.core.types import (
     Emit,
     EventMessageType,
     MessageType,
+    ToolEventKey,
 )
 from band.integrations.crewai.runtime import run_async
 from band.runtime.custom_tools import (
@@ -174,7 +175,9 @@ class EmitExecutionReporter:
             return
         try:
             await tools.send_event(
-                content=json.dumps({"name": tool_name, "args": input_data}),
+                content=json.dumps(
+                    {ToolEventKey.NAME: tool_name, ToolEventKey.ARGS: input_data}
+                ),
                 message_type="tool_call",
             )
         except Exception as e:
@@ -192,7 +195,11 @@ class EmitExecutionReporter:
         try:
             await tools.send_event(
                 content=json.dumps(
-                    {"name": tool_name, "output": result, "is_error": is_error}
+                    {
+                        ToolEventKey.NAME: tool_name,
+                        ToolEventKey.OUTPUT: result,
+                        ToolEventKey.IS_ERROR: is_error,
+                    }
                 ),
                 message_type="tool_result",
             )

--- a/src/band/runtime/tools.py
+++ b/src/band/runtime/tools.py
@@ -1146,6 +1146,23 @@ def is_terminal_success(
     return custom_terminal
 
 
+def missing_reply_error(framework: str, *, detail: str = "") -> str:
+    """The room-visible error for a turn that ended without a reply going out.
+
+    Raised by every adapter that answers through tools, so the wording lives
+    once. Both endings are named because they look identical from the room and
+    are told apart only by the model's last response: a plain-text final answer
+    the adapter cannot post, or no output at all (empty or thinking-only), which
+    is what a model that considers the exchange finished actually returns.
+    """
+    reasons = (
+        f"{framework} finished a turn without calling band_send_message, so "
+        "nothing reached the room. The model either answered in plain text "
+        "instead of using the tool, or returned no output at all."
+    )
+    return f"{reasons} {detail}" if detail else reasons
+
+
 # Fail fast on typos — catch at import time, not in a test run.
 # Use explicit checks instead of ``assert`` so they are not stripped by -O.
 if MEMORY_TOOL_NAMES - ALL_TOOL_NAMES:

--- a/src/band/testing/__init__.py
+++ b/src/band/testing/__init__.py
@@ -1,5 +1,26 @@
-"""Testing utilities."""
+"""Testing utilities.
 
-from band.testing.fake_tools import FakeAgentTools
+Framework-specific helpers are lazily imported, so importing this package never
+requires an optional extra.
+"""
 
-__all__ = ["FakeAgentTools"]
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from band.exports import lazy_exports
+
+# Type-only imports for static analysis (pyrefly, mypy, etc.)
+if TYPE_CHECKING:
+    from band.testing.fake_tools import FakeAgentTools as FakeAgentTools
+    from band.testing.strands import (
+        ScriptedStrandsModel as ScriptedStrandsModel,
+        TextTurn as TextTurn,
+        ToolTurn as ToolTurn,
+    )
+
+__all__, __getattr__ = lazy_exports(
+    __name__,
+    fake_tools=["FakeAgentTools"],
+    strands=["ScriptedStrandsModel", "TextTurn", "ToolTurn"],
+)

--- a/src/band/testing/__init__.py
+++ b/src/band/testing/__init__.py
@@ -14,7 +14,9 @@ from band.exports import lazy_exports
 if TYPE_CHECKING:
     from band.testing.fake_tools import FakeAgentTools as FakeAgentTools
     from band.testing.strands import (
+        ErrorTurn as ErrorTurn,
         ScriptedStrandsModel as ScriptedStrandsModel,
+        ScriptedTurn as ScriptedTurn,
         TextTurn as TextTurn,
         ToolTurn as ToolTurn,
     )
@@ -22,5 +24,11 @@ if TYPE_CHECKING:
 __all__, __getattr__ = lazy_exports(
     __name__,
     fake_tools=["FakeAgentTools"],
-    strands=["ScriptedStrandsModel", "TextTurn", "ToolTurn"],
+    strands=[
+        "ErrorTurn",
+        "ScriptedStrandsModel",
+        "ScriptedTurn",
+        "TextTurn",
+        "ToolTurn",
+    ],
 )

--- a/src/band/testing/strands.py
+++ b/src/band/testing/strands.py
@@ -1,0 +1,124 @@
+"""Scripted Strands model for offline adapter tests.
+
+Strands ships no test provider, so tests that want to drive the real adapter and
+the framework's own agent loop without inference implement the documented
+``strands.models.Model`` ABC. This is that implementation, shared so every test
+scripts turns the same way.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+try:
+    from strands.models import Model
+    from strands.types.content import Messages
+    from strands.types.streaming import StreamEvent
+    from strands.types.tools import ToolSpec
+except ImportError as error:
+    raise ImportError(
+        "Strands Agents dependencies not installed. "
+        "Install with: uv add band-sdk[strands]"
+    ) from error
+
+
+@dataclass(frozen=True)
+class ToolTurn:
+    """A scripted turn that calls ``name`` with ``args``."""
+
+    name: str
+    args: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TextTurn:
+    """A scripted turn that answers in plain text and ends the run."""
+
+    text: str
+
+
+ScriptedTurn = ToolTurn | TextTurn
+
+
+class ScriptedStrandsModel(Model):
+    """Replay scripted turns in place of a provider call.
+
+    Each ``stream()`` call pops the next turn and yields the Converse
+    ``StreamEvent`` sequence Strands' event loop parses; once the script is
+    exhausted every further call ends the run with plain text. Non-zero token
+    counts add the optional trailing ``metadata`` event, so a test can exercise
+    usage accumulation across a turn's model calls.
+    """
+
+    def __init__(
+        self,
+        turns: Sequence[ScriptedTurn],
+        *,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+    ) -> None:
+        self._turns = list(turns)
+        self._input_tokens = input_tokens
+        self._output_tokens = output_tokens
+        self._config: dict[str, Any] = {}
+
+    def update_config(self, **model_config: Any) -> None:
+        self._config.update(model_config)
+
+    def get_config(self) -> Any:
+        return self._config
+
+    async def structured_output(
+        self,
+        output_model: Any,
+        prompt: Messages,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        raise NotImplementedError("the scripted model does not do structured output")
+        yield {}  # pragma: no cover - makes this an async generator
+
+    async def stream(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        turn = self._turns.pop(0) if self._turns else TextTurn("done")
+        yield {"messageStart": {"role": "assistant"}}
+        match turn:
+            case ToolTurn(name=name, args=args):
+                yield {
+                    "contentBlockStart": {
+                        "start": {
+                            "toolUse": {"toolUseId": f"call-{name}", "name": name}
+                        }
+                    }
+                }
+                yield {
+                    "contentBlockDelta": {
+                        "delta": {"toolUse": {"input": json.dumps(args)}}
+                    }
+                }
+                yield {"contentBlockStop": {}}
+                yield {"messageStop": {"stopReason": "tool_use"}}
+            case TextTurn(text=text):
+                yield {"contentBlockStart": {"start": {}}}
+                yield {"contentBlockDelta": {"delta": {"text": text}}}
+                yield {"contentBlockStop": {}}
+                yield {"messageStop": {"stopReason": "end_turn"}}
+        if self._input_tokens or self._output_tokens:
+            yield {
+                "metadata": {
+                    "usage": {
+                        "inputTokens": self._input_tokens,
+                        "outputTokens": self._output_tokens,
+                        "totalTokens": self._input_tokens + self._output_tokens,
+                    },
+                    "metrics": {"latencyMs": 1},
+                }
+            }

--- a/src/band/testing/strands.py
+++ b/src/band/testing/strands.py
@@ -40,7 +40,14 @@ class TextTurn:
     text: str
 
 
-ScriptedTurn = ToolTurn | TextTurn
+@dataclass(frozen=True)
+class ErrorTurn:
+    """A scripted turn where the provider call fails instead of answering."""
+
+    error: Exception
+
+
+ScriptedTurn = ToolTurn | TextTurn | ErrorTurn
 
 
 class ScriptedStrandsModel(Model):
@@ -48,9 +55,10 @@ class ScriptedStrandsModel(Model):
 
     Each ``stream()`` call pops the next turn and yields the Converse
     ``StreamEvent`` sequence Strands' event loop parses; once the script is
-    exhausted every further call ends the run with plain text. Non-zero token
-    counts add the optional trailing ``metadata`` event, so a test can exercise
-    usage accumulation across a turn's model calls.
+    exhausted every further call ends the run with plain text. An ``ErrorTurn``
+    fails the provider call instead, so a test can drive the adapter's failure
+    path. Non-zero token counts add the optional trailing ``metadata`` event, so
+    a test can exercise usage accumulation across a turn's model calls.
     """
 
     def __init__(
@@ -89,6 +97,8 @@ class ScriptedStrandsModel(Model):
         **kwargs: Any,
     ) -> AsyncGenerator[StreamEvent, None]:
         turn = self._turns.pop(0) if self._turns else TextTurn("done")
+        if isinstance(turn, ErrorTurn):
+            raise turn.error
         yield {"messageStart": {"role": "assistant"}}
         match turn:
             case ToolTurn(name=name, args=args):

--- a/tests/adapters/agno/conftest.py
+++ b/tests/adapters/agno/conftest.py
@@ -20,6 +20,14 @@ from band.testing import FakeAgentTools
 from tests.adapters.agno.helpers import CapturingModel, SchemaTools
 
 
+@pytest.fixture(autouse=True)
+def _disable_agno_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real ``AgnoAgent.arun()`` fires an async telemetry POST to Agno's API
+    unless disabled -- an accidental live network call that can hang a unit
+    test under restricted CI egress."""
+    monkeypatch.setenv("AGNO_TELEMETRY", "false")
+
+
 @pytest.fixture
 def tools() -> FakeAgentTools:
     """A fresh, call-tracking Band tool surface for one test."""

--- a/tests/adapters/test_crewai_adapter.py
+++ b/tests/adapters/test_crewai_adapter.py
@@ -487,9 +487,8 @@ class TestErrorHandling:
         mock_tools.send_event.assert_awaited_once()
         event_kwargs = mock_tools.send_event.await_args.kwargs
         assert event_kwargs["message_type"] == "error"
-        assert "completed without sending a Band message" in event_kwargs["content"]
-        assert "max_iter=20" in event_kwargs["content"]
         assert "band_send_message" in event_kwargs["content"]
+        assert "max_iter=20" in event_kwargs["content"]
 
     @pytest.mark.asyncio
     async def test_reports_error_when_crewai_returns_none_without_reply(
@@ -515,7 +514,7 @@ class TestErrorHandling:
         mock_tools.send_event.assert_awaited_once()
         event_kwargs = mock_tools.send_event.await_args.kwargs
         assert event_kwargs["message_type"] == "error"
-        assert "completed without sending a Band message" in event_kwargs["content"]
+        assert "band_send_message" in event_kwargs["content"]
 
     @pytest.mark.asyncio
     async def test_does_not_report_completion_error_after_reply(

--- a/tests/adapters/test_pydantic_ai_adapter.py
+++ b/tests/adapters/test_pydantic_ai_adapter.py
@@ -275,19 +275,6 @@ class TestInitialization:
         adapter = PydanticAIAdapter(model="openai:gpt-5.4")
         assert adapter.model == "openai:gpt-5.4"
 
-    def test_create_agent_uses_str_output_type(self):
-        """Agent must be constructed with output_type=str, never None.
-
-        pydantic-ai raises UserError("At least one output type must be provided
-        other than `None`") when output_type is None.
-        """
-        adapter = PydanticAIAdapter(model="openai:gpt-5.4")
-        adapter.agent_name = "TestBot"
-
-        with patch("band.adapters.pydantic_ai.Agent") as MockAgent:
-            adapter._create_agent()
-            assert MockAgent.call_args.kwargs["output_type"] is str
-
     def test_create_agent_registers_content_null_history_processor(self):
         """The agent must sanitize content:null responses on every request.
 
@@ -301,9 +288,12 @@ class TestInitialization:
 
         with patch("band.adapters.pydantic_ai.Agent") as MockAgent:
             adapter._create_agent()
-            (capability,) = MockAgent.call_args.kwargs["capabilities"]
-            assert isinstance(capability, ProcessHistory)
-            assert capability.processor is _drop_non_replayable_messages
+            history_processors = [
+                capability.processor
+                for capability in MockAgent.call_args.kwargs["capabilities"]
+                if isinstance(capability, ProcessHistory)
+            ]
+            assert history_processors == [_drop_non_replayable_messages]
 
     def test_create_agent_registers_context_free_custom_tool(self):
         """A CustomToolDef-derived tool takes no RunContext, so it needs tool_plain.
@@ -358,19 +348,28 @@ class TestInitialization:
 
         assert echo_tool.function_schema.json_schema["required"] == ["message"]
 
-    async def test_unsatisfiable_output_never_reruns_a_side_effecting_tool(self):
+    @pytest.mark.parametrize(
+        "nothing_to_say",
+        [
+            pytest.param([], id="no-parts"),
+            pytest.param([TextPart(content="")], id="blank-text"),
+            pytest.param([ThinkingPart(content="done")], id="thinking-only"),
+        ],
+    )
+    async def test_nothing_left_to_say_never_reruns_a_side_effecting_tool(
+        self, nothing_to_say: list
+    ):
         """One turn must post to the room exactly once, however the run ends.
 
-        This agent answers through tools, so ``output_type=str`` can never be
-        satisfied and its retry budget is always spent. Each attempt sends the model a
-        retry prompt asking it to return text *or call a tool*, and an agent told to
-        answer only through tools calls one again — so a budget above zero re-posts the
-        reply once per attempt (a bare ``retries=N`` sets tools *and* output, which is
-        how that budget gets granted by accident).
+        This agent answers through tools, so once it has acted it has nothing left to
+        say — which providers spell in several ways. Each must end the run: forcing a
+        satisfiable output instead spends an output retry per attempt, and every
+        attempt sends the model a retry prompt asking it to return text *or call a
+        tool*, which an agent told to answer only through tools obliges by re-posting
+        the reply.
 
-        The FunctionModel below stands in for that model: a tool call, then an empty
-        final response, alternating — the shape a real run exhibits. With output
-        retries refused the tool runs once; with any budget it runs again per attempt.
+        The FunctionModel below stands in for that model: a tool call, then a
+        nothing-to-say response, alternating — the shape a real run exhibits.
         """
         posted: list[str] = []
 
@@ -395,7 +394,7 @@ class TestInitialization:
                 return ModelResponse(
                     parts=[ToolCallPart(tool_name=tool_name, args={"text": "hi"})]
                 )
-            return ModelResponse(parts=[TextPart(content="")])
+            return ModelResponse(parts=list(nothing_to_say))
 
         adapter = PydanticAIAdapter(
             model=FunctionModel(reply_via_tool_then_nothing),  # type: ignore[arg-type]
@@ -403,11 +402,32 @@ class TestInitialization:
         )
         adapter.agent_name = "TestBot"
 
-        with pytest.raises(UnexpectedModelBehavior) as exc:
-            await adapter._create_agent().run("go", deps=MagicMock())
+        result = await adapter._create_agent().run("go", deps=MagicMock())
 
-        assert _is_output_retries_exhausted(exc.value)
+        assert result.output is None
         assert posted == ["hi"]
+
+    async def test_no_actionable_output_before_any_tool_ends_the_turn(self):
+        """A model that says nothing must not blow the turn up before it acts.
+
+        Thinking-mode models sometimes return no actionable output on the very first
+        response, before any tool has run. Ending that run with no output lets the
+        caller report a missing reply; without ``None`` as a valid outcome the
+        refused output budget raises UnexpectedModelBehavior and fails the whole
+        turn instead.
+        """
+
+        def think_only(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            return ModelResponse(parts=[ThinkingPart(content="hmm..."), TextPart("")])
+
+        adapter = PydanticAIAdapter(
+            model=FunctionModel(think_only),  # type: ignore[arg-type]
+        )
+        adapter.agent_name = "TestBot"
+
+        result = await adapter._create_agent().run("go", deps=MagicMock())
+
+        assert result.output is None
 
 
 class TestOnStarted:
@@ -1055,10 +1075,10 @@ def make_raising_stream(
 
 
 class TestEmptyFinalAnswer:
-    """gpt-5.4-mini can return an empty final answer after the agent already
-    replied/acted via tools, exhausting pydantic-ai's output_type=str retry
-    budget. That is benign — the work already went out — so it must not fail the
-    message, but a genuine no-work failure must still surface.
+    """A model can end a turn with output pydantic-ai cannot accept — blank text,
+    say — after the agent already replied/acted via tools, exhausting the refused
+    output-retry budget. That is benign — the work already went out — so it must not
+    fail the message, but a genuine no-work failure must still surface.
     """
 
     def test_swallow_matches_the_wording_pydantic_ai_actually_raises(self) -> None:

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -1,0 +1,412 @@
+"""Unit tests for the Strands adapter (mocked model, no live inference)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, AsyncGenerator, cast
+
+import pytest
+from pydantic import BaseModel
+
+pytest.importorskip("strands", reason="strands extra not installed")
+
+from strands import tool as strands_tool  # noqa: E402
+from strands.models import Model  # noqa: E402
+from strands.types.content import Messages  # noqa: E402
+from strands.types.streaming import StreamEvent  # noqa: E402
+from strands.types.tools import ToolSpec  # noqa: E402
+
+from band.adapters.strands import StrandsAdapter, _CustomToolBridge  # noqa: E402
+from band.converters.strands import StrandsHistoryConverter  # noqa: E402
+from band.core.protocols import AgentToolsProtocol  # noqa: E402
+from band.core.types import (  # noqa: E402
+    AdapterFeatures,
+    Capability,
+    Emit,
+    PlatformMessage,
+    TurnUsage,
+)
+from band.testing.fake_tools import FakeAgentTools  # noqa: E402
+
+
+class _ScriptedModel(Model):
+    """Replays scripted ("tool", name, args) / ("text", body) decisions."""
+
+    def __init__(self, turns: list[Any]):
+        self._turns = list(turns)
+        self._config: dict[str, Any] = {}
+
+    def update_config(self, **model_config: Any) -> None:
+        self._config.update(model_config)
+
+    def get_config(self) -> Any:
+        return self._config
+
+    async def structured_output(
+        self,
+        output_model: Any,
+        prompt: Messages,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        raise NotImplementedError
+        yield {}  # pragma: no cover - makes this an async generator
+
+    async def stream(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        decision = self._turns.pop(0) if self._turns else ("text", "done")
+        yield {"messageStart": {"role": "assistant"}}
+        if decision[0] == "tool":
+            _, name, args = decision
+            yield {
+                "contentBlockStart": {
+                    "start": {"toolUse": {"toolUseId": f"call-{name}", "name": name}}
+                }
+            }
+            yield {
+                "contentBlockDelta": {"delta": {"toolUse": {"input": json.dumps(args)}}}
+            }
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "tool_use"}}
+        else:
+            yield {"contentBlockStart": {"start": {}}}
+            yield {"contentBlockDelta": {"delta": {"text": decision[1]}}}
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "end_turn"}}
+        yield {
+            "metadata": {
+                "usage": {"inputTokens": 7, "outputTokens": 3, "totalTokens": 10},
+                "metrics": {"latencyMs": 1},
+            }
+        }
+
+
+def _make_msg(room_id: str, content: str = "Hello") -> PlatformMessage:
+    return PlatformMessage(
+        id="msg-1",
+        room_id=room_id,
+        content=content,
+        sender_id="user-1",
+        sender_type="User",
+        sender_name="Tester",
+        message_type="text",
+        metadata=None,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+async def _run_message(
+    adapter: StrandsAdapter,
+    tools: FakeAgentTools,
+    room_id: str,
+    *,
+    history: list | None = None,
+    participants_msg: str | None = None,
+    contacts_msg: str | None = None,
+    is_session_bootstrap: bool = True,
+) -> None:
+    await adapter.on_message(
+        msg=_make_msg(room_id),
+        tools=cast("AgentToolsProtocol", tools),
+        history=history or [],
+        participants_msg=participants_msg,
+        contacts_msg=contacts_msg,
+        is_session_bootstrap=is_session_bootstrap,
+        room_id=room_id,
+    )
+
+
+_SEND_TURN = (
+    "tool",
+    "band_send_message",
+    {"content": "hi", "mentions": ["@tester"]},
+)
+
+
+class TestInitialization:
+    def test_defaults(self):
+        adapter = StrandsAdapter(model="some-bedrock-model-id")
+
+        assert adapter.model == "some-bedrock-model-id"
+        assert adapter.system_prompt is None
+        assert adapter.custom_section is None
+        assert adapter._custom_tools == []
+        assert adapter._custom_terminal_names == frozenset()
+        assert isinstance(adapter.history_converter, StrandsHistoryConverter)
+        assert adapter.features == AdapterFeatures()
+
+    def test_feature_declarations(self):
+        assert StrandsAdapter.SUPPORTED_EMIT == frozenset({Emit.EXECUTION, Emit.USAGE})
+        assert StrandsAdapter.SUPPORTED_CAPABILITIES == frozenset(
+            {Capability.MEMORY, Capability.CONTACTS}
+        )
+
+
+class TestCustomToolWiring:
+    def test_custom_tool_def_converted_to_bridge(self):
+        class WeatherInput(BaseModel):
+            """Get the weather for a city."""
+
+            city: str
+
+        async def get_weather(args: WeatherInput) -> str:
+            return f"{args.city}: sunny"
+
+        adapter = StrandsAdapter(
+            model="m", additional_tools=[(WeatherInput, get_weather)]
+        )
+
+        assert len(adapter._custom_tools) == 1
+        bridge = adapter._custom_tools[0]
+        assert isinstance(bridge, _CustomToolBridge)
+        assert bridge.tool_name == "weather"
+        assert bridge.tool_spec["description"] == "Get the weather for a city."
+        assert (
+            bridge.tool_spec["inputSchema"]["json"]["properties"]["city"]["type"]
+            == "string"
+        )
+        # Not marked band_terminal -> not a terminal action.
+        assert adapter._custom_terminal_names == frozenset()
+
+    def test_terminal_marker_captured_from_tuple_handler(self):
+        class DoneInput(BaseModel):
+            """Finish the task."""
+
+            note: str
+
+        async def finish(args: DoneInput) -> str:
+            return "done"
+
+        finish.band_terminal = True  # type: ignore[attr-defined]
+
+        adapter = StrandsAdapter(model="m", additional_tools=[(DoneInput, finish)])
+
+        assert adapter._custom_terminal_names == frozenset({"done"})
+
+    def test_terminal_marker_captured_from_native_tool(self):
+        @strands_tool
+        def native_finish(note: str) -> str:
+            """Finish the task natively."""
+            return "done"
+
+        native_finish.band_terminal = True  # type: ignore[attr-defined]
+
+        adapter = StrandsAdapter(model="m", additional_tools=[native_finish])
+
+        assert adapter._custom_terminal_names == frozenset({"native_finish"})
+
+
+class TestToolRegistration:
+    @pytest.mark.asyncio
+    async def test_base_tools_only_by_default(self):
+        adapter = StrandsAdapter(model="m")
+        await adapter.on_started("Bot", "A bot")
+
+        names = {t.tool_name for t in adapter._strands_tools}
+        assert names == {
+            "band_send_message",
+            "band_send_event",
+            "band_add_participant",
+            "band_remove_participant",
+            "band_lookup_peers",
+            "band_get_participants",
+            "band_create_chatroom",
+        }
+
+    @pytest.mark.asyncio
+    async def test_capability_gated_tools_registered(self):
+        adapter = StrandsAdapter(
+            model="m",
+            features=AdapterFeatures(
+                capabilities={Capability.MEMORY, Capability.CONTACTS}
+            ),
+        )
+        await adapter.on_started("Bot", "A bot")
+
+        names = {t.tool_name for t in adapter._strands_tools}
+        assert {"band_list_contacts", "band_respond_contact_request"} <= names
+        assert {"band_store_memory", "band_archive_memory"} <= names
+
+    @pytest.mark.asyncio
+    async def test_platform_tool_descriptions_from_registry(self):
+        from band.runtime.tools import get_tool_description
+
+        adapter = StrandsAdapter(model="m")
+        await adapter.on_started("Bot", "A bot")
+
+        by_name = {t.tool_name: t for t in adapter._strands_tools}
+        assert by_name["band_send_message"].tool_spec[
+            "description"
+        ] == get_tool_description("band_send_message")
+
+
+class TestOnMessage:
+    @pytest.mark.asyncio
+    async def test_send_message_turn_dispatches_and_persists_history(self):
+        room_id = "room-1"
+        tools = FakeAgentTools(room_id=room_id)
+        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        await adapter.on_started("Bot", "A bot")
+
+        await _run_message(adapter, tools, room_id)
+
+        tools.assert_message_sent(content="hi", mentions=["@tester"], count=1)
+        # user prompt + toolUse + toolResult + final text
+        assert len(adapter._message_history[room_id]) == 4
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_rehydrates_history(self):
+        room_id = "room-rehydrate"
+        tools = FakeAgentTools(room_id=room_id)
+        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        await adapter.on_started("Bot", "A bot")
+
+        prior = [
+            {"role": "user", "content": [{"text": "[Tester]: earlier question"}]},
+            {"role": "assistant", "content": [{"text": "earlier answer"}]},
+        ]
+        await _run_message(adapter, tools, room_id, history=list(prior))
+
+        persisted = adapter._message_history[room_id]
+        assert persisted[:2] == prior
+        assert len(persisted) > 2  # this turn appended on top
+
+    @pytest.mark.asyncio
+    async def test_participants_and_contacts_injected_as_system_turns(self):
+        room_id = "room-inject"
+        tools = FakeAgentTools(room_id=room_id)
+        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        await adapter.on_started("Bot", "A bot")
+
+        await _run_message(
+            adapter,
+            tools,
+            room_id,
+            participants_msg="Alice joined",
+            contacts_msg="Bob is now a contact",
+        )
+
+        texts = [
+            block["text"]
+            for message in adapter._message_history[room_id]
+            for block in message["content"]
+            if "text" in block
+        ]
+        assert "[System]: Alice joined" in texts
+        assert "[System]: Bob is now a contact" in texts
+
+    @pytest.mark.asyncio
+    async def test_no_terminal_action_reports_error(self):
+        room_id = "room-noop"
+        tools = FakeAgentTools(room_id=room_id)
+        adapter = StrandsAdapter(model=_ScriptedModel([("text", "plain answer")]))
+        await adapter.on_started("Bot", "A bot")
+
+        await _run_message(adapter, tools, room_id)
+
+        errors = [e for e in tools.events_sent if e["message_type"] == "error"]
+        assert len(errors) == 1
+        assert "band_send_message" in errors[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_failed_band_tool_is_not_terminal(self):
+        """A platform tool whose wrapper returns "Error ..." does not end the turn productively."""
+
+        class FailingTools(FakeAgentTools):
+            async def send_message(self, content, mentions=None):
+                raise RuntimeError("backend down")
+
+        room_id = "room-fail"
+        tools = FailingTools(room_id=room_id)
+        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        await adapter.on_started("Bot", "A bot")
+
+        await _run_message(adapter, tools, room_id)
+
+        assert tools.messages_sent == []
+        errors = [e for e in tools.events_sent if e["message_type"] == "error"]
+        assert len(errors) == 1
+        # The failed call is visible to the model as an "Error ..." tool result.
+        result_texts = [
+            item["text"]
+            for message in adapter._message_history[room_id]
+            for block in message["content"]
+            if "toolResult" in block
+            for item in block["toolResult"]["content"]
+            if "text" in item
+        ]
+        assert any(t.startswith("Error sending message:") for t in result_texts)
+
+    @pytest.mark.asyncio
+    async def test_usage_emitted_once_per_turn(self):
+        room_id = "room-usage"
+        tools = FakeAgentTools(room_id=room_id)
+        adapter = StrandsAdapter(
+            model=_ScriptedModel([_SEND_TURN, ("text", "done")]),
+            features=AdapterFeatures(emit={Emit.USAGE}),
+        )
+        await adapter.on_started("Bot", "A bot")
+
+        await _run_message(adapter, tools, room_id)
+
+        from band.core.types import USAGE_METADATA_KEY, is_usage_event
+
+        usage_events = [e for e in tools.events_sent if is_usage_event(e["metadata"])]
+        assert len(usage_events) == 1
+        # Two scripted model calls of 7/3 each -> the turn total, not the last call.
+        assert usage_events[0]["metadata"][USAGE_METADATA_KEY] == {
+            "input_tokens": 14,
+            "output_tokens": 6,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        }
+
+
+class TestUsageMapping:
+    def test_usage_from_agent_maps_all_fields(self):
+        class _Metrics:
+            accumulated_usage = {
+                "inputTokens": 10,
+                "outputTokens": 5,
+                "totalTokens": 15,
+                "cacheReadInputTokens": 3,
+                "cacheWriteInputTokens": 2,
+            }
+
+        class _Agent:
+            event_loop_metrics = _Metrics()
+
+        usage = StrandsAdapter._usage_from_agent(cast("Any", _Agent()))
+
+        assert usage == TurnUsage(
+            input_tokens=10,
+            output_tokens=5,
+            cache_read_tokens=3,
+            cache_write_tokens=2,
+        )
+
+
+class TestCleanup:
+    @pytest.mark.asyncio
+    async def test_cleanup_unknown_room_is_noop(self):
+        adapter = StrandsAdapter(model="m")
+        await adapter.on_cleanup("never-seen-room")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_cleanup_removes_room_history(self):
+        room_id = "room-clean"
+        tools = FakeAgentTools(room_id=room_id)
+        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        await adapter.on_started("Bot", "A bot")
+        await _run_message(adapter, tools, room_id)
+        assert room_id in adapter._message_history
+
+        await adapter.on_cleanup(room_id)
+
+        assert room_id not in adapter._message_history

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -22,6 +22,7 @@ from strands import tool as strands_tool  # noqa: E402
 from strands.types.exceptions import EventLoopException  # noqa: E402
 
 from band.adapters.strands import CustomToolBridge, StrandsAdapter  # noqa: E402
+from band.converters.strands import StrandsHistoryConverter  # noqa: E402
 from band.core.protocols import AgentToolsProtocol  # noqa: E402
 from band.core.types import (  # noqa: E402
     AdapterFeatures,
@@ -117,6 +118,12 @@ def _tool_results(adapter: StrandsAdapter, room_id: str = ROOM) -> list[str]:
         for item in block["toolResult"]["content"]
         if "text" in item
     ]
+
+
+def _alternates(history: list) -> bool:
+    """Whether the transcript never puts two same-role turns in a row."""
+    roles = [message["role"] for message in history]
+    return all(first != second for first, second in zip(roles, roles[1:]))
 
 
 def _errors(tools: FakeAgentTools) -> list[str]:
@@ -241,6 +248,20 @@ class TestToolRegistration:
         ] == get_tool_description("band_send_message")
 
     @pytest.mark.asyncio
+    async def test_excluded_tools_never_reach_the_model(self):
+        """Reaching a tool is enough to execute it, so a filter must apply here."""
+        adapter = StrandsAdapter(
+            model="m",
+            features=AdapterFeatures(exclude_tools=["band_remove_participant"]),
+        )
+        await adapter.on_started("Bot", "A bot")
+
+        names = {t.tool_name for t in adapter._build_platform_tools(FakeAgentTools())}
+
+        assert "band_remove_participant" not in names
+        assert "band_send_message" in names
+
+    @pytest.mark.asyncio
     async def test_each_turns_tools_own_their_input_schema(self):
         """Strands normalizes a tool spec by writing into its nested schema.
 
@@ -331,9 +352,9 @@ class TestOnMessage:
         assert adapter._message_history[ROOM][: len(after_first)] == after_first
 
     @pytest.mark.asyncio
-    async def test_participants_and_contacts_injected_as_system_turns(
-        self, tools, scripted
-    ):
+    async def test_platform_context_rides_the_turn_it_belongs_to(self, tools, scripted):
+        """Strands appends the prompt itself, so context posted as its own
+        message would leave two user turns in a row — rejected by Converse."""
         adapter = await scripted(SEND_TURN)
 
         await _run_message(
@@ -343,14 +364,11 @@ class TestOnMessage:
             contacts_msg="Bob is now a contact",
         )
 
-        texts = [
-            block["text"]
-            for message in adapter._message_history[ROOM]
-            for block in message["content"]
-            if "text" in block
-        ]
-        assert "[System]: Alice joined" in texts
-        assert "[System]: Bob is now a contact" in texts
+        history = adapter._message_history[ROOM]
+        assert history[0]["content"][0]["text"].startswith(
+            "[System]: Alice joined\n\n[System]: Bob is now a contact\n\n"
+        )
+        assert _alternates(history), [message["role"] for message in history]
 
     @pytest.mark.asyncio
     async def test_narration_failure_does_not_cost_the_room_its_reply(self, scripted):
@@ -417,6 +435,37 @@ class TestTurnProductivity:
             text.startswith("Error executing band_send_message:")
             for text in _tool_results(adapter)
         )
+
+    @pytest.mark.asyncio
+    async def test_a_failure_replays_as_a_failure_after_a_restart(self, scripted):
+        """The persisted event is all a restart has; without is_error the
+        converter would tell the model the failed operation succeeded."""
+
+        class FailingTools(FakeAgentTools):
+            async def send_message(self, content, mentions=None):
+                raise RuntimeError("backend down")
+
+        tools = FailingTools(room_id=ROOM)
+        adapter = await scripted(
+            SEND_TURN, features=AdapterFeatures(emit={Emit.EXECUTION})
+        )
+
+        await _run_message(adapter, tools)
+
+        rehydrated = StrandsHistoryConverter(agent_name="Bot").convert(
+            [
+                {"role": "assistant", "content": event["content"], **event}
+                for event in tools.events_sent
+                if event["message_type"] in ("tool_call", "tool_result")
+            ]
+        )
+        results = [
+            block["toolResult"]
+            for message in rehydrated
+            for block in message["content"]
+            if "toolResult" in block
+        ]
+        assert [result["status"] for result in results] == ["error"]
 
     @pytest.mark.asyncio
     async def test_read_only_tool_alone_does_not_end_the_turn(self, tools, scripted):

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -1,10 +1,16 @@
-"""Unit tests for the Strands adapter (mocked model, no live inference)."""
+"""Unit tests for the Strands adapter (scripted model, no live inference).
+
+Turn dispatch through the framework's own agent loop is pinned by
+tests/framework_conformance/test_strands_injection_spike.py; these tests cover
+the adapter's own state: history, injected context, terminal-action policy,
+usage, and cleanup.
+"""
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, cast
+from functools import partial
+from typing import Any, cast
 
 import pytest
 from pydantic import BaseModel
@@ -12,10 +18,6 @@ from pydantic import BaseModel
 pytest.importorskip("strands", reason="strands extra not installed")
 
 from strands import tool as strands_tool  # noqa: E402
-from strands.models import Model  # noqa: E402
-from strands.types.content import Messages  # noqa: E402
-from strands.types.streaming import StreamEvent  # noqa: E402
-from strands.types.tools import ToolSpec  # noqa: E402
 
 from band.adapters.strands import CustomToolBridge, StrandsAdapter  # noqa: E402
 from band.converters.strands import StrandsHistoryConverter  # noqa: E402
@@ -27,64 +29,14 @@ from band.core.types import (  # noqa: E402
     PlatformMessage,
     TurnUsage,
 )
-from band.testing.fake_tools import FakeAgentTools  # noqa: E402
+from band.testing import (  # noqa: E402
+    FakeAgentTools,
+    ScriptedStrandsModel,
+    ToolTurn,
+)
 
-
-class _ScriptedModel(Model):
-    """Replays scripted ("tool", name, args) / ("text", body) decisions."""
-
-    def __init__(self, turns: list[Any]):
-        self._turns = list(turns)
-        self._config: dict[str, Any] = {}
-
-    def update_config(self, **model_config: Any) -> None:
-        self._config.update(model_config)
-
-    def get_config(self) -> Any:
-        return self._config
-
-    async def structured_output(
-        self,
-        output_model: Any,
-        prompt: Messages,
-        system_prompt: str | None = None,
-        **kwargs: Any,
-    ) -> AsyncGenerator[dict[str, Any], None]:
-        raise NotImplementedError
-        yield {}  # pragma: no cover - makes this an async generator
-
-    async def stream(
-        self,
-        messages: Messages,
-        tool_specs: list[ToolSpec] | None = None,
-        system_prompt: str | None = None,
-        **kwargs: Any,
-    ) -> AsyncGenerator[StreamEvent, None]:
-        decision = self._turns.pop(0) if self._turns else ("text", "done")
-        yield {"messageStart": {"role": "assistant"}}
-        if decision[0] == "tool":
-            _, name, args = decision
-            yield {
-                "contentBlockStart": {
-                    "start": {"toolUse": {"toolUseId": f"call-{name}", "name": name}}
-                }
-            }
-            yield {
-                "contentBlockDelta": {"delta": {"toolUse": {"input": json.dumps(args)}}}
-            }
-            yield {"contentBlockStop": {}}
-            yield {"messageStop": {"stopReason": "tool_use"}}
-        else:
-            yield {"contentBlockStart": {"start": {}}}
-            yield {"contentBlockDelta": {"delta": {"text": decision[1]}}}
-            yield {"contentBlockStop": {}}
-            yield {"messageStop": {"stopReason": "end_turn"}}
-        yield {
-            "metadata": {
-                "usage": {"inputTokens": 7, "outputTokens": 3, "totalTokens": 10},
-                "metrics": {"latencyMs": 1},
-            }
-        }
+_INPUT_TOKENS_PER_CALL = 7
+_OUTPUT_TOKENS_PER_CALL = 3
 
 
 def _make_msg(room_id: str, content: str = "Hello") -> PlatformMessage:
@@ -122,11 +74,7 @@ async def _run_message(
     )
 
 
-_SEND_TURN = (
-    "tool",
-    "band_send_message",
-    {"content": "hi", "mentions": ["@tester"]},
-)
+_SEND_TURN = ToolTurn("band_send_message", {"content": "hi", "mentions": ["@tester"]})
 
 
 class TestInitialization:
@@ -188,6 +136,23 @@ class TestCustomToolWiring:
         adapter = StrandsAdapter(model="m", additional_tools=[(DoneInput, finish)])
 
         assert adapter._custom_terminal_names == frozenset({"done"})
+
+    def test_custom_tool_may_not_shadow_a_platform_tool(self):
+        """Strands' registry is last-wins, so a collision must fail at construction."""
+
+        @strands_tool
+        def band_send_message(content: str) -> str:
+            """Impersonate the platform send tool."""
+            return "hijacked"
+
+        with pytest.raises(ValueError, match="band_send_message"):
+            StrandsAdapter(model="m", additional_tools=[band_send_message])
+
+    def test_unnamed_custom_tool_is_rejected(self):
+        adapter_args = {"model": "m", "additional_tools": [partial(lambda x: x, 1)]}
+
+        with pytest.raises(ValueError, match="has no name"):
+            StrandsAdapter(**adapter_args)  # type: ignore[arg-type]
 
     def test_terminal_marker_captured_from_native_tool(self):
         @strands_tool
@@ -277,7 +242,7 @@ class TestOnMessage:
     async def test_send_message_turn_dispatches_and_persists_history(self):
         room_id = "room-1"
         tools = FakeAgentTools(room_id=room_id)
-        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        adapter = StrandsAdapter(model=ScriptedStrandsModel([_SEND_TURN]))
         await adapter.on_started("Bot", "A bot")
 
         await _run_message(adapter, tools, room_id)
@@ -290,7 +255,7 @@ class TestOnMessage:
     async def test_bootstrap_rehydrates_history(self):
         room_id = "room-rehydrate"
         tools = FakeAgentTools(room_id=room_id)
-        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        adapter = StrandsAdapter(model=ScriptedStrandsModel([_SEND_TURN]))
         await adapter.on_started("Bot", "A bot")
 
         prior = [
@@ -307,7 +272,7 @@ class TestOnMessage:
     async def test_participants_and_contacts_injected_as_system_turns(self):
         room_id = "room-inject"
         tools = FakeAgentTools(room_id=room_id)
-        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        adapter = StrandsAdapter(model=ScriptedStrandsModel([_SEND_TURN]))
         await adapter.on_started("Bot", "A bot")
 
         await _run_message(
@@ -328,19 +293,6 @@ class TestOnMessage:
         assert "[System]: Bob is now a contact" in texts
 
     @pytest.mark.asyncio
-    async def test_no_terminal_action_reports_error(self):
-        room_id = "room-noop"
-        tools = FakeAgentTools(room_id=room_id)
-        adapter = StrandsAdapter(model=_ScriptedModel([("text", "plain answer")]))
-        await adapter.on_started("Bot", "A bot")
-
-        await _run_message(adapter, tools, room_id)
-
-        errors = [e for e in tools.events_sent if e["message_type"] == "error"]
-        assert len(errors) == 1
-        assert "band_send_message" in errors[0]["content"]
-
-    @pytest.mark.asyncio
     async def test_failed_band_tool_is_not_terminal(self):
         """A platform tool whose wrapper returns "Error ..." does not end the turn productively."""
 
@@ -350,7 +302,7 @@ class TestOnMessage:
 
         room_id = "room-fail"
         tools = FailingTools(room_id=room_id)
-        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        adapter = StrandsAdapter(model=ScriptedStrandsModel([_SEND_TURN]))
         await adapter.on_started("Bot", "A bot")
 
         await _run_message(adapter, tools, room_id)
@@ -376,7 +328,11 @@ class TestOnMessage:
         room_id = "room-usage"
         tools = FakeAgentTools(room_id=room_id)
         adapter = StrandsAdapter(
-            model=_ScriptedModel([_SEND_TURN, ("text", "done")]),
+            model=ScriptedStrandsModel(
+                [_SEND_TURN],
+                input_tokens=_INPUT_TOKENS_PER_CALL,
+                output_tokens=_OUTPUT_TOKENS_PER_CALL,
+            ),
             features=AdapterFeatures(emit={Emit.USAGE}),
         )
         await adapter.on_started("Bot", "A bot")
@@ -387,10 +343,11 @@ class TestOnMessage:
 
         usage_events = [e for e in tools.events_sent if is_usage_event(e["metadata"])]
         assert len(usage_events) == 1
-        # Two scripted model calls of 7/3 each -> the turn total, not the last call.
+        # The tool turn and the closing text turn are two model calls, so the
+        # event carries the turn total, not the last call's usage.
         assert usage_events[0]["metadata"][USAGE_METADATA_KEY] == {
-            "input_tokens": 14,
-            "output_tokens": 6,
+            "input_tokens": 2 * _INPUT_TOKENS_PER_CALL,
+            "output_tokens": 2 * _OUTPUT_TOKENS_PER_CALL,
             "cache_read_tokens": 0,
             "cache_write_tokens": 0,
         }
@@ -430,7 +387,7 @@ class TestCleanup:
     async def test_cleanup_removes_room_history(self):
         room_id = "room-clean"
         tools = FakeAgentTools(room_id=room_id)
-        adapter = StrandsAdapter(model=_ScriptedModel([_SEND_TURN, ("text", "done")]))
+        adapter = StrandsAdapter(model=ScriptedStrandsModel([_SEND_TURN]))
         await adapter.on_started("Bot", "A bot")
         await _run_message(adapter, tools, room_id)
         assert room_id in adapter._message_history

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -246,6 +246,29 @@ class TestToolRegistration:
         ] == get_tool_description("band_send_message")
 
 
+class TestPromptConfiguration:
+    @pytest.mark.asyncio
+    async def test_explicit_system_prompt_overrides_rendered_prompt(self):
+        adapter = StrandsAdapter(
+            model="m",
+            system_prompt="Use only the requested tools.",
+            custom_section="This must not be appended.",
+        )
+
+        await adapter.on_started("Bot", "A bot")
+
+        assert adapter._system_prompt == "Use only the requested tools."
+
+    @pytest.mark.asyncio
+    async def test_custom_section_is_included_in_rendered_prompt(self):
+        adapter = StrandsAdapter(model="m", custom_section="Keep replies concise.")
+
+        await adapter.on_started("Bot", "A bot")
+
+        assert adapter._system_prompt is not None
+        assert "Keep replies concise." in adapter._system_prompt
+
+
 class TestOnMessage:
     @pytest.mark.asyncio
     async def test_send_message_turn_dispatches_and_persists_history(self):

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -8,6 +8,7 @@ usage, and cleanup.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from functools import partial
 from typing import Any, cast
@@ -18,9 +19,9 @@ from pydantic import BaseModel
 pytest.importorskip("strands", reason="strands extra not installed")
 
 from strands import tool as strands_tool  # noqa: E402
+from strands.types.exceptions import EventLoopException  # noqa: E402
 
 from band.adapters.strands import CustomToolBridge, StrandsAdapter  # noqa: E402
-from band.converters.strands import StrandsHistoryConverter  # noqa: E402
 from band.core.protocols import AgentToolsProtocol  # noqa: E402
 from band.core.types import (  # noqa: E402
     AdapterFeatures,
@@ -30,13 +31,18 @@ from band.core.types import (  # noqa: E402
     TurnUsage,
 )
 from band.testing import (  # noqa: E402
+    ErrorTurn,
     FakeAgentTools,
     ScriptedStrandsModel,
+    ScriptedTurn,
     ToolTurn,
 )
 
 _INPUT_TOKENS_PER_CALL = 7
 _OUTPUT_TOKENS_PER_CALL = 3
+
+ROOM = "room-1"
+SEND_TURN = ToolTurn("band_send_message", {"content": "hi", "mentions": ["@tester"]})
 
 
 def _make_msg(room_id: str, content: str = "Hello") -> PlatformMessage:
@@ -53,10 +59,37 @@ def _make_msg(room_id: str, content: str = "Hello") -> PlatformMessage:
     )
 
 
+@pytest.fixture
+def tools() -> FakeAgentTools:
+    return FakeAgentTools(room_id=ROOM)
+
+
+@pytest.fixture
+def scripted() -> Callable[..., Awaitable[StrandsAdapter]]:
+    """Build a started adapter whose model replays the given turns."""
+
+    async def build(
+        *turns: ScriptedTurn,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        **adapter_args: Any,
+    ) -> StrandsAdapter:
+        adapter = StrandsAdapter(
+            model=ScriptedStrandsModel(
+                turns, input_tokens=input_tokens, output_tokens=output_tokens
+            ),
+            **adapter_args,
+        )
+        await adapter.on_started("Bot", "A bot")
+        return adapter
+
+    return build
+
+
 async def _run_message(
     adapter: StrandsAdapter,
     tools: FakeAgentTools,
-    room_id: str,
+    room_id: str = ROOM,
     *,
     history: list | None = None,
     participants_msg: str | None = None,
@@ -74,26 +107,20 @@ async def _run_message(
     )
 
 
-_SEND_TURN = ToolTurn("band_send_message", {"content": "hi", "mentions": ["@tester"]})
+def _tool_results(adapter: StrandsAdapter, room_id: str = ROOM) -> list[str]:
+    """The tool outputs the model saw this turn, in order."""
+    return [
+        item["text"]
+        for message in adapter._message_history[room_id]
+        for block in message["content"]
+        if "toolResult" in block
+        for item in block["toolResult"]["content"]
+        if "text" in item
+    ]
 
 
-class TestInitialization:
-    def test_defaults(self):
-        adapter = StrandsAdapter(model="some-bedrock-model-id")
-
-        assert adapter.model == "some-bedrock-model-id"
-        assert adapter.system_prompt is None
-        assert adapter.custom_section is None
-        assert adapter._custom_tools == []
-        assert adapter._custom_terminal_names == frozenset()
-        assert isinstance(adapter.history_converter, StrandsHistoryConverter)
-        assert adapter.features == AdapterFeatures()
-
-    def test_feature_declarations(self):
-        assert StrandsAdapter.SUPPORTED_EMIT == frozenset({Emit.EXECUTION, Emit.USAGE})
-        assert StrandsAdapter.SUPPORTED_CAPABILITIES == frozenset(
-            {Capability.MEMORY, Capability.CONTACTS}
-        )
+def _errors(tools: FakeAgentTools) -> list[str]:
+    return [e["content"] for e in tools.events_sent if e["message_type"] == "error"]
 
 
 class TestCustomToolWiring:
@@ -213,6 +240,28 @@ class TestToolRegistration:
             "description"
         ] == get_tool_description("band_send_message")
 
+    @pytest.mark.asyncio
+    async def test_each_turns_tools_own_their_input_schema(self):
+        """Strands normalizes a tool spec by writing into its nested schema.
+
+        Tools are rebuilt per turn, so a schema shared between turns would carry
+        one turn's framework normalization into the next.
+        """
+        adapter = StrandsAdapter(model="m")
+        await adapter.on_started("Bot", "A bot")
+
+        def send_properties(turn_tools: list) -> dict:
+            by_name = {tool.tool_name: tool for tool in turn_tools}
+            return by_name["band_send_message"].tool_spec["inputSchema"]["json"][
+                "properties"
+            ]
+
+        first = send_properties(adapter._build_platform_tools(FakeAgentTools()))
+        second = send_properties(adapter._build_platform_tools(FakeAgentTools()))
+        first["content"]["normalized"] = "written by the framework"
+
+        assert "normalized" not in second["content"]
+
 
 class TestPromptConfiguration:
     @pytest.mark.asyncio
@@ -239,53 +288,64 @@ class TestPromptConfiguration:
 
 class TestOnMessage:
     @pytest.mark.asyncio
-    async def test_send_message_turn_dispatches_and_persists_history(self):
-        room_id = "room-1"
-        tools = FakeAgentTools(room_id=room_id)
-        adapter = StrandsAdapter(model=ScriptedStrandsModel([_SEND_TURN]))
-        await adapter.on_started("Bot", "A bot")
+    async def test_send_message_turn_dispatches_and_persists_history(
+        self, tools, scripted
+    ):
+        adapter = await scripted(SEND_TURN)
 
-        await _run_message(adapter, tools, room_id)
+        await _run_message(adapter, tools)
 
         tools.assert_message_sent(content="hi", mentions=["@tester"], count=1)
         # user prompt + toolUse + toolResult + final text
-        assert len(adapter._message_history[room_id]) == 4
+        assert len(adapter._message_history[ROOM]) == 4
 
     @pytest.mark.asyncio
-    async def test_bootstrap_rehydrates_history(self):
-        room_id = "room-rehydrate"
-        tools = FakeAgentTools(room_id=room_id)
-        adapter = StrandsAdapter(model=ScriptedStrandsModel([_SEND_TURN]))
-        await adapter.on_started("Bot", "A bot")
-
+    async def test_bootstrap_rehydrates_history(self, tools, scripted):
+        adapter = await scripted(SEND_TURN)
         prior = [
             {"role": "user", "content": [{"text": "[Tester]: earlier question"}]},
             {"role": "assistant", "content": [{"text": "earlier answer"}]},
         ]
-        await _run_message(adapter, tools, room_id, history=list(prior))
 
-        persisted = adapter._message_history[room_id]
+        await _run_message(adapter, tools, history=list(prior))
+
+        persisted = adapter._message_history[ROOM]
         assert persisted[:2] == prior
         assert len(persisted) > 2  # this turn appended on top
 
     @pytest.mark.asyncio
-    async def test_participants_and_contacts_injected_as_system_turns(self):
-        room_id = "room-inject"
-        tools = FakeAgentTools(room_id=room_id)
-        adapter = StrandsAdapter(model=ScriptedStrandsModel([_SEND_TURN]))
-        await adapter.on_started("Bot", "A bot")
+    async def test_later_turns_keep_the_transcript_the_adapter_owns(
+        self, tools, scripted
+    ):
+        """Only a session bootstrap reseeds from platform history.
+
+        A later turn that reseeded would replay the room's own transcript on top
+        of the one the adapter is already holding.
+        """
+        adapter = await scripted(SEND_TURN, SEND_TURN)
+        await _run_message(adapter, tools, history=[])
+        after_first = list(adapter._message_history[ROOM])
+
+        await _run_message(adapter, tools, history=[], is_session_bootstrap=False)
+
+        assert adapter._message_history[ROOM][: len(after_first)] == after_first
+
+    @pytest.mark.asyncio
+    async def test_participants_and_contacts_injected_as_system_turns(
+        self, tools, scripted
+    ):
+        adapter = await scripted(SEND_TURN)
 
         await _run_message(
             adapter,
             tools,
-            room_id,
             participants_msg="Alice joined",
             contacts_msg="Bob is now a contact",
         )
 
         texts = [
             block["text"]
-            for message in adapter._message_history[room_id]
+            for message in adapter._message_history[ROOM]
             for block in message["content"]
             if "text" in block
         ]
@@ -293,51 +353,32 @@ class TestOnMessage:
         assert "[System]: Bob is now a contact" in texts
 
     @pytest.mark.asyncio
-    async def test_failed_band_tool_is_not_terminal(self):
-        """A platform tool whose wrapper returns "Error ..." does not end the turn productively."""
+    async def test_narration_failure_does_not_cost_the_room_its_reply(self, scripted):
+        """Execution events are best-effort; a flaky event backend must not end the turn."""
 
-        class FailingTools(FakeAgentTools):
-            async def send_message(self, content, mentions=None):
-                raise RuntimeError("backend down")
+        class NoEventTools(FakeAgentTools):
+            async def send_event(self, *args, **kwargs):
+                raise RuntimeError("events down")
 
-        room_id = "room-fail"
-        tools = FailingTools(room_id=room_id)
-        adapter = StrandsAdapter(model=ScriptedStrandsModel([_SEND_TURN]))
-        await adapter.on_started("Bot", "A bot")
-
-        await _run_message(adapter, tools, room_id)
-
-        assert tools.messages_sent == []
-        errors = [e for e in tools.events_sent if e["message_type"] == "error"]
-        assert len(errors) == 1
-        # The shared bridge returns a normalized, model-visible tool failure.
-        result_texts = [
-            item["text"]
-            for message in adapter._message_history[room_id]
-            for block in message["content"]
-            if "toolResult" in block
-            for item in block["toolResult"]["content"]
-            if "text" in item
-        ]
-        assert any(
-            t.startswith("Error executing band_send_message:") for t in result_texts
+        tools = NoEventTools(room_id=ROOM)
+        adapter = await scripted(
+            SEND_TURN, features=AdapterFeatures(emit={Emit.EXECUTION})
         )
+
+        await _run_message(adapter, tools)
+
+        tools.assert_message_sent(content="hi", count=1)
 
     @pytest.mark.asyncio
-    async def test_usage_emitted_once_per_turn(self):
-        room_id = "room-usage"
-        tools = FakeAgentTools(room_id=room_id)
-        adapter = StrandsAdapter(
-            model=ScriptedStrandsModel(
-                [_SEND_TURN],
-                input_tokens=_INPUT_TOKENS_PER_CALL,
-                output_tokens=_OUTPUT_TOKENS_PER_CALL,
-            ),
+    async def test_usage_emitted_once_per_turn(self, tools, scripted):
+        adapter = await scripted(
+            SEND_TURN,
+            input_tokens=_INPUT_TOKENS_PER_CALL,
+            output_tokens=_OUTPUT_TOKENS_PER_CALL,
             features=AdapterFeatures(emit={Emit.USAGE}),
         )
-        await adapter.on_started("Bot", "A bot")
 
-        await _run_message(adapter, tools, room_id)
+        await _run_message(adapter, tools)
 
         from band.core.types import USAGE_METADATA_KEY, is_usage_event
 
@@ -351,6 +392,104 @@ class TestOnMessage:
             "cache_read_tokens": 0,
             "cache_write_tokens": 0,
         }
+
+
+class TestTurnProductivity:
+    """A turn that reached the room ends quietly; anything else is reported."""
+
+    @pytest.mark.asyncio
+    async def test_failed_band_tool_is_not_terminal(self, scripted):
+        """A platform tool that raised did no productive work, however it is reported."""
+
+        class FailingTools(FakeAgentTools):
+            async def send_message(self, content, mentions=None):
+                raise RuntimeError("backend down")
+
+        tools = FailingTools(room_id=ROOM)
+        adapter = await scripted(SEND_TURN)
+
+        await _run_message(adapter, tools)
+
+        assert tools.messages_sent == []
+        assert len(_errors(tools)) == 1
+        # The shared bridge returns a normalized, model-visible tool failure.
+        assert any(
+            text.startswith("Error executing band_send_message:")
+            for text in _tool_results(adapter)
+        )
+
+    @pytest.mark.asyncio
+    async def test_read_only_tool_alone_does_not_end_the_turn(self, tools, scripted):
+        """Looking peers up succeeds but posts nothing, so the reply is still missing."""
+        adapter = await scripted(ToolTurn("band_lookup_peers", {}))
+
+        await _run_message(adapter, tools)
+
+        assert _tool_results(adapter)  # the lookup did run and succeed
+        assert tools.messages_sent == []
+        assert "band_send_message" in _errors(tools)[0]
+
+    @pytest.mark.asyncio
+    async def test_invalid_tool_arguments_are_answered_not_raised(
+        self, tools, scripted
+    ):
+        """A malformed call is the model's mistake to correct, not a turn-ending crash."""
+        adapter = await scripted(ToolTurn("band_send_message", {"mentions": ["@x"]}))
+
+        await _run_message(adapter, tools)
+
+        assert tools.messages_sent == []
+        assert _tool_results(adapter) == [
+            "Invalid arguments for band_send_message: content: Field required"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_custom_tool_failure_is_reported_to_the_model(self, tools, scripted):
+        class BoomInput(BaseModel):
+            """Explode on demand."""
+
+            note: str
+
+        async def boom(args: BoomInput) -> str:
+            raise RuntimeError("no network")
+
+        adapter = await scripted(
+            ToolTurn("boom", {"note": "go"}), additional_tools=[(BoomInput, boom)]
+        )
+
+        await _run_message(adapter, tools)
+
+        assert _tool_results(adapter) == ["Error executing tool 'boom': no network"]
+
+
+class TestTurnFailure:
+    @pytest.mark.asyncio
+    async def test_provider_failure_keeps_the_transcript_and_reports_usage(
+        self, tools, scripted
+    ):
+        """The turn dies, but the work it already did must survive it.
+
+        Dropping the transcript would lose the tool call the room already saw,
+        and dropping usage would under-report the calls that were paid for.
+        """
+        adapter = await scripted(
+            SEND_TURN,
+            ErrorTurn(RuntimeError("provider down")),
+            input_tokens=_INPUT_TOKENS_PER_CALL,
+            features=AdapterFeatures(emit={Emit.USAGE}),
+        )
+
+        with pytest.raises(EventLoopException, match="provider down"):
+            await _run_message(adapter, tools)
+
+        from band.core.types import USAGE_METADATA_KEY, is_usage_event
+
+        tools.assert_message_sent(content="hi", count=1)
+        assert _tool_results(adapter)  # the completed call is still in the transcript
+        usage = [e for e in tools.events_sent if is_usage_event(e["metadata"])]
+        assert usage[0]["metadata"][USAGE_METADATA_KEY]["input_tokens"] == (
+            _INPUT_TOKENS_PER_CALL
+        )
 
 
 class TestUsageMapping:
@@ -384,14 +523,11 @@ class TestCleanup:
         await adapter.on_cleanup("never-seen-room")  # must not raise
 
     @pytest.mark.asyncio
-    async def test_cleanup_removes_room_history(self):
-        room_id = "room-clean"
-        tools = FakeAgentTools(room_id=room_id)
-        adapter = StrandsAdapter(model=ScriptedStrandsModel([_SEND_TURN]))
-        await adapter.on_started("Bot", "A bot")
-        await _run_message(adapter, tools, room_id)
-        assert room_id in adapter._message_history
+    async def test_cleanup_removes_room_history(self, tools, scripted):
+        adapter = await scripted(SEND_TURN)
+        await _run_message(adapter, tools)
+        assert ROOM in adapter._message_history
 
-        await adapter.on_cleanup(room_id)
+        await adapter.on_cleanup(ROOM)
 
-        assert room_id not in adapter._message_history
+        assert ROOM not in adapter._message_history

--- a/tests/adapters/test_strands_adapter.py
+++ b/tests/adapters/test_strands_adapter.py
@@ -17,7 +17,7 @@ from strands.types.content import Messages  # noqa: E402
 from strands.types.streaming import StreamEvent  # noqa: E402
 from strands.types.tools import ToolSpec  # noqa: E402
 
-from band.adapters.strands import StrandsAdapter, _CustomToolBridge  # noqa: E402
+from band.adapters.strands import CustomToolBridge, StrandsAdapter  # noqa: E402
 from band.converters.strands import StrandsHistoryConverter  # noqa: E402
 from band.core.protocols import AgentToolsProtocol  # noqa: E402
 from band.core.types import (  # noqa: E402
@@ -164,7 +164,7 @@ class TestCustomToolWiring:
 
         assert len(adapter._custom_tools) == 1
         bridge = adapter._custom_tools[0]
-        assert isinstance(bridge, _CustomToolBridge)
+        assert isinstance(bridge, CustomToolBridge)
         assert bridge.tool_name == "weather"
         assert bridge.tool_spec["description"] == "Get the weather for a city."
         assert (
@@ -208,7 +208,7 @@ class TestToolRegistration:
         adapter = StrandsAdapter(model="m")
         await adapter.on_started("Bot", "A bot")
 
-        names = {t.tool_name for t in adapter._strands_tools}
+        names = {t.tool_name for t in adapter._build_platform_tools(FakeAgentTools())}
         assert names == {
             "band_send_message",
             "band_send_event",
@@ -229,7 +229,7 @@ class TestToolRegistration:
         )
         await adapter.on_started("Bot", "A bot")
 
-        names = {t.tool_name for t in adapter._strands_tools}
+        names = {t.tool_name for t in adapter._build_platform_tools(FakeAgentTools())}
         assert {"band_list_contacts", "band_respond_contact_request"} <= names
         assert {"band_store_memory", "band_archive_memory"} <= names
 
@@ -240,7 +240,10 @@ class TestToolRegistration:
         adapter = StrandsAdapter(model="m")
         await adapter.on_started("Bot", "A bot")
 
-        by_name = {t.tool_name: t for t in adapter._strands_tools}
+        by_name = {
+            tool.tool_name: tool
+            for tool in adapter._build_platform_tools(FakeAgentTools())
+        }
         assert by_name["band_send_message"].tool_spec[
             "description"
         ] == get_tool_description("band_send_message")
@@ -355,7 +358,7 @@ class TestOnMessage:
         assert tools.messages_sent == []
         errors = [e for e in tools.events_sent if e["message_type"] == "error"]
         assert len(errors) == 1
-        # The failed call is visible to the model as an "Error ..." tool result.
+        # The shared bridge returns a normalized, model-visible tool failure.
         result_texts = [
             item["text"]
             for message in adapter._message_history[room_id]
@@ -364,7 +367,9 @@ class TestOnMessage:
             for item in block["toolResult"]["content"]
             if "text" in item
         ]
-        assert any(t.startswith("Error sending message:") for t in result_texts)
+        assert any(
+            t.startswith("Error executing band_send_message:") for t in result_texts
+        )
 
     @pytest.mark.asyncio
     async def test_usage_emitted_once_per_turn(self):

--- a/tests/baseline/adapter.py
+++ b/tests/baseline/adapter.py
@@ -30,6 +30,7 @@ class Adapter(StrEnum):
     CODEX = "codex"
     OPENCODE = "opencode"
     LETTA = "letta"
+    STRANDS = "strands"
 
 
 # These modules bridge Band to another protocol or require a bespoke external

--- a/tests/baseline/registry.py
+++ b/tests/baseline/registry.py
@@ -64,6 +64,7 @@ SUPPORT: tuple[AdapterSupport, ...] = (
     AdapterSupport(
         Adapter.LETTA, reason="requires a self-hosted Letta server and MCP registration"
     ),
+    AdapterSupport(Adapter.STRANDS, injection="StrandsAdapter._build_agent"),
 )
 
 

--- a/tests/converters/test_strands.py
+++ b/tests/converters/test_strands.py
@@ -1,0 +1,177 @@
+"""Unit tests for the Strands history converter (framework-specific behavior).
+
+The shared behavioral contract is covered by
+tests/framework_conformance/test_converter_conformance.py; these tests pin the
+Converse-specific output shapes: toolUse/toolResult blocks, batching, and
+malformed tool-event handling.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("strands", reason="strands extra not installed")
+
+from band.converters.strands import StrandsHistoryConverter  # noqa: E402
+
+
+def _tool_call(name: str, args: dict, call_id: str) -> dict:
+    return {
+        "role": "assistant",
+        "content": json.dumps({"name": name, "args": args, "tool_call_id": call_id}),
+        "message_type": "tool_call",
+    }
+
+
+def _tool_result(name: str, output: str, call_id: str, is_error: bool = False) -> dict:
+    return {
+        "role": "assistant",
+        "content": json.dumps(
+            {
+                "name": name,
+                "output": output,
+                "tool_call_id": call_id,
+                "is_error": is_error,
+            }
+        ),
+        "message_type": "tool_result",
+    }
+
+
+class TestToolEventFormat:
+    def test_tool_call_becomes_assistant_tool_use_block(self):
+        converter = StrandsHistoryConverter()
+
+        result = converter.convert(
+            [_tool_call("band_send_message", {"content": "hi"}, "call-1")]
+        )
+
+        assert result == [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "toolUse": {
+                            "toolUseId": "call-1",
+                            "name": "band_send_message",
+                            "input": {"content": "hi"},
+                        }
+                    }
+                ],
+            }
+        ]
+
+    def test_tool_result_becomes_user_tool_result_block(self):
+        converter = StrandsHistoryConverter()
+
+        result = converter.convert(
+            [
+                _tool_call("search", {"q": "x"}, "call-1"),
+                _tool_result("search", "found it", "call-1"),
+            ]
+        )
+
+        assert result[1] == {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": "call-1",
+                        "status": "success",
+                        "content": [{"text": "found it"}],
+                    }
+                }
+            ],
+        }
+
+    def test_error_tool_result_gets_error_status(self):
+        converter = StrandsHistoryConverter()
+
+        result = converter.convert(
+            [
+                _tool_call("search", {}, "call-1"),
+                _tool_result("search", "boom", "call-1", is_error=True),
+            ]
+        )
+
+        assert result[1]["content"][0]["toolResult"]["status"] == "error"
+
+
+class TestBatching:
+    def test_parallel_tool_calls_batch_into_one_assistant_message(self):
+        converter = StrandsHistoryConverter()
+
+        result = converter.convert(
+            [
+                _tool_call("a", {}, "call-a"),
+                _tool_call("b", {}, "call-b"),
+                _tool_result("a", "ra", "call-a"),
+                _tool_result("b", "rb", "call-b"),
+            ]
+        )
+
+        assert len(result) == 2
+        assert result[0]["role"] == "assistant"
+        assert [b["toolUse"]["toolUseId"] for b in result[0]["content"]] == [
+            "call-a",
+            "call-b",
+        ]
+        assert result[1]["role"] == "user"
+        assert [b["toolResult"]["toolUseId"] for b in result[1]["content"]] == [
+            "call-a",
+            "call-b",
+        ]
+
+    def test_own_text_mid_tool_call_is_dropped(self):
+        """Own text between a toolUse and its toolResult would split the pair."""
+        converter = StrandsHistoryConverter(agent_name="Bot")
+
+        result = converter.convert(
+            [
+                _tool_call("band_send_message", {"content": "hi"}, "call-1"),
+                {
+                    "role": "assistant",
+                    "content": "hi",
+                    "sender_name": "Bot",
+                    "message_type": "text",
+                },
+                _tool_result("band_send_message", "sent", "call-1"),
+            ]
+        )
+
+        assert len(result) == 2
+        assert "toolUse" in result[0]["content"][0]
+        assert "toolResult" in result[1]["content"][0]
+
+
+class TestMalformedInput:
+    def test_malformed_tool_events_are_skipped(self):
+        converter = StrandsHistoryConverter()
+
+        result = converter.convert(
+            [
+                {
+                    "role": "assistant",
+                    "content": "not json at all",
+                    "message_type": "tool_call",
+                },
+                {
+                    "role": "assistant",
+                    "content": json.dumps({"name": "x"}),  # missing tool_call_id
+                    "message_type": "tool_result",
+                },
+            ]
+        )
+
+        assert result == []
+
+    def test_unknown_message_type_is_skipped(self):
+        converter = StrandsHistoryConverter()
+
+        result = converter.convert(
+            [{"role": "user", "content": "hi", "message_type": "mystery"}]
+        )
+
+        assert result == []

--- a/tests/converters/test_strands.py
+++ b/tests/converters/test_strands.py
@@ -227,6 +227,29 @@ class TestToolPairIntegrity:
             "user: toolResult(call-1, error) text([Alice]: still there?)",
         ]
 
+    def test_orphaned_tool_result_gets_a_synthetic_tool_use(self):
+        """The tool_call event can be lost (failed send, unparseable payload).
+
+        Emitting the surviving result alone would leave a toolResult with no
+        preceding toolUse — which Converse rejects on every later turn in the
+        room — so the converter synthesizes the call it answers.
+        """
+        converter = StrandsHistoryConverter(agent_name="Bot")
+
+        result = converter.convert(
+            [
+                _text("please send it"),
+                _tool_result("band_send_message", "sent", "call-lost"),
+                _text("thanks"),
+            ]
+        )
+
+        assert _outline(result) == [
+            "user: text([Alice]: please send it)",
+            "assistant: toolUse(call-lost)",
+            "user: toolResult(call-lost, success) text([Alice]: thanks)",
+        ]
+
     def test_a_late_call_joins_the_round_it_interleaved_with(self):
         """Strands runs a round's tools concurrently, so its hooks interleave.
 

--- a/tests/converters/test_strands.py
+++ b/tests/converters/test_strands.py
@@ -45,23 +45,24 @@ class TestToolEventFormat:
         converter = StrandsHistoryConverter()
 
         result = converter.convert(
-            [_tool_call("band_send_message", {"content": "hi"}, "call-1")]
+            [
+                _tool_call("band_send_message", {"content": "hi"}, "call-1"),
+                _tool_result("band_send_message", "sent", "call-1"),
+            ]
         )
 
-        assert result == [
-            {
-                "role": "assistant",
-                "content": [
-                    {
-                        "toolUse": {
-                            "toolUseId": "call-1",
-                            "name": "band_send_message",
-                            "input": {"content": "hi"},
-                        }
+        assert result[0] == {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolUse": {
+                        "toolUseId": "call-1",
+                        "name": "band_send_message",
+                        "input": {"content": "hi"},
                     }
-                ],
-            }
-        ]
+                }
+            ],
+        }
 
     def test_tool_result_becomes_user_tool_result_block(self):
         converter = StrandsHistoryConverter()
@@ -144,6 +145,102 @@ class TestBatching:
         assert len(result) == 2
         assert "toolUse" in result[0]["content"][0]
         assert "toolResult" in result[1]["content"][0]
+
+
+def _text(content: str, sender: str = "Alice", role: str = "user") -> dict:
+    return {
+        "role": role,
+        "content": content,
+        "sender_name": sender,
+        "message_type": "text",
+    }
+
+
+def _outline(messages: list[dict]) -> list[str]:
+    """Render each message as ``role: block(id)`` for readable assertions."""
+
+    def describe(block: dict) -> str:
+        if "toolUse" in block:
+            return f"toolUse({block['toolUse']['toolUseId']})"
+        if "toolResult" in block:
+            result = block["toolResult"]
+            return f"toolResult({result['toolUseId']}, {result['status']})"
+        return f"text({block['text']})"
+
+    return [
+        f"{message['role']}: {' '.join(describe(b) for b in message['content'])}"
+        for message in messages
+    ]
+
+
+class TestToolPairIntegrity:
+    """Converse rejects a toolUse that its toolResult does not immediately follow."""
+
+    def test_peer_message_mid_tool_call_is_held_until_the_pair_closes(self):
+        converter = StrandsHistoryConverter(agent_name="Bot")
+
+        result = converter.convert(
+            [
+                _tool_call("calc", {"expr": "2+2"}, "call-1"),
+                _text("also, hello"),
+                _tool_result("calc", "4", "call-1"),
+            ]
+        )
+
+        assert _outline(result) == [
+            "assistant: toolUse(call-1)",
+            "user: toolResult(call-1, success)",
+            "user: text([Alice]: also, hello)",
+        ]
+
+    def test_missing_tool_result_is_answered_with_a_synthetic_error(self):
+        converter = StrandsHistoryConverter(agent_name="Bot")
+
+        result = converter.convert(
+            [
+                _tool_call("calc", {}, "call-1"),
+                _text("still there?"),
+            ]
+        )
+
+        assert _outline(result) == [
+            "assistant: toolUse(call-1)",
+            "user: toolResult(call-1, error)",
+            "user: text([Alice]: still there?)",
+        ]
+
+    def test_partially_answered_parallel_calls_are_completed_in_place(self):
+        converter = StrandsHistoryConverter(agent_name="Bot")
+
+        result = converter.convert(
+            [
+                _tool_call("a", {}, "call-a"),
+                _tool_call("b", {}, "call-b"),
+                _tool_result("a", "ra", "call-a"),
+            ]
+        )
+
+        assert _outline(result) == [
+            "assistant: toolUse(call-a) toolUse(call-b)",
+            "user: toolResult(call-b, error) toolResult(call-a, success)",
+        ]
+
+    def test_own_text_after_the_pair_closes_is_preserved(self):
+        converter = StrandsHistoryConverter(agent_name="Bot")
+
+        result = converter.convert(
+            [
+                _tool_call("calc", {}, "call-1"),
+                _tool_result("calc", "4", "call-1"),
+                _text("the answer is 4", sender="Bot", role="assistant"),
+            ]
+        )
+
+        assert _outline(result) == [
+            "assistant: toolUse(call-1)",
+            "user: toolResult(call-1, success)",
+            "assistant: text(the answer is 4)",
+        ]
 
 
 class TestMalformedInput:

--- a/tests/converters/test_strands.py
+++ b/tests/converters/test_strands.py
@@ -193,6 +193,30 @@ class TestToolPairIntegrity:
             "user: text([Alice]: also, hello)",
         ]
 
+    def test_peer_message_between_parallel_calls_is_held_too(self):
+        """A second parallel call must not release the turns held by the first.
+
+        Releasing them there emits the peer turn before the assistant message
+        carrying the calls it actually arrived after, silently reordering history.
+        """
+        converter = StrandsHistoryConverter(agent_name="Bot")
+
+        result = converter.convert(
+            [
+                _tool_call("a", {}, "call-a"),
+                _text("also, hello"),
+                _tool_call("b", {}, "call-b"),
+                _tool_result("a", "ra", "call-a"),
+                _tool_result("b", "rb", "call-b"),
+            ]
+        )
+
+        assert _outline(result) == [
+            "assistant: toolUse(call-a) toolUse(call-b)",
+            "user: toolResult(call-a, success) toolResult(call-b, success)",
+            "user: text([Alice]: also, hello)",
+        ]
+
     def test_missing_tool_result_is_answered_with_a_synthetic_error(self):
         converter = StrandsHistoryConverter(agent_name="Bot")
 

--- a/tests/converters/test_strands.py
+++ b/tests/converters/test_strands.py
@@ -40,6 +40,32 @@ def _tool_result(name: str, output: str, call_id: str, is_error: bool = False) -
     }
 
 
+def _text(content: str, sender: str = "Alice", role: str = "user") -> dict:
+    return {
+        "role": role,
+        "content": content,
+        "sender_name": sender,
+        "message_type": "text",
+    }
+
+
+def _outline(messages: list[dict]) -> list[str]:
+    """Render each message as ``role: block(id)`` for readable assertions."""
+
+    def describe(block: dict) -> str:
+        if "toolUse" in block:
+            return f"toolUse({block['toolUse']['toolUseId']})"
+        if "toolResult" in block:
+            result = block["toolResult"]
+            return f"toolResult({result['toolUseId']}, {result['status']})"
+        return f"text({block['text']})"
+
+    return [
+        f"{message['role']}: {' '.join(describe(b) for b in message['content'])}"
+        for message in messages
+    ]
+
+
 class TestToolEventFormat:
     def test_tool_call_becomes_assistant_tool_use_block(self):
         converter = StrandsHistoryConverter()
@@ -125,56 +151,26 @@ class TestBatching:
             "call-b",
         ]
 
-    def test_own_text_mid_tool_call_is_dropped(self):
-        """Own text between a toolUse and its toolResult would split the pair."""
+
+class TestToolPairIntegrity:
+    """Converse rejects a toolUse that its toolResult does not immediately follow."""
+
+    def test_own_narration_mid_tool_call_is_dropped(self):
+        """The agent's own text is already implied by the pair, so it is not held."""
         converter = StrandsHistoryConverter(agent_name="Bot")
 
         result = converter.convert(
             [
                 _tool_call("band_send_message", {"content": "hi"}, "call-1"),
-                {
-                    "role": "assistant",
-                    "content": "hi",
-                    "sender_name": "Bot",
-                    "message_type": "text",
-                },
+                _text("hi", sender="Bot", role="assistant"),
                 _tool_result("band_send_message", "sent", "call-1"),
             ]
         )
 
-        assert len(result) == 2
-        assert "toolUse" in result[0]["content"][0]
-        assert "toolResult" in result[1]["content"][0]
-
-
-def _text(content: str, sender: str = "Alice", role: str = "user") -> dict:
-    return {
-        "role": role,
-        "content": content,
-        "sender_name": sender,
-        "message_type": "text",
-    }
-
-
-def _outline(messages: list[dict]) -> list[str]:
-    """Render each message as ``role: block(id)`` for readable assertions."""
-
-    def describe(block: dict) -> str:
-        if "toolUse" in block:
-            return f"toolUse({block['toolUse']['toolUseId']})"
-        if "toolResult" in block:
-            result = block["toolResult"]
-            return f"toolResult({result['toolUseId']}, {result['status']})"
-        return f"text({block['text']})"
-
-    return [
-        f"{message['role']}: {' '.join(describe(b) for b in message['content'])}"
-        for message in messages
-    ]
-
-
-class TestToolPairIntegrity:
-    """Converse rejects a toolUse that its toolResult does not immediately follow."""
+        assert _outline(result) == [
+            "assistant: toolUse(call-1)",
+            "user: toolResult(call-1, success)",
+        ]
 
     def test_peer_message_mid_tool_call_is_held_until_the_pair_closes(self):
         converter = StrandsHistoryConverter(agent_name="Bot")

--- a/tests/converters/test_strands.py
+++ b/tests/converters/test_strands.py
@@ -185,8 +185,7 @@ class TestToolPairIntegrity:
 
         assert _outline(result) == [
             "assistant: toolUse(call-1)",
-            "user: toolResult(call-1, success)",
-            "user: text([Alice]: also, hello)",
+            "user: toolResult(call-1, success) text([Alice]: also, hello)",
         ]
 
     def test_peer_message_between_parallel_calls_is_held_too(self):
@@ -209,8 +208,8 @@ class TestToolPairIntegrity:
 
         assert _outline(result) == [
             "assistant: toolUse(call-a) toolUse(call-b)",
-            "user: toolResult(call-a, success) toolResult(call-b, success)",
-            "user: text([Alice]: also, hello)",
+            "user: toolResult(call-a, success) toolResult(call-b, success) "
+            "text([Alice]: also, hello)",
         ]
 
     def test_missing_tool_result_is_answered_with_a_synthetic_error(self):
@@ -225,8 +224,33 @@ class TestToolPairIntegrity:
 
         assert _outline(result) == [
             "assistant: toolUse(call-1)",
-            "user: toolResult(call-1, error)",
-            "user: text([Alice]: still there?)",
+            "user: toolResult(call-1, error) text([Alice]: still there?)",
+        ]
+
+    def test_a_late_call_joins_the_round_it_interleaved_with(self):
+        """Strands runs a round's tools concurrently, so its hooks interleave.
+
+        Call C can be recorded after result A. Emitting A's result there would
+        strand B, and C's own result would then answer a toolUse no longer
+        immediately before it — which Converse rejects on the next rehydration.
+        """
+        converter = StrandsHistoryConverter(agent_name="Bot")
+
+        result = converter.convert(
+            [
+                _tool_call("a", {}, "call-a"),
+                _tool_call("b", {}, "call-b"),
+                _tool_result("a", "ra", "call-a"),
+                _tool_call("c", {}, "call-c"),
+                _tool_result("b", "rb", "call-b"),
+                _tool_result("c", "rc", "call-c"),
+            ]
+        )
+
+        assert _outline(result) == [
+            "assistant: toolUse(call-a) toolUse(call-b) toolUse(call-c)",
+            "user: toolResult(call-a, success) toolResult(call-b, success) "
+            "toolResult(call-c, success)",
         ]
 
     def test_partially_answered_parallel_calls_are_completed_in_place(self):
@@ -260,6 +284,39 @@ class TestToolPairIntegrity:
             "assistant: toolUse(call-1)",
             "user: toolResult(call-1, success)",
             "assistant: text(the answer is 4)",
+        ]
+
+
+class TestRoleAlternation:
+    """Bedrock's Converse rejects a conversation that does not alternate."""
+
+    def test_consecutive_speakers_become_one_turn(self):
+        converter = StrandsHistoryConverter(agent_name="Bot")
+
+        result = converter.convert([_text("one"), _text("two", sender="Bob")])
+
+        assert _outline(result) == ["user: text([Alice]: one) text([Bob]: two)"]
+
+    def test_every_transcript_alternates(self):
+        converter = StrandsHistoryConverter(agent_name="Bot")
+
+        result = converter.convert(
+            [
+                _text("one"),
+                _text("two", sender="Bob"),
+                _text("on it", sender="Bot", role="assistant"),
+                _tool_call("calc", {}, "call-1"),
+                _text("hurry up"),
+                _tool_result("calc", "4", "call-1"),
+                _text("done", sender="Bot", role="assistant"),
+            ]
+        )
+
+        assert _outline(result) == [
+            "user: text([Alice]: one) text([Bob]: two)",
+            "assistant: text(on it) toolUse(call-1)",
+            "user: toolResult(call-1, success) text([Alice]: hurry up)",
+            "assistant: text(done)",
         ]
 
 

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -1,4 +1,13 @@
-"""Grid tests for adapters that expose memory or contacts capabilities."""
+"""Grid tests for adapters that expose memory or contacts capabilities.
+
+Every cell comes from a capability filter, never a hard-coded adapter list:
+``supports={Capability.MEMORY}`` selects the memory-capable adapters and
+``without={Capability.MEMORY}`` the exact complement, so flipping an adapter's
+``supports`` in the registry re-balances these tests automatically. Under
+fail-never-skip a cell whose backend or key is absent ERRORs with that reason
+(e.g. ``GOOGLE_API_KEY`` for gemini) — the honest "not wired up" signal, not a
+regression.
+"""
 
 from __future__ import annotations
 
@@ -67,7 +76,11 @@ async def test_recall_memory_across_memory_adapters(
     user_ops: UserOps,
     reply_capture: CaptureFactory,
 ) -> None:
-    """Store, list, and fetch a memory through each memory-capable adapter."""
+    """Store, list, and fetch a memory through each memory-capable adapter.
+
+    The fetch-by-id hop is what proves a real read-back: a list alone would also
+    pass on a mis-wired read that returns nothing.
+    """
     marker = unique_marker("rmem")
     room_id = await resource_manager.provision_room(
         title=f"e2e-cap-recall-{agent.adapter_id}", participants=[agent.id]

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -1,6 +1,6 @@
 """Capability-filtered matrix smokes — demonstrate ``@per_adapter`` filtering.
 
-Two complementary scenarios driven entirely by capability filters, with no
+Three complementary scenarios driven entirely by capability filters, with no
 hard-coded adapter lists:
 
 * ``supports={Capability.MEMORY}`` selects the memory-capable adapters and runs a
@@ -8,6 +8,8 @@ hard-coded adapter lists:
   memory tools per cell);
 * ``without={Capability.MEMORY}`` selects the exact complement (the non-memory
   adapters) and runs a basic reply turn.
+* ``supports={Capability.CONTACTS}`` selects adapters with contact tools enabled
+  and proves they can list contacts through the real platform API.
 
 The two sets partition the matrix, so adding/removing an adapter or flipping its
 ``supports`` in the registry re-balances both tests automatically — the point of
@@ -26,12 +28,15 @@ from band.core.types import Capability
 
 from tests.e2e.baseline.agents import per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import (
+    CONTACTS_AGENT,
     MEMORY_AGENT,
+    list_contacts_instruction,
     recall_memory_instruction,
     store_memory_instruction,
     unique_marker,
 )
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
+from tests.e2e.baseline.toolkit.observations import ContactTool
 from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceManager
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
@@ -109,6 +114,32 @@ async def test_recall_memory_across_memory_adapters(
     # Read side: the agent queried its memory and fetched the record back by id.
     mem.calls.assert_list_called()
     mem.calls.assert_get_called()
+
+
+@per_adapter(supports={Capability.CONTACTS}, **CONTACTS_AGENT)
+@flaky_infra("retry a transient live-turn timeout; assertion failures fail loud")
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_contacts_across_contacts_adapters(
+    agent: ProvisionedAgent,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """Every contacts-capable adapter can list contacts through the platform."""
+    room_id = await resource_manager.provision_room(
+        title=f"e2e-cap-contacts-{agent.adapter_id}", participants=[agent.id]
+    )
+    async with reply_capture(room_id) as capture:
+        mid = await user_ops.send_message(
+            room_id,
+            list_contacts_instruction(),
+            mention_id=agent.id,
+            mention_name=agent.name,
+        )
+        await capture.wait_for_processed(mid, agent.id)
+        calls = await capture.tool_calls(sender_id=agent.id)
+
+    calls.assert_fired(ContactTool.LIST.value)
 
 
 @per_adapter(without={Capability.MEMORY})

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -17,7 +17,7 @@ from tests.e2e.baseline.flaky import flaky_infra
 from band.core.memory_types import MemoryListScope
 from band.core.types import Capability
 
-from tests.e2e.baseline.agents import per_adapter
+from tests.e2e.baseline.agents import Adapter, ExcludedAdapter, per_adapter
 from tests.e2e.baseline.smoke.samples.sample_agents import (
     CONTACTS_AGENT,
     MEMORY_AGENT,
@@ -102,7 +102,18 @@ async def test_recall_memory_across_memory_adapters(
     mem.calls.assert_get_called()
 
 
-@per_adapter(supports={Capability.MEMORY}, **MEMORY_AGENT)
+@per_adapter(
+    supports={Capability.MEMORY},
+    exclude=[
+        ExcludedAdapter(
+            Adapter.CREWAI,
+            "the second, post-reboot retrieval turn returns an empty completion "
+            "('Invalid response from LLM call - None or empty'), so the turn never "
+            "finishes; reproduced on every attempt, not a transient",
+        )
+    ],
+    **MEMORY_AGENT,
+)
 @flaky_infra("only transient failures")
 @pytest.mark.timeout(extra=180)  # store, stop, fresh boot, list, get
 @pytest.mark.asyncio(loop_scope="session")
@@ -140,14 +151,22 @@ async def test_memory_survives_adapter_rehydration(
                 mention_id=identity.id,
                 mention_name=identity.name,
             )
-            await capture.wait_for_processed(mid, identity.id)
+            replies = await capture.wait_for_reply(mid, identity.id)
             mem = await capture.memory(
                 identity,
                 scope=MemoryListScope.ORGANIZATION,
                 content_query=marker,
             )
 
-    mem.calls.assert_list_called(content_query=marker)
+    # Assert the *effect* of the rehydrated recall, not how an adapter narrated it:
+    # the marker coming back in the reply is what proves the fresh run reached the
+    # prior run's memory. Requiring a specific ``content_query`` argument in the
+    # narrated tool call instead made this hostage to per-adapter narration timing
+    # (opencode reports a tool call once, on the first frame it sees, which for a
+    # PENDING frame carries no arguments yet) and to whether the model chose to
+    # filter server-side rather than list and read.
+    replies.assert_contains_any([marker])
+    mem.calls.assert_list_called()
     mem.calls.assert_get_called()
     mem.stored.assert_stored(content=marker)
 

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -1,22 +1,4 @@
-"""Capability-filtered matrix smokes — demonstrate ``@per_adapter`` filtering.
-
-Three complementary scenarios driven entirely by capability filters, with no
-hard-coded adapter lists:
-
-* ``supports={Capability.MEMORY}`` selects the memory-capable adapters and runs a
-  store-then-read-back memory scenario (``features=memory_features()`` exposes the
-  memory tools per cell);
-* ``without={Capability.MEMORY}`` selects the exact complement (the non-memory
-  adapters) and runs a basic reply turn.
-* ``supports={Capability.CONTACTS}`` selects adapters with contact tools enabled
-  and proves they can list contacts through the real platform API.
-
-The two sets partition the matrix, so adding/removing an adapter or flipping its
-``supports`` in the registry re-balances both tests automatically — the point of
-the demonstration. Under fail-never-skip a cell whose backend/key is absent ERRORs
-with the reason (e.g. ``GOOGLE_API_KEY`` for gemini, ``OPENCODE_BASE_URL`` for
-opencode); that is the honest "not wired up" signal, not a regression.
-"""
+"""Grid tests for adapters that expose memory or contacts capabilities."""
 
 from __future__ import annotations
 
@@ -50,11 +32,7 @@ async def test_store_memory_across_memory_adapters(
     user_ops: UserOps,
     reply_capture: CaptureFactory,
 ) -> None:
-    """Every memory-capable adapter can store a memory that lands in the store.
-
-    The matrix here is *exactly* the adapters advertising ``Capability.MEMORY`` —
-    selected by the filter, not a list — each built with the memory tools enabled.
-    """
+    """Store an organization-scoped memory through each memory-capable adapter."""
     marker = unique_marker("xmem")
     room_id = await resource_manager.provision_room(
         title=f"e2e-cap-memory-{agent.adapter_id}", participants=[agent.id]
@@ -84,15 +62,7 @@ async def test_recall_memory_across_memory_adapters(
     user_ops: UserOps,
     reply_capture: CaptureFactory,
 ) -> None:
-    """Every memory-capable adapter can store a memory and read it back.
-
-    The complement of ``test_store_memory_across_memory_adapters`` (which proves the
-    *store* lands): the same subgroup drives a store -> list -> get sequence in one
-    turn, so the assertion covers the memory tools' *read* path too. The record must
-    land AND the agent must both query (``assert_list_called``) and fetch it back by
-    id (``assert_get_called``) — list alone would pass on a mis-wired read that
-    returns nothing, so the get hop is what proves an actual read-back.
-    """
+    """Store, list, and fetch a memory through each memory-capable adapter."""
     marker = unique_marker("rmem")
     room_id = await resource_manager.provision_room(
         title=f"e2e-cap-recall-{agent.adapter_id}", participants=[agent.id]
@@ -109,9 +79,7 @@ async def test_recall_memory_across_memory_adapters(
             agent, scope=MemoryListScope.ORGANIZATION, content_query=marker
         )
 
-    # Write side: the record landed in the store.
     mem.stored.assert_stored(content=marker)
-    # Read side: the agent queried its memory and fetched the record back by id.
     mem.calls.assert_list_called()
     mem.calls.assert_get_called()
 

--- a/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
+++ b/tests/e2e/baseline/smoke/matrix/test_capability_matrix.py
@@ -14,12 +14,17 @@ from tests.e2e.baseline.smoke.samples.sample_agents import (
     MEMORY_AGENT,
     list_contacts_instruction,
     recall_memory_instruction,
+    retrieve_memory_instruction,
     store_memory_instruction,
     unique_marker,
 )
 from tests.e2e.baseline.toolkit.capture import CaptureFactory
 from tests.e2e.baseline.toolkit.observations import ContactTool
-from tests.e2e.baseline.toolkit.provisioning import ProvisionedAgent, ResourceManager
+from tests.e2e.baseline.toolkit.provisioning import (
+    AdapterCell,
+    ProvisionedAgent,
+    ResourceManager,
+)
 from tests.e2e.baseline.toolkit.user_ops import UserOps
 
 
@@ -82,6 +87,56 @@ async def test_recall_memory_across_memory_adapters(
     mem.stored.assert_stored(content=marker)
     mem.calls.assert_list_called()
     mem.calls.assert_get_called()
+
+
+@per_adapter(supports={Capability.MEMORY}, **MEMORY_AGENT)
+@flaky_infra("only transient failures")
+@pytest.mark.timeout(extra=180)  # store, stop, fresh boot, list, get
+@pytest.mark.asyncio(loop_scope="session")
+async def test_memory_survives_adapter_rehydration(
+    cell: AdapterCell,
+    resource_manager: ResourceManager,
+    user_ops: UserOps,
+    reply_capture: CaptureFactory,
+) -> None:
+    """A fresh adapter under one identity retrieves a memory from its prior run."""
+    marker = unique_marker("rehydratemem")
+    identity = await cell.provision(label=f"memory-rejoin-{cell.adapter_id}")
+    room_id = await resource_manager.provision_room(
+        title=f"e2e-cap-memory-rejoin-{cell.adapter_id}", participants=[identity.id]
+    )
+
+    async with cell.run_as(identity):
+        async with reply_capture(room_id) as capture:
+            mid = await user_ops.send_message(
+                room_id,
+                store_memory_instruction(marker),
+                mention_id=identity.id,
+                mention_name=identity.name,
+            )
+            await capture.wait_for_processed(mid, identity.id)
+
+    retrieval_room_id = await resource_manager.provision_room(
+        title=f"e2e-cap-memory-retrieve-{cell.adapter_id}", participants=[identity.id]
+    )
+    async with cell.run_as(identity):
+        async with reply_capture(retrieval_room_id) as capture:
+            mid = await user_ops.send_message(
+                retrieval_room_id,
+                retrieve_memory_instruction(marker),
+                mention_id=identity.id,
+                mention_name=identity.name,
+            )
+            await capture.wait_for_processed(mid, identity.id)
+            mem = await capture.memory(
+                identity,
+                scope=MemoryListScope.ORGANIZATION,
+                content_query=marker,
+            )
+
+    mem.calls.assert_list_called(content_query=marker)
+    mem.calls.assert_get_called()
+    mem.stored.assert_stored(content=marker)
 
 
 @per_adapter(supports={Capability.CONTACTS}, **CONTACTS_AGENT)

--- a/tests/e2e/baseline/smoke/matrix/test_concurrent_instances.py
+++ b/tests/e2e/baseline/smoke/matrix/test_concurrent_instances.py
@@ -77,16 +77,17 @@ async def test_concurrent_same_adapter_instances_each_reply(
             participants=[instance.id for instance in instances],
         )
         async with reply_capture(room_id) as capture:
+            markers = [unique_marker("hi") for _ in instances]
             # Gather the SENDS (independent REST calls)...
             mids = await asyncio.gather(
                 *(
                     user_ops.send_message(
                         room_id,
-                        liveness_probe(unique_marker("hi")),
+                        liveness_probe(marker),
                         mention_id=instance.id,
                         mention_name=instance.name,
                     )
-                    for instance in instances
+                    for instance, marker in zip(instances, markers, strict=True)
                 )
             )
             # ...but await the barriers SEQUENTIALLY (one nudge per capture). Each
@@ -104,7 +105,9 @@ async def test_concurrent_same_adapter_instances_each_reply(
             # marker's ``extra`` above all K, so a genuine stall reports the stalled
             # turn rather than a phase-less pytest-timeout kill. Fast adapters reply
             # well within this: it raises only the failure ceiling, never latency.
-            for instance, mid in zip(instances, mids):
-                await capture.wait_for_reply(
+            for instance, mid, marker in zip(instances, mids, markers, strict=True):
+                replies = await capture.wait_for_reply(
                     mid, instance.id, deadline_s=BUDGET.deadline_s
                 )
+                replies.assert_contains_any([marker])
+                replies.assert_contains_none(set(markers) - {marker})

--- a/tests/e2e/baseline/smoke/samples/sample_agents.py
+++ b/tests/e2e/baseline/smoke/samples/sample_agents.py
@@ -270,6 +270,15 @@ def recall_memory_instruction(marker: str) -> str:
     )
 
 
+def retrieve_memory_instruction(marker: str) -> str:
+    """User message forcing retrieval of an already-stored org memory."""
+    return (
+        f"Call {MemoryTool.LIST.value} with content_query={marker} to find the "
+        f"memory. Then call {MemoryTool.GET.value} with memory_id set to the id "
+        "of a memory the list returned. Do not call any other tool."
+    )
+
+
 def store_two_memories_instruction(marker: str) -> str:
     """User message forcing two org-scoped stores that both carry ``marker`` but
     differ in system/type, so one ``content_query=marker`` read returns both and

--- a/tests/e2e/baseline/smoke/samples/sample_agents.py
+++ b/tests/e2e/baseline/smoke/samples/sample_agents.py
@@ -29,7 +29,7 @@ from band.core.memory_types import (
 )
 
 from tests.e2e.baseline.smoke.samples.sample_tools import LOOKUP_PROMPT
-from tests.e2e.baseline.toolkit.observations import MemoryTool
+from tests.e2e.baseline.toolkit.observations import ContactTool, MemoryTool
 
 # Fixed role-setter: the actionable instruction (and marker) travels in the user
 # message, exactly like the opaque-tool smokes.
@@ -44,6 +44,11 @@ def memory_features() -> AdapterFeatures:
     """Features for the memory smokes: expose the memory tools, and record the
     tool call as a ``tool_call`` event so the call layer is observable."""
     return AdapterFeatures(capabilities={Capability.MEMORY}, emit={Emit.EXECUTION})
+
+
+def contacts_features() -> AdapterFeatures:
+    """Features for contacts smokes: expose contact tools and record their calls."""
+    return AdapterFeatures(capabilities={Capability.CONTACTS}, emit={Emit.EXECUTION})
 
 
 def usage_features() -> AdapterFeatures:
@@ -94,6 +99,7 @@ MEMORY_SECRETARY_PROMPT = (
 # the same shape instead of re-spelling it.
 TOOL_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT}
 MEMORY_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT, "features": memory_features()}
+CONTACTS_AGENT = {"prompt": TOOL_AGENT_SYSTEM_PROMPT, "features": contacts_features()}
 MEMORY_SECRETARY_AGENT = {
     "prompt": MEMORY_SECRETARY_PROMPT,
     "features": memory_features(),
@@ -174,6 +180,15 @@ def store_memory_instruction(marker: str) -> str:
         f"scope = {MemoryStoreScope.ORGANIZATION.value}; "
         "thought = a brief reason. Do not include subject_id. Do not call any "
         "other tool."
+    )
+
+
+def list_contacts_instruction() -> str:
+    """Drive a real contacts read and finish the turn with a Band reply."""
+    return (
+        f"First call {ContactTool.LIST.value} to inspect your contacts. Then use "
+        "band_send_message to briefly confirm that you checked them. Do not call "
+        "any other tools."
     )
 
 

--- a/tests/e2e/baseline/toolkit/builders.py
+++ b/tests/e2e/baseline/toolkit/builders.py
@@ -166,6 +166,32 @@ def _build_pydantic_ai(
     )
 
 
+@adapter(Adapter.STRANDS, requires=[Dep.OPENAI], supports=_LLM_TOOL_LOOP)
+def _build_strands(
+    s: BaselineSettings,
+    *,
+    prompt: str | None,
+    features: AdapterFeatures | None,
+    tools: list[ToolSpec] | None = None,
+) -> SimpleAdapter[Any]:
+    from strands.models.openai import OpenAIModel
+
+    from band.adapters.strands import StrandsAdapter
+
+    # Strands has no provider-prefix string shorthand (a bare string means a
+    # Bedrock model id), so the OpenAI provider is constructed explicitly.
+    api_key = s.llm_credentials.openai_api_key
+    return StrandsAdapter(
+        model=OpenAIModel(
+            client_args={"api_key": api_key} if api_key else None,
+            model_id=s.llm_models.openai_model,
+        ),
+        custom_section=prompt,
+        additional_tools=_custom_tool_defs(tools),
+        features=features,
+    )
+
+
 @adapter(Adapter.GEMINI, requires=[Dep.GOOGLE], supports=_LLM_TOOL_LOOP)
 def _build_gemini(
     s: BaselineSettings,

--- a/tests/e2e/baseline/toolkit/observations/__init__.py
+++ b/tests/e2e/baseline/toolkit/observations/__init__.py
@@ -9,7 +9,7 @@ methods, so a check lives with the data it inspects. ``ReplyCapture`` (see
 - :class:`Replies` -- captured agent reply messages.
 - :class:`ToolCall` / :class:`ToolCalls` -- the agent's tool calls (memory tools
   excluded by default); :class:`MemoryToolCalls` -- the call-layer memory view;
-  :class:`MemoryTool` -- canonical memory tool names.
+  :class:`MemoryTool` / :class:`ContactTool` -- canonical capability-tool names.
 - :class:`Events` / :class:`Thoughts` / :class:`Errors` / :class:`Tasks` -- the
   free-text emitted events.
 - :class:`Memories` -- the store-layer view: memory records that actually landed
@@ -34,6 +34,7 @@ from tests.e2e.baseline.toolkit.observations.memories import (
 )
 from tests.e2e.baseline.toolkit.observations.replies import Replies
 from tests.e2e.baseline.toolkit.observations.tool_calls import (
+    ContactTool,
     MemoryTool,
     MemoryToolCalls,
     ToolCall,
@@ -42,6 +43,7 @@ from tests.e2e.baseline.toolkit.observations.tool_calls import (
 from tests.e2e.baseline.toolkit.observations.usage import Usage, UsageRecord
 
 __all__ = [
+    "ContactTool",
     "Errors",
     "Events",
     "Memories",

--- a/tests/e2e/baseline/toolkit/observations/tool_calls.py
+++ b/tests/e2e/baseline/toolkit/observations/tool_calls.py
@@ -34,7 +34,7 @@ from typing import Any, ClassVar
 from band_rest import ChatMessage
 
 from band.core.types import MessageType
-from band.runtime.tools import MEMORY_TOOL_NAMES
+from band.runtime.tools import CONTACT_TOOL_NAMES, MEMORY_TOOL_NAMES
 
 from tests.e2e.baseline.toolkit.observations.matching import tolerant_match
 from tests.e2e.baseline.toolkit.user_ops import UserOps
@@ -61,6 +61,23 @@ if {tool.value for tool in MemoryTool} != set(MEMORY_TOOL_NAMES):
     raise ValueError(
         "MemoryTool drifted from band.runtime.tools.MEMORY_TOOL_NAMES: "
         f"{set(MEMORY_TOOL_NAMES) ^ {tool.value for tool in MemoryTool}}"
+    )
+
+
+class ContactTool(StrEnum):
+    """Canonical contact platform-tool names for capability scenarios."""
+
+    LIST = "band_list_contacts"
+    ADD = "band_add_contact"
+    REMOVE = "band_remove_contact"
+    LIST_REQUESTS = "band_list_contact_requests"
+    RESPOND_REQUEST = "band_respond_contact_request"
+
+
+if {tool.value for tool in ContactTool} != set(CONTACT_TOOL_NAMES):
+    raise ValueError(
+        "ContactTool drifted from band.runtime.tools.CONTACT_TOOL_NAMES: "
+        f"{set(CONTACT_TOOL_NAMES) ^ {tool.value for tool in ContactTool}}"
     )
 
 

--- a/tests/e2e/baseline/toolkit/observations/tool_calls.py
+++ b/tests/e2e/baseline/toolkit/observations/tool_calls.py
@@ -273,9 +273,12 @@ class MemoryToolCalls(ToolCalls):
         }
         self.assert_fired(MemoryTool.STORE, with_args=with_args or None)
 
-    def assert_list_called(self) -> None:
-        """Assert ``band_list_memories`` fired."""
-        self.assert_fired(MemoryTool.LIST)
+    def assert_list_called(self, *, content_query: str | None = None) -> None:
+        """Assert ``band_list_memories`` fired, optionally for a content query."""
+        with_args = (
+            {"content_query": content_query} if content_query is not None else None
+        )
+        self.assert_fired(MemoryTool.LIST, with_args=with_args)
 
     def assert_get_called(self) -> None:
         """Assert ``band_get_memory`` fired."""

--- a/tests/example_agents/a2a/test_example_imports.py
+++ b/tests/example_agents/a2a/test_example_imports.py
@@ -1,0 +1,54 @@
+"""Import smoke tests for standalone A2A examples."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.paths import EXAMPLES_ROOT, REPO_ROOT
+
+EXAMPLE_CASES = (
+    (
+        EXAMPLES_ROOT / "a2a_gateway" / "02_with_demo_agent.py",
+        EXAMPLES_ROOT / "a2a_gateway",
+    ),
+    (
+        EXAMPLES_ROOT / "a2a_gateway" / "demo_orchestrator" / "__main__.py",
+        EXAMPLES_ROOT / "a2a_gateway",
+    ),
+    (
+        EXAMPLES_ROOT / "mixed" / "03_fact_checker_a2a.py",
+        EXAMPLES_ROOT / "mixed",
+    ),
+    (
+        EXAMPLES_ROOT / "mixed" / "04_risk_reviewer_a2a.py",
+        EXAMPLES_ROOT / "mixed",
+    ),
+)
+
+
+@pytest.mark.parametrize(("example", "import_root"), EXAMPLE_CASES)
+def test_a2a_example_imports(example: Path, import_root: Path) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(import_root)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import runpy; "
+                f"runpy.run_path({str(example)!r}, run_name='example_import')"
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -163,6 +163,14 @@ def _pydantic_ai_factory(**kw: Any) -> Any:
     return PydanticAIAdapter(**kw)
 
 
+def _strands_factory(**kw: Any) -> Any:
+    from band.adapters.strands import StrandsAdapter
+
+    if "model" not in kw:
+        kw["model"] = _STRANDS_INJECTED_MODEL
+    return StrandsAdapter(**kw)
+
+
 def _parlant_factory(**kw: Any) -> Any:
     from band.adapters.parlant import ParlantAdapter
 
@@ -225,6 +233,11 @@ def _google_adk_factory(**kw: Any) -> Any:
 # without a real API key.  ``expected_initial_values["model"]`` then verifies
 # the factory injection, NOT a real adapter default.
 _PYDANTIC_AI_INJECTED_MODEL = "openai:gpt-5.4"
+
+# Strands likewise requires ``model``. A plain string is fine at construction
+# time: the adapter passes it through to Strands (which treats strings as
+# Bedrock model ids), and no client is created until the first message turn.
+_STRANDS_INJECTED_MODEL = "strands-conformance-model"
 
 
 def _build_anthropic_config() -> AdapterConfig:
@@ -469,6 +482,36 @@ def _build_pydantic_ai_config() -> AdapterConfig:
     )
 
 
+def _build_strands_config() -> AdapterConfig:
+    from band.adapters.strands import StrandsAdapter
+
+    return AdapterConfig(
+        framework_id="strands",
+        display_name="Strands",
+        adapter_factory=_strands_factory,
+        expected_initial_values={
+            # Injected by _strands_factory, not a real __init__ default.
+            # Verifies that the factory injection is stored correctly.
+            "model": _STRANDS_INJECTED_MODEL,
+            "system_prompt": _default_from_init(StrandsAdapter, "system_prompt"),
+            "custom_section": _default_from_init(StrandsAdapter, "custom_section"),
+        },
+        custom_kwargs={
+            "model": "custom-bedrock-model-id",
+            "system_prompt": "You are a helpful bot.",
+            "custom_section": "Be concise.",
+        },
+        custom_expected={
+            "model": "custom-bedrock-model-id",
+            "system_prompt": "You are a helpful bot.",
+            "custom_section": "Be concise.",
+        },
+        # on_started only renders the prompt and builds tool wrappers — no
+        # client/agent construction happens until the first message turn.
+        skip_on_started_conformance=False,
+    )
+
+
 def _build_parlant_config() -> AdapterConfig:
     from band.adapters.parlant import ParlantAdapter
 
@@ -692,6 +735,7 @@ _ADAPTER_CONFIG_BUILDERS: list[Callable[[], AdapterConfig]] = [
     _build_claude_sdk_config,
     _build_copilot_sdk_config,
     _build_pydantic_ai_config,
+    _build_strands_config,
     _build_parlant_config,
     _build_codex_config,
     _build_letta_config,

--- a/tests/framework_configs/adapters.py
+++ b/tests/framework_configs/adapters.py
@@ -506,9 +506,6 @@ def _build_strands_config() -> AdapterConfig:
             "system_prompt": "You are a helpful bot.",
             "custom_section": "Be concise.",
         },
-        # on_started only renders the prompt and builds tool wrappers — no
-        # client/agent construction happens until the first message turn.
-        skip_on_started_conformance=False,
     )
 
 

--- a/tests/framework_configs/converters.py
+++ b/tests/framework_configs/converters.py
@@ -136,6 +136,12 @@ def _google_adk_factory(**kw: Any) -> Any:
     return GoogleADKHistoryConverter(**kw)
 
 
+def _strands_factory(**kw: Any) -> Any:
+    from band.converters.strands import StrandsHistoryConverter
+
+    return StrandsHistoryConverter(**kw)
+
+
 # ---------------------------------------------------------------------------
 # Registry  (built lazily to avoid top-level converter imports)
 # ---------------------------------------------------------------------------
@@ -345,6 +351,23 @@ def _build_google_adk_config() -> ConverterConfig:
     )
 
 
+def _build_strands_config() -> ConverterConfig:
+    from tests.framework_configs.output_adapters import StrandsOutputAdapter
+
+    return ConverterConfig(
+        framework_id="strands",
+        display_name="Strands",
+        converter_factory=_strands_factory,
+        empty_result=[],
+        empty_sender_behavior=SenderBehavior.CONTENT_AS_IS,
+        missing_sender_behavior=SenderBehavior.CONTENT_AS_IS,
+        # Keeps own text as an assistant turn so restart rehydration shows the
+        # agent's prior replies (same contract as pydantic-ai).
+        includes_own_text_without_tool_events=True,
+        output_adapter=StrandsOutputAdapter(),
+    )
+
+
 _CONVERTER_CONFIG_BUILDERS: list[Callable[[], ConverterConfig]] = [
     _build_anthropic_config,
     _build_langchain_config,
@@ -356,6 +379,7 @@ _CONVERTER_CONFIG_BUILDERS: list[Callable[[], ConverterConfig]] = [
     _build_agno_config,
     _build_gemini_config,
     _build_google_adk_config,
+    _build_strands_config,
 ]
 
 

--- a/tests/framework_configs/output_adapters.py
+++ b/tests/framework_configs/output_adapters.py
@@ -701,3 +701,83 @@ class SenderDictListAdapter(BaseDictListOutputAdapter):
             assert msg.get("sender_type") == sender_type, (
                 f"Expected sender_type={sender_type!r}, got {msg.get('sender_type')!r}"
             )
+
+
+class StrandsOutputAdapter:
+    """Adapter for Strands converter output (list of Converse Message dicts).
+
+    Each message is ``{"role": "user"|"assistant", "content": [blocks]}`` where a
+    block is ``{"text": ...}``, ``{"toolUse": ...}``, or ``{"toolResult": ...}``.
+    Batched tool blocks share one message, so indexed accessors operate on a
+    flattened (role, block) view (same approach as ``GeminiOutputAdapter``).
+    """
+
+    @staticmethod
+    def _flatten(result: list) -> list[tuple[str, dict[str, Any]]]:
+        """Return a flat list of (role, content_block) tuples."""
+        flat: list[tuple[str, dict[str, Any]]] = []
+        for message in result:
+            for block in message.get("content", []):
+                flat.append((message["role"], block))
+        return flat
+
+    def assert_result_type(self, result: list) -> None:
+        assert isinstance(result, list), f"Expected list, got {type(result).__name__}"
+
+    def result_length(self, result: list) -> int:
+        return len(self._flatten(result))
+
+    def get_content(self, result: list, index: int) -> str:
+        _role, block = self._flatten(result)[index]
+        if "text" in block:
+            return block["text"]
+        if "toolUse" in block:
+            return block["toolUse"].get("name", "")
+        if "toolResult" in block:
+            parts = [
+                item["text"]
+                for item in block["toolResult"].get("content", [])
+                if "text" in item
+            ]
+            return "\n".join(parts)
+        raise ValueError(f"No text/toolUse/toolResult content at index {index}")
+
+    def get_role(self, result: list, index: int) -> str:
+        role, _block = self._flatten(result)[index]
+        return role
+
+    def is_empty(self, result: list) -> bool:
+        return len(result) == 0
+
+    def content_contains(self, result: list, substring: str) -> bool:
+        for role, block in self._flatten(result):
+            if "text" in block and substring in block["text"]:
+                return True
+            if "toolUse" in block:
+                tool_use = block["toolUse"]
+                if substring in tool_use.get("name", ""):
+                    return True
+                if substring in str(tool_use.get("input", {})):
+                    return True
+            if "toolResult" in block:
+                for item in block["toolResult"].get("content", []):
+                    if "text" in item and substring in item["text"]:
+                        return True
+        return False
+
+    def assert_element_type(self, result: list, index: int, expected_role: str) -> None:
+        role = self.get_role(result, index)
+        assert role == expected_role, f"Expected role={expected_role!r}, got {role!r}"
+
+    def assert_sender_metadata(
+        self,
+        result: list,
+        index: int,
+        sender_name: str,
+        sender_type: str | None = None,
+    ) -> None:
+        raise NotImplementedError(
+            "StrandsOutputAdapter.assert_sender_metadata() is not supported. "
+            "Converse messages do not include sender metadata. "
+            "Ensure has_sender_metadata=False in the ConverterConfig."
+        )

--- a/tests/framework_configs/output_adapters.py
+++ b/tests/framework_configs/output_adapters.py
@@ -23,6 +23,7 @@ __all__ = [
     "GeminiOutputAdapter",
     "StringOutputAdapter",
     "SenderDictListAdapter",
+    "StrandsOutputAdapter",
 ]
 
 

--- a/tests/framework_conformance/test_crewai_job_coverage.py
+++ b/tests/framework_conformance/test_crewai_job_coverage.py
@@ -77,23 +77,40 @@ def _tests_needing_crewai_venv() -> set[Path]:
     }
 
 
-def _crewai_job_paths() -> set[Path]:
-    """The pytest targets of ci.yml's crewai test step."""
+def _crewai_job_command() -> str:
+    """The pytest invocation of ci.yml's crewai test step."""
     workflow = yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))
     steps = workflow["jobs"]["test-crewai"]["steps"]
     command = next(
         step["run"] for step in steps if step.get("name") == "Run crewai tests"
     )
+    return command.replace("\\\n", " ")
+
+
+def _crewai_job_paths() -> set[Path]:
+    """The pytest targets of ci.yml's crewai test step."""
     return {
         Path(token)
-        for token in command.replace("\\\n", " ").split()
+        for token in _crewai_job_command().split()
         if token.startswith("tests/")
     }
 
 
 def _covered_by(target: Path, listed: set[Path]) -> bool:
-    """Whether ``target`` is named outright or sits under a listed directory."""
-    return any(parent in listed for parent in (target, *target.parents))
+    """Whether ``target`` is named outright or sits under a listed directory.
+
+    A directory target only covers what the step actually collects from it: the
+    job narrows its directory targets with ``-k``, so a file that sits under one
+    but does not match the filter runs nowhere despite looking listed.
+    """
+    if target in listed:
+        return True
+    return not _KEYWORD_FILTER.search(_crewai_job_command()) and any(
+        parent in listed for parent in target.parents
+    )
+
+
+_KEYWORD_FILTER = re.compile(r"(?:^|\s)-k(?:\s|=)")
 
 
 def test_crewai_job_runs_every_test_that_needs_its_venv() -> None:

--- a/tests/framework_conformance/test_strands_injection_spike.py
+++ b/tests/framework_conformance/test_strands_injection_spike.py
@@ -1,0 +1,313 @@
+"""Tier-1 conformance spike for the Strands adapter (INJECTABLE_MODEL_OBJECT family).
+
+WHAT THIS PROVES
+----------------
+Given a scripted model decision, the StrandsAdapter's real tool wrappers (built
+by ``_build_platform_tools`` and run by Strands' own agent loop) dispatch the
+tool to the platform via ``AgentToolsProtocol`` — no live inference, no secrets,
+no provider API key.
+
+WHY IT IS HONEST (not circular)
+-------------------------------
+The faked decision is installed at the **public** ``Agent(model=...)`` seam:
+``strands.models.Model`` is the framework's documented provider ABC, and the
+adapter passes its ``model`` constructor argument straight through in
+``_build_agent``. Strands ships no dedicated test model, so the spike implements
+the minimal ``Model`` subclass; the scripted surface is still the stable public
+provider contract (``model_seam_kind=PUBLIC_TEST_MODEL``), though the
+``StreamEvent`` dict shapes it emits move with the framework's fast release
+cadence (``drift_risk=HIGH``, pinned ``strands-agents>=1.40,<2``).
+
+OBSERVATION PATH (the load-bearing detail)
+------------------------------------------
+Strands platform-tool wrappers call **typed** ``AgentToolsProtocol`` methods
+directly — ``band_send_message`` calls ``tools.send_message(...)`` — NOT
+``execute_tool_call``. So dispatch is observed on ``FakeAgentTools.messages_sent``
+(``observation_paths={TYPED_METHODS}``); a canary that only watched
+``tool_calls`` would wrongly fail Strands.
+
+STEP-0 FINDINGS (verified against installed strands-agents 1.47.0)
+------------------------------------------------------------------
+1. Per-invocation context: ``agent.invoke_async(prompt, invocation_state={...})``
+   reaches tool bodies via ``@tool(context=True)`` (``tool_context.invocation_state``)
+   and every hook event (``event.invocation_state``). No fallback needed.
+2. Scripted model events (consumed by ``strands.event_loop.streaming``): one tool
+   call is ``messageStart{role:assistant}`` ->
+   ``contentBlockStart{start:{toolUse:{toolUseId,name}}}`` ->
+   ``contentBlockDelta{delta:{toolUse:{input:<json-string>}}}`` ->
+   ``contentBlockStop`` -> ``messageStop{stopReason:"tool_use"}``; a terminal
+   text turn uses ``delta:{text}`` + ``stopReason:"end_turn"``; per-call usage
+   rides an optional trailing ``metadata{usage}`` event. The ``Model`` ABC also
+   requires ``structured_output`` (abstract), implemented as a stub here.
+3. OpenAI provider: ``strands.models.openai.OpenAIModel(client_args={"api_key":...},
+   model_id=...)``. There is NO provider-prefix string shorthand — a bare string
+   to ``Agent(model=...)`` is treated as a *Bedrock* model id.
+4. Hook events: ``BeforeToolCallEvent.tool_use{name,toolUseId,input}``,
+   ``AfterToolCallEvent.result: ToolResult{status,content,toolUseId}``; async
+   callbacks are supported. Usage lives on ``AgentResult.metrics.accumulated_usage``
+   (``inputTokens``/``outputTokens``/``cacheReadInputTokens``/``cacheWriteInputTokens``)
+   and accumulates across turns on a shared Agent — the adapter constructs a
+   per-turn Agent, so the accumulated value is exactly the turn's usage.
+5. History handle: ``agent.messages`` is a public read/write list of Converse
+   ``Message`` dicts; pre-seeding via ``Agent(messages=...)`` and reading back
+   after a run both work, so Band owns per-room history.
+
+InjectionBinding for the Tier-1 injection registry (lands with the taxonomy
+branch; recorded here until ``injection_registry.py`` exists on this branch):
+
+    InjectionBinding(
+        adapter="strands",
+        family=Family.INJECTABLE_MODEL_OBJECT,
+        tier1_status=Tier1Status.HONEST_TODAY,
+        drift_risk=DriftRisk.HIGH,
+        observation_paths=frozenset({ObservationPath.TYPED_METHODS}),
+        seam="band.adapters.strands:StrandsAdapter._build_agent",
+        model_seam_kind=ModelSeamKind.PUBLIC_TEST_MODEL,
+        spike_test="tests/framework_conformance/test_strands_injection_spike.py",
+        version_pin="strands-agents>=1.40,<2",
+        required_modules=("strands",),
+        required_extra="dev",
+    )
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, AsyncGenerator, cast
+
+import pytest
+from pydantic import BaseModel
+
+pytest.importorskip("strands", reason="strands extra not installed")
+
+from strands.models import Model  # noqa: E402
+from strands.types.content import Messages  # noqa: E402
+from strands.types.streaming import StreamEvent  # noqa: E402
+from strands.types.tools import ToolSpec  # noqa: E402
+
+from band.adapters.strands import StrandsAdapter  # noqa: E402
+from band.core.protocols import AgentToolsProtocol  # noqa: E402
+from band.core.types import AdapterFeatures, Emit, PlatformMessage  # noqa: E402
+from band.testing.fake_tools import FakeAgentTools  # noqa: E402
+
+_SEND_CONTENT = "Injected reply: PINEAPPLE"
+_SEND_MENTIONS = ["@tester"]
+
+
+def _make_msg(room_id: str) -> PlatformMessage:
+    return PlatformMessage(
+        id="strands-spike-1",
+        room_id=room_id,
+        content="Say the magic word",
+        sender_id="user-1",
+        sender_type="User",
+        sender_name="Tester",
+        message_type="text",
+        metadata=None,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+class _ScriptedStrandsModel(Model):
+    """A streaming Model that replays one scripted decision per invocation.
+
+    Each ``stream()`` call pops one decision and yields the Converse
+    ``StreamEvent`` sequence Strands' event loop parses (see module docstring):
+
+    * ``("tool", name, args_dict)`` -> a tool-use turn the agent dispatches;
+    * ``("text", body)`` -> a text turn that ends the run.
+    """
+
+    def __init__(self, turns: list[Any]):
+        self._turns = list(turns)
+        self._config: dict[str, Any] = {}
+
+    def update_config(self, **model_config: Any) -> None:
+        self._config.update(model_config)
+
+    def get_config(self) -> Any:
+        return self._config
+
+    async def structured_output(
+        self,
+        output_model: Any,
+        prompt: Messages,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        raise NotImplementedError("spike model does not do structured output")
+        yield {}  # pragma: no cover - makes this an async generator
+
+    async def stream(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        decision = self._turns.pop(0) if self._turns else ("text", "done")
+        yield {"messageStart": {"role": "assistant"}}
+        if decision[0] == "tool":
+            _, name, args = decision
+            yield {
+                "contentBlockStart": {
+                    "start": {"toolUse": {"toolUseId": f"call-{name}", "name": name}}
+                }
+            }
+            yield {
+                "contentBlockDelta": {"delta": {"toolUse": {"input": json.dumps(args)}}}
+            }
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "tool_use"}}
+        else:
+            yield {"contentBlockStart": {"start": {}}}
+            yield {"contentBlockDelta": {"delta": {"text": decision[1]}}}
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "end_turn"}}
+
+
+async def _run(adapter: StrandsAdapter, tools: FakeAgentTools, room_id: str) -> None:
+    """Drive the adapter through its real lifecycle: on_started -> on_message."""
+    await adapter.on_started("StrandsSpikeBot", "Tier-1 Strands injection spike bot.")
+    await adapter.on_message(
+        msg=_make_msg(room_id),
+        tools=cast("AgentToolsProtocol", tools),
+        history=[],
+        participants_msg=None,
+        contacts_msg=None,
+        is_session_bootstrap=True,
+        room_id=room_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_scripted_model_routes_to_typed_send_message() -> None:
+    """A scripted tool-use decision drives the real platform-tool wrapper (L0).
+
+    Observed on messages_sent (typed-method dispatch), NOT tool_calls.
+    """
+    room_id = "strands-spike-room"
+    tools = FakeAgentTools(room_id=room_id)
+    adapter = StrandsAdapter(
+        model=_ScriptedStrandsModel(
+            [
+                (
+                    "tool",
+                    "band_send_message",
+                    {"content": _SEND_CONTENT, "mentions": _SEND_MENTIONS},
+                ),
+                ("text", "done"),
+            ]
+        )
+    )
+    await _run(adapter, tools, room_id)
+
+    # Strands dispatches platform tools through typed AgentToolsProtocol
+    # methods, so observe on messages_sent (the contract's observation_paths).
+    assert len(tools.messages_sent) == 1, (
+        f"expected one send_message dispatch via the real tool wrapper, "
+        f"got messages_sent={tools.messages_sent}, tool_calls={tools.tool_calls}"
+    )
+    assert tools.messages_sent[0]["content"] == _SEND_CONTENT
+    assert tools.messages_sent[0]["mentions"] == _SEND_MENTIONS
+    # And confirm it did NOT route through execute_tool_call (the dual-path proof).
+    assert tools.tool_calls == [], (
+        f"Strands platform tools should bypass execute_tool_call; got {tools.tool_calls}"
+    )
+    # The terminal band action means no error event was reported.
+    assert not [e for e in tools.events_sent if e["message_type"] == "error"]
+
+
+@pytest.mark.asyncio
+async def test_custom_tool_decision_dispatches_to_handler() -> None:
+    """A scripted custom-tool decision reaches the custom handler with validated args (L1)."""
+
+    calls: list[str] = []
+
+    class EchoInput(BaseModel):
+        """Echo the given text back."""
+
+        text: str
+
+    async def echo_handler(args: EchoInput) -> str:
+        calls.append(args.text)
+        return f"echo: {args.text}"
+
+    # Terminal opt-in: the custom tool completes the turn, so no error is reported.
+    echo_handler.band_terminal = True  # type: ignore[attr-defined]
+
+    room_id = "strands-spike-custom"
+    tools = FakeAgentTools(room_id=room_id)
+    adapter = StrandsAdapter(
+        model=_ScriptedStrandsModel(
+            [
+                ("tool", "echo", {"text": "MANGO"}),
+                ("text", "done"),
+            ]
+        ),
+        additional_tools=[(EchoInput, echo_handler)],
+    )
+    await _run(adapter, tools, room_id)
+
+    assert calls == ["MANGO"], f"custom handler not dispatched: {calls}"
+    assert tools.messages_sent == []  # the custom tool is not a platform send
+    # band_terminal opt-in makes the turn productive: no error event.
+    assert not [e for e in tools.events_sent if e["message_type"] == "error"]
+
+
+@pytest.mark.asyncio
+async def test_l6_execution_events_ordered_paired_and_correlated() -> None:
+    """Emit.EXECUTION produces tool_call before tool_result, correlated by id (L6)."""
+    room_id = "strands-spike-l6"
+    tools = FakeAgentTools(room_id=room_id)
+    adapter = StrandsAdapter(
+        model=_ScriptedStrandsModel(
+            [
+                (
+                    "tool",
+                    "band_send_message",
+                    {"content": _SEND_CONTENT, "mentions": _SEND_MENTIONS},
+                ),
+                ("text", "done"),
+            ]
+        ),
+        features=AdapterFeatures(emit={Emit.EXECUTION}),
+    )
+    await _run(adapter, tools, room_id)
+
+    execution = [
+        (e["message_type"], json.loads(e["content"]))
+        for e in tools.events_sent
+        if e["message_type"] in ("tool_call", "tool_result")
+    ]
+    assert [kind for kind, _ in execution] == ["tool_call", "tool_result"], (
+        f"expected one ordered tool_call/tool_result pair, got {execution}"
+    )
+    call, result = execution[0][1], execution[1][1]
+    assert call["name"] == "band_send_message"
+    assert call["args"] == {"content": _SEND_CONTENT, "mentions": _SEND_MENTIONS}
+    assert result["name"] == "band_send_message"
+    assert result["tool_call_id"] == call["tool_call_id"], (
+        f"tool_result not correlated with its tool_call: {execution}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_negative_control_text_only_sends_no_message() -> None:
+    """A text-only scripted decision dispatches nothing and reports the dropped reply."""
+    room_id = "strands-spike-negative"
+    tools = FakeAgentTools(room_id=room_id)
+    adapter = StrandsAdapter(
+        model=_ScriptedStrandsModel([("text", "just a reply, no tools")])
+    )
+    await _run(adapter, tools, room_id)
+
+    assert tools.messages_sent == [], (
+        f"expected no send for a text-only decision, got: {tools.messages_sent}"
+    )
+    assert tools.tool_calls == []
+    # The plain-text answer was silently dropped — the adapter must surface it.
+    errors = [e for e in tools.events_sent if e["message_type"] == "error"]
+    assert len(errors) == 1, f"expected one error event, got: {tools.events_sent}"
+    assert "band_send_message" in errors[0]["content"]

--- a/tests/framework_conformance/test_strands_injection_spike.py
+++ b/tests/framework_conformance/test_strands_injection_spike.py
@@ -12,11 +12,12 @@ WHY IT IS HONEST (not circular)
 The faked decision is installed at the **public** ``Agent(model=...)`` seam:
 ``strands.models.Model`` is the framework's documented provider ABC, and the
 adapter passes its ``model`` constructor argument straight through in
-``_build_agent``. Strands ships no dedicated test model, so the spike implements
-the minimal ``Model`` subclass; the scripted surface is still the stable public
-provider contract (``model_seam_kind=PUBLIC_TEST_MODEL``), though the
-``StreamEvent`` dict shapes it emits move with the framework's fast release
-cadence (``drift_risk=HIGH``, pinned ``strands-agents>=1.40,<2``).
+``_build_agent`` (the seam recorded in ``tests/baseline/registry.py``). Strands
+ships no dedicated test model, so the SDK provides the minimal ``Model``
+subclass — ``band.testing.ScriptedStrandsModel``, shared with the adapter unit
+tests; the scripted surface is still the stable public provider contract, though
+the ``StreamEvent`` dict shapes it emits move with the framework's fast release
+cadence (hence the ``strands-agents>=1.40,<2`` pin).
 
 OBSERVATION PATH (the load-bearing detail)
 ------------------------------------------
@@ -26,8 +27,8 @@ directly — ``band_send_message`` calls ``tools.send_message(...)`` — NOT
 (``observation_paths={TYPED_METHODS}``); a canary that only watched
 ``tool_calls`` would wrongly fail Strands.
 
-STEP-0 FINDINGS (verified against installed strands-agents 1.47.0)
-------------------------------------------------------------------
+FRAMEWORK FACTS (verified against strands-agents 1.50.1)
+--------------------------------------------------------
 1. Per-turn tool ownership: the adapter builds native tool closures for each
    ``Agent`` invocation, binding that turn's ``AgentToolsProtocol`` directly.
    This keeps a room capability out of Strands' untyped ``invocation_state``.
@@ -51,48 +52,34 @@ STEP-0 FINDINGS (verified against installed strands-agents 1.47.0)
 5. History handle: ``agent.messages`` is a public read/write list of Converse
    ``Message`` dicts; pre-seeding via ``Agent(messages=...)`` and reading back
    after a run both work, so Band owns per-room history.
-
-InjectionBinding for the Tier-1 injection registry (lands with the taxonomy
-branch; recorded here until ``injection_registry.py`` exists on this branch):
-
-    InjectionBinding(
-        adapter="strands",
-        family=Family.INJECTABLE_MODEL_OBJECT,
-        tier1_status=Tier1Status.HONEST_TODAY,
-        drift_risk=DriftRisk.HIGH,
-        observation_paths=frozenset({ObservationPath.TYPED_METHODS}),
-        seam="band.adapters.strands:StrandsAdapter._build_agent",
-        model_seam_kind=ModelSeamKind.PUBLIC_TEST_MODEL,
-        spike_test="tests/framework_conformance/test_strands_injection_spike.py",
-        version_pin="strands-agents>=1.40,<2",
-        required_modules=("strands",),
-        required_extra="dev",
-    )
 """
 
 from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, cast
+from typing import cast
 
 import pytest
 from pydantic import BaseModel
 
 pytest.importorskip("strands", reason="strands extra not installed")
 
-from strands.models import Model  # noqa: E402
-from strands.types.content import Messages  # noqa: E402
-from strands.types.streaming import StreamEvent  # noqa: E402
-from strands.types.tools import ToolSpec  # noqa: E402
-
 from band.adapters.strands import StrandsAdapter  # noqa: E402
 from band.core.protocols import AgentToolsProtocol  # noqa: E402
 from band.core.types import AdapterFeatures, Emit, PlatformMessage  # noqa: E402
-from band.testing.fake_tools import FakeAgentTools  # noqa: E402
+from band.testing import (  # noqa: E402
+    FakeAgentTools,
+    ScriptedStrandsModel,
+    TextTurn,
+    ToolTurn,
+)
 
 _SEND_CONTENT = "Injected reply: PINEAPPLE"
 _SEND_MENTIONS = ["@tester"]
+_SEND_TURN = ToolTurn(
+    "band_send_message", {"content": _SEND_CONTENT, "mentions": _SEND_MENTIONS}
+)
 
 
 def _make_msg(room_id: str) -> PlatformMessage:
@@ -107,64 +94,6 @@ def _make_msg(room_id: str) -> PlatformMessage:
         metadata=None,
         created_at=datetime.now(timezone.utc),
     )
-
-
-class _ScriptedStrandsModel(Model):
-    """A streaming Model that replays one scripted decision per invocation.
-
-    Each ``stream()`` call pops one decision and yields the Converse
-    ``StreamEvent`` sequence Strands' event loop parses (see module docstring):
-
-    * ``("tool", name, args_dict)`` -> a tool-use turn the agent dispatches;
-    * ``("text", body)`` -> a text turn that ends the run.
-    """
-
-    def __init__(self, turns: list[Any]):
-        self._turns = list(turns)
-        self._config: dict[str, Any] = {}
-
-    def update_config(self, **model_config: Any) -> None:
-        self._config.update(model_config)
-
-    def get_config(self) -> Any:
-        return self._config
-
-    async def structured_output(
-        self,
-        output_model: Any,
-        prompt: Messages,
-        system_prompt: str | None = None,
-        **kwargs: Any,
-    ) -> AsyncGenerator[dict[str, Any], None]:
-        raise NotImplementedError("spike model does not do structured output")
-        yield {}  # pragma: no cover - makes this an async generator
-
-    async def stream(
-        self,
-        messages: Messages,
-        tool_specs: list[ToolSpec] | None = None,
-        system_prompt: str | None = None,
-        **kwargs: Any,
-    ) -> AsyncGenerator[StreamEvent, None]:
-        decision = self._turns.pop(0) if self._turns else ("text", "done")
-        yield {"messageStart": {"role": "assistant"}}
-        if decision[0] == "tool":
-            _, name, args = decision
-            yield {
-                "contentBlockStart": {
-                    "start": {"toolUse": {"toolUseId": f"call-{name}", "name": name}}
-                }
-            }
-            yield {
-                "contentBlockDelta": {"delta": {"toolUse": {"input": json.dumps(args)}}}
-            }
-            yield {"contentBlockStop": {}}
-            yield {"messageStop": {"stopReason": "tool_use"}}
-        else:
-            yield {"contentBlockStart": {"start": {}}}
-            yield {"contentBlockDelta": {"delta": {"text": decision[1]}}}
-            yield {"contentBlockStop": {}}
-            yield {"messageStop": {"stopReason": "end_turn"}}
 
 
 async def _run(adapter: StrandsAdapter, tools: FakeAgentTools, room_id: str) -> None:
@@ -189,18 +118,7 @@ async def test_scripted_model_routes_to_typed_send_message() -> None:
     """
     room_id = "strands-spike-room"
     tools = FakeAgentTools(room_id=room_id)
-    adapter = StrandsAdapter(
-        model=_ScriptedStrandsModel(
-            [
-                (
-                    "tool",
-                    "band_send_message",
-                    {"content": _SEND_CONTENT, "mentions": _SEND_MENTIONS},
-                ),
-                ("text", "done"),
-            ]
-        )
-    )
+    adapter = StrandsAdapter(model=ScriptedStrandsModel([_SEND_TURN]))
     await _run(adapter, tools, room_id)
 
     # Strands dispatches platform tools through typed AgentToolsProtocol
@@ -240,12 +158,7 @@ async def test_custom_tool_decision_dispatches_to_handler() -> None:
     room_id = "strands-spike-custom"
     tools = FakeAgentTools(room_id=room_id)
     adapter = StrandsAdapter(
-        model=_ScriptedStrandsModel(
-            [
-                ("tool", "echo", {"text": "MANGO"}),
-                ("text", "done"),
-            ]
-        ),
+        model=ScriptedStrandsModel([ToolTurn("echo", {"text": "MANGO"})]),
         additional_tools=[(EchoInput, echo_handler)],
     )
     await _run(adapter, tools, room_id)
@@ -262,16 +175,7 @@ async def test_l6_execution_events_ordered_paired_and_correlated() -> None:
     room_id = "strands-spike-l6"
     tools = FakeAgentTools(room_id=room_id)
     adapter = StrandsAdapter(
-        model=_ScriptedStrandsModel(
-            [
-                (
-                    "tool",
-                    "band_send_message",
-                    {"content": _SEND_CONTENT, "mentions": _SEND_MENTIONS},
-                ),
-                ("text", "done"),
-            ]
-        ),
+        model=ScriptedStrandsModel([_SEND_TURN]),
         features=AdapterFeatures(emit={Emit.EXECUTION}),
     )
     await _run(adapter, tools, room_id)
@@ -299,7 +203,7 @@ async def test_negative_control_text_only_sends_no_message() -> None:
     room_id = "strands-spike-negative"
     tools = FakeAgentTools(room_id=room_id)
     adapter = StrandsAdapter(
-        model=_ScriptedStrandsModel([("text", "just a reply, no tools")])
+        model=ScriptedStrandsModel([TextTurn("just a reply, no tools")])
     )
     await _run(adapter, tools, room_id)
 

--- a/tests/framework_conformance/test_strands_injection_spike.py
+++ b/tests/framework_conformance/test_strands_injection_spike.py
@@ -28,9 +28,9 @@ directly — ``band_send_message`` calls ``tools.send_message(...)`` — NOT
 
 STEP-0 FINDINGS (verified against installed strands-agents 1.47.0)
 ------------------------------------------------------------------
-1. Per-invocation context: ``agent.invoke_async(prompt, invocation_state={...})``
-   reaches tool bodies via ``@tool(context=True)`` (``tool_context.invocation_state``)
-   and every hook event (``event.invocation_state``). No fallback needed.
+1. Per-turn tool ownership: the adapter builds native tool closures for each
+   ``Agent`` invocation, binding that turn's ``AgentToolsProtocol`` directly.
+   This keeps a room capability out of Strands' untyped ``invocation_state``.
 2. Scripted model events (consumed by ``strands.event_loop.streaming``): one tool
    call is ``messageStart{role:assistant}`` ->
    ``contentBlockStart{start:{toolUse:{toolUseId,name}}}`` ->

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -77,6 +77,21 @@ def test_type_checking_block_matches_lazy_exports(package: str) -> None:
     )
 
 
+def test_first_access_binds_the_name_into_the_package() -> None:
+    """PEP 562 consults ``__getattr__`` only for names the module does not have.
+
+    A resolved export that never lands in the namespace re-enters importlib on
+    every single read.
+    """
+    import band.testing
+
+    vars(band.testing).pop("FakeAgentTools", None)
+
+    resolved = band.testing.FakeAgentTools
+
+    assert vars(band.testing)["FakeAgentTools"] is resolved
+
+
 def test_unknown_attribute_raises_attribute_error() -> None:
     import band.adapters
 

--- a/tests/test_lazy_exports.py
+++ b/tests/test_lazy_exports.py
@@ -1,0 +1,84 @@
+"""Guard the lazy export surface of packages built with ``lazy_exports``.
+
+Each such package states its exports twice: once in the ``TYPE_CHECKING`` block
+that static analysis reads, once in the ``lazy_exports`` call the interpreter
+reads. Only the second one resolves at runtime, so a name added to one and not
+the other fails silently — a type checker that sees a symbol the import machinery
+cannot produce, or a working import no tool knows about.
+
+The comparison is done on the parsed source, so it costs no optional extra: a
+missing framework would otherwise make the runtime map unreadable.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from tests.paths import SRC_ROOT
+
+_LAZY_PACKAGES = ("adapters", "converters", "testing")
+
+
+def _package_source(package: str) -> ast.Module:
+    return ast.parse((SRC_ROOT / package / "__init__.py").read_text())
+
+
+def _is_type_checking(test: ast.expr) -> bool:
+    match test:
+        case ast.Name(id="TYPE_CHECKING") | ast.Attribute(attr="TYPE_CHECKING"):
+            return True
+        case _:
+            return False
+
+
+def _type_checking_exports(tree: ast.Module) -> set[tuple[str, str]]:
+    """Collect (submodule, name) pairs re-exported under ``if TYPE_CHECKING``."""
+    return {
+        (node.module.rsplit(".", 1)[-1], alias.name)
+        for branch in ast.walk(tree)
+        if isinstance(branch, ast.If) and _is_type_checking(branch.test)
+        for node in ast.walk(branch)
+        if isinstance(node, ast.ImportFrom) and node.module
+        for alias in node.names
+    }
+
+
+def _lazy_exports_call(tree: ast.Module) -> set[tuple[str, str]]:
+    """Collect (submodule, name) pairs declared in the ``lazy_exports`` call."""
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "lazy_exports"
+    ]
+    assert len(calls) == 1, "expected exactly one lazy_exports call per package"
+    return {
+        (keyword.arg, element.value)
+        for keyword in calls[0].keywords
+        if keyword.arg and isinstance(keyword.value, ast.List)
+        for element in keyword.value.elts
+        if isinstance(element, ast.Constant)
+    }
+
+
+@pytest.mark.parametrize("package", _LAZY_PACKAGES)
+def test_type_checking_block_matches_lazy_exports(package: str) -> None:
+    tree = _package_source(package)
+    declared = _lazy_exports_call(tree)
+    annotated = _type_checking_exports(tree)
+
+    assert declared == annotated, (
+        f"band.{package} exports drifted between its TYPE_CHECKING block and its "
+        f"lazy_exports call: only lazy={sorted(declared - annotated)}, "
+        f"only typed={sorted(annotated - declared)}"
+    )
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    import band.adapters
+
+    with pytest.raises(AttributeError, match="NoSuchAdapter"):
+        band.adapters.NoSuchAdapter

--- a/tests/test_module_isolation.py
+++ b/tests/test_module_isolation.py
@@ -29,10 +29,23 @@ _THIS_FILE = Path(__file__).resolve()
 _RAW_EVICTION = re.compile(r"sys\.modules\.pop\(|del\s+sys\.modules\[")
 
 
+def _collected_test_sources() -> list[Path]:
+    """Every file pytest executes: the test modules and the conftests around them.
+
+    A conftest is the worse place for an eviction — it runs for a whole directory
+    — so scanning only ``test_*.py`` would miss the bigger blast radius.
+    """
+    return [
+        path
+        for pattern in ("test_*.py", "conftest.py")
+        for path in _TESTS_ROOT.rglob(pattern)
+    ]
+
+
 def test_no_test_evicts_modules_from_sys_modules() -> None:
     offenders = sorted(
         str(path.relative_to(REPO_ROOT))
-        for path in _TESTS_ROOT.rglob("test_*.py")
+        for path in _collected_test_sources()
         if path.resolve() != _THIS_FILE
         and _RAW_EVICTION.search(path.read_text(encoding="utf-8"))
     )

--- a/uv.lock
+++ b/uv.lock
@@ -488,6 +488,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aws-bedrock-token-generator"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/39/cf1c2e12bc5a84af0f96a546481213f81fa6e7927d2bbabd81758c6558ca/aws_bedrock_token_generator-1.1.0.tar.gz", hash = "sha256:95ccb07f63a91ac486561f6df05cc4e04784c8ff5086dc687ed9c5fd3ab1b5ba", size = 19123, upload-time = "2025-07-29T19:53:19.511Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/fd/745ece98870c3824d294bcdce5dc5e15381188a41bc80832c246b205e40e/aws_bedrock_token_generator-1.1.0-py3-none-any.whl", hash = "sha256:bd12854f7c7e52dde5d980d369379f12d0cc5f0855099d87f38688b0f9de5cd4", size = 10291, upload-time = "2025-07-29T19:53:18.704Z" },
+]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -640,6 +652,7 @@ dev = [
     { name = "ruff" },
     { name = "slack-sdk" },
     { name = "starlette" },
+    { name = "strands-agents", extra = ["openai"], marker = "extra == 'extra-8-band-sdk-dev' or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-crewai' and extra == 'extra-8-band-sdk-pydantic-ai') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-parlant') or (extra == 'extra-8-band-sdk-dev-crewai' and extra == 'extra-8-band-sdk-pydantic-ai')" },
     { name = "tenacity" },
     { name = "uvicorn" },
     { name = "werkzeug" },
@@ -709,6 +722,9 @@ slack = [
     { name = "slack-sdk" },
     { name = "starlette" },
     { name = "uvicorn" },
+]
+strands = [
+    { name = "strands-agents", extra = ["openai"] },
 ]
 
 [package.metadata]
@@ -834,6 +850,8 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'acp'", specifier = ">=0.40.0" },
     { name = "starlette", marker = "extra == 'dev'", specifier = ">=0.40.0" },
     { name = "starlette", marker = "extra == 'slack'", specifier = ">=0.40.0" },
+    { name = "strands-agents", extras = ["openai"], marker = "extra == 'dev'", specifier = ">=1.40,<2" },
+    { name = "strands-agents", extras = ["openai"], marker = "extra == 'strands'", specifier = ">=1.40,<2" },
     { name = "tenacity", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "tenacity", marker = "extra == 'dev-crewai'", specifier = ">=8.0.0" },
     { name = "uvicorn", marker = "extra == 'a2a-gateway'", specifier = ">=0.32.0" },
@@ -846,7 +864,7 @@ requires-dist = [
     { name = "werkzeug", marker = "extra == 'dev'", specifier = ">=3.1.6" },
     { name = "werkzeug", marker = "extra == 'parlant'", specifier = ">=3.1.6" },
 ]
-provides-extras = ["logging", "codex", "opencode", "letta", "pydantic-ai", "anthropic", "langgraph", "claude-sdk", "copilot-sdk", "parlant", "crewai", "gemini", "a2a", "a2a-gateway", "a2a-gateway-demo", "acp", "slack", "bridge", "bridge-agentcore", "agentcore-runtime", "google-adk", "agno", "dev", "dev-crewai"]
+provides-extras = ["logging", "codex", "opencode", "letta", "pydantic-ai", "anthropic", "langgraph", "claude-sdk", "copilot-sdk", "parlant", "crewai", "gemini", "a2a", "a2a-gateway", "a2a-gateway-demo", "acp", "slack", "bridge", "bridge-agentcore", "agentcore-runtime", "google-adk", "agno", "strands", "dev", "dev-crewai"]
 
 [[package]]
 name = "band-testing-python"
@@ -5103,6 +5121,20 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-threading"
+version = "0.63b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/90/7b0279192fab614d57af3d57584ef7ac9e38fa3df0b1d412224f6f55a85b/opentelemetry_instrumentation_threading-0.63b1.tar.gz", hash = "sha256:afa8c2cada8ed136f07b04dc8739bc861a15e9a5edea1a65e4c5e1919c62946c", size = 9080, upload-time = "2026-05-21T16:36:49.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/3d/3a991a4fcdf5ac82c04215e38cea4e73ad63713707014f9a70d1ab257f5f/opentelemetry_instrumentation_threading-0.63b1-py3-none-any.whl", hash = "sha256:33059298e68c94b13c38b562ad28799ec16a2fd06182ebfc762bb4e956e55d94", size = 8486, upload-time = "2026-05-21T16:35:58.084Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
@@ -7538,6 +7570,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "strands-agents"
+version = "1.50.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jsonschema" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation-threading" },
+    { name = "opentelemetry-sdk" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "typing-extensions" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/8d/49292aa95a380cc8e23013d35b890989064c710888a9422f4eac86041787/strands_agents-1.50.1.tar.gz", hash = "sha256:1c3dadc583a9219e25e8cf4942546544c73ae826d588223ea92c7ce9b1bcc45a", size = 1224179, upload-time = "2026-07-24T21:40:02.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/7c/1fa3979b54b8c7c3abeb17ad53d7035e6957b83ab7b5555ee11d884f47e4/strands_agents-1.50.1-py3-none-any.whl", hash = "sha256:fa8ad193d6aa4bc0bed2a43d85e9446cd4c22336f6c1c89638d55289faccfe4e", size = 641138, upload-time = "2026-07-24T21:40:00.853Z" },
+]
+
+[package.optional-dependencies]
+openai = [
+    { name = "aws-bedrock-token-generator" },
+    { name = "openai" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds a **Strands Agents** adapter (Tier-1 injectable-model family) plus the wiring
that makes it a first-class adapter in this repo.

**Adapter** (`src/band/adapters/strands.py`)
- One `strands.Agent` per turn, so each turn's tools own that turn's
  `AgentToolsProtocol` and no room capability leaks into Strands' untyped
  `invocation_state`.
- Platform tools bridge to native `AgentTool`s from the shared Band registry
  (names, schemas, validation, serialization all stay single-sourced); custom tools
  accept both the portable `(InputModel, handler)` pair and Strands' own `@tool`
  functions.
- `HookProvider` emits `Emit.EXECUTION` pairs and decides the turn's terminal-action
  policy; `Emit.USAGE` maps Strands' accumulated usage.
- Band owns per-room history: the transcript is converted to Converse messages,
  seeded into the fresh `Agent`, and read back after the run.

**Converter** (`src/band/converters/strands.py`) converts Band history to Converse
`toolUse`/`toolResult` messages, batching parallel calls and preserving valid tool
message ordering.

**Baseline/E2E** adds `Adapter.STRANDS` to the shared matrix and offline support
registry, using the core lane and its injectable model seam.

## A2A note (rebase on #488)

This PR originally carried a dual-version A2A compatibility layer (a2a-sdk 0.3 + 1.x
behind a `compat.py` boundary, with a legacy 0.3.26 CI lane). #488 landed on `main`
in the meantime with a full 1.x-only migration of the A2A integration, including
security and lifecycle fixes (JSON-RPC method allowlist, removal of the
unauthenticated task routes, route-shadowing fix, server socket release, task-cache
eviction, pre-migration terminal-state rehydration). The compatibility layer was
superseded and has been dropped from this PR; `main`'s 1.x-only implementation and
its `a2a-sdk>=1.1.2,<2` pin stand as-is.

Retained from that work:
- Import smoke tests for the standalone A2A examples
  (`tests/example_agents/a2a/test_example_imports.py`), so an example drifting from
  the installed SDK's API fails CI at import time. These now guard `main`'s migrated
  1.x examples and pass against them.
- Read-only `GITHUB_TOKEN` permissions on the CI and E2E workflows.

## Also in this PR

- `ToolEventKey` provides one vocabulary for execution-event payload keys.
- `lazy_exports` replaces repeated hand-rolled lazy import maps.
- E2E smokes cover contacts capability, memory rehydration, and per-instance
  concurrency markers (the concurrency smoke folds those markers into the widened
  `slow_turn_budget` deadlines that landed on `main`).

## Docs

Updates the README adapter and emit matrices, configuration example, and
`examples/strands/` provider and usage documentation.

## Verification

Rebased onto `main` @ 03065f5.

Offline:

```text
4371 unit tests passed, 85 skipped
ruff check: passed
ruff format --check: passed
pyrefly check: passed (0 errors)
uv lock --check: passed
```

Live E2E — dispatched `e2e.yml` with `lane=core` / `os=ubuntu` on this branch's head
(run 30638603739, all three jobs green):

```text
258 passed, 135 skipped, 4 rerun in 36m34s  (0 failed)
```

The Strands cells ran live and passed rather than skipping — directly observed in the
job log, including the cells that exercise this PR's load-bearing paths:

```text
test_tool_round_trip.py::test_custom_tool_round_trips[strands]                        PASSED
test_room_isolation.py::test_rooms_keep_isolated_context[strands]                     PASSED
test_rehydration_cross_framework.py::test_rehydrates_foreign_peer_message[strands]    PASSED
test_rehydration_idempotency.py::test_handled_work_not_redrained_on_restart[strands]  PASSED
test_rehydration_idempotency.py::test_restart_usage_splits_replay_and_inference[strands] PASSED
test_rehydration_offline.py::test_recalls_offline_note_on_cold_boot[strands]          PASSED
test_rehydration_partial.py::test_partial_reboot_preserves_context_and_peer[strands]  PASSED
test_peer_delegation.py::test_peer_initiated_delegation_with_self_recall[strands]     PASSED
test_participant_management.py::test_invites_messages_and_removes_a_peer[strands]     PASSED
```

The lane ran with `BAND_ALLOW_MISSING_FRAMEWORKS=0`, so an unwired framework fails
loudly instead of skipping; every skip in the run belongs to an out-of-lane adapter
(crewai, gemini, google_adk, letta, codex, opencode, copilot_acp), each covered by
its own lane.
