### PR TITLE
fix: OneShotInvoker history pagination + participant roster surfacing

### DIFF
--- a/examples/agentcore/BUILDING.md
+++ b/examples/agentcore/BUILDING.md
@@ -251,6 +251,16 @@ Claude alongside the platform tools. See
 [`custom_tools_llm_server.py`](custom_tools_llm_server.py) for a full,
 runnable container variant wired this way.
 
+**Make side-effecting tools idempotent.** A container can die between a
+tool call completing and the message being marked processed; the platform
+then re-serves the same message to the next invocation, which replays the
+whole turn — including the tool call — from scratch. `OneShotInvoker` has
+no cross-process state to detect this (same boundary `single_instance.py`
+and `claims.py` document for the long-running path), so a tool that emails,
+charges, or writes to an external system needs its own idempotency (e.g. a
+key derived from the tool's own arguments) if being called twice would
+matter.
+
 ## Common gotchas
 
 - **The LLM might over-help.** Claude will try to address every

--- a/examples/agentcore/BUILDING.md
+++ b/examples/agentcore/BUILDING.md
@@ -223,27 +223,33 @@ same `AgentInput` regardless of which adapter consumes it.
 
 ### Adding custom tools
 
-The SDK supports custom tools via the adapter's `additional_tools` arg:
+The SDK supports custom tools via the adapter's `additional_tools` arg. A
+`CustomToolDef` is a `(InputModel, handler)` pair — a Pydantic model for the
+tool's arguments (its class name minus an optional `Input` suffix, lowercased,
+becomes the tool name) and an async or sync callable that takes a validated
+instance of that model:
 
 ```python
-from band.runtime.custom_tools import CustomToolDef
+from pydantic import BaseModel
 
-custom_tools = [
-    CustomToolDef(
-        name="search_company_db",
-        description="Look up a customer by name",
-        input_schema={...},
-        handler=async_handler,
-    )
-]
+class WeatherInput(BaseModel):
+    """Get the weather for a city."""
+
+    city: str
+
+async def get_weather(args: WeatherInput) -> str:
+    return f"{args.city}: sunny, 22°C"
+
 return AnthropicAdapter(
     ...,
-    additional_tools=custom_tools,
+    additional_tools=[(WeatherInput, get_weather)],
 )
 ```
 
-Custom tool schemas are merged with the SDK's built-in tools and exposed
-to Claude alongside the platform tools.
+Custom tool schemas are merged with the SDK's built-in tools and exposed to
+Claude alongside the platform tools. See
+[`custom_tools_llm_server.py`](custom_tools_llm_server.py) for a full,
+runnable container variant wired this way.
 
 ## Common gotchas
 

--- a/examples/agentcore/agentcore_llm_server.py
+++ b/examples/agentcore/agentcore_llm_server.py
@@ -90,7 +90,7 @@ def _build_adapter(anthropic_api_key: str) -> AnthropicAdapter:
     )
     return AnthropicAdapter(
         model=model,
-        api_key=anthropic_api_key,
+        provider_key=anthropic_api_key,
         prompt=system_prompt,
         features=AdapterFeatures(emit=emit),
     )

--- a/examples/agentcore/custom_tools_llm_server.py
+++ b/examples/agentcore/custom_tools_llm_server.py
@@ -80,7 +80,7 @@ def _build_adapter(anthropic_api_key: str) -> AnthropicAdapter:
     )
     return AnthropicAdapter(
         model=model,
-        api_key=anthropic_api_key,
+        provider_key=anthropic_api_key,
         prompt=system_prompt,
         features=AdapterFeatures(emit=emit),
         additional_tools=[(WeatherInput, get_weather)],

--- a/examples/agentcore/custom_tools_llm_server.py
+++ b/examples/agentcore/custom_tools_llm_server.py
@@ -1,0 +1,145 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "band-sdk[anthropic]",
+#   "fastapi>=0.110",
+#   "uvicorn>=0.29",
+#   "pydantic>=2",
+# ]
+#
+# [tool.uv.sources]
+# band-sdk = { git = "https://github.com/band-ai/band-sdk-python.git" }
+# ///
+"""AgentCore container variant with a custom tool wired in.
+
+Same shape as ``agentcore_llm_server.py`` (see that file for the full
+lifecycle/transport walkthrough). The only difference is ``_build_adapter``
+passing ``additional_tools`` — see BUILDING.md's "Adding custom tools"
+section.
+
+Environment variables: same as ``agentcore_llm_server.py``.
+
+Run locally::
+
+    BAND_AGENT_ID=... BAND_API_KEY=... ANTHROPIC_API_KEY=... \\
+        uv run python examples/agentcore/custom_tools_llm_server.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+
+from band.adapters.anthropic import AnthropicAdapter
+from band.core.types import AdapterFeatures, Emit
+from band.platform.link import BandLink
+from band.runtime.oneshot import OneShotEnvelopeError, OneShotInvoker
+
+logging.basicConfig(
+    level=getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), logging.INFO),
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value or not value.strip():
+        raise ValueError(f"{name} environment variable is required")
+    return value
+
+
+class WeatherInput(BaseModel):
+    """Get the weather for a city."""
+
+    city: str
+
+
+async def get_weather(args: WeatherInput) -> str:
+    """Deterministic stand-in for a real weather API."""
+    return f"{args.city}: sunny, 22°C"
+
+
+def _build_adapter(anthropic_api_key: str) -> AnthropicAdapter:
+    model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-5-20250929")
+    system_prompt = os.environ.get("SYSTEM_PROMPT")
+    emit_execution = os.environ.get("EMIT_EXECUTION", "true").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    emit: frozenset[Emit] = (
+        frozenset({Emit.EXECUTION}) if emit_execution else frozenset()
+    )
+    return AnthropicAdapter(
+        model=model,
+        api_key=anthropic_api_key,
+        prompt=system_prompt,
+        features=AdapterFeatures(emit=emit),
+        additional_tools=[(WeatherInput, get_weather)],
+    )
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    agent_id = _require_env("BAND_AGENT_ID")
+    api_key = _require_env("BAND_API_KEY")
+    anthropic_api_key = _require_env("ANTHROPIC_API_KEY")
+    ws_url = os.environ.get("BAND_WS_URL", "wss://app.band.ai/api/v1/socket/websocket")
+    rest_url = os.environ.get("BAND_REST_URL", "https://app.band.ai")
+
+    link = BandLink(
+        agent_id=agent_id, api_key=api_key, ws_url=ws_url, rest_url=rest_url
+    )
+    invoker = OneShotInvoker(
+        link=link,
+        adapter=_build_adapter(anthropic_api_key),
+        agent_id=agent_id,
+    )
+    await invoker.startup()
+    logger.info("Container ready: agent_id=%s name=%s", agent_id, invoker.agent_name)
+
+    app.state.invoker = invoker
+
+    try:
+        yield
+    finally:
+        await invoker.shutdown()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/ping")
+async def ping() -> dict[str, str]:
+    return {"status": "Healthy"}
+
+
+@app.post("/invocations")
+async def invocations(request: Request) -> dict[str, Any]:
+    invoker: OneShotInvoker = app.state.invoker
+    body = await request.json()
+    try:
+        return await invoker.handle_event(body)
+    except OneShotEnvelopeError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception:
+        logger.exception("invocation failed")
+        raise HTTPException(status_code=500, detail="invocation failed")
+
+
+def main() -> None:
+    port = int(os.environ.get("PORT", "8080"))
+    host = os.environ.get("HOST", "0.0.0.0")
+    uvicorn.run(app, host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/band/runtime/oneshot.py
+++ b/src/band/runtime/oneshot.py
@@ -474,13 +474,22 @@ class OneShotInvoker:
                     exc_info=True,
                 )
                 if page_num == 0:
-                    return [], set(), False
+                    return [], set(), True
                 truncated = True
                 break
             items.extend(response.data or [])
             if not response.metadata.has_more:
                 break
             cursor = response.metadata.next_cursor
+            if cursor is None:
+                logger.warning(
+                    "has_more=True but no next_cursor for room %s (page %d) — "
+                    "stopping pagination",
+                    room_id,
+                    page_num,
+                )
+                truncated = True
+                break
         else:
             truncated = True
             logger.warning(

--- a/src/band/runtime/oneshot.py
+++ b/src/band/runtime/oneshot.py
@@ -40,6 +40,7 @@ Example usage::
 from __future__ import annotations
 
 import logging
+from collections import deque
 from datetime import datetime, timezone
 from typing import Any
 
@@ -67,11 +68,18 @@ DEFAULT_DRAIN_CAP = 50
 # Items per page when following the context endpoint's cursor pagination.
 DEFAULT_HISTORY_LIMIT = 50
 
-# Defensive cap on how many pages of history to follow per invocation. A room
-# shouldn't backlog thousands of messages for a single agent in normal
-# operation; if it does, surface it via ``history_truncated`` rather than
-# paginating indefinitely on every stateless invocation.
+# How many of the most recent pages of history to retain per invocation. The
+# context endpoint is oldest-first with no way to request newest-first (see
+# ``_fetch_history``), so pagination always walks to the true end regardless
+# of this value — it only bounds memory/what reaches the LLM, never causes
+# the newest messages to be dropped in favor of older ones.
 DEFAULT_HISTORY_PAGE_CAP = 20
+
+# Absolute ceiling on pagination round-trips per invocation, independent of
+# how many pages are retained (``DEFAULT_HISTORY_PAGE_CAP``). Guards against
+# a backend that never reports ``has_more=False`` — hitting this is a
+# backend contract violation, not a real conversation length.
+DEFAULT_HISTORY_FETCH_CEILING = 500
 
 
 class OneShotEnvelopeError(ValueError):
@@ -93,8 +101,8 @@ class OneShotInvoker:
         agent_id: This container's Band agent identity (used for
             self-message filtering and the adapter's runtime identity).
         drain_cap: Defensive ceiling on the drain loop. Default 50.
-        history_page_cap: Defensive ceiling on how many pages of history to
-            follow per invocation. Default 20.
+        history_page_cap: How many of the most recent pages of history to
+            retain per invocation. Default 20.
     """
 
     def __init__(
@@ -446,17 +454,19 @@ class OneShotInvoker:
         swallows a message that arrived after this snapshot.
 
         Follows the endpoint's cursor pagination (``next_cursor``/
-        ``has_more``) rather than fetching a single page — ``page``/
-        ``page_size`` are deprecated on the real API and, single-page, would
-        silently drop any turn past the first page. Bounded by
-        ``self._history_page_cap``; the third return value reports whether
-        that cap (or a mid-pagination fetch failure) left history
-        incomplete.
+        ``has_more``) to the true end of the room's history — the endpoint
+        is oldest-first with no ``sort_order``/``before`` parameter, so
+        stopping early would keep the oldest pages and drop the newest ones,
+        including the turns the triggering message is replying to. Retains
+        only the trailing ``self._history_page_cap`` pages in memory; the
+        third return value reports whether any earlier pages were evicted
+        (or a mid-pagination fetch failure left history incomplete).
         """
-        items: list[Any] = []
+        pages: deque[list[Any]] = deque(maxlen=self._history_page_cap)
         cursor: str | None = None
+        fetched_pages = 0
         truncated = False
-        for page_num in range(self._history_page_cap):
+        for page_num in range(DEFAULT_HISTORY_FETCH_CEILING):
             try:
                 response = (
                     await self._link.rest.agent_api_context.get_agent_chat_context(
@@ -477,7 +487,8 @@ class OneShotInvoker:
                     return [], set(), True
                 truncated = True
                 break
-            items.extend(response.data or [])
+            pages.append(response.data or [])
+            fetched_pages += 1
             if not response.metadata.has_more:
                 break
             cursor = response.metadata.next_cursor
@@ -493,11 +504,16 @@ class OneShotInvoker:
         else:
             truncated = True
             logger.warning(
-                "Hit history page cap (%d) for room %s — history may be incomplete",
-                self._history_page_cap,
+                "Hit history fetch ceiling (%d) for room %s — backend never "
+                "reported has_more=False",
+                DEFAULT_HISTORY_FETCH_CEILING,
                 room_id,
             )
 
+        if fetched_pages > self._history_page_cap:
+            truncated = True
+
+        items = [item for page in pages for item in page]
         seen_ids = {item.id for item in items if getattr(item, "id", None)}
         raw_messages = [context_item_to_dict(item) for item in items]
         history = (

--- a/src/band/runtime/oneshot.py
+++ b/src/band/runtime/oneshot.py
@@ -49,7 +49,11 @@ from band.core.simple_adapter import SimpleAdapter
 from band.core.types import AgentInput, HistoryProvider, PlatformMessage
 from band.platform.link import BandLink
 from band.runtime.context_serialization import context_item_to_dict
-from band.runtime.formatters import format_history_for_llm, replace_uuid_mentions
+from band.runtime.formatters import (
+    build_participants_message,
+    format_history_for_llm,
+    replace_uuid_mentions,
+)
 from band.runtime.tools import AgentTools
 
 logger = logging.getLogger(__name__)
@@ -303,7 +307,12 @@ class OneShotInvoker:
                 msg=msg,
                 tools=tools,
                 history=HistoryProvider(raw=history),
-                participants_msg=None,
+                # OneShotInvoker has no cross-call state to diff the roster
+                # against, so every invocation is "first time" from that
+                # perspective — the same condition under which the
+                # long-running path itself sends the roster (see
+                # ExecutionContext.participants_changed).
+                participants_msg=build_participants_message(participants),
                 contacts_msg=None,
                 is_session_bootstrap=True,
                 room_id=room_id,

--- a/src/band/runtime/oneshot.py
+++ b/src/band/runtime/oneshot.py
@@ -60,6 +60,15 @@ logger = logging.getLogger(__name__)
 # ``drain_truncated`` rather than draining indefinitely.
 DEFAULT_DRAIN_CAP = 50
 
+# Items per page when following the context endpoint's cursor pagination.
+DEFAULT_HISTORY_LIMIT = 50
+
+# Defensive cap on how many pages of history to follow per invocation. A room
+# shouldn't backlog thousands of messages for a single agent in normal
+# operation; if it does, surface it via ``history_truncated`` rather than
+# paginating indefinitely on every stateless invocation.
+DEFAULT_HISTORY_PAGE_CAP = 20
+
 
 class OneShotEnvelopeError(ValueError):
     """Raised when the forwarded event envelope is missing required fields."""
@@ -80,6 +89,8 @@ class OneShotInvoker:
         agent_id: This container's Band agent identity (used for
             self-message filtering and the adapter's runtime identity).
         drain_cap: Defensive ceiling on the drain loop. Default 50.
+        history_page_cap: Defensive ceiling on how many pages of history to
+            follow per invocation. Default 20.
     """
 
     def __init__(
@@ -89,11 +100,13 @@ class OneShotInvoker:
         adapter: FrameworkAdapter | SimpleAdapter,
         agent_id: str,
         drain_cap: int = DEFAULT_DRAIN_CAP,
+        history_page_cap: int = DEFAULT_HISTORY_PAGE_CAP,
     ) -> None:
         self._link = link
         self._adapter = adapter
         self._agent_id = agent_id
         self._drain_cap = drain_cap
