### PR TITLE
fix(ci): forward Docker Hub secrets to kit publisher

### DIFF
--- a/.github/workflows/kit-image-rebuild.yml
+++ b/.github/workflows/kit-image-rebuild.yml
@@ -283,6 +283,9 @@ jobs:
       cancel-in-progress: false
       queue: max
     uses: ./.github/workflows/kit-publish.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       ref: ${{ needs.decide.outputs.tag }}
       version: ${{ needs.decide.outputs.rversion }}

--- a/.github/workflows/kit-publish-manual.yml
+++ b/.github/workflows/kit-publish-manual.yml
@@ -57,6 +57,9 @@ jobs:
       cancel-in-progress: false
       queue: max
     uses: ./.github/workflows/kit-publish.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       ref: ${{ inputs.ref }}
       version: ${{ inputs.version }}

--- a/.github/workflows/kit-publish.yml
+++ b/.github/workflows/kit-publish.yml
@@ -291,8 +291,8 @@ jobs:
           grep 'image:' staging/ghcr/spec.yaml
           echo "── Hub stamped sandbox.image ──"
           grep 'image:' staging/hub/spec.yaml
-          grep -qF "${IMAGE_NAME}@${digest}" staging/ghcr/spec.yaml
-          grep -qF "${HUB_IMAGE_NAME}@${digest}" staging/hub/spec.yaml
+          grep -qF "${IMAGE_NAME}:${{ inputs.version }}@${digest}" staging/ghcr/spec.yaml
+          grep -qF "${HUB_IMAGE_NAME}:${{ inputs.version }}@${digest}" staging/hub/spec.yaml
 
       - name: Assemble the OCI v2 kit layers
         run: |

--- a/.github/workflows/kit-publish.yml
+++ b/.github/workflows/kit-publish.yml
@@ -7,7 +7,10 @@
 # Hub refs are flat (Hub has no nested package path like GHCR's `/image`):
 #   image → docker.io/bandhq/band-python-kit-image
 #   kit   → docker.io/bandhq/band-python-kit
-# Auth: release-environment secrets DOCKERHUB_USERNAME + DOCKERHUB_TOKEN
+# Auth: repository secrets DOCKERHUB_USERNAME + DOCKERHUB_TOKEN, explicitly
+# forwarded by each caller. The jobs still use the release environment as the
+# deployment gate, but the credentials live at repository scope because GitHub
+# does not reliably expose environment secrets through this reusable workflow.
 # (login-action@v4 / build-push-action@v7 multi-registry pattern — see
 # https://docs.docker.com/build/ci/github-actions/push-multi-registries/).
 #
@@ -27,6 +30,13 @@ name: kit-publish
 
 on:
   workflow_call:
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: Docker Hub organization name
+        required: true
+      DOCKERHUB_TOKEN:
+        description: Docker Hub organization access token
+        required: true
     inputs:
       ref:
         description: Git ref to check out and build from (e.g. band-sdk-vX.Y.Z)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,9 @@ jobs:
       cancel-in-progress: false
       queue: max
     uses: ./.github/workflows/kit-publish.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       ref: ${{ needs.release.outputs.tag_name }}
       version: ${{ needs.release.outputs.major }}.${{ needs.release.outputs.minor }}.${{ needs.release.outputs.patch }}

--- a/docker/band_python_kit/RELEASING.md
+++ b/docker/band_python_kit/RELEASING.md
@@ -200,11 +200,11 @@ the registries stay in lockstep — same pattern as CI:
 ## One-time Docker Hub setup
 
 1. Org `bandhq` on Hub; public repos `band-python-kit` and `band-python-kit-image`.
