### PR TITLE
fix(examples): start ACP band-mcp with current console script

### DIFF
--- a/examples/acp/copilot_docker/colocated/.env.example
+++ b/examples/acp/copilot_docker/colocated/.env.example
@@ -5,7 +5,7 @@ GITHUB_TOKEN=
 # The single container is one Band identity; all tool calls act as this agent.
 BAND_AGENT_KEY=
 
-# Band platform endpoints (client.py uses these; THENVOI_BASE_URL for band-mcp
+# Band platform endpoints (client.py uses these; BAND_BASE_URL for band-mcp
 # defaults to BAND_REST_URL inside entrypoint.sh).
 BAND_REST_URL=https://app.band.ai
 BAND_WS_URL=wss://app.band.ai/api/v1/socket/websocket

--- a/examples/acp/copilot_docker/compose/.env.example
+++ b/examples/acp/copilot_docker/compose/.env.example
@@ -5,7 +5,7 @@ GITHUB_TOKEN=
 # band-mcp is one Band identity; all tool calls act as this agent.
 BAND_AGENT_KEY=
 
-# Band platform endpoints (client.py uses these; THENVOI_BASE_URL for band-mcp
+# Band platform endpoints (client.py uses these; BAND_BASE_URL for band-mcp
 # defaults to BAND_REST_URL in docker-compose.yml).
 BAND_REST_URL=https://app.band.ai
 BAND_WS_URL=wss://app.band.ai/api/v1/socket/websocket

--- a/examples/acp/copilot_docker/compose/Dockerfile.band-mcp
+++ b/examples/acp/copilot_docker/compose/Dockerfile.band-mcp
@@ -1,15 +1,16 @@
 # Band tools exposed over MCP (SSE) for a co-networked Copilot to call.
 #
-# band-mcp (PyPI: band-mcp; console script: thenvoi-mcp) speaks the older MCP SSE
+# band-mcp (PyPI: band-mcp; console script: band-mcp) speaks the older MCP SSE
 # transport (endpoint /sse), not streamable HTTP. It holds ONE Band identity via
 # an agent key it reads from its own environment; MCP clients present no creds.
 FROM python:3.12-slim
 
-RUN pip install --no-cache-dir band-mcp
+# Pin mcp<2: band-mcp 1.3.2 imports mcp.server.fastmcp, removed in mcp 2.0.
+RUN pip install --no-cache-dir "band-mcp>=1.3.2" "mcp>=1.23.0,<2"
 
 EXPOSE 3000
 
 # Bind 0.0.0.0 so the peer Copilot container can reach it over the compose network.
 # NOTE: SSE requests are rejected with HTTP 421 unless the caller's Host header is
 # allow-listed — ALLOWED_HOSTS is set in docker-compose.yml.
-CMD ["thenvoi-mcp", "--transport", "sse", "--host", "0.0.0.0", "--port", "3000"]
+CMD ["band-mcp", "--transport", "sse", "--host", "0.0.0.0", "--port", "3000"]

--- a/examples/acp/copilot_docker/compose/README.md
+++ b/examples/acp/copilot_docker/compose/README.md
@@ -20,7 +20,7 @@ process never resolves that name.
 |------|---------|
 | `docker-compose.yml` | Two services: `copilot` (ACP over TCP) + `band-mcp` (Band tools over SSE) |
 | `Dockerfile.copilot` | Copilot CLI + `socat` bridging `copilot --acp` (stdio) onto TCP `0.0.0.0:8080` |
-| `Dockerfile.band-mcp` | `pip install band-mcp`, run the `thenvoi-mcp` SSE server |
+| `Dockerfile.band-mcp` | `pip install band-mcp>=1.3.2`, run the `band-mcp` SSE server |
 | `client.py` | Host-side Band agent: TCP to Copilot, `inject_band_tools=False`, explicit MCP URL |
 | `.env.example` | Required secrets/endpoints |
 
@@ -69,6 +69,9 @@ and calls Band tools via band-mcp.
   reachable off-host. Widen it (behind your own auth) only for a remote SDK host.
 - **band-mcp uses SSE, not streamable HTTP.** The endpoint is `/sse`; the adapter's
   `mcp_servers` entry is `{"type": "sse", …}`.
+- **`mcp<2` pin.** `Dockerfile.band-mcp` installs `band-mcp>=1.3.2` with
+  `mcp>=1.23.0,<2` because band-mcp 1.3.2 imports `mcp.server.fastmcp`, which
+  mcp 2.0 removed.
 - **DNS-rebinding protection.** band-mcp rejects SSE requests with **HTTP 421**
   unless the caller's `Host` is allow-listed. `docker-compose.yml` sets
   `ALLOWED_HOSTS='["band-mcp:*"]'` (the compose-DNS name Copilot dials). Add your