+        self._history_page_cap = history_page_cap
         self._agent_name: str = ""
         self._agent_description: str = ""
         self._started = False
@@ -274,7 +287,7 @@ class OneShotInvoker:
             sender_name = _lookup_sender_name(participants, payload.get("sender_id"))
 
             msg = _build_platform_message(payload, room_id, sender_name, participants)
-            history, seen_ids = await self._fetch_history(
+            history, seen_ids, history_truncated = await self._fetch_history(
                 room_id,
                 exclude_message_id=msg.id,
                 participants=participants,
@@ -374,6 +387,8 @@ class OneShotInvoker:
             result["drained"] = drained
         if drain_truncated:
             result["drain_truncated"] = True
+        if history_truncated:
+            result["history_truncated"] = True
         return result
 
     # --- REST helpers ---
@@ -416,24 +431,55 @@ class OneShotInvoker:
         *,
         exclude_message_id: str | None,
         participants: list[dict[str, Any]],
-    ) -> tuple[list[dict[str, Any]], set[str]]:
+    ) -> tuple[list[dict[str, Any]], set[str], bool]:
         """Fetch room history formatted for the LLM, plus the set of message
         ids the LLM will see. The id set scopes the drain loop so it never
         swallows a message that arrived after this snapshot.
+
+        Follows the endpoint's cursor pagination (``next_cursor``/
+        ``has_more``) rather than fetching a single page — ``page``/
+        ``page_size`` are deprecated on the real API and, single-page, would
+        silently drop any turn past the first page. Bounded by
+        ``self._history_page_cap``; the third return value reports whether
+        that cap (or a mid-pagination fetch failure) left history
+        incomplete.
         """
-        try:
-            response = await self._link.rest.agent_api_context.get_agent_chat_context(
-                chat_id=room_id,
-                page=1,
-                page_size=50,
-                request_options=DEFAULT_REQUEST_OPTIONS,
-            )
-        except Exception:
+        items: list[Any] = []
+        cursor: str | None = None
+        truncated = False
+        for page_num in range(self._history_page_cap):
+            try:
+                response = (
+                    await self._link.rest.agent_api_context.get_agent_chat_context(
+                        chat_id=room_id,
+                        cursor=cursor,
+                        limit=DEFAULT_HISTORY_LIMIT,
+                        request_options=DEFAULT_REQUEST_OPTIONS,
+                    )
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to fetch history for room %s (page %d)",
+                    room_id,
+                    page_num,
+                    exc_info=True,
+                )
+                if page_num == 0:
+                    return [], set(), False
+                truncated = True
+                break
+            items.extend(response.data or [])
+            if not response.metadata.has_more:
+                break
+            cursor = response.metadata.next_cursor
+        else:
+            truncated = True
             logger.warning(
-                "Failed to fetch history for room %s", room_id, exc_info=True
+                "Hit history page cap (%d) for room %s — history may be incomplete",
+                self._history_page_cap,
+                room_id,
             )
-            return [], set()
-        items = response.data or []
+
         seen_ids = {item.id for item in items if getattr(item, "id", None)}
         raw_messages = [context_item_to_dict(item) for item in items]
         history = (
@@ -444,7 +490,7 @@ class OneShotInvoker:
             )
             or []
         )
-        return history, seen_ids
+        return history, seen_ids, truncated
 
 
 # --- Module-level helpers (no state, easy to unit-test) ---