-2. Secrets on the `release` environment: `DOCKERHUB_USERNAME` and
-   `DOCKERHUB_TOKEN`. For an organization access token (OAT), username must be
-   the org name (`bandhq`), not a personal Hub user. The called jobs in
-   `kit-publish.yml` declare `environment: release`, so callers do not pass
-   these secrets; keeping them environment-only avoids duplicate credentials.
+2. Repository secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`. For an
+   organization access token (OAT), username must be the org name (`bandhq`),
+   not a personal Hub user. Every caller passes only these two secrets to
+   `kit-publish.yml`; its jobs still declare `environment: release` as the
+   deployment gate.
 
 ## One-time GHCR setup
 

--- a/tests/docker/test_kit_publish_workflow.py
+++ b/tests/docker/test_kit_publish_workflow.py
@@ -43,3 +43,17 @@ def test_every_caller_forwards_only_the_dockerhub_secrets() -> None:
         assert set(call["secrets"]) == DOCKERHUB_SECRETS
         for secret in DOCKERHUB_SECRETS:
             assert call["secrets"][secret] == f"${{{{ secrets.{secret} }}}}"
+
+
+def test_stamped_specs_are_verified_against_the_versioned_image_refs() -> None:
+    workflow = load_workflow("kit-publish.yml")
+    stamp = next(
+        step
+        for step in workflow["jobs"]["kit"]["steps"]
+        if step.get("name") == "Stamp distribution specs (GHCR + Hub image digests)"
+    )
+
+    assert 'grep -qF "${IMAGE_NAME}:${{ inputs.version }}@${digest}"' in stamp["run"]
+    assert (
+        'grep -qF "${HUB_IMAGE_NAME}:${{ inputs.version }}@${digest}"' in stamp["run"]
+    )

--- a/tests/docker/test_kit_publish_workflow.py
+++ b/tests/docker/test_kit_publish_workflow.py
@@ -1,0 +1,45 @@
+"""Structural contracts for the reusable kit publishing workflow."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+from tests.paths import REPO_ROOT
+
+DOCKERHUB_SECRETS = {"DOCKERHUB_USERNAME", "DOCKERHUB_TOKEN"}
+CALLER_WORKFLOWS = (
+    "release.yml",
+    "kit-image-rebuild.yml",
+    "kit-publish-manual.yml",
+)
+
+
+def load_workflow(name: str) -> dict[str, Any]:
+    return yaml.load(
+        (REPO_ROOT / ".github/workflows" / name).read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+
+
+def test_reusable_workflow_declares_dockerhub_secrets() -> None:
+    workflow = load_workflow("kit-publish.yml")
+    declared = workflow["on"]["workflow_call"]["secrets"]
+
+    assert set(declared) == DOCKERHUB_SECRETS
+    assert all(secret["required"] == "true" for secret in declared.values())
+
+
+def test_every_caller_forwards_only_the_dockerhub_secrets() -> None:
+    for name in CALLER_WORKFLOWS:
+        workflow = load_workflow(name)
+        call = next(
+            job
+            for job in workflow["jobs"].values()
+            if job.get("uses") == "./.github/workflows/kit-publish.yml"
+        )
+
+        assert set(call["secrets"]) == DOCKERHUB_SECRETS
+        for secret in DOCKERHUB_SECRETS:
+            assert call["secrets"][secret] == f"${{{{ secrets.{secret} }}}}"


### PR DESCRIPTION
## Summary

- declare the two Docker Hub credentials as required reusable-workflow secrets
- explicitly forward only those secrets from the release, rebuild, and manual callers
- keep the `release` environment as the deployment gate and document repository-level credential ownership
- add structural regression coverage for every caller
- verify stamped kit specs against the full versioned image reference

## Root cause

Release run [30805272028](https://github.com/band-ai/band-sdk-python/actions/runs/30805272028) reached `docker/login-action` with empty username and password inputs. The credentials were valid, but environment-scoped secrets were not exposed through the reusable workflow invocation. Refreshing the environment secrets and rerunning reproduced the same failure.

The credentials have been moved to repository secrets so callers can explicitly pass them without exposing unrelated secrets.

The first live publish then reached a pre-existing assertion that omitted the version tag from the expected image reference. The workflow now checks the same versioned reference that `stamp-kit-spec.py` writes.

## Validation

- local Docker Hub login with the `.env.test` credentials
- `27 passed` across the new workflow contract, registry probe, and lock-age tests
- Ruff check and format check for the new test
- Pyrefly check for the new test
- actionlint reported only the existing unsupported `concurrency.queue` keys; no new workflow errors
- live v1.6.0 publish passed for the image, kit artifacts, provenance, and floating tags: [run 30898026100](https://github.com/band-ai/band-sdk-python/actions/runs/30898026100)

Linear: [INT-1168](https://linear.app/thenvoi/issue/INT-1168/fix-docker-hub-credentials-in-reusable-kit-publish-workflow)