@@ -91,8 +94,8 @@ and calls Band tools via band-mcp.
   call (scoped within that one identity). This differs from the SDK's in-process
   `inject_band_tools` path (which injects a `room_id` per tool) — expect the agent
   to reference `chat_id` when driven through band-mcp.
-- **Platform base URL.** band-mcp defaults to `https://app.thenvoi.com`; the
-  compose file points it at `BAND_REST_URL` (default `https://app.band.ai`).
+- **Platform base URL.** band-mcp (`BAND_BASE_URL`) defaults to `https://app.band.ai`;
+  the compose file points it at `BAND_REST_URL` (default `https://app.band.ai`).
 
 > This example is a deployment template — it needs Docker, live Band credentials,
 > and a Copilot-entitled token, so it is not run in CI.

--- a/examples/acp/copilot_docker/compose/docker-compose.yml
+++ b/examples/acp/copilot_docker/compose/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       # The MCP client (Copilot) sends no credentials, so keep this service off the
       # host network — it is a trusted sidecar reachable only within the compose net.
       BAND_AGENT_KEY: ${BAND_AGENT_KEY:?set BAND_AGENT_KEY in .env}
-      # Point band-mcp at your Band platform (its own default is app.thenvoi.com).
-      THENVOI_BASE_URL: ${BAND_REST_URL:-https://app.band.ai}
+      # Point band-mcp at your Band platform (its own default is https://app.band.ai).
+      BAND_BASE_URL: ${BAND_REST_URL:-https://app.band.ai}
       # Allow the compose-DNS host Copilot dials; without this every SSE request 421s.
       ALLOWED_HOSTS: '["band-mcp:*"]'
     expose:

--- a/examples/acp/copilot_sandbox/band-mcp-kit/README.md
+++ b/examples/acp/copilot_sandbox/band-mcp-kit/README.md
@@ -35,7 +35,7 @@ sandbox and calls Band tools through `band-mcp` on `127.0.0.1:3000`.
 
 - This is a local-sandbox deployment example, not a CI fixture.
 - The kit targets `https://app.band.ai`. For another Band deployment, update
-  `caps.network.allow`, `THENVOI_BASE_URL`, and the `--host` passed to
+  `caps.network.allow`, `BAND_BASE_URL`, and the `--host` passed to
   `sbx secret set-custom`.
 - `band-mcp` is one trusted Band identity. Keep it bound to loopback, as this kit
   does, unless you add your own network and auth controls.

--- a/examples/acp/copilot_sandbox/band-mcp-kit/spec.yaml
+++ b/examples/acp/copilot_sandbox/band-mcp-kit/spec.yaml
@@ -15,7 +15,7 @@ environment:
   variables:
     ALLOWED_HOSTS: '["localhost:*","127.0.0.1:*"]'
     BAND_AGENT_KEY: proxy-managed
-    THENVOI_BASE_URL: https://app.band.ai
+    BAND_BASE_URL: https://app.band.ai
 
 commands:
   install:
@@ -24,7 +24,7 @@ commands:
       description: Install band-mcp
   startup:
     - command:
-        - /home/agent/.local/bin/thenvoi-mcp
+        - /home/agent/.local/bin/band-mcp
         - --transport
         - sse
         - --host


### PR DESCRIPTION
## Summary
- Fix [INT-1129](https://linear.app/thenvoi/issue/INT-1129/acp-copilot-docker-compose-example-starts-removed-thenvoi-mcp): Compose `band-mcp` image and sandbox kit start the current `band-mcp` console script instead of the removed `thenvoi-mcp`.
- Wire `BAND_BASE_URL` (not dead `THENVOI_BASE_URL`) and pin `band-mcp>=1.3.2` with `mcp>=1.23.0,<2` so a clean build reaches SSE readiness (mcp 2.0 dropped `fastmcp`).
- Update related README / `.env.example` comments to match colocated.

## Test plan
- [x] `rg` clean for `thenvoi-mcp` / `THENVOI_BASE_URL` / `app.thenvoi.com` in changed trees
- [x] `docker compose … build --no-cache band-mcp` installs `band-mcp` (not `thenvoi-mcp`)
- [x] `docker compose … up band-mcp` stays running; logs show SSE on `0.0.0.0:3000`
- [x] Compose-network probe to `http://band-mcp:3000/sse` returns HTTP 200
- [x] Container env has `BAND_BASE_URL` from `BAND_REST_URL`
- [x] `sbx kit validate examples/acp/copilot_sandbox/band-mcp-kit`


Made with [Cursor](https://cursor.com)