--- a/tests/agentcore_container/test_custom_tools_container.py
+++ b/tests/agentcore_container/test_custom_tools_container.py
@@ -1,0 +1,132 @@
+"""Tests for examples/agentcore/custom_tools_llm_server.py.
+
+Same shape as test_container.py (see that file for the boilerplate rationale).
+This module additionally covers the custom-tool wiring that distinguishes
+this variant: the ``WeatherInput``/``get_weather`` pair passed as
+``additional_tools`` to the adapter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from types import ModuleType
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from band.runtime.oneshot import OneShotEnvelopeError
+from tests.loaders import load_script_module
+from tests.paths import EXAMPLES_ROOT
+
+_CONTAINER_PATH = EXAMPLES_ROOT / "agentcore" / "custom_tools_llm_server.py"
+
+
+def _load_container_module() -> ModuleType:
+    # Provide env vars so the module imports cleanly (lifespan is lazy, not eager)
+    os.environ.setdefault("BAND_AGENT_ID", "test-agent")
+    os.environ.setdefault("BAND_API_KEY", "test-key")
+    os.environ.setdefault("ANTHROPIC_API_KEY", "test-anthropic")
+    return load_script_module(_CONTAINER_PATH, "custom_tools_llm_server")
+
+
+container = _load_container_module()
+
+
+class _FakeRequest:
+    """Minimal stand-in for a Starlette Request — only .json() is used."""
+
+    def __init__(self, body: dict[str, Any]) -> None:
+        self._body = body
+
+    async def json(self) -> dict[str, Any]:
+        return self._body
+
+
+def _set_invoker(handle_event: AsyncMock) -> MagicMock:
+    """Install a mock OneShotInvoker on app.state and return it."""
+    invoker = MagicMock()
+    invoker.handle_event = handle_event
+    container.app.state.invoker = invoker
+    return invoker
+
+
+# ---------------------------------------------------------------------------
+# Custom tool wiring
+# ---------------------------------------------------------------------------
+
+
+class TestWeatherTool:
+    async def test_get_weather_reports_city(self) -> None:
+        args = container.WeatherInput(city="Lisbon")
+        assert await container.get_weather(args) == "Lisbon: sunny, 22°C"
+
+    def test_build_adapter_registers_weather_tool(self) -> None:
+        adapter = container._build_adapter("test-anthropic")
+        assert adapter._custom_tools == [
+            (container.WeatherInput, container.get_weather)
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Env parsing
+# ---------------------------------------------------------------------------
+
+
+class TestRequireEnv:
+    def test_returns_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("__TEST_VAR__", "value")
+        assert container._require_env("__TEST_VAR__") == "value"
+
+    def test_raises_on_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("__TEST_VAR__", raising=False)
+        with pytest.raises(ValueError, match="__TEST_VAR__"):
+            container._require_env("__TEST_VAR__")
+
+    def test_raises_on_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("__TEST_VAR__", "   ")
+        with pytest.raises(ValueError, match="__TEST_VAR__"):
+            container._require_env("__TEST_VAR__")
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+class TestPingEndpoint:
+    def test_returns_healthy(self) -> None:
+        assert asyncio.run(container.ping()) == {"status": "Healthy"}
+
+
+class TestInvocationsRoute:
+    async def test_delegates_to_invoker(self) -> None:
+        handle_event = AsyncMock(return_value={"status": "done", "message_id": "m1"})
+        invoker = _set_invoker(handle_event)
+        body = {"event_type": "message_created", "room_id": "r1", "payload": {}}
+
+        result = await container.invocations(_FakeRequest(body))
+
+        assert result == {"status": "done", "message_id": "m1"}
+        handle_event.assert_awaited_once_with(body)
+        # Route is a pure pass-through; it doesn't inspect the body itself.
+        assert invoker.handle_event is handle_event
+
+    async def test_envelope_error_maps_to_400(self) -> None:
+        _set_invoker(AsyncMock(side_effect=OneShotEnvelopeError("missing room_id")))
+        body = {"event_type": "message_created", "payload": {"id": "m1"}}
+
+        with pytest.raises(HTTPException) as exc:
+            await container.invocations(_FakeRequest(body))
+        assert exc.value.status_code == 400
+        assert "room_id" in exc.value.detail
+
+    async def test_unexpected_error_maps_to_500(self) -> None:
+        _set_invoker(AsyncMock(side_effect=RuntimeError("boom")))
+        body = {"event_type": "message_created", "room_id": "r1", "payload": {}}
+
+        with pytest.raises(HTTPException) as exc:
+            await container.invocations(_FakeRequest(body))
+        assert exc.value.status_code == 500

--- a/tests/e2e/vscode/server.py
+++ b/tests/e2e/vscode/server.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import socket
+
+from tests.ports import reserve_port
 
 logger = logging.getLogger(__name__)
 
@@ -29,17 +30,6 @@ READY_TIMEOUT_S = 30.0
 STOP_TIMEOUT_S = 10.0
 
 
-def _reserve_port() -> int:
-    """Take one ephemeral loopback port from the OS, then release it for the server.
-
-    The close→rebind gap is the standard reservation race — acceptable for a
-    single local server (mirrors ``parlant_server._reserve_two_ports``).
-    """
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
-
-
 class BandMCPServer:
     """Lifecycle of one band-mcp SSE subprocess bound to a stable loopback port."""
 
@@ -52,7 +42,7 @@ class BandMCPServer:
         self._command = command
         self._agent_key = agent_key
         self._base_url = base_url
-        self._port = port or _reserve_port()
+        self._port = port or reserve_port()
         self._process: asyncio.subprocess.Process | None = None
 
     @property

--- a/tests/integration/test_agentcore_concurrency.py
+++ b/tests/integration/test_agentcore_concurrency.py
@@ -1,0 +1,118 @@
+"""Integration test: concurrent AgentCore container instances on one host.
+
+Verifies INT-527's L3 "co-resident instances" requirement for the AgentCore
+container: N instances must start independently with no manual per-instance
+configuration beyond a port, and no port, lock-file, or shared-resource
+collision.
+
+Each instance's startup() makes a real Band REST call (fetching agent
+identity), so this needs BAND_API_KEY/TEST_AGENT_ID from .env.test.
+ANTHROPIC_API_KEY is a dummy — no turn is ever driven through /invocations,
+so proving this property needs no real LLM key.
+
+Run with: uv run pytest tests/integration/test_agentcore_concurrency.py -v -s
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+from tests.conftest_integration import get_api_key, get_base_url, get_test_agent_id
+from tests.integration.conftest import requires_api
+from tests.paths import EXAMPLES_ROOT
+
+_SCRIPT = EXAMPLES_ROOT / "agentcore" / "custom_tools_llm_server.py"
+_STARTUP_TIMEOUT = 15.0
+_POLL_INTERVAL = 0.5
+
+
+def _spawn(port: int) -> subprocess.Popen[str]:
+    env = {
+        **os.environ,
+        "BAND_AGENT_ID": get_test_agent_id() or "",
+        "BAND_API_KEY": get_api_key() or "",
+        "ANTHROPIC_API_KEY": "test-anthropic",
+        "BAND_REST_URL": get_base_url(),
+        "PORT": str(port),
+        "LOG_LEVEL": "WARNING",
+    }
+    return subprocess.Popen(
+        [sys.executable, str(_SCRIPT)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def _terminate(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _wait_for_ping(port: int, deadline: float) -> str:
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/ping", timeout=2
+            ) as resp:
+                return resp.read().decode()
+        except (urllib.error.URLError, ConnectionError) as e:
+            last_error = e
+            time.sleep(_POLL_INTERVAL)
+    raise TimeoutError(f"port {port} never answered /ping: {last_error}")
+
+
+@requires_api
+class TestConcurrentContainerInstances:
+    """L3 co-resident instances: no port, lock-file, or shared-resource collision."""
+
+    def test_three_instances_start_independently_on_one_host(self) -> None:
+        ports = [8191, 8192, 8193]
+        procs = [_spawn(port) for port in ports]
+        deadline = time.monotonic() + _STARTUP_TIMEOUT
+        try:
+            for port, proc in zip(ports, procs):
+                if proc.poll() is not None:
+                    out = proc.stdout.read() if proc.stdout else ""
+                    pytest.fail(f"port {port} exited early ({proc.returncode}):\n{out}")
+                assert "Healthy" in _wait_for_ping(port, deadline)
+        finally:
+            for proc in procs:
+                _terminate(proc)
+
+    def test_reusing_a_bound_port_fails_at_the_socket_not_the_app(self) -> None:
+        """The only per-instance resource is the port — nothing else
+        silently collides. A deliberate port clash fails at the OS bind
+        step, not because of a shared lock file or app-level singleton.
+        """
+        port = 8194
+        holder = _spawn(port)
+        try:
+            _wait_for_ping(port, time.monotonic() + _STARTUP_TIMEOUT)
+
+            clasher = _spawn(port)
+            try:
+                returncode = clasher.wait(timeout=10)
+                out = clasher.stdout.read() if clasher.stdout else ""
+            finally:
+                _terminate(clasher)
+
+            assert returncode != 0
+            assert "address already in use" in out
+        finally:
+            _terminate(holder)

--- a/tests/integration/test_agentcore_concurrency.py
+++ b/tests/integration/test_agentcore_concurrency.py
@@ -16,7 +16,6 @@ Run with: uv run pytest tests/integration/test_agentcore_concurrency.py -v -s
 from __future__ import annotations
 
 import os
-import socket
 import subprocess
 import sys
 import time
@@ -28,16 +27,11 @@ import pytest
 from tests.conftest_integration import get_api_key, get_base_url, get_test_agent_id
 from tests.integration.conftest import requires_api
 from tests.paths import EXAMPLES_ROOT
+from tests.ports import reserve_port
 
 _SCRIPT = EXAMPLES_ROOT / "agentcore" / "custom_tools_llm_server.py"
 _STARTUP_TIMEOUT = 15.0
 _POLL_INTERVAL = 0.5
-
-
-def _free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
 
 
 def _spawn(port: int) -> subprocess.Popen[str]:
@@ -89,7 +83,7 @@ class TestConcurrentContainerInstances:
     """L3 co-resident instances: no port, lock-file, or shared-resource collision."""
 
     def test_three_instances_start_independently_on_one_host(self) -> None:
-        ports = [_free_port(), _free_port(), _free_port()]
+        ports = [reserve_port(), reserve_port(), reserve_port()]
         procs = [_spawn(port) for port in ports]
         deadline = time.monotonic() + _STARTUP_TIMEOUT
         try:
@@ -107,7 +101,7 @@ class TestConcurrentContainerInstances:
         silently collides. A deliberate port clash fails at the OS bind
         step, not because of a shared lock file or app-level singleton.
         """
-        port = _free_port()
+        port = reserve_port()
         holder = _spawn(port)
         try:
             _wait_for_ping(port, time.monotonic() + _STARTUP_TIMEOUT)

--- a/tests/integration/test_agentcore_concurrency.py
+++ b/tests/integration/test_agentcore_concurrency.py
@@ -16,6 +16,7 @@ Run with: uv run pytest tests/integration/test_agentcore_concurrency.py -v -s
 from __future__ import annotations
 
 import os
+import socket
 import subprocess
 import sys
 import time
@@ -31,6 +32,12 @@ from tests.paths import EXAMPLES_ROOT
 _SCRIPT = EXAMPLES_ROOT / "agentcore" / "custom_tools_llm_server.py"
 _STARTUP_TIMEOUT = 15.0
 _POLL_INTERVAL = 0.5
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
 
 
 def _spawn(port: int) -> subprocess.Popen[str]:
@@ -82,7 +89,7 @@ class TestConcurrentContainerInstances:
     """L3 co-resident instances: no port, lock-file, or shared-resource collision."""
 
     def test_three_instances_start_independently_on_one_host(self) -> None:
-        ports = [8191, 8192, 8193]
+        ports = [_free_port(), _free_port(), _free_port()]
         procs = [_spawn(port) for port in ports]
         deadline = time.monotonic() + _STARTUP_TIMEOUT
         try:
@@ -100,19 +107,25 @@ class TestConcurrentContainerInstances:
         silently collides. A deliberate port clash fails at the OS bind
         step, not because of a shared lock file or app-level singleton.
         """
-        port = 8194
+        port = _free_port()
         holder = _spawn(port)
         try:
             _wait_for_ping(port, time.monotonic() + _STARTUP_TIMEOUT)
 
             clasher = _spawn(port)
             try:
-                returncode = clasher.wait(timeout=10)
-                out = clasher.stdout.read() if clasher.stdout else ""
-            finally:
-                _terminate(clasher)
+                # communicate() drains stdout while waiting — a plain wait()
+                # risks deadlock if the child blocks on a full pipe buffer.
+                out, _ = clasher.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                clasher.kill()
+                out, _ = clasher.communicate()
+            returncode = clasher.returncode
 
             assert returncode != 0
-            assert "address already in use" in out
+            # asyncio's own bind-error wrapper text (stdlib, same across
+            # platforms) — the OSError strerror after it is OS-specific
+            # ("address already in use" vs. Windows' own wording).
+            assert "attempting to bind" in out
         finally:
             _terminate(holder)

--- a/tests/ports.py
+++ b/tests/ports.py
@@ -1,0 +1,28 @@
+"""Ephemeral port reservation shared across the test suite.
+
+Deliberately a plain module, matching ``tests/paths.py`` and
+``tests/loaders.py`` — a single, tiny, import-time helper, not conftest
+fixtures.
+"""
+
+from __future__ import annotations
+
+import socket
+
+__all__ = ["reserve_port"]
+
+
+def reserve_port(host: str = "127.0.0.1") -> int:
+    """Take one ephemeral port from the OS, then release it for the caller.
+
+    The close-then-rebind gap is the standard ephemeral-port reservation
+    race — acceptable for a single local server or subprocess. For a
+    dual-port case with host-specific quirks (e.g. Parlant's hardcoded
+    tool-service host), see
+    ``band.integrations.parlant.ports.reserve_server_ports`` instead — that
+    one is shaped around Parlant's own constraints, not a general-purpose
+    counterpart to this.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return sock.getsockname()[1]

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -1,0 +1,189 @@
+"""Shared REST/BandLink test doubles for tests/runtime.
+
+These build real ``band_rest`` (Fern-generated) model instances and the
+``band.core.types.PlatformMessage`` OneShotInvoker actually type-annotates
+against — not bare MagicMocks — so a real schema change (a renamed field, a
+newly required one, ``data`` widening from a bare list to Optional) breaks
+these fixtures the same way it would break production, instead of a loose
+mock silently tolerating the drift.
+
+Note: ``band.runtime.types.PlatformMessage`` (used by the root
+``tests/conftest.py`` WS-event builders) is a *different* class from
+``band.core.types.PlatformMessage`` used here — the two aren't
+interchangeable, so don't reach for ``sample_platform_message`` from the root
+conftest when building oneshot/REST-side fixtures.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from band_rest import (
+    AgentMe,
+    ChatMessage,
+    ChatParticipant,
+    GetAgentChatContextResponse,
+    GetAgentChatContextResponseMetadata,
+    GetAgentMeResponse,
+    ListAgentChatParticipantsResponse,
+)
+
+from band.core.types import PlatformMessage
+
+
+def make_participant(p: dict[str, Any]) -> ChatParticipant:
+    return ChatParticipant(
+        id=p["id"],
+        name=p["name"],
+        type=p["type"],
+        handle=p.get("handle"),
+        role="member",
+        status="active",
+    )
+
+
+def platform_msg(
+    msg_id: str, *, sender_type: str = "User", sender_id: str = "user-1"
+) -> PlatformMessage:
+    """Stand-in for a PlatformMessage from get_next_message. Callers
+    typically only care about ``id``/``sender_type``/``sender_id``; the rest
+    are real required fields on the dataclass, filled with plausible values.
+    """
+    return PlatformMessage(
+        id=msg_id,
+        room_id="room-1",
+        content="hello",
+        sender_id=sender_id,
+        sender_type=sender_type,
+        sender_name=None,
+        message_type="user",
+        metadata=None,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def ctx_item(
+    msg_id: str,
+    *,
+    content: str = "hi",
+    sender_id: str = "user-1",
+    sender_type: str = "User",
+    sender_name: str = "Alice",
+) -> ChatMessage:
+    """A context item as returned by get_agent_chat_context."""
+    return ChatMessage(
+        id=msg_id,
+        content=content,
+        sender_id=sender_id,
+        sender_type=sender_type,
+        sender_name=sender_name,
+        message_type="user",
+        metadata={},
+        inserted_at=datetime(2026, 5, 21, 10, 0, tzinfo=timezone.utc),
+    )
+
+
+def make_link_mock(
+    participants: list[dict[str, Any]] | None = None,
+    history_items: list[ChatMessage] | None = None,
+    next_messages: list[PlatformMessage | None] | None = None,
+    *,
+    agent_name: str = "TestBot",
+    agent_description: str = "a test agent",
+    history_pages: list[list[ChatMessage]] | None = None,
+) -> MagicMock:
+    """Build a fake BandLink.
+
+    ``next_messages`` controls successive ``get_next_message`` returns; once
+    exhausted, all further calls return ``None``. The identity endpoint is
+    stubbed so ``startup()`` succeeds. Only the async REST *calls* are
+    mocked — everything they return is a real ``band_rest`` model instance,
+    so the response shape (required fields, ``data`` never ``None`` for a
+    list field, cursor-based pagination metadata) matches what the live API
+    actually sends.
+
+    ``history_pages`` models the context endpoint's cursor pagination across
+    multiple invocations: page *n*'s response has ``has_more=True`` and a
+    ``next_cursor`` until the last page. Give either this or ``history_items``
+    (a single-page shorthand), not both.
+    """
+    link = MagicMock()
+
+    # Identity (for startup()).
+    identity_response = GetAgentMeResponse(
+        data=AgentMe(
+            handle="test/bot",
+            id="agent-1",
+            inserted_at=datetime.now(timezone.utc),
+            name=agent_name,
+            description=agent_description,
+            owner_uuid="owner-1",
+            updated_at=datetime.now(timezone.utc),
+        )
+    )
+    link.rest.agent_api_identity.get_agent_me = AsyncMock(
+        return_value=identity_response
+    )
+
+    # Participants. ``data`` is a bare (never Optional) list on the real
+    # response type — an empty room is `[]`, not `None`.
+    participants_response = ListAgentChatParticipantsResponse(
+        data=[make_participant(p) for p in (participants or [])]
+    )
+    link.rest.agent_api_participants.list_agent_chat_participants = AsyncMock(
+        return_value=participants_response
+    )
+
+    # History / context. Metadata is cursor-based (``has_more``/
+    # ``next_cursor``); ``page``/``page_size`` on the request side are
+    # documented deprecated on the real client.
+    if history_pages is not None:
+        cursors: list[str | None] = [f"cursor-{i}" for i in range(len(history_pages))]
+        responses_by_cursor: dict[str | None, GetAgentChatContextResponse] = {}
+        for i, page_items in enumerate(history_pages):
+            is_last = i == len(history_pages) - 1
+            requested_by = None if i == 0 else cursors[i - 1]
+            responses_by_cursor[requested_by] = GetAgentChatContextResponse(
+                data=page_items,
+                metadata=GetAgentChatContextResponseMetadata(
+                    has_more=not is_last,
+                    limit=50,
+                    next_cursor=None if is_last else cursors[i],
+                ),
+            )
+
+        async def _get_context(
+            *_args: Any, cursor: str | None = None, **_kwargs: Any
+        ) -> GetAgentChatContextResponse:
+            return responses_by_cursor[cursor]
+
+        link.rest.agent_api_context.get_agent_chat_context = AsyncMock(
+            side_effect=_get_context
+        )
+    else:
+        context_response = GetAgentChatContextResponse(
+            data=history_items or [],
+            metadata=GetAgentChatContextResponseMetadata(
+                has_more=False,
+                limit=50,
+                next_cursor=None,
+            ),
+        )
+        link.rest.agent_api_context.get_agent_chat_context = AsyncMock(
+            return_value=context_response
+        )
+
+    # Lifecycle markers.
+    sequence = list(next_messages or [])
+
+    async def _get_next(*_args: Any, **_kwargs: Any) -> PlatformMessage | None:
+        return sequence.pop(0) if sequence else None
+
+    link.get_next_message = AsyncMock(side_effect=_get_next)
+    link.mark_processing = AsyncMock()
+    link.mark_processed = AsyncMock()
+    link.mark_failed = AsyncMock()
+    link.disconnect = AsyncMock()
+    return link

--- a/tests/runtime/test_oneshot.py
+++ b/tests/runtime/test_oneshot.py
@@ -14,7 +14,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from anthropic.types import ToolUseBlock
-from band_rest import CreateAgentChatMessageResponse, MessageSentResponse
+from band_rest import (
+    CreateAgentChatMessageResponse,
+    GetAgentChatContextResponse,
+    GetAgentChatContextResponseMetadata,
+    MessageSentResponse,
+)
 from pydantic import BaseModel, Field
 
 from band.adapters.anthropic import AnthropicAdapter
@@ -551,6 +556,53 @@ class TestHistoryPagination:
 
         result = await invoker.handle_event(_msg_body())
 
+        assert result["history_truncated"] is True
+
+    async def test_first_page_fetch_failure_is_reported_as_truncated(self) -> None:
+        """A page-0 fetch failure is the worst case of "history incomplete" —
+        the LLM runs with zero history instead of some. It must not be
+        reported identically to a fully successful fetch.
+        """
+        link = make_link_mock(next_messages=[platform_msg("msg-1"), None])
+        link.rest.agent_api_context.get_agent_chat_context = AsyncMock(
+            side_effect=RuntimeError("context endpoint unavailable")
+        )
+        adapter = _make_adapter_mock()
+        invoker = await _make_invoker(link, adapter)
+
+        result = await invoker.handle_event(_msg_body())
+
+        assert adapter.received_input.history.raw == []
+        assert result["history_truncated"] is True
+
+    async def test_has_more_without_a_next_cursor_stops_instead_of_looping(
+        self,
+    ) -> None:
+        """``has_more=True`` with no ``next_cursor`` is a backend contract
+        violation the response type doesn't rule out (``next_cursor`` is
+        ``Optional``). Re-requesting with ``cursor=None`` would just refetch
+        page 0 forever (until the page cap) and duplicate its items — this
+        must instead stop after one page and say so honestly.
+        """
+        link = make_link_mock(next_messages=[platform_msg("msg-1"), None])
+        malformed_response = GetAgentChatContextResponse(
+            data=[ctx_item("hist-1", content="page with a broken cursor contract")],
+            metadata=GetAgentChatContextResponseMetadata(
+                has_more=True,
+                limit=50,
+                next_cursor=None,
+            ),
+        )
+        get_context = AsyncMock(return_value=malformed_response)
+        link.rest.agent_api_context.get_agent_chat_context = get_context
+        adapter = _make_adapter_mock()
+        invoker = await _make_invoker(link, adapter, history_page_cap=5)
+
+        result = await invoker.handle_event(_msg_body())
+
+        get_context.assert_awaited_once()
+        history_content = [m["content"] for m in adapter.received_input.history.raw]
+        assert history_content.count("page with a broken cursor contract") == 1
         assert result["history_truncated"] is True
 
 

--- a/tests/runtime/test_oneshot.py
+++ b/tests/runtime/test_oneshot.py
@@ -539,10 +539,15 @@ class TestHistoryPagination:
         self,
     ) -> None:
         """A room that's been running for months can carry far more history
-        than any one page holds. The agent still has to answer promptly, so
-        it stops at a bound rather than replaying the entire backlog on every
-        message — and says so honestly instead of presenting a partial
-        conversation as the whole thing.
+        than the retention window holds. The agent still has to answer
+        promptly, so it keeps only the trailing pages rather than replaying
+        the entire backlog on every message — and says so honestly instead
+        of presenting a partial conversation as the whole thing.
+
+        Critically, "partial" must mean the *most recent* days, not the
+        oldest ones — the endpoint is oldest-first with no way to request
+        newest-first, so pagination has to walk to the true end and evict
+        old pages, never stop early and keep the stale ones.
         """
         months_of_daily_updates = [
             [ctx_item(f"hist-{day}", content=f"day {day} update")] for day in range(5)
@@ -556,6 +561,15 @@ class TestHistoryPagination:
 
         result = await invoker.handle_event(_msg_body())
 
+        get_context = link.rest.agent_api_context.get_agent_chat_context
+        assert get_context.await_count == 5  # walked to the true end, not the cap
+
+        history_content = [m["content"] for m in adapter.received_input.history.raw]
+        assert history_content == [
+            "day 2 update",
+            "day 3 update",
+            "day 4 update",
+        ]
         assert result["history_truncated"] is True
 
     async def test_first_page_fetch_failure_is_reported_as_truncated(self) -> None:

--- a/tests/runtime/test_oneshot.py
+++ b/tests/runtime/test_oneshot.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from band.runtime.formatters import build_participants_message
 from band.runtime.oneshot import (
     OneShotEnvelopeError,
     OneShotInvoker,
@@ -21,119 +22,32 @@ from band.runtime.oneshot import (
     _lookup_sender_name,
     _parse_inserted_at,
 )
+from tests.runtime.conftest import ctx_item, make_link_mock, platform_msg
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers local to this file. The BandLink/REST fakes (make_link_mock,
+# platform_msg, ctx_item) live in tests/runtime/conftest.py — shared with
+# other tests/runtime files, real band_rest model instances rather than bare
+# MagicMocks.
 # ---------------------------------------------------------------------------
-
-
-def _make_participant_mock(p: dict[str, Any]) -> MagicMock:
-    """Build a participant mock. ``name`` must be set after construction —
-    passing ``name=`` to MagicMock() sets the mock's identity, not its
-    ``.name`` attribute.
-    """
-    mock = MagicMock(id=p["id"], type=p["type"], handle=p.get("handle"))
-    mock.name = p["name"]
-    return mock
-
-
-def _platform_msg(
-    msg_id: str, *, sender_type: str = "User", sender_id: str = "user-1"
-) -> MagicMock:
-    """Stand-in for a PlatformMessage from get_next_message. The drain loop
-    reads ``id``, ``sender_type``, and ``sender_id``.
-    """
-    m = MagicMock()
-    m.id = msg_id
-    m.sender_type = sender_type
-    m.sender_id = sender_id
-    return m
-
-
-def _ctx_item(
-    msg_id: str,
-    *,
-    content: str = "hi",
-    sender_id: str = "user-1",
-    sender_type: str = "User",
-    sender_name: str = "Alice",
-) -> MagicMock:
-    """A context item as returned by get_agent_chat_context. Real string
-    attributes so context_item_to_dict + format_history_for_llm don't choke.
-    """
-    item = MagicMock()
-    item.id = msg_id
-    item.content = content
-    item.sender_id = sender_id
-    item.sender_type = sender_type
-    item.sender_name = sender_name
-    item.message_type = "user"
-    item.metadata = {}
-    item.inserted_at = "2026-05-21T10:00:00Z"
-    return item
-
-
-def _make_link_mock(
-    participants: list[dict[str, Any]] | None = None,
-    history_items: list[Any] | None = None,
-    next_messages: list[MagicMock | None] | None = None,
-    *,
-    agent_name: str = "TestBot",
-    agent_description: str = "a test agent",
-) -> MagicMock:
-    """Build a fake BandLink.
-
-    ``next_messages`` controls successive ``get_next_message`` returns; once
-    exhausted, all further calls return ``None``. The identity endpoint is
-    stubbed so ``startup()`` succeeds.
-    """
-    link = MagicMock()
-
-    # Identity (for startup()).
-    agent_me = MagicMock()
-    agent_me.name = agent_name
-    agent_me.description = agent_description
-    identity_response = MagicMock()
-    identity_response.data = agent_me
-    link.rest.agent_api_identity.get_agent_me = AsyncMock(
-        return_value=identity_response
-    )
-
-    # Participants.
-    participants_response = MagicMock()
-    participants_response.data = [
-        _make_participant_mock(p) for p in (participants or [])
-    ] or None
-    link.rest.agent_api_participants.list_agent_chat_participants = AsyncMock(
-        return_value=participants_response
-    )
-
-    # History / context.
-    context_response = MagicMock()
-    context_response.data = history_items or []
-    link.rest.agent_api_context.get_agent_chat_context = AsyncMock(
-        return_value=context_response
-    )
-
-    # Lifecycle markers.
-    sequence = list(next_messages or [])
-
-    async def _get_next(*_args: Any, **_kwargs: Any) -> MagicMock | None:
-        return sequence.pop(0) if sequence else None
-
-    link.get_next_message = AsyncMock(side_effect=_get_next)
-    link.mark_processing = AsyncMock()
-    link.mark_processed = AsyncMock()
-    link.mark_failed = AsyncMock()
-    link.disconnect = AsyncMock()
-    return link
 
 
 def _make_adapter_mock() -> MagicMock:
+    """A fake adapter that records the AgentInput it was run with as a plain
+    ``received_input`` attribute — reading that is what a test should assert
+    on, rather than reaching into ``on_event.call_args.args[0]``. Still an
+    AsyncMock underneath, so ``on_event.assert_awaited_once()`` etc. keep
+    working unchanged.
+    """
     adapter = MagicMock()
+    adapter.received_input = None
+
+    async def _capture(inp: Any) -> None:
+        adapter.received_input = inp
+
     adapter.on_started = AsyncMock()
-    adapter.on_event = AsyncMock()
+    adapter.on_event = AsyncMock(side_effect=_capture)
     adapter.on_cleanup = AsyncMock()
     return adapter
 
@@ -144,12 +58,14 @@ async def _make_invoker(
     *,
     agent_id: str = "agent-1",
     drain_cap: int = 50,
+    history_page_cap: int = 20,
 ) -> OneShotInvoker:
     invoker = OneShotInvoker(
         link=link,
         adapter=adapter or _make_adapter_mock(),
         agent_id=agent_id,
         drain_cap=drain_cap,
+        history_page_cap=history_page_cap,
     )
     await invoker.startup()
     return invoker
@@ -264,7 +180,7 @@ class TestBuildPlatformMessage:
 
 class TestStartup:
     async def test_fetches_metadata_and_primes_adapter(self) -> None:
-        link = _make_link_mock(agent_name="Weather", agent_description="forecasts")
+        link = make_link_mock(agent_name="Weather", agent_description="forecasts")
         adapter = _make_adapter_mock()
         invoker = OneShotInvoker(link=link, adapter=adapter, agent_id="agent-1")
 
@@ -277,7 +193,7 @@ class TestStartup:
         adapter.on_started.assert_awaited_once_with("Weather", "forecasts")
 
     async def test_startup_is_idempotent(self) -> None:
-        link = _make_link_mock()
+        link = make_link_mock()
         adapter = _make_adapter_mock()
         invoker = OneShotInvoker(link=link, adapter=adapter, agent_id="agent-1")
 
@@ -288,7 +204,7 @@ class TestStartup:
         adapter.on_started.assert_awaited_once()
 
     async def test_handle_event_before_startup_raises(self) -> None:
-        link = _make_link_mock()
+        link = make_link_mock()
         invoker = OneShotInvoker(
             link=link, adapter=_make_adapter_mock(), agent_id="agent-1"
         )
@@ -296,7 +212,7 @@ class TestStartup:
             await invoker.handle_event(_msg_body())
 
     async def test_shutdown_disconnects_link(self) -> None:
-        link = _make_link_mock()
+        link = make_link_mock()
         invoker = await _make_invoker(link)
         await invoker.shutdown()
         link.disconnect.assert_awaited_once()
@@ -309,7 +225,7 @@ class TestStartup:
 
 class TestHandleEventRouting:
     async def test_non_message_event_returns_ignored(self) -> None:
-        link = _make_link_mock()
+        link = make_link_mock()
         adapter = _make_adapter_mock()
         invoker = await _make_invoker(link, adapter)
 
@@ -326,7 +242,7 @@ class TestHandleEventRouting:
         many rooms. Without on_cleanup on room teardown, per-room caches
         (Anthropic history, Claude SDK sessions, etc.) leak.
         """
-        link = _make_link_mock()
+        link = make_link_mock()
         adapter = _make_adapter_mock()
         invoker = await _make_invoker(link, adapter)
 
@@ -343,7 +259,7 @@ class TestHandleEventRouting:
         link.get_next_message.assert_not_awaited()
 
     async def test_room_deleted_triggers_adapter_cleanup(self) -> None:
-        link = _make_link_mock()
+        link = make_link_mock()
         adapter = _make_adapter_mock()
         invoker = await _make_invoker(link, adapter)
 
@@ -354,7 +270,7 @@ class TestHandleEventRouting:
         adapter.on_cleanup.assert_awaited_once_with("r1")
 
     async def test_room_removed_falls_back_to_payload_id(self) -> None:
-        link = _make_link_mock()
+        link = make_link_mock()
         adapter = _make_adapter_mock()
         invoker = await _make_invoker(link, adapter)
 
@@ -365,7 +281,7 @@ class TestHandleEventRouting:
         adapter.on_cleanup.assert_awaited_once_with("r-payload")
 
     async def test_room_removed_swallows_cleanup_errors(self) -> None:
-        link = _make_link_mock()
+        link = make_link_mock()
         adapter = _make_adapter_mock()
         adapter.on_cleanup = AsyncMock(side_effect=RuntimeError("adapter blew up"))
         invoker = await _make_invoker(link, adapter)
@@ -377,7 +293,7 @@ class TestHandleEventRouting:
         assert result["status"] == "cleaned_up"
 
     async def test_missing_room_id_raises_envelope_error(self) -> None:
-        link = _make_link_mock()
+        link = make_link_mock()
         invoker = await _make_invoker(link)
         body = {
             "event_type": "message_created",
@@ -388,7 +304,7 @@ class TestHandleEventRouting:
             await invoker.handle_event(body)
 
     async def test_missing_message_id_raises_envelope_error(self) -> None:
-        link = _make_link_mock()
+        link = make_link_mock()
         invoker = await _make_invoker(link)
         body = {
             "event_type": "message_created",
@@ -400,7 +316,7 @@ class TestHandleEventRouting:
             await invoker.handle_event(body)
 
     async def test_falls_back_to_payload_chat_room_id(self) -> None:
-        link = _make_link_mock(next_messages=[_platform_msg("msg-1"), None])
+        link = make_link_mock(next_messages=[platform_msg("msg-1"), None])
         invoker = await _make_invoker(link)
         body = {
             "event_type": "message_created",
@@ -425,11 +341,11 @@ class TestHandleEventRouting:
 
 class TestProcessMessage:
     async def test_processes_message(self) -> None:
-        link = _make_link_mock(
+        link = make_link_mock(
             participants=[
                 {"id": "user-1", "name": "Alice", "type": "User", "handle": "alice"},
             ],
-            next_messages=[_platform_msg("msg-1"), None],
+            next_messages=[platform_msg("msg-1"), None],
         )
         adapter = _make_adapter_mock()
         invoker = await _make_invoker(link, adapter)
@@ -441,7 +357,7 @@ class TestProcessMessage:
         assert result["message_id"] == "msg-1"
 
         adapter.on_event.assert_awaited_once()
-        inp = adapter.on_event.call_args.args[0]
+        inp = adapter.received_input
         assert inp.msg.id == "msg-1"
         assert inp.msg.sender_name == "Alice"
 
@@ -450,7 +366,7 @@ class TestProcessMessage:
         link.mark_failed.assert_not_awaited()
 
     async def test_skips_self_message(self) -> None:
-        link = _make_link_mock()
+        link = make_link_mock()
         adapter = _make_adapter_mock()
         invoker = await _make_invoker(link, adapter)
         body = _msg_body(
@@ -468,7 +384,7 @@ class TestProcessMessage:
 
     async def test_skips_when_no_pending(self) -> None:
         """get_next_message returns None — already processed by a sibling."""
-        link = _make_link_mock(next_messages=[None])
+        link = make_link_mock(next_messages=[None])
         adapter = _make_adapter_mock()
         invoker = await _make_invoker(link, adapter)
 
@@ -480,7 +396,7 @@ class TestProcessMessage:
         link.mark_processing.assert_not_awaited()
 
     async def test_skips_when_different_message_is_next(self) -> None:
-        link = _make_link_mock(next_messages=[_platform_msg("msg-other")])
+        link = make_link_mock(next_messages=[platform_msg("msg-other")])
         adapter = _make_adapter_mock()
         invoker = await _make_invoker(link, adapter)
 
@@ -497,7 +413,7 @@ class TestProcessMessage:
         not be silently treated as ``no_pending`` — that would leave the
         message open on the platform and tell the bridge it was handled.
         """
-        link = _make_link_mock()
+        link = make_link_mock()
         link.get_next_message = AsyncMock(side_effect=RuntimeError("network down"))
         adapter = _make_adapter_mock()
         invoker = await _make_invoker(link, adapter)
@@ -510,7 +426,7 @@ class TestProcessMessage:
         adapter.on_event.assert_not_awaited()
 
     async def test_marks_failed_on_adapter_error(self) -> None:
-        link = _make_link_mock(next_messages=[_platform_msg("msg-1")])
+        link = make_link_mock(next_messages=[platform_msg("msg-1")])
         adapter = _make_adapter_mock()
         adapter.on_event = AsyncMock(side_effect=RuntimeError("LLM crashed"))
         invoker = await _make_invoker(link, adapter)
@@ -524,6 +440,117 @@ class TestProcessMessage:
 
 
 # ---------------------------------------------------------------------------
+# Participant roster surfaced to the model
+#
+# The long-running path treats "no prior roster sent yet" as changed (see
+# ExecutionContext.participants_changed: `_last_participants_sent is None`
+# -> True), so a room's very first message already carries the roster via
+# `participants_msg`. OneShotInvoker has no cross-call state to diff
+# against, so every invocation is that same "first time" case — it should
+# always build and pass the current roster, never a hardcoded None.
+# ---------------------------------------------------------------------------
+
+
+class TestParticipantsSurfaced:
+    async def test_participants_msg_reflects_current_roster(self) -> None:
+        participants = [
+            {"id": "user-1", "name": "Alice", "type": "User", "handle": "alice"},
+            {"id": "agent-2", "name": "Bot2", "type": "Agent", "handle": "bot2"},
+        ]
+        link = make_link_mock(
+            participants=participants,
+            next_messages=[platform_msg("msg-1"), None],
+        )
+        adapter = _make_adapter_mock()
+        invoker = await _make_invoker(link, adapter)
+
+        await invoker.handle_event(_msg_body())
+
+        adapter.on_event.assert_awaited_once()
+        inp = adapter.received_input
+        assert inp.participants_msg == build_participants_message(participants)
+
+    async def test_participants_msg_none_when_room_has_no_other_participants(
+        self,
+    ) -> None:
+        """Even an empty roster is a deliberate 'no one else here' statement,
+        not an absent one — the model shouldn't have to call a tool to learn
+        it's alone in the room.
+        """
+        link = make_link_mock(
+            participants=[],
+            next_messages=[platform_msg("msg-1"), None],
+        )
+        adapter = _make_adapter_mock()
+        invoker = await _make_invoker(link, adapter)
+
+        await invoker.handle_event(_msg_body())
+
+        inp = adapter.received_input
+        assert inp.participants_msg == build_participants_message([])
+
+
+# ---------------------------------------------------------------------------
+# History pagination
+#
+# The real context endpoint paginates with a cursor (``next_cursor`` /
+# ``has_more``); ``page``/``page_size`` are deprecated and scheduled for
+# removal. A room whose history spans more than one page must not silently
+# lose the earlier pages.
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryPagination:
+    async def test_long_running_room_keeps_facts_from_the_start_of_the_conversation(
+        self,
+    ) -> None:
+        """A project channel active long enough to span more than one fetch
+        holds facts the model still needs — the codename set on day one is as
+        relevant as this morning's standup update. Neither should quietly
+        fall out of context just because the room outgrew a single page.
+        """
+        link = make_link_mock(
+            history_pages=[
+                [ctx_item("hist-1", content="the project codename is NIGHTHAWK")],
+                [ctx_item("hist-2", content="today's standup moved to 3pm")],
+            ],
+            next_messages=[platform_msg("msg-1"), None],
+        )
+        adapter = _make_adapter_mock()
+        invoker = await _make_invoker(link, adapter)
+
+        result = await invoker.handle_event(_msg_body())
+
+        history_content = [m["content"] for m in adapter.received_input.history.raw]
+        assert "the project codename is NIGHTHAWK" in history_content
+        assert "today's standup moved to 3pm" in history_content
+        assert "history_truncated" not in result
+
+    async def test_room_active_for_months_gets_a_prompt_reply_not_a_full_replay(
+        self,
+    ) -> None:
+        """A room that's been running for months can carry far more history
+        than any one page holds. The agent still has to answer promptly, so
+        it stops at a bound rather than replaying the entire backlog on every
+        message — and says so honestly instead of presenting a partial
+        conversation as the whole thing.
+        """
+        months_of_daily_updates = [
+            [ctx_item(f"hist-{day}", content=f"day {day} update")] for day in range(5)
+        ]
+        link = make_link_mock(
+            history_pages=months_of_daily_updates,
+            next_messages=[platform_msg("msg-1"), None],
+        )
+        adapter = _make_adapter_mock()
+        invoker = await _make_invoker(link, adapter, history_page_cap=3)
+
+        result = await invoker.handle_event(_msg_body())
+
+        assert result["history_truncated"] is True
+
+
+# ---------------------------------------------------------------------------
 # Drain (race fix + self-skip + cap surfacing)
 # ---------------------------------------------------------------------------
 
@@ -533,12 +560,12 @@ class TestDrain:
         """The case drain is for: the LLM saw msg-2 and msg-3 in its history
         snapshot. Drain marks them processed without re-invoking the LLM.
         """
-        link = _make_link_mock(
-            history_items=[_ctx_item("msg-2"), _ctx_item("msg-3")],
+        link = make_link_mock(
+            history_items=[ctx_item("msg-2"), ctx_item("msg-3")],
             next_messages=[
-                _platform_msg("msg-1"),  # claim check
-                _platform_msg("msg-2"),  # drain (in snapshot)
-                _platform_msg("msg-3"),  # drain (in snapshot)
+                platform_msg("msg-1"),  # claim check
+                platform_msg("msg-2"),  # drain (in snapshot)
+                platform_msg("msg-3"),  # drain (in snapshot)
                 None,
             ],
         )
@@ -562,11 +589,11 @@ class TestDrain:
         in seen_ids). Drain must stop and leave it open for the next
         invocation rather than swallowing it without an LLM call.
         """
-        link = _make_link_mock(
-            history_items=[_ctx_item("msg-1")],  # snapshot = msg-1 only
+        link = make_link_mock(
+            history_items=[ctx_item("msg-1")],  # snapshot = msg-1 only
             next_messages=[
-                _platform_msg("msg-1"),  # claim check
-                _platform_msg("msg-2"),  # arrived after snapshot → leave open
+                platform_msg("msg-1"),  # claim check
+                platform_msg("msg-2"),  # arrived after snapshot → leave open
                 None,
             ],
         )
@@ -586,11 +613,11 @@ class TestDrain:
         get_next_message during drain, skip it without marking — parity with
         the SDK's ExecutionContext self-message guard.
         """
-        self_msg = _platform_msg("msg-self", sender_type="Agent", sender_id="agent-1")
-        link = _make_link_mock(
-            history_items=[_ctx_item("msg-1"), _ctx_item("msg-self")],
+        self_msg = platform_msg("msg-self", sender_type="Agent", sender_id="agent-1")
+        link = make_link_mock(
+            history_items=[ctx_item("msg-1"), ctx_item("msg-self")],
             next_messages=[
-                _platform_msg("msg-1"),  # claim check
+                platform_msg("msg-1"),  # claim check
                 self_msg,  # our own message — skip
                 None,
             ],
@@ -612,10 +639,10 @@ class TestDrain:
         """
         # Always return an in-snapshot message so drain never naturally stops;
         # the cap is the only exit.
-        always_stale = _platform_msg("msg-x")
-        link = _make_link_mock(history_items=[_ctx_item("msg-x")])
+        always_stale = platform_msg("msg-x")
+        link = make_link_mock(history_items=[ctx_item("msg-x")])
         link.get_next_message = AsyncMock(
-            side_effect=[_platform_msg("msg-1")]  # claim check
+            side_effect=[platform_msg("msg-1")]  # claim check
             + [always_stale] * 10  # drain keeps finding msg-x
         )
         invoker = await _make_invoker(link, _make_adapter_mock(), drain_cap=3)

--- a/tests/runtime/test_oneshot.py
+++ b/tests/runtime/test_oneshot.py
@@ -735,3 +735,89 @@ class TestCustomToolDispatch:
         ]
         assert "4471-ECHO" in sent.content
         assert sent.mentions[0].id == "user-1"
+
+
+# ---------------------------------------------------------------------------
+# Tool-call replay across a container crash.
+#
+# OneShotInvoker keeps no state across calls by design, so nothing survives
+# a crash between a tool's side effect and mark_processed — the platform's
+# /next re-serves the same still-"processing" message to whatever container
+# picks it up next, and a fresh adapter instance replays the whole turn from
+# scratch. This documents that as current, real behavior (not a bug this
+# file can fix — see band.runtime.single_instance and
+# band.runtime.claims.MessageClaimRegistry, both of which state the same
+# cross-process boundary is out of the SDK's reach).
+# ---------------------------------------------------------------------------
+
+
+class SendEmailInput(BaseModel):
+    """Send an email to an address."""
+
+    to: str
+
+
+class TestToolCallReplayAcrossCrash:
+    async def test_crash_before_mark_processed_replays_the_tool(self) -> None:
+        sent_emails: list[str] = []
+
+        async def send_email(args: SendEmailInput) -> str:
+            sent_emails.append(args.to)
+            return "sent"
+
+        link = make_link_mock(next_messages=[platform_msg("msg-1")])
+
+        # --- Attempt 1: the tool's side effect fires, then the container
+        # dies before the turn finishes (never reaches mark_processed).
+        adapter_a = AnthropicAdapter(additional_tools=[(SendEmailInput, send_email)])
+        invoker_a = await _make_invoker(link, adapter_a)
+
+        tool_use_email = MagicMock(stop_reason="tool_use")
+        tool_use_email.content = [
+            ToolUseBlock(
+                type="tool_use",
+                id="call-1",
+                name="sendemail",
+                input={"to": "boss@example.com"},
+            )
+        ]
+        with (
+            patch.object(
+                adapter_a,
+                "_call_anthropic",
+                AsyncMock(side_effect=[tool_use_email, SystemExit("container killed")]),
+            ),
+            pytest.raises(SystemExit),
+        ):
+            await invoker_a.handle_event(_msg_body())
+
+        assert sent_emails == ["boss@example.com"]
+        link.mark_processed.assert_not_awaited()
+        link.mark_failed.assert_not_awaited()
+
+        # --- Restart: a fresh container, fresh adapter, same still-open
+        # message — /next re-serves it exactly as it would after a crash.
+        link.get_next_message = AsyncMock(side_effect=[platform_msg("msg-1"), None])
+        link.mark_processing.reset_mock()
+        adapter_b = AnthropicAdapter(additional_tools=[(SendEmailInput, send_email)])
+        invoker_b = await _make_invoker(link, adapter_b)
+
+        turn_end = MagicMock(stop_reason="end_turn")
+        turn_end.content = []
+        with patch.object(
+            adapter_b,
+            "_call_anthropic",
+            AsyncMock(side_effect=[tool_use_email, turn_end]),
+        ):
+            result = await invoker_b.handle_event(_msg_body())
+
+        assert result["status"] == "done"
+        link.mark_processed.assert_awaited_once_with("room-1", "msg-1")
+
+        # The email tool fired twice for one logical request — nothing in
+        # OneShotInvoker (or the platform's claim primitives it relies on)
+        # prevents a crash-and-restart from replaying a completed side
+        # effect. Custom tools with real-world side effects need their own
+        # idempotency (e.g. keying on tool arguments), same as any at-least-
+        # once delivery system.
+        assert sent_emails == ["boss@example.com", "boss@example.com"]

--- a/tests/runtime/test_oneshot.py
+++ b/tests/runtime/test_oneshot.py
@@ -10,10 +10,14 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from anthropic.types import ToolUseBlock
+from band_rest import CreateAgentChatMessageResponse, MessageSentResponse
+from pydantic import BaseModel, Field
 
+from band.adapters.anthropic import AnthropicAdapter
 from band.runtime.formatters import build_participants_message
 from band.runtime.oneshot import (
     OneShotEnvelopeError,
@@ -54,7 +58,7 @@ def _make_adapter_mock() -> MagicMock:
 
 async def _make_invoker(
     link: MagicMock,
-    adapter: MagicMock | None = None,
+    adapter: MagicMock | AnthropicAdapter | None = None,
     *,
     agent_id: str = "agent-1",
     drain_cap: int = 50,
@@ -651,3 +655,83 @@ class TestDrain:
 
         assert result["status"] == "done"
         assert result.get("drain_truncated") is True
+
+
+# ---------------------------------------------------------------------------
+# Custom tool dispatch through a real adapter and its real AgentTools.
+# ---------------------------------------------------------------------------
+
+
+class VaultCodeInput(BaseModel):
+    """Look up the vault code for a topic."""
+
+    topic: str = Field(description="Topic to look up")
+
+
+class TestCustomToolDispatch:
+    async def test_custom_tool_result_reaches_the_platform_reply(self) -> None:
+        """The model calls a custom tool it needs to answer, then reports
+        back via the real band_send_message platform tool.
+        """
+        looked_up: list[str] = []
+
+        async def lookup_vault_code(args: VaultCodeInput) -> str:
+            looked_up.append(args.topic)
+            return "vault code is 4471-ECHO"
+
+        link = make_link_mock(
+            participants=[
+                {"id": "user-1", "name": "Alice", "type": "User", "handle": "alice"},
+            ],
+            next_messages=[platform_msg("msg-1"), None],
+        )
+        link.rest.agent_api_messages.create_agent_chat_message = AsyncMock(
+            return_value=CreateAgentChatMessageResponse(
+                data=MessageSentResponse(id="sent-1", recipients=[], success=True)
+            )
+        )
+
+        adapter = AnthropicAdapter(
+            additional_tools=[(VaultCodeInput, lookup_vault_code)]
+        )
+        invoker = await _make_invoker(link, adapter)
+
+        turn_1 = MagicMock(stop_reason="tool_use")
+        turn_1.content = [
+            ToolUseBlock(
+                type="tool_use", id="call-1", name="vaultcode", input={"topic": "vault"}
+            )
+        ]
+        turn_2 = MagicMock(stop_reason="tool_use")
+        turn_2.content = [
+            ToolUseBlock(
+                type="tool_use",
+                id="call-2",
+                name="band_send_message",
+                input={
+                    "content": "The vault code is 4471-ECHO",
+                    "mentions": ["alice"],
+                },
+            )
+        ]
+        turn_3 = MagicMock(stop_reason="end_turn")
+        turn_3.content = []
+
+        with patch.object(
+            adapter, "_call_anthropic", AsyncMock(side_effect=[turn_1, turn_2, turn_3])
+        ):
+            result = await invoker.handle_event(_msg_body())
+
+        assert result["status"] == "done"
+        link.mark_processed.assert_awaited_once_with("room-1", "msg-1")
+        link.mark_failed.assert_not_awaited()
+
+        # Ran directly, not via AgentTools.execute_tool_call.
+        assert looked_up == ["vault"]
+
+        link.rest.agent_api_messages.create_agent_chat_message.assert_awaited_once()
+        sent = link.rest.agent_api_messages.create_agent_chat_message.call_args.kwargs[
+            "message"
+        ]
+        assert "4471-ECHO" in sent.content
+        assert sent.mentions[0].id == "user-1"


### PR DESCRIPTION
## Summary
Two fixes found while validating the AgentCore integration against the coding-agent adapter conformance ladder (INT-1119):

- **History pagination**: `get_agent_chat_context`'s `page`/`page_size` params are deprecated on the real API and scheduled for removal (2026-10-01). `OneShotInvoker` used them for a single fetch and never read `has_more`/`next_cursor`, so any room's history past one page was silently dropped on every invocation. Now follows the cursor while `has_more`, bounded by a `history_page_cap` (mirrors the existing `drain_cap` pattern), surfacing `history_truncated` in the result if the cap is hit. Code review then caught two more edge cases in that same loop: a page-0 fetch failure reported `history_truncated=False` (the worst case looked identical to full success), and `has_more=True` with a `null` `next_cursor` re-requested `cursor=None` forever, duplicating page-0 items until the cap. Both fixed with regression tests confirmed red on the old code.
- **Participant roster surfacing**: the long-running path sends the roster to the model on a room's first message too (`ExecutionContext.participants_changed` treats "never sent before" as changed). `OneShotInvoker` has no cross-call state to diff against — every invocation is that same "first time" case — but hardcoded `participants_msg=None` regardless, so the model got zero roster signal unless it proactively called a tool. Now builds it from the current fetch every call.

**Custom tool dispatch coverage**: nothing exercised the seam between OneShotInvoker's real AgentTools (REST-backed) and an adapter configured with `additional_tools` — added a test driving a real `AnthropicAdapter` through `handle_event`, proving a custom-tool call resolves to the custom handler while the same turn's platform tool call still reaches the real REST client. Also adds `examples/agentcore/custom_tools_llm_server.py`, a runnable container variant wiring `additional_tools`, and fixes BUILDING.md's custom-tools snippet (it showed a constructor call that doesn't match the real `CustomToolDef` type, a `(InputModel, handler)` tuple).

**Tool-call replay across a crash (L4#4)**: characterized rather than fixed — added a test proving a side-effecting custom tool fires twice across a simulated container crash+restart (nothing survives between a tool's side effect and `mark_processed`, and the platform re-serves the same still-open message). Confirmed this is an accepted architectural boundary, not an oversight — `single_instance.py` and `claims.py` already document the same cross-process boundary as out of the SDK's reach for the long-running path too. Added a note to BUILDING.md: side-effecting custom tools need their own idempotency.

**Co-resident instances (L3)**: added an integration test (`tests/integration/test_agentcore_concurrency.py`, `requires_api`-gated) spawning real container processes — three concurrent instances each complete a real Band REST startup and answer `/ping` independently, and a deliberate port clash fails at the OS bind step, not a shared lock or singleton. Also verified live against the dev platform for both this and the custom-tool dispatch above.

Also extracted the BandLink/REST test doubles from `test_oneshot.py` into a shared `tests/runtime/conftest.py`, built from real `band_rest` model instances instead of bare `MagicMock`s (catches real schema drift instead of silently tolerating it), and replaced the fake adapter's `call_args`-based inspection with a plain `received_input` attribute. Also extracted a shared `tests/ports.py::reserve_port()` ephemeral-port helper and refactored the two real duplicates onto it (`tests/e2e/vscode/server.py`, `tests/integration/test_agentcore_concurrency.py`).

## Test plan
- [x] `uv run pytest tests/runtime/test_oneshot.py -v --no-cov` — 40 passed
- [x] `uv run pytest tests/ --ignore=tests/integration/ --ignore=tests/e2e/ --no-cov` — 4311 passed, 20 pre-existing unrelated failures (strands adapter, config-drift — confirmed failing identically on clean `main`, tracked as INT-1165), 0 from this change
- [x] `uv run pytest tests/integration/test_agentcore_concurrency.py -v --no-cov` (real Band creds) — 2 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01EoBzp9vWrsrPhxcgLw9yWT